### PR TITLE
feat(assertions): Assertion source rollout

### DIFF
--- a/metadata-ingestion/src/datahub/api/entities/assertion/assertion.py
+++ b/metadata-ingestion/src/datahub/api/entities/assertion/assertion.py
@@ -5,6 +5,7 @@ from pydantic import Field
 
 from datahub.api.entities.assertion.assertion_trigger import AssertionTrigger
 from datahub.configuration.common import ConfigModel
+from datahub.emitter.mce_builder import make_assertion_source
 from datahub.metadata.com.linkedin.pegasus2avro.assertion import AssertionInfo
 
 
@@ -46,6 +47,15 @@ class BaseAssertion(ConfigModel):
     meta: Optional[dict] = None
 
 
+def _ensure_source_created(info: AssertionInfo) -> AssertionInfo:
+    """Ensure AssertionInfo has source.created populated."""
+    if info.source is None:
+        info.source = make_assertion_source()
+    elif info.source.created is None:
+        info.source.created = make_assertion_source().created
+    return info
+
+
 class BaseEntityAssertion(BaseAssertion):
     entity: str = Field(
         description="The entity urn that the assertion is associated with"
@@ -54,3 +64,10 @@ class BaseEntityAssertion(BaseAssertion):
     trigger: Optional[AssertionTrigger] = Field(
         default=None, description="The trigger schedule for assertion", alias="schedule"
     )
+
+    @abstractmethod
+    def get_assertion_info(self) -> AssertionInfo:
+        pass
+
+    def get_assertion_info_aspect(self) -> AssertionInfo:
+        return _ensure_source_created(self.get_assertion_info())

--- a/metadata-ingestion/src/datahub/api/entities/assertion/field_assertion.py
+++ b/metadata-ingestion/src/datahub/api/entities/assertion/field_assertion.py
@@ -98,9 +98,6 @@ class FieldValuesAssertion(BaseEntityAssertion):
         }
         return self.id or datahub_guid(guid_dict)
 
-    def get_assertion_info_aspect(self) -> AssertionInfo:
-        return self.get_assertion_info()
-
     def get_assertion_trigger(self) -> Optional[AssertionTrigger]:
         return self.trigger
 
@@ -143,9 +140,6 @@ class FieldMetricAssertion(BaseEntityAssertion):
             "id_raw": self.id_raw,
         }
         return self.id or datahub_guid(guid_dict)
-
-    def get_assertion_info_aspect(self) -> AssertionInfo:
-        return self.get_assertion_info()
 
     def get_assertion_trigger(self) -> Optional[AssertionTrigger]:
         return self.trigger

--- a/metadata-ingestion/src/datahub/api/entities/assertion/freshness_assertion.py
+++ b/metadata-ingestion/src/datahub/api/entities/assertion/freshness_assertion.py
@@ -68,9 +68,6 @@ class CronFreshnessAssertion(BaseEntityAssertion):
         }
         return self.id or datahub_guid(guid_dict)
 
-    def get_assertion_info_aspect(self) -> AssertionInfo:
-        return self.get_assertion_info()
-
     def get_assertion_trigger(self) -> Optional[AssertionTrigger]:
         return self.trigger
 
@@ -118,9 +115,6 @@ class FixedIntervalFreshnessAssertion(BaseEntityAssertion):
             "id_raw": self.id_raw,
         }
         return self.id or datahub_guid(guid_dict)
-
-    def get_assertion_info_aspect(self) -> AssertionInfo:
-        return self.get_assertion_info()
 
     def get_assertion_trigger(self) -> Optional[AssertionTrigger]:
         return self.trigger

--- a/metadata-ingestion/src/datahub/api/entities/assertion/sql_assertion.py
+++ b/metadata-ingestion/src/datahub/api/entities/assertion/sql_assertion.py
@@ -46,9 +46,6 @@ class SqlMetricAssertion(BaseEntityAssertion):
         }
         return self.id or datahub_guid(guid_dict)
 
-    def get_assertion_info_aspect(self) -> AssertionInfo:
-        return self.get_assertion_info()
-
     def get_assertion_trigger(self) -> Optional[AssertionTrigger]:
         return self.trigger
 
@@ -86,9 +83,6 @@ class SqlMetricChangeAssertion(BaseEntityAssertion):
             "id_raw": self.id_raw,
         }
         return self.id or datahub_guid(guid_dict)
-
-    def get_assertion_info_aspect(self) -> AssertionInfo:
-        return self.get_assertion_info()
 
     def get_assertion_trigger(self) -> Optional[AssertionTrigger]:
         return self.trigger

--- a/metadata-ingestion/src/datahub/api/entities/assertion/volume_assertion.py
+++ b/metadata-ingestion/src/datahub/api/entities/assertion/volume_assertion.py
@@ -51,9 +51,6 @@ class RowCountTotalVolumeAssertion(BaseEntityAssertion):
         }
         return self.id or datahub_guid(guid_dict)
 
-    def get_assertion_info_aspect(self) -> AssertionInfo:
-        return self.get_assertion_info()
-
     def get_assertion_trigger(self) -> Optional[AssertionTrigger]:
         return self.trigger
 
@@ -93,9 +90,6 @@ class RowCountChangeVolumeAssertion(BaseEntityAssertion):
             "id_raw": self.id_raw,
         }
         return self.id or datahub_guid(guid_dict)
-
-    def get_assertion_info_aspect(self) -> AssertionInfo:
-        return self.get_assertion_info()
 
     def get_assertion_trigger(self) -> Optional[AssertionTrigger]:
         return self.trigger

--- a/metadata-ingestion/src/datahub/api/entities/datacontract/data_quality_assertion.py
+++ b/metadata-ingestion/src/datahub/api/entities/datacontract/data_quality_assertion.py
@@ -55,6 +55,7 @@ class CustomSQLAssertion(IdConfigMixin, BaseAssertion):
         return AssertionInfoClass(
             type=AssertionTypeClass.SQL,
             sqlAssertion=sql_assertion_info,
+            source=builder.make_assertion_source(),
             description=self.description,
         )
 
@@ -84,6 +85,7 @@ class ColumnUniqueAssertion(IdConfigMixin, BaseAssertion):
         return AssertionInfoClass(
             type=AssertionTypeClass.DATASET,
             datasetAssertion=dataset_assertion_info,
+            source=builder.make_assertion_source(),
             description=self.description,
         )
 

--- a/metadata-ingestion/src/datahub/api/entities/datacontract/freshness_assertion.py
+++ b/metadata-ingestion/src/datahub/api/entities/datacontract/freshness_assertion.py
@@ -7,6 +7,7 @@ from pydantic import Field, RootModel
 from typing_extensions import Literal
 
 from datahub.api.entities.datacontract.assertion import BaseAssertion
+from datahub.emitter.mce_builder import make_assertion_source
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.metadata.schema_classes import (
     AssertionInfoClass,
@@ -78,6 +79,7 @@ class FreshnessAssertion(
                 type=FreshnessAssertionTypeClass.DATASET_CHANGE,
                 schedule=self.root.generate_freshness_assertion_schedule(),
             ),
+            source=make_assertion_source(),
             description=self.root.description,
         )
         return [MetadataChangeProposalWrapper(entityUrn=assertion_urn, aspect=aspect)]

--- a/metadata-ingestion/src/datahub/api/entities/datacontract/schema_assertion.py
+++ b/metadata-ingestion/src/datahub/api/entities/datacontract/schema_assertion.py
@@ -7,6 +7,7 @@ from pydantic import ConfigDict, Field, RootModel
 from typing_extensions import Literal
 
 from datahub.api.entities.datacontract.assertion import BaseAssertion
+from datahub.emitter.mce_builder import make_assertion_source
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.extractor.json_schema_util import get_schema_metadata
 from datahub.metadata.schema_classes import (
@@ -73,6 +74,7 @@ class SchemaAssertion(RootModel[Union[JsonSchemaContract, FieldListSchemaContrac
                 entity=entity_urn,
                 schema=self.root._schema_metadata,
             ),
+            source=make_assertion_source(),
             description=self.root.description,
         )
 

--- a/metadata-ingestion/src/datahub/emitter/mce_builder.py
+++ b/metadata-ingestion/src/datahub/emitter/mce_builder.py
@@ -29,6 +29,8 @@ from datahub.configuration.env_vars import get_dataset_urn_to_lower
 from datahub.emitter.enum_helpers import get_enum_options
 from datahub.metadata.schema_classes import (
     AssertionKeyClass,
+    AssertionSourceClass,
+    AssertionSourceTypeClass,
     AuditStampClass,
     ChartKeyClass,
     ContainerKeyClass,
@@ -72,6 +74,7 @@ ALL_ENV_TYPES: Set[str] = set(get_enum_options(FabricTypeClass))
 
 DEFAULT_FLOW_CLUSTER = "prod"
 UNKNOWN_USER = "urn:li:corpuser:unknown"
+SYSTEM_ACTOR = "urn:li:corpuser:__datahub_system"
 DATASET_URN_TO_LOWER: bool = get_dataset_urn_to_lower() == "true"
 
 if TYPE_CHECKING:
@@ -226,6 +229,17 @@ def datahub_guid(obj: dict) -> str:
 
 def make_assertion_urn(assertion_id: str) -> str:
     return f"urn:li:assertion:{assertion_id}"
+
+
+def make_assertion_source() -> AssertionSourceClass:
+    """Create a standard AssertionSource for ingestion-created assertions."""
+    return AssertionSourceClass(
+        type=AssertionSourceTypeClass.EXTERNAL,
+        created=AuditStampClass(
+            time=int(time.time() * 1000),
+            actor=SYSTEM_ACTOR,
+        ),
+    )
 
 
 def assertion_urn_to_key(assertion_urn: str) -> Optional[AssertionKeyClass]:

--- a/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_tests.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_tests.py
@@ -206,6 +206,7 @@ def make_assertion_from_test(
         assertion_info = AssertionInfoClass(
             type=AssertionTypeClass.DATASET,
             customProperties=extra_custom_props,
+            source=mce_builder.make_assertion_source(),
             datasetAssertion=DatasetAssertionInfoClass(
                 dataset=upstream_urn,
                 scope=assertion_params.scope,
@@ -239,6 +240,7 @@ def make_assertion_from_test(
         assertion_info = AssertionInfoClass(
             type=AssertionTypeClass.DATASET,
             customProperties=extra_custom_props,
+            source=mce_builder.make_assertion_source(),
             datasetAssertion=DatasetAssertionInfoClass(
                 dataset=upstream_urn,
                 scope=DatasetAssertionScopeClass.DATASET_COLUMN,
@@ -255,6 +257,7 @@ def make_assertion_from_test(
         assertion_info = AssertionInfoClass(
             type=AssertionTypeClass.DATASET,
             customProperties=extra_custom_props,
+            source=mce_builder.make_assertion_source(),
             datasetAssertion=DatasetAssertionInfoClass(
                 dataset=upstream_urn,
                 scope=DatasetAssertionScopeClass.DATASET_ROWS,
@@ -327,6 +330,7 @@ def make_assertion_from_freshness(
     assertion_info = AssertionInfoClass(
         type=AssertionTypeClass.CUSTOM,
         customProperties=custom_props,
+        source=mce_builder.make_assertion_source(),
         customAssertion=CustomAssertionInfoClass(
             type="dbt Freshness", entity=upstream_urn
         ),

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_assertion.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_assertion.py
@@ -6,6 +6,7 @@ from typing import Dict, Iterable, List, Optional
 from pydantic import BaseModel, field_validator
 
 from datahub.emitter.mce_builder import (
+    make_assertion_source,
     make_assertion_urn,
     make_data_platform_urn,
     make_dataplatform_instance_urn,
@@ -30,8 +31,6 @@ from datahub.metadata.com.linkedin.pegasus2avro.assertion import (
 from datahub.metadata.com.linkedin.pegasus2avro.common import DataPlatformInstance
 from datahub.metadata.schema_classes import (
     AssertionInfoClass,
-    AssertionSourceClass,
-    AssertionSourceTypeClass,
     AssertionTypeClass,
     CustomAssertionInfoClass,
 )
@@ -164,9 +163,7 @@ class SnowflakeAssertionsHandler:
                 entity=dataset_urn,
                 field=field_urn,
             ),
-            source=AssertionSourceClass(
-                type=AssertionSourceTypeClass.EXTERNAL,
-            ),
+            source=make_assertion_source(),
             description=f"External Snowflake DMF: {dmf_name}",
             customProperties=custom_properties,
         )

--- a/metadata-ingestion/src/datahub/testing/compare_metadata_json.py
+++ b/metadata-ingestion/src/datahub/testing/compare_metadata_json.py
@@ -33,6 +33,8 @@ default_exclude_paths = [
     # Nested timestamps in upstreams array (from query usage lineage)
     r"root\[\d+\]\['aspect'\]\['json'\]\['upstreams'\]\[\d+\]\['created'\]\['time'\]",
     r"root\[\d+\]\['aspect'\]\['json'\]\['upstreams'\]\[\d+\]\['lastModified'\]\['time'\]",
+    # Assertion source created timestamp (set at emit time)
+    r"root\[\d+\]\['aspect'\]\['json'\]\['source'\]\['created'\]\['time'\]",
 ]
 
 

--- a/metadata-ingestion/tests/integration/dbt/dbt_enabled_with_schemas_mces_golden.json
+++ b/metadata-ingestion/tests/integration/dbt/dbt_enabled_with_schemas_mces_golden.json
@@ -1,5909 +1,5993 @@
 [
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "owner": "@alice2",
-                            "business_owner": "jdoe.last@gmail.com",
-                            "data_governance.team_owner": "Finance",
-                            "has_pii": "True",
-                            "int_property": "1",
-                            "double_property": "2.5",
-                            "node_type": "model",
-                            "materialization": "ephemeral",
-                            "dbt_file_path": "models/transform/customer_details.sql",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.customer_details",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "customer_details",
-                        "description": "",
-                        "tags": [
-                            "dbt:test_tag"
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:alice2",
-                                "type": "DATAOWNER",
-                                "source": {
-                                    "type": "SOURCE_CONTROL"
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "owner": "@alice2",
+                                "business_owner": "jdoe.last@gmail.com",
+                                "data_governance.team_owner": "Finance",
+                                "has_pii": "True",
+                                "int_property": "1",
+                                "double_property": "2.5",
+                                "node_type": "model",
+                                "materialization": "ephemeral",
+                                "dbt_file_path": "models/transform/customer_details.sql",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.customer_details",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "customer_details",
+                            "description": "",
+                            "tags": [
+                                "dbt:test_tag"
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:alice2",
+                                    "type": "DATAOWNER",
+                                    "source": {
+                                        "type": "SOURCE_CONTROL"
+                                    }
+                                },
+                                {
+                                    "owner": "urn:li:corpuser:jdoe.last@gmail.com",
+                                    "type": "DATAOWNER",
+                                    "source": {
+                                        "type": "SOURCE_CONTROL"
+                                    }
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.GlobalTags": {
+                            "tags": [
+                                {
+                                    "tag": "urn:li:tag:dbt:has_pii_test"
+                                },
+                                {
+                                    "tag": "urn:li:tag:dbt:int_meta_property"
+                                },
+                                {
+                                    "tag": "urn:li:tag:dbt:my_query_tag"
+                                },
+                                {
+                                    "tag": "urn:li:tag:dbt:test_tag"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.GlossaryTerms": {
+                            "terms": [
+                                {
+                                    "urn": "urn:li:glossaryTerm:Finance_test"
+                                },
+                                {
+                                    "urn": "urn:li:glossaryTerm:double_meta_property"
+                                }
+                            ],
+                            "auditStamp": {
+                                "time": 1643871600000,
+                                "actor": "urn:li:corpuser:datahub"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.customer_details",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
                                 }
                             },
-                            {
-                                "owner": "urn:li:corpuser:jdoe.last@gmail.com",
-                                "type": "DATAOWNER",
-                                "source": {
-                                    "type": "SOURCE_CONTROL"
+                            "fields": [
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "INT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "full_name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "VARCHAR",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "email",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "address",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "city",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "postal_code",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "phone",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 }
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),full_name)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),email)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),address)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),city)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),postal_code)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),postal_code)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),phone)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),phone)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": false,
+                            "viewLogic": "{{ config(\n    materialized = \"ephemeral\",\n) }}\n\nSELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name as \"full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\nFROM\n    {{ source('pagila', 'customer')}} c\n    left outer join {{ source('pagila', 'address')}} a on c.address_id = a.address_id\n    left outer join {{ source('pagila', 'city') }} m on a.city_id = m.city_id",
+                            "formattedViewLogic": "SELECT\n  c.customer_id,\n  c.first_name || ' ' || c.last_name AS \"full_name\",\n  c.email,\n  a.address,\n  m.city,\n  a.postal_code,\n  a.phone\nFROM \"pagila\".\"public\".\"customer\" AS c\nLEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n  ON c.address_id = a.address_id\nLEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n  ON a.city_id = m.city_id",
+                            "viewLanguage": "SQL"
                         }
                     }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.GlobalTags": {
-                        "tags": [
-                            {
-                                "tag": "urn:li:tag:dbt:has_pii_test"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "business_owner": "jdoe.last",
+                                "data_governance.team_owner": "Sales",
+                                "has_pii": "False",
+                                "int_property": "2",
+                                "double_property": "3.5",
+                                "node_type": "model",
+                                "materialization": "table",
+                                "dbt_file_path": "models/billing/monthly_billing_with_cust.sql",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.monthly_billing_with_cust",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
                             },
-                            {
-                                "tag": "urn:li:tag:dbt:int_meta_property"
-                            },
-                            {
-                                "tag": "urn:li:tag:dbt:my_query_tag"
-                            },
-                            {
-                                "tag": "urn:li:tag:dbt:test_tag"
+                            "name": "an-aliased-view-for-monthly-billing",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:jdoe.last",
+                                    "type": "DATAOWNER",
+                                    "source": {
+                                        "type": "SOURCE_CONTROL"
+                                    }
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
                             }
-                        ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.monthly_billing_with_cust",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "billing_month",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "email",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": true,
+                            "viewLogic": "{{ config(\n    materialized = \"table\",\n    alias='an-aliased-view-for-monthly-billing'\n) }}\n\nSELECT \n    pbc.billing_month,\n    pbc.customer_id,\n    pbc.amount,\n    cust.email\nFROM\n    {{ ref('payments_by_customer_by_month')}} pbc\n    left outer join {{ ref('customer_details')}} cust on pbc.customer_id = cust.customer_id\nORDER BY\n    pbc.billing_month",
+                            "formattedViewLogic": "WITH __dbt__CTE__customer_details AS (\n  SELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name AS \"full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\n  FROM \"pagila\".\"public\".\"customer\" AS c\n  LEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n    ON c.address_id = a.address_id\n  LEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n    ON a.city_id = m.city_id\n)\nSELECT\n  pbc.billing_month,\n  pbc.customer_id,\n  pbc.amount,\n  cust.email\nFROM \"pagila\".\"dbt_postgres\".\"payments_by_customer_by_month\" AS pbc\nLEFT OUTER JOIN __dbt__CTE__customer_details AS cust\n  ON pbc.customer_id = cust.customer_id\nORDER BY\n  pbc.billing_month",
+                            "viewLanguage": "SQL"
+                        }
                     }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.GlossaryTerms": {
-                        "terms": [
-                            {
-                                "urn": "urn:li:glossaryTerm:Finance_test"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "model",
+                                "materialization": "view",
+                                "dbt_file_path": "models/base/payments_base.sql",
+                                "catalog_type": "VIEW",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.payments_base",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
                             },
-                            {
-                                "urn": "urn:li:glossaryTerm:double_meta_property"
+                            "name": "an-aliased-view-for-payments",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.payments_base",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": false,
+                            "viewLogic": "{{ config(\n    materialized=\"view\",\n    alias='an-aliased-view-for-payments'\n) }}\n\nwith payments as (\n\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_01')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_03')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_04')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_05')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_06')}}\n)\n\nselect *\nfrom payments",
+                            "formattedViewLogic": "WITH payments AS (\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_01\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_03\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_04\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_05\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_06\"\n)\nSELECT\n  *\nFROM payments",
+                            "viewLanguage": "SQL"
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "model",
+                                "materialization": "table",
+                                "dbt_file_path": "models/transform/payments_by_customer_by_month.sql",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.payments_by_customer_by_month",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payments_by_customer_by_month",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.payments_by_customer_by_month",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "billing_month",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": true,
+                            "viewLogic": "{{ config(\n    materialized = \"table\",\n) }}\n\nSELECT\n    date_trunc('month', payment_date) as \"billing_month\",\n    customer_id,\n    sum(amount) as \"amount\"\nFROM\n    {{ ref('payments_base')}}\nGROUP BY\n    billing_month,\n    customer_id",
+                            "formattedViewLogic": "SELECT\n  DATE_TRUNC('MONTH', payment_date) AS \"billing_month\",\n  customer_id,\n  SUM(amount) AS \"amount\"\nFROM \"pagila\".\"dbt_postgres\".\"an-aliased-view-for-payments\"\nGROUP BY\n  billing_month,\n  customer_id",
+                            "viewLanguage": "SQL"
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "model_maturity": "in dev",
+                                "some_other_property": "test 1",
+                                "owner": "@alice1",
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.actor",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "actor",
+                            "description": "description for actor table from dbt",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:alice1",
+                                    "type": "DATAOWNER",
+                                    "source": {
+                                        "type": "SOURCE_CONTROL"
+                                    }
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
                             }
-                        ],
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.actor",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1581759273000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "actor_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "first_name",
+                                    "nullable": false,
+                                    "description": "dbt comment: Actors column \u2013 from postgres\n\ndbt model description: description for first_name from dbt",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "globalTags": {
+                                        "tags": [
+                                            {
+                                                "tag": "urn:li:tag:dbt:column_tag"
+                                            }
+                                        ]
+                                    },
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_name",
+                                    "nullable": false,
+                                    "description": "description for last_name from dbt",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "description": "description for last_update from dbt",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),actor_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),actor_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),first_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),first_name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),last_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),last_name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.address",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "address",
+                            "description": "a user's address",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.address",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1623751200000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "address",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "address2",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "address_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "city_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "district",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "phone",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "postal_code",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address2)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address2)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),city_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),city_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),district)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),district)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),phone)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),phone)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),postal_code)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),postal_code)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.category",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "category",
+                            "description": "a user's category",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.category",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1623319200000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "category_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),category_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),category_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.city",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "city",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.city",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1581759925000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "city",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "city_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "country_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),city)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),city_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),country_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),country_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "model_maturity": "in prod",
+                                "owner": "@bob",
+                                "some_other_property": "test 2",
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.country",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "country",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:bob",
+                                    "type": "DATAOWNER",
+                                    "source": {
+                                        "type": "SOURCE_CONTROL"
+                                    }
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.country",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1624033800000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "country",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "country_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),country)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),country)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),country_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),country_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.customer",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "customer",
+                            "description": "description for customer table from dbt",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.customer",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1624032000000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "active",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "activebool",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.BooleanType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "boolean",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "address_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "create_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.DateType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "date",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "email",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "first_name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "store_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),active)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),active)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),activebool)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),activebool)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),address_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),address_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),create_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),create_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),email)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),first_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),store_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),store_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_01",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_01",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1580505371996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "an_array_property": "['alpha', 'beta', 'charlie']",
+                                "model_maturity": "in prod",
+                                "owner": "@charles",
+                                "some_other_property": "test 3",
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_02",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:charles",
+                                    "type": "DATAOWNER",
+                                    "source": {
+                                        "type": "SOURCE_CONTROL"
+                                    }
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_02",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1582319845996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_03",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_03",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1584998318996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_04",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_04",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1588287228996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_05",
+                            "description": "a payment",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_05",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1589460269996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_06",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_06",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": -62135596800000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+                    "value": {
                         "auditStamp": {
                             "time": 1643871600000,
-                            "actor": "urn:li:corpuser:datahub"
-                        }
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.customer_details",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
                             "actor": "urn:li:corpuser:unknown"
                         },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "INT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "full_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "VARCHAR",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "email",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "city",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "postal_code",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "phone",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+                        "type": "COPY"
                     }
                 },
                 {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),full_name)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),email)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),address)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),city)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),postal_code)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),postal_code)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),phone)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),phone)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)",
+                    "value": {
+                        "confidenceScore": 1.0
                     }
                 },
                 {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": false,
-                        "viewLogic": "{{ config(\n    materialized = \"ephemeral\",\n) }}\n\nSELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name as \"full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\nFROM\n    {{ source('pagila', 'customer')}} c\n    left outer join {{ source('pagila', 'address')}} a on c.address_id = a.address_id\n    left outer join {{ source('pagila', 'city') }} m on a.city_id = m.city_id",
-                        "formattedViewLogic": "SELECT\n  c.customer_id,\n  c.first_name || ' ' || c.last_name AS \"full_name\",\n  c.email,\n  a.address,\n  m.city,\n  a.postal_code,\n  a.phone\nFROM \"pagila\".\"public\".\"customer\" AS c\nLEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n  ON c.address_id = a.address_id\nLEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n  ON a.city_id = m.city_id",
-                        "viewLanguage": "SQL"
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),email)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),email)",
+                    "value": {
+                        "confidenceScore": 1.0
                     }
                 }
             ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-            "aspects": [
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
                 {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "business_owner": "jdoe.last",
-                            "data_governance.team_owner": "Sales",
-                            "has_pii": "False",
-                            "int_property": "2",
-                            "double_property": "3.5",
-                            "node_type": "model",
-                            "materialization": "table",
-                            "dbt_file_path": "models/billing/monthly_billing_with_cust.sql",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.monthly_billing_with_cust",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "an-aliased-view-for-monthly-billing",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:jdoe.last",
-                                "type": "DATAOWNER",
-                                "source": {
-                                    "type": "SOURCE_CONTROL"
-                                }
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        }
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.monthly_billing_with_cust",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+                    "value": {
+                        "auditStamp": {
+                            "time": 1643871600000,
                             "actor": "urn:li:corpuser:unknown"
                         },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "billing_month",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "email",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+                        "type": "COPY"
                     }
                 },
                 {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)",
+                    "value": {
+                        "confidenceScore": 1.0
                     }
                 },
                 {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": true,
-                        "viewLogic": "{{ config(\n    materialized = \"table\",\n    alias='an-aliased-view-for-monthly-billing'\n) }}\n\nSELECT \n    pbc.billing_month,\n    pbc.customer_id,\n    pbc.amount,\n    cust.email\nFROM\n    {{ ref('payments_by_customer_by_month')}} pbc\n    left outer join {{ ref('customer_details')}} cust on pbc.customer_id = cust.customer_id\nORDER BY\n    pbc.billing_month",
-                        "formattedViewLogic": "WITH __dbt__CTE__customer_details AS (\n  SELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name AS \"full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\n  FROM \"pagila\".\"public\".\"customer\" AS c\n  LEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n    ON c.address_id = a.address_id\n  LEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n    ON a.city_id = m.city_id\n)\nSELECT\n  pbc.billing_month,\n  pbc.customer_id,\n  pbc.amount,\n  cust.email\nFROM \"pagila\".\"dbt_postgres\".\"payments_by_customer_by_month\" AS pbc\nLEFT OUTER JOIN __dbt__CTE__customer_details AS cust\n  ON pbc.customer_id = cust.customer_id\nORDER BY\n  pbc.billing_month",
-                        "viewLanguage": "SQL"
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)",
+                    "value": {
+                        "confidenceScore": 1.0
                     }
                 }
             ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-            "aspects": [
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
                 {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "model",
-                            "materialization": "view",
-                            "dbt_file_path": "models/base/payments_base.sql",
-                            "catalog_type": "VIEW",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.payments_base",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "an-aliased-view-for-payments",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.payments_base",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+                    "value": {
+                        "auditStamp": {
+                            "time": 1643871600000,
                             "actor": "urn:li:corpuser:unknown"
                         },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+                        "type": "COPY"
                     }
                 },
                 {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)",
+                    "value": {
+                        "confidenceScore": 1.0
                     }
                 },
                 {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": false,
-                        "viewLogic": "{{ config(\n    materialized=\"view\",\n    alias='an-aliased-view-for-payments'\n) }}\n\nwith payments as (\n\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_01')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_03')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_04')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_05')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_06')}}\n)\n\nselect *\nfrom payments",
-                        "formattedViewLogic": "WITH payments AS (\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_01\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_03\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_04\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_05\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_06\"\n)\nSELECT\n  *\nFROM payments",
-                        "viewLanguage": "SQL"
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)",
+                    "value": {
+                        "confidenceScore": 1.0
                     }
                 }
             ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "model",
-                            "materialization": "table",
-                            "dbt_file_path": "models/transform/payments_by_customer_by_month.sql",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.payments_by_customer_by_month",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payments_by_customer_by_month",
-                        "description": "",
-                        "tags": []
-                    }
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.actor",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
                 },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)"
                 },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.payments_by_customer_by_month",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "billing_month",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": true,
-                        "viewLogic": "{{ config(\n    materialized = \"table\",\n) }}\n\nSELECT\n    date_trunc('month', payment_date) as \"billing_month\",\n    customer_id,\n    sum(amount) as \"amount\"\nFROM\n    {{ ref('payments_base')}}\nGROUP BY\n    billing_month,\n    customer_id",
-                        "formattedViewLogic": "SELECT\n  DATE_TRUNC('MONTH', payment_date) AS \"billing_month\",\n  customer_id,\n  SUM(amount) AS \"amount\"\nFROM \"pagila\".\"dbt_postgres\".\"an-aliased-view-for-payments\"\nGROUP BY\n  billing_month,\n  customer_id",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "model_maturity": "in dev",
-                            "some_other_property": "test 1",
-                            "owner": "@alice1",
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.actor",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "actor",
-                        "description": "description for actor table from dbt",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:alice1",
-                                "type": "DATAOWNER",
-                                "source": {
-                                    "type": "SOURCE_CONTROL"
-                                }
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        }
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.actor",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1581759273000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "actor_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "first_name",
-                                "nullable": false,
-                                "description": "dbt comment: Actors column \u2013 from postgres\n\ndbt model description: description for first_name from dbt",
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "globalTags": {
-                                    "tags": [
-                                        {
-                                            "tag": "urn:li:tag:dbt:column_tag"
-                                        }
-                                    ]
-                                },
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_name",
-                                "nullable": false,
-                                "description": "description for last_name from dbt",
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "description": "description for last_update from dbt",
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),actor_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),actor_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),first_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),first_name)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),last_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),last_name)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.address",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "address",
-                        "description": "a user's address",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.address",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1623751200000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "address",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address2",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "city_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "district",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "phone",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "postal_code",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address2)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address2)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),city_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),city_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),district)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),district)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),phone)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),phone)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),postal_code)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),postal_code)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.category",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "category",
-                        "description": "a user's category",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.category",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1623319200000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "category_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),category_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),category_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),name)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.city",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "city",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.city",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1581759925000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "city",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "city_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "country_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),city)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),city_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),country_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),country_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "model_maturity": "in prod",
-                            "owner": "@bob",
-                            "some_other_property": "test 2",
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.country",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "country",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:bob",
-                                "type": "DATAOWNER",
-                                "source": {
-                                    "type": "SOURCE_CONTROL"
-                                }
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        }
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.country",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1624033800000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "country",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "country_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),country)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),country)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),country_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),country_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.customer",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "customer",
-                        "description": "description for customer table from dbt",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.customer",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1624032000000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "active",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "activebool",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.BooleanType": {}
-                                    }
-                                },
-                                "nativeDataType": "boolean",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "create_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.DateType": {}
-                                    }
-                                },
-                                "nativeDataType": "date",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "email",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "first_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "store_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),active)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),active)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),activebool)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),activebool)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),address_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),address_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),create_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),create_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),email)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),first_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),store_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),store_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_01",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_01",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1580505371996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "an_array_property": "['alpha', 'beta', 'charlie']",
-                            "model_maturity": "in prod",
-                            "owner": "@charles",
-                            "some_other_property": "test 3",
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_02",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:charles",
-                                "type": "DATAOWNER",
-                                "source": {
-                                    "type": "SOURCE_CONTROL"
-                                }
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        }
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_02",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1582319845996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_03",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_03",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1584998318996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_04",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_04",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1588287228996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_05",
-                        "description": "a payment",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_05",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1589460269996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_06",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_06",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": -62135596800000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-                "value": {
-                    "auditStamp": {
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
                         "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
-                    },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-                    "type": "COPY"
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),email)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),email)",
-                "value": {
-                    "confidenceScore": 1.0
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
             }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-                "value": {
-                    "auditStamp": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
-                    },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-                    "type": "COPY"
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-                "value": {
-                    "auditStamp": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
-                    },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-                    "type": "COPY"
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.actor",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-15T09:34:33+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.address",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "warn",
-                    "max_loaded_at": "2021-06-15T10:00:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "259200.0"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.category",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "FAILURE",
-                "nativeResults": {
-                    "status": "error",
-                    "max_loaded_at": "2021-06-10T10:00:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "691200.0"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.city",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "error_after_count": "1",
-                "error_after_period": "day"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-15T09:45:25+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.country",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "30",
-                "warn_after_period": "minute"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2021-06-18T16:30:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "2335.925443"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.customer",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "1",
-                "warn_after_period": "day",
-                "error_after_count": "2",
-                "error_after_period": "day"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2021-06-18T16:00:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "4085.925443"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "3",
-                "warn_after_period": "day",
-                "error_after_count": "7",
-                "error_after_period": "day"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-01-31T21:16:11.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-21T21:17:25.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-03-23T21:18:38.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-04-30T22:53:48.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-05-14T12:44:29.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "0001-01-01T00:00:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
-    "changeType": "UPSERT",
-    "aspectName": "dashboardInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "exposure.sample_dbt.customer_dashboard",
-                "exposure_type": "dashboard",
-                "maturity": "high",
-                "dbt_package_name": "sample_dbt",
-                "dbt_file_path": "models/exposures.yml",
-                "team": "analytics"
-            },
-            "externalUrl": "https://bi.example.com/dashboards/customer",
-            "title": "customer_dashboard",
-            "description": "Dashboard showing customer details and billing",
-            "charts": [],
-            "datasets": [
-                "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-                "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)"
-            ],
-            "dashboards": [],
-            "lastModified": {
-                "created": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:dbt_ingestion"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-15T09:34:33+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
                 },
+                "assertionUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.address",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "warn",
+                        "max_loaded_at": "2021-06-15T10:00:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "259200.0"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.category",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "FAILURE",
+                    "nativeResults": {
+                        "status": "error",
+                        "max_loaded_at": "2021-06-10T10:00:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "691200.0"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.city",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "error_after_count": "1",
+                    "error_after_period": "day"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-15T09:45:25+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.country",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "30",
+                    "warn_after_period": "minute"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2021-06-18T16:30:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "2335.925443"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.customer",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "1",
+                    "warn_after_period": "day",
+                    "error_after_count": "2",
+                    "error_after_period": "day"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2021-06-18T16:00:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "4085.925443"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "3",
+                    "warn_after_period": "day",
+                    "error_after_count": "7",
+                    "error_after_period": "day"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-01-31T21:16:11.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-21T21:17:25.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-03-23T21:18:38.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-04-30T22:53:48.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-05-14T12:44:29.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "0001-01-01T00:00:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
+        "changeType": "UPSERT",
+        "aspectName": "dashboardInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "exposure.sample_dbt.customer_dashboard",
+                    "exposure_type": "dashboard",
+                    "maturity": "high",
+                    "dbt_package_name": "sample_dbt",
+                    "dbt_file_path": "models/exposures.yml",
+                    "team": "analytics"
+                },
+                "externalUrl": "https://bi.example.com/dashboards/customer",
+                "title": "customer_dashboard",
+                "description": "Dashboard showing customer details and billing",
+                "charts": [],
+                "datasets": [
+                    "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+                    "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)"
+                ],
+                "dashboards": [],
                 "lastModified": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:dbt_ingestion"
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:dbt_ingestion"
+                    },
+                    "lastModified": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:dbt_ingestion"
+                    }
                 }
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Dashboard"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
-    "changeType": "UPSERT",
-    "aspectName": "ownership",
-    "aspect": {
-        "json": {
-            "owners": [
-                {
-                    "owner": "urn:li:corpuser:analytics@example.com",
-                    "type": "DATAOWNER"
-                }
-            ],
-            "ownerTypes": {},
-            "lastModified": {
-                "time": 0,
-                "actor": "urn:li:corpuser:unknown"
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
-    "changeType": "UPSERT",
-    "aspectName": "globalTags",
-    "aspect": {
-        "json": {
-            "tags": [
-                {
-                    "tag": "urn:li:tag:dbt:executive"
-                },
-                {
-                    "tag": "urn:li:tag:dbt:customer"
-                }
-            ]
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Dashboard"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
-    "changeType": "UPSERT",
-    "aspectName": "dashboardInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "exposure.sample_dbt.payments_ml_model",
-                "exposure_type": "ml",
-                "maturity": "medium",
-                "dbt_package_name": "sample_dbt",
-                "dbt_file_path": "models/exposures.yml"
-            },
-            "externalUrl": "https://mlflow.example.com/models/payments",
-            "title": "payments_ml_model",
-            "description": "ML model for payment predictions",
-            "charts": [],
-            "datasets": [
-                "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)"
-            ],
-            "dashboards": [],
-            "lastModified": {
-                "created": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:dbt_ingestion"
-                },
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
+        "changeType": "UPSERT",
+        "aspectName": "ownership",
+        "aspect": {
+            "json": {
+                "owners": [
+                    {
+                        "owner": "urn:li:corpuser:analytics@example.com",
+                        "type": "DATAOWNER"
+                    }
+                ],
+                "ownerTypes": {},
                 "lastModified": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:dbt_ingestion"
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
                 }
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "ML Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
-    "changeType": "UPSERT",
-    "aspectName": "ownership",
-    "aspect": {
-        "json": {
-            "owners": [
-                {
-                    "owner": "urn:li:corpuser:ds@example.com",
-                    "type": "DATAOWNER"
-                }
-            ],
-            "ownerTypes": {},
-            "lastModified": {
-                "time": 0,
-                "actor": "urn:li:corpuser:unknown"
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
+        "changeType": "UPSERT",
+        "aspectName": "globalTags",
+        "aspect": {
+            "json": {
+                "tags": [
+                    {
+                        "tag": "urn:li:tag:dbt:executive"
+                    },
+                    {
+                        "tag": "urn:li:tag:dbt:customer"
+                    }
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
-    "changeType": "UPSERT",
-    "aspectName": "globalTags",
-    "aspect": {
-        "json": {
-            "tags": [
-                {
-                    "tag": "urn:li:tag:dbt:ml"
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
+        "changeType": "UPSERT",
+        "aspectName": "dashboardInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "exposure.sample_dbt.payments_ml_model",
+                    "exposure_type": "ml",
+                    "maturity": "medium",
+                    "dbt_package_name": "sample_dbt",
+                    "dbt_file_path": "models/exposures.yml"
                 },
-                {
-                    "tag": "urn:li:tag:dbt:payments"
+                "externalUrl": "https://mlflow.example.com/models/payments",
+                "title": "payments_ml_model",
+                "description": "ML model for payment predictions",
+                "charts": [],
+                "datasets": [
+                    "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)"
+                ],
+                "dashboards": [],
+                "lastModified": {
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:dbt_ingestion"
+                    },
+                    "lastModified": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:dbt_ingestion"
+                    }
                 }
-            ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "ML Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
+        "changeType": "UPSERT",
+        "aspectName": "ownership",
+        "aspect": {
+            "json": {
+                "owners": [
+                    {
+                        "owner": "urn:li:corpuser:ds@example.com",
+                        "type": "DATAOWNER"
+                    }
+                ],
+                "ownerTypes": {},
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
+        "changeType": "UPSERT",
+        "aspectName": "globalTags",
+        "aspect": {
+            "json": {
+                "tags": [
+                    {
+                        "tag": "urn:li:tag:dbt:ml"
+                    },
+                    {
+                        "tag": "urn:li:tag:dbt:payments"
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "glossaryTerm",
-    "entityUrn": "urn:li:glossaryTerm:Finance_test",
-    "changeType": "UPSERT",
-    "aspectName": "glossaryTermKey",
-    "aspect": {
-        "json": {
-            "name": "Finance_test"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "glossaryTerm",
-    "entityUrn": "urn:li:glossaryTerm:double_meta_property",
-    "changeType": "UPSERT",
-    "aspectName": "glossaryTermKey",
-    "aspect": {
-        "json": {
-            "name": "double_meta_property"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:column_tag",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:column_tag"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:customer",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:customer"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:executive",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:executive"
+    {
+        "entityType": "glossaryTerm",
+        "entityUrn": "urn:li:glossaryTerm:Finance_test",
+        "changeType": "UPSERT",
+        "aspectName": "glossaryTermKey",
+        "aspect": {
+            "json": {
+                "name": "Finance_test"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:has_pii_test",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:has_pii_test"
+    {
+        "entityType": "glossaryTerm",
+        "entityUrn": "urn:li:glossaryTerm:double_meta_property",
+        "changeType": "UPSERT",
+        "aspectName": "glossaryTermKey",
+        "aspect": {
+            "json": {
+                "name": "double_meta_property"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:int_meta_property",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:int_meta_property"
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:column_tag",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:column_tag"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:ml",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:ml"
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:customer",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:customer"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:my_query_tag",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:my_query_tag"
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:executive",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:executive"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:payments",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:payments"
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:has_pii_test",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:has_pii_test"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:test_tag",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:test_tag"
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:int_meta_property",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:int_meta_property"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-schemas-dbt-enabled",
-        "lastRunId": "no-run-id-provided"
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:ml",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:ml"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:my_query_tag",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:my_query_tag"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:payments",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:payments"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:test_tag",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:test_tag"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-schemas-dbt-enabled",
+            "lastRunId": "no-run-id-provided"
+        }
     }
-}
 ]

--- a/metadata-ingestion/tests/integration/dbt/dbt_test_events_golden.json
+++ b/metadata-ingestion/tests/integration/dbt/dbt_test_events_golden.json
@@ -1,4520 +1,4695 @@
 [
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "model",
-                            "materialization": "table",
-                            "dbt_file_path": "models/customers.sql",
-                            "catalog_type": "table",
-                            "language": "sql",
-                            "dbt_unique_id": "model.jaffle_shop.customers",
-                            "dbt_package_name": "jaffle_shop",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
-                            "manifest_version": "1.1.0",
-                            "manifest_adapter": "bigquery",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.1.0"
-                        },
-                        "name": "customers",
-                        "description": "This table has basic information about a customer, as well as some derived facts based on a customer's orders",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.jaffle_shop.customers",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "description": "This is a unique identifier for a customer",
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "INT64",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "first_name",
-                                "nullable": false,
-                                "description": "Customer's first name. PII.",
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "STRING",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_name",
-                                "nullable": false,
-                                "description": "Customer's last name. PII.",
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "STRING",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "first_order",
-                                "nullable": false,
-                                "description": "Date (UTC) of a customer's first order",
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.DateType": {}
-                                    }
-                                },
-                                "nativeDataType": "DATE",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "most_recent_order",
-                                "nullable": false,
-                                "description": "Date (UTC) of a customer's most recent order",
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.DateType": {}
-                                    }
-                                },
-                                "nativeDataType": "DATE",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "number_of_orders",
-                                "nullable": false,
-                                "description": "Count of the number of orders a customer has placed",
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "INT64",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_lifetime_value",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "FLOAT64",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_customers,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_orders,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_payments,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": true,
-                        "viewLogic": "with customers as (\n\n    select * from {{ ref('stg_customers') }}\n\n),\n\norders as (\n\n    select * from {{ ref('stg_orders') }}\n\n),\n\npayments as (\n\n    select * from {{ ref('stg_payments') }}\n\n),\n\ncustomer_orders as (\n\n        select\n        customer_id,\n\n        min(order_date) as first_order,\n        max(order_date) as most_recent_order,\n        count(order_id) as number_of_orders\n    from orders\n\n    group by customer_id\n\n),\n\ncustomer_payments as (\n\n    select\n        orders.customer_id,\n        sum(amount) as total_amount\n\n    from payments\n\n    left join orders on\n         payments.order_id = orders.order_id\n\n    group by orders.customer_id\n\n),\n\nfinal as (\n\n    select\n        customers.customer_id,\n        customers.first_name,\n        customers.last_name,\n        customer_orders.first_order,\n        customer_orders.most_recent_order,\n        customer_orders.number_of_orders,\n        customer_payments.total_amount as customer_lifetime_value\n\n    from customers\n\n    left join customer_orders\n        on customers.customer_id = customer_orders.customer_id\n\n    left join customer_payments\n        on  customers.customer_id = customer_payments.customer_id\n\n)\n\nselect * from final",
-                        "formattedViewLogic": "with customers as (\n\n    select * from `calm-pagoda-323403`.`jaffle_shop`.`stg_customers`\n\n),\n\norders as (\n\n    select * from `calm-pagoda-323403`.`jaffle_shop`.`stg_orders`\n\n),\n\npayments as (\n\n    select * from `calm-pagoda-323403`.`jaffle_shop`.`stg_payments`\n\n),\n\ncustomer_orders as (\n\n        select\n        customer_id,\n\n        min(order_date) as first_order,\n        max(order_date) as most_recent_order,\n        count(order_id) as number_of_orders\n    from orders\n\n    group by customer_id\n\n),\n\ncustomer_payments as (\n\n    select\n        orders.customer_id,\n        sum(amount) as total_amount\n\n    from payments\n\n    left join orders on\n         payments.order_id = orders.order_id\n\n    group by orders.customer_id\n\n),\n\nfinal as (\n\n    select\n        customers.customer_id,\n        customers.first_name,\n        customers.last_name,\n        customer_orders.first_order,\n        customer_orders.most_recent_order,\n        customer_orders.number_of_orders,\n        customer_payments.total_amount as customer_lifetime_value\n\n    from customers\n\n    left join customer_orders\n        on customers.customer_id = customer_orders.customer_id\n\n    left join customer_payments\n        on  customers.customer_id = customer_payments.customer_id\n\n)\n\nselect * from final",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetProfile",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1643871600000,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "rowCount": 100,
-            "columnCount": 7,
-            "sizeInBytes": 3970
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "model",
-                            "materialization": "table",
-                            "dbt_file_path": "models/orders.sql",
-                            "catalog_type": "table",
-                            "language": "sql",
-                            "dbt_unique_id": "model.jaffle_shop.orders",
-                            "dbt_package_name": "jaffle_shop",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
-                            "manifest_version": "1.1.0",
-                            "manifest_adapter": "bigquery",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.1.0"
-                        },
-                        "name": "orders",
-                        "description": "This table has basic information about orders, as well as some derived facts based on payments",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.jaffle_shop.orders",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "order_id",
-                                "nullable": false,
-                                "description": "This is a unique identifier for an order",
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "INT64",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "description": "Foreign key to the customers table",
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "INT64",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "order_date",
-                                "nullable": false,
-                                "description": "Date (UTC) that the order was placed",
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.DateType": {}
-                                    }
-                                },
-                                "nativeDataType": "DATE",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "status",
-                                "nullable": false,
-                                "description": "Orders can be one of the following statuses:\n\n| status         | description                                                                                                            |\n|----------------|------------------------------------------------------------------------------------------------------------------------|\n| placed         | The order has been placed but has not yet left the warehouse                                                           |\n| shipped        | The order has ben shipped to the customer and is currently in transit                                                  |\n| completed      | The order has been received by the customer                                                                            |\n| return_pending | The customer has indicated that they would like to return the order, but it has not yet been received at the warehouse |\n| returned       | The order has been returned by the customer and received at the warehouse                                              |",
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "STRING",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "credit_card_amount",
-                                "nullable": false,
-                                "description": "Amount of the order (AUD) paid for by credit card",
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "FLOAT64",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "coupon_amount",
-                                "nullable": false,
-                                "description": "Amount of the order (AUD) paid for by coupon",
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "FLOAT64",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "bank_transfer_amount",
-                                "nullable": false,
-                                "description": "Amount of the order (AUD) paid for by bank transfer",
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "FLOAT64",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "gift_card_amount",
-                                "nullable": false,
-                                "description": "Amount of the order (AUD) paid for by gift card",
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "FLOAT64",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "description": "Total amount (AUD) of the order",
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "FLOAT64",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_orders,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_payments,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": true,
-                        "viewLogic": "{% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}\n\nwith orders as (\n\n    select * from {{ ref('stg_orders') }}\n\n),\n\npayments as (\n\n    select * from {{ ref('stg_payments') }}\n\n),\n\norder_payments as (\n\n    select\n        order_id,\n\n        {% for payment_method in payment_methods -%}\n        sum(case when payment_method = '{{ payment_method }}' then amount else 0 end) as {{ payment_method }}_amount,\n        {% endfor -%}\n\n        sum(amount) as total_amount\n\n    from payments\n\n    group by order_id\n\n),\n\nfinal as (\n\n    select\n        orders.order_id,\n        orders.customer_id,\n        orders.order_date,\n        orders.status,\n\n        {% for payment_method in payment_methods -%}\n\n        order_payments.{{ payment_method }}_amount,\n\n        {% endfor -%}\n\n        order_payments.total_amount as amount\n\n    from orders\n\n\n    left join order_payments\n        on orders.order_id = order_payments.order_id\n\n)\n\nselect * from final",
-                        "formattedViewLogic": "\n\nwith orders as (\n\n    select * from `calm-pagoda-323403`.`jaffle_shop`.`stg_orders`\n\n),\n\npayments as (\n\n    select * from `calm-pagoda-323403`.`jaffle_shop`.`stg_payments`\n\n),\n\norder_payments as (\n\n    select\n        order_id,\n\n        sum(case when payment_method = 'credit_card' then amount else 0 end) as credit_card_amount,\n        sum(case when payment_method = 'coupon' then amount else 0 end) as coupon_amount,\n        sum(case when payment_method = 'bank_transfer' then amount else 0 end) as bank_transfer_amount,\n        sum(case when payment_method = 'gift_card' then amount else 0 end) as gift_card_amount,\n        sum(amount) as total_amount\n\n    from payments\n\n    group by order_id\n\n),\n\nfinal as (\n\n    select\n        orders.order_id,\n        orders.customer_id,\n        orders.order_date,\n        orders.status,\n\n        order_payments.credit_card_amount,\n\n        order_payments.coupon_amount,\n\n        order_payments.bank_transfer_amount,\n\n        order_payments.gift_card_amount,\n\n        order_payments.total_amount as amount\n\n    from orders\n\n\n    left join order_payments\n        on orders.order_id = order_payments.order_id\n\n)\n\nselect * from final",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetProfile",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1643871600000,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "rowCount": 99,
-            "columnCount": 9,
-            "sizeInBytes": 7366
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_customers,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_customers,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_customers,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "model",
-                            "materialization": "view",
-                            "dbt_file_path": "models/staging/stg_customers.sql",
-                            "catalog_type": "view",
-                            "language": "sql",
-                            "dbt_unique_id": "model.jaffle_shop.stg_customers",
-                            "dbt_package_name": "jaffle_shop",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
-                            "manifest_version": "1.1.0",
-                            "manifest_adapter": "bigquery",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.1.0"
-                        },
-                        "name": "stg_customers",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.jaffle_shop.stg_customers",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "INT64",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "first_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "STRING",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "STRING",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_customers,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": false,
-                        "viewLogic": "with source as (\n\n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_customers') }}\n\n),\n\nrenamed as (\n\n    select\n        id as customer_id,\n        first_name,\n        last_name\n\n    from source\n\n)\n\nselect * from renamed",
-                        "formattedViewLogic": "with source as (\n    select * from `calm-pagoda-323403`.`jaffle_shop`.`raw_customers`\n\n),\n\nrenamed as (\n\n    select\n        id as customer_id,\n        first_name,\n        last_name\n\n    from source\n\n)\n\nselect * from renamed",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "model",
-                            "materialization": "view",
-                            "dbt_file_path": "models/staging/stg_orders.sql",
-                            "catalog_type": "view",
-                            "language": "sql",
-                            "dbt_unique_id": "model.jaffle_shop.stg_orders",
-                            "dbt_package_name": "jaffle_shop",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
-                            "manifest_version": "1.1.0",
-                            "manifest_adapter": "bigquery",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.1.0"
-                        },
-                        "name": "stg_orders",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.jaffle_shop.stg_orders",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "order_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "INT64",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "INT64",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "order_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.DateType": {}
-                                    }
-                                },
-                                "nativeDataType": "DATE",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "status",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "STRING",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_orders,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": false,
-                        "viewLogic": "with source as (\n\n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_orders') }}\n\n),\n\nrenamed as (\n\n    select\n        id as order_id,\n        user_id as customer_id,\n        order_date,\n        status\n\n    from source\n\n)\n\nselect * from renamed",
-                        "formattedViewLogic": "with source as (\n    select * from `calm-pagoda-323403`.`jaffle_shop`.`raw_orders`\n\n),\n\nrenamed as (\n\n    select\n        id as order_id,\n        user_id as customer_id,\n        order_date,\n        status\n\n    from source\n\n)\n\nselect * from renamed",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "model",
-                            "materialization": "view",
-                            "dbt_file_path": "models/staging/stg_payments.sql",
-                            "catalog_type": "view",
-                            "language": "sql",
-                            "dbt_unique_id": "model.jaffle_shop.stg_payments",
-                            "dbt_package_name": "jaffle_shop",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
-                            "manifest_version": "1.1.0",
-                            "manifest_adapter": "bigquery",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.1.0"
-                        },
-                        "name": "stg_payments",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.jaffle_shop.stg_payments",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "INT64",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "order_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "INT64",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_method",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "STRING",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "FLOAT64",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_payments,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": false,
-                        "viewLogic": "with source as (\n    \n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_payments') }}\n\n),\n\nrenamed as (\n\n    select\n        id as payment_id,\n        order_id,\n        payment_method,\n\n        -- `amount` is currently stored in cents, so we convert it to dollars\n        amount / 100 as amount\n\n    from source\n\n)\n\nselect * from renamed",
-                        "formattedViewLogic": "with source as (\n    select * from `calm-pagoda-323403`.`jaffle_shop`.`raw_payments`\n\n),\n\nrenamed as (\n\n    select\n        id as payment_id,\n        order_id,\n        payment_method,\n\n        -- `amount` is currently stored in cents, so we convert it to dollars\n        amount / 100 as amount\n\n    from source\n\n)\n\nselect * from renamed",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_customers,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Seed"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_customers,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_customers,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "seed",
-                            "materialization": "seed",
-                            "dbt_file_path": "seeds/raw_customers.csv",
-                            "catalog_type": "table",
-                            "language": "sql",
-                            "dbt_unique_id": "seed.jaffle_shop.raw_customers",
-                            "dbt_package_name": "jaffle_shop",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
-                            "manifest_version": "1.1.0",
-                            "manifest_adapter": "bigquery",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.1.0"
-                        },
-                        "name": "raw_customers",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "seed.jaffle_shop.raw_customers",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "INT64",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "first_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "STRING",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "STRING",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_customers,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetProfile",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1643871600000,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "rowCount": 100,
-            "columnCount": 3,
-            "sizeInBytes": 1986
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_orders,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Seed"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_orders,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_orders,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "seed",
-                            "materialization": "seed",
-                            "dbt_file_path": "seeds/raw_orders.csv",
-                            "catalog_type": "table",
-                            "language": "sql",
-                            "dbt_unique_id": "seed.jaffle_shop.raw_orders",
-                            "dbt_package_name": "jaffle_shop",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
-                            "manifest_version": "1.1.0",
-                            "manifest_adapter": "bigquery",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.1.0"
-                        },
-                        "name": "raw_orders",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "seed.jaffle_shop.raw_orders",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "INT64",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "user_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "INT64",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "order_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.DateType": {}
-                                    }
-                                },
-                                "nativeDataType": "DATE",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "status",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "STRING",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_orders,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetProfile",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1643871600000,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "rowCount": 99,
-            "columnCount": 4,
-            "sizeInBytes": 3406
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_payments,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Seed"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_payments,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_payments,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "seed",
-                            "materialization": "seed",
-                            "dbt_file_path": "seeds/raw_payments.csv",
-                            "catalog_type": "table",
-                            "language": "sql",
-                            "dbt_unique_id": "seed.jaffle_shop.raw_payments",
-                            "dbt_package_name": "jaffle_shop",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
-                            "manifest_version": "1.1.0",
-                            "manifest_adapter": "bigquery",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.1.0"
-                        },
-                        "name": "raw_payments",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "seed.jaffle_shop.raw_payments",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "INT64",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "order_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "INT64",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_method",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "STRING",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "INT64",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_payments,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetProfile",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1643871600000,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "rowCount": 113,
-            "columnCount": 4,
-            "sizeInBytes": 4158
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.customers,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD)",
-                "value": {
-                    "auditStamp": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
-                    },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD)",
-                    "type": "COPY"
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.customers,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD),customer_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.customers,PROD),first_name)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD),first_name)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.customers,PROD),last_name)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD),last_name)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.customers,PROD),first_order)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD),first_order)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.customers,PROD),most_recent_order)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD),most_recent_order)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.customers,PROD),number_of_orders)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD),number_of_orders)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.customers,PROD),customer_lifetime_value)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD),customer_lifetime_value)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
             }
-        ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.orders,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
-                "value": {
-                    "auditStamp": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "model",
+                                "materialization": "table",
+                                "dbt_file_path": "models/customers.sql",
+                                "catalog_type": "table",
+                                "language": "sql",
+                                "dbt_unique_id": "model.jaffle_shop.customers",
+                                "dbt_package_name": "jaffle_shop",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
+                                "manifest_version": "1.1.0",
+                                "manifest_adapter": "bigquery",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.1.0"
+                            },
+                            "name": "customers",
+                            "description": "This table has basic information about a customer, as well as some derived facts based on a customer's orders",
+                            "tags": []
+                        }
                     },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.jaffle_shop.customers",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "description": "This is a unique identifier for a customer",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "INT64",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "first_name",
+                                    "nullable": false,
+                                    "description": "Customer's first name. PII.",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "STRING",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_name",
+                                    "nullable": false,
+                                    "description": "Customer's last name. PII.",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "STRING",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "first_order",
+                                    "nullable": false,
+                                    "description": "Date (UTC) of a customer's first order",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.DateType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "DATE",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "most_recent_order",
+                                    "nullable": false,
+                                    "description": "Date (UTC) of a customer's most recent order",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.DateType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "DATE",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "number_of_orders",
+                                    "nullable": false,
+                                    "description": "Count of the number of orders a customer has placed",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "INT64",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_lifetime_value",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "FLOAT64",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_customers,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_orders,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_payments,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": true,
+                            "viewLogic": "with customers as (\n\n    select * from {{ ref('stg_customers') }}\n\n),\n\norders as (\n\n    select * from {{ ref('stg_orders') }}\n\n),\n\npayments as (\n\n    select * from {{ ref('stg_payments') }}\n\n),\n\ncustomer_orders as (\n\n        select\n        customer_id,\n\n        min(order_date) as first_order,\n        max(order_date) as most_recent_order,\n        count(order_id) as number_of_orders\n    from orders\n\n    group by customer_id\n\n),\n\ncustomer_payments as (\n\n    select\n        orders.customer_id,\n        sum(amount) as total_amount\n\n    from payments\n\n    left join orders on\n         payments.order_id = orders.order_id\n\n    group by orders.customer_id\n\n),\n\nfinal as (\n\n    select\n        customers.customer_id,\n        customers.first_name,\n        customers.last_name,\n        customer_orders.first_order,\n        customer_orders.most_recent_order,\n        customer_orders.number_of_orders,\n        customer_payments.total_amount as customer_lifetime_value\n\n    from customers\n\n    left join customer_orders\n        on customers.customer_id = customer_orders.customer_id\n\n    left join customer_payments\n        on  customers.customer_id = customer_payments.customer_id\n\n)\n\nselect * from final",
+                            "formattedViewLogic": "with customers as (\n\n    select * from `calm-pagoda-323403`.`jaffle_shop`.`stg_customers`\n\n),\n\norders as (\n\n    select * from `calm-pagoda-323403`.`jaffle_shop`.`stg_orders`\n\n),\n\npayments as (\n\n    select * from `calm-pagoda-323403`.`jaffle_shop`.`stg_payments`\n\n),\n\ncustomer_orders as (\n\n        select\n        customer_id,\n\n        min(order_date) as first_order,\n        max(order_date) as most_recent_order,\n        count(order_id) as number_of_orders\n    from orders\n\n    group by customer_id\n\n),\n\ncustomer_payments as (\n\n    select\n        orders.customer_id,\n        sum(amount) as total_amount\n\n    from payments\n\n    left join orders on\n         payments.order_id = orders.order_id\n\n    group by orders.customer_id\n\n),\n\nfinal as (\n\n    select\n        customers.customer_id,\n        customers.first_name,\n        customers.last_name,\n        customer_orders.first_order,\n        customer_orders.most_recent_order,\n        customer_orders.number_of_orders,\n        customer_payments.total_amount as customer_lifetime_value\n\n    from customers\n\n    left join customer_orders\n        on customers.customer_id = customer_orders.customer_id\n\n    left join customer_payments\n        on  customers.customer_id = customer_payments.customer_id\n\n)\n\nselect * from final",
+                            "viewLanguage": "SQL"
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "datasetProfile",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1643871600000,
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                },
+                "rowCount": 100,
+                "columnCount": 7,
+                "sizeInBytes": 3970
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "model",
+                                "materialization": "table",
+                                "dbt_file_path": "models/orders.sql",
+                                "catalog_type": "table",
+                                "language": "sql",
+                                "dbt_unique_id": "model.jaffle_shop.orders",
+                                "dbt_package_name": "jaffle_shop",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
+                                "manifest_version": "1.1.0",
+                                "manifest_adapter": "bigquery",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.1.0"
+                            },
+                            "name": "orders",
+                            "description": "This table has basic information about orders, as well as some derived facts based on payments",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.jaffle_shop.orders",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "order_id",
+                                    "nullable": false,
+                                    "description": "This is a unique identifier for an order",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "INT64",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "description": "Foreign key to the customers table",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "INT64",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "order_date",
+                                    "nullable": false,
+                                    "description": "Date (UTC) that the order was placed",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.DateType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "DATE",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "status",
+                                    "nullable": false,
+                                    "description": "Orders can be one of the following statuses:\n\n| status         | description                                                                                                            |\n|----------------|------------------------------------------------------------------------------------------------------------------------|\n| placed         | The order has been placed but has not yet left the warehouse                                                           |\n| shipped        | The order has ben shipped to the customer and is currently in transit                                                  |\n| completed      | The order has been received by the customer                                                                            |\n| return_pending | The customer has indicated that they would like to return the order, but it has not yet been received at the warehouse |\n| returned       | The order has been returned by the customer and received at the warehouse                                              |",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "STRING",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "credit_card_amount",
+                                    "nullable": false,
+                                    "description": "Amount of the order (AUD) paid for by credit card",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "FLOAT64",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "coupon_amount",
+                                    "nullable": false,
+                                    "description": "Amount of the order (AUD) paid for by coupon",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "FLOAT64",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "bank_transfer_amount",
+                                    "nullable": false,
+                                    "description": "Amount of the order (AUD) paid for by bank transfer",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "FLOAT64",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "gift_card_amount",
+                                    "nullable": false,
+                                    "description": "Amount of the order (AUD) paid for by gift card",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "FLOAT64",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "description": "Total amount (AUD) of the order",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "FLOAT64",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_orders,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_payments,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": true,
+                            "viewLogic": "{% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}\n\nwith orders as (\n\n    select * from {{ ref('stg_orders') }}\n\n),\n\npayments as (\n\n    select * from {{ ref('stg_payments') }}\n\n),\n\norder_payments as (\n\n    select\n        order_id,\n\n        {% for payment_method in payment_methods -%}\n        sum(case when payment_method = '{{ payment_method }}' then amount else 0 end) as {{ payment_method }}_amount,\n        {% endfor -%}\n\n        sum(amount) as total_amount\n\n    from payments\n\n    group by order_id\n\n),\n\nfinal as (\n\n    select\n        orders.order_id,\n        orders.customer_id,\n        orders.order_date,\n        orders.status,\n\n        {% for payment_method in payment_methods -%}\n\n        order_payments.{{ payment_method }}_amount,\n\n        {% endfor -%}\n\n        order_payments.total_amount as amount\n\n    from orders\n\n\n    left join order_payments\n        on orders.order_id = order_payments.order_id\n\n)\n\nselect * from final",
+                            "formattedViewLogic": "\n\nwith orders as (\n\n    select * from `calm-pagoda-323403`.`jaffle_shop`.`stg_orders`\n\n),\n\npayments as (\n\n    select * from `calm-pagoda-323403`.`jaffle_shop`.`stg_payments`\n\n),\n\norder_payments as (\n\n    select\n        order_id,\n\n        sum(case when payment_method = 'credit_card' then amount else 0 end) as credit_card_amount,\n        sum(case when payment_method = 'coupon' then amount else 0 end) as coupon_amount,\n        sum(case when payment_method = 'bank_transfer' then amount else 0 end) as bank_transfer_amount,\n        sum(case when payment_method = 'gift_card' then amount else 0 end) as gift_card_amount,\n        sum(amount) as total_amount\n\n    from payments\n\n    group by order_id\n\n),\n\nfinal as (\n\n    select\n        orders.order_id,\n        orders.customer_id,\n        orders.order_date,\n        orders.status,\n\n        order_payments.credit_card_amount,\n\n        order_payments.coupon_amount,\n\n        order_payments.bank_transfer_amount,\n\n        order_payments.gift_card_amount,\n\n        order_payments.total_amount as amount\n\n    from orders\n\n\n    left join order_payments\n        on orders.order_id = order_payments.order_id\n\n)\n\nselect * from final",
+                            "viewLanguage": "SQL"
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "datasetProfile",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1643871600000,
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                },
+                "rowCount": 99,
+                "columnCount": 9,
+                "sizeInBytes": 7366
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_customers,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_customers,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_customers,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "model",
+                                "materialization": "view",
+                                "dbt_file_path": "models/staging/stg_customers.sql",
+                                "catalog_type": "view",
+                                "language": "sql",
+                                "dbt_unique_id": "model.jaffle_shop.stg_customers",
+                                "dbt_package_name": "jaffle_shop",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
+                                "manifest_version": "1.1.0",
+                                "manifest_adapter": "bigquery",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.1.0"
+                            },
+                            "name": "stg_customers",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.jaffle_shop.stg_customers",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "INT64",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "first_name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "STRING",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "STRING",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_customers,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": false,
+                            "viewLogic": "with source as (\n\n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_customers') }}\n\n),\n\nrenamed as (\n\n    select\n        id as customer_id,\n        first_name,\n        last_name\n\n    from source\n\n)\n\nselect * from renamed",
+                            "formattedViewLogic": "with source as (\n    select * from `calm-pagoda-323403`.`jaffle_shop`.`raw_customers`\n\n),\n\nrenamed as (\n\n    select\n        id as customer_id,\n        first_name,\n        last_name\n\n    from source\n\n)\n\nselect * from renamed",
+                            "viewLanguage": "SQL"
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "model",
+                                "materialization": "view",
+                                "dbt_file_path": "models/staging/stg_orders.sql",
+                                "catalog_type": "view",
+                                "language": "sql",
+                                "dbt_unique_id": "model.jaffle_shop.stg_orders",
+                                "dbt_package_name": "jaffle_shop",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
+                                "manifest_version": "1.1.0",
+                                "manifest_adapter": "bigquery",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.1.0"
+                            },
+                            "name": "stg_orders",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.jaffle_shop.stg_orders",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "order_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "INT64",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "INT64",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "order_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.DateType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "DATE",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "status",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "STRING",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_orders,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": false,
+                            "viewLogic": "with source as (\n\n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_orders') }}\n\n),\n\nrenamed as (\n\n    select\n        id as order_id,\n        user_id as customer_id,\n        order_date,\n        status\n\n    from source\n\n)\n\nselect * from renamed",
+                            "formattedViewLogic": "with source as (\n    select * from `calm-pagoda-323403`.`jaffle_shop`.`raw_orders`\n\n),\n\nrenamed as (\n\n    select\n        id as order_id,\n        user_id as customer_id,\n        order_date,\n        status\n\n    from source\n\n)\n\nselect * from renamed",
+                            "viewLanguage": "SQL"
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "model",
+                                "materialization": "view",
+                                "dbt_file_path": "models/staging/stg_payments.sql",
+                                "catalog_type": "view",
+                                "language": "sql",
+                                "dbt_unique_id": "model.jaffle_shop.stg_payments",
+                                "dbt_package_name": "jaffle_shop",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
+                                "manifest_version": "1.1.0",
+                                "manifest_adapter": "bigquery",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.1.0"
+                            },
+                            "name": "stg_payments",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.jaffle_shop.stg_payments",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "INT64",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "order_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "INT64",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_method",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "STRING",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "FLOAT64",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_payments,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": false,
+                            "viewLogic": "with source as (\n    \n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_payments') }}\n\n),\n\nrenamed as (\n\n    select\n        id as payment_id,\n        order_id,\n        payment_method,\n\n        -- `amount` is currently stored in cents, so we convert it to dollars\n        amount / 100 as amount\n\n    from source\n\n)\n\nselect * from renamed",
+                            "formattedViewLogic": "with source as (\n    select * from `calm-pagoda-323403`.`jaffle_shop`.`raw_payments`\n\n),\n\nrenamed as (\n\n    select\n        id as payment_id,\n        order_id,\n        payment_method,\n\n        -- `amount` is currently stored in cents, so we convert it to dollars\n        amount / 100 as amount\n\n    from source\n\n)\n\nselect * from renamed",
+                            "viewLanguage": "SQL"
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_customers,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Seed"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_customers,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_customers,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "seed",
+                                "materialization": "seed",
+                                "dbt_file_path": "seeds/raw_customers.csv",
+                                "catalog_type": "table",
+                                "language": "sql",
+                                "dbt_unique_id": "seed.jaffle_shop.raw_customers",
+                                "dbt_package_name": "jaffle_shop",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
+                                "manifest_version": "1.1.0",
+                                "manifest_adapter": "bigquery",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.1.0"
+                            },
+                            "name": "raw_customers",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "seed.jaffle_shop.raw_customers",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "INT64",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "first_name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "STRING",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "STRING",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_customers,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "datasetProfile",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1643871600000,
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                },
+                "rowCount": 100,
+                "columnCount": 3,
+                "sizeInBytes": 1986
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_orders,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Seed"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_orders,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_orders,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "seed",
+                                "materialization": "seed",
+                                "dbt_file_path": "seeds/raw_orders.csv",
+                                "catalog_type": "table",
+                                "language": "sql",
+                                "dbt_unique_id": "seed.jaffle_shop.raw_orders",
+                                "dbt_package_name": "jaffle_shop",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
+                                "manifest_version": "1.1.0",
+                                "manifest_adapter": "bigquery",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.1.0"
+                            },
+                            "name": "raw_orders",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "seed.jaffle_shop.raw_orders",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "INT64",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "user_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "INT64",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "order_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.DateType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "DATE",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "status",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "STRING",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_orders,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "datasetProfile",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1643871600000,
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                },
+                "rowCount": 99,
+                "columnCount": 4,
+                "sizeInBytes": 3406
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_payments,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Seed"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_payments,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_payments,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "seed",
+                                "materialization": "seed",
+                                "dbt_file_path": "seeds/raw_payments.csv",
+                                "catalog_type": "table",
+                                "language": "sql",
+                                "dbt_unique_id": "seed.jaffle_shop.raw_payments",
+                                "dbt_package_name": "jaffle_shop",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
+                                "manifest_version": "1.1.0",
+                                "manifest_adapter": "bigquery",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.1.0"
+                            },
+                            "name": "raw_payments",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "seed.jaffle_shop.raw_payments",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "INT64",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "order_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "INT64",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_method",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "STRING",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "INT64",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_payments,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "datasetProfile",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1643871600000,
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                },
+                "rowCount": 113,
+                "columnCount": 4,
+                "sizeInBytes": 4158
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.customers,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD)",
+                    "value": {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD)",
+                        "type": "COPY"
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.customers,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD),customer_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.customers,PROD),first_name)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD),first_name)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.customers,PROD),last_name)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD),last_name)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.customers,PROD),first_order)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD),first_order)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.customers,PROD),most_recent_order)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD),most_recent_order)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.customers,PROD),number_of_orders)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD),number_of_orders)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.customers,PROD),customer_lifetime_value)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD),customer_lifetime_value)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.orders,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
+                    "value": {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
+                        "type": "COPY"
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.orders,PROD),order_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),order_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.orders,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),customer_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.orders,PROD),order_date)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),order_date)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.orders,PROD),status)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),status)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.orders,PROD),credit_card_amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),credit_card_amount)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.orders,PROD),coupon_amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),coupon_amount)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.orders,PROD),bank_transfer_amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),bank_transfer_amount)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.orders,PROD),gift_card_amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),gift_card_amount)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.orders,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),amount)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_customers,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_customers,PROD)",
+                    "value": {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_customers,PROD)",
+                        "type": "COPY"
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_customers,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_customers,PROD),customer_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_customers,PROD),first_name)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_customers,PROD),first_name)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_customers,PROD),last_name)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_customers,PROD),last_name)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_orders,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD)",
+                    "value": {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD)",
+                        "type": "COPY"
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_orders,PROD),order_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD),order_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_orders,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD),customer_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_orders,PROD),order_date)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD),order_date)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_orders,PROD),status)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD),status)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_payments,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD)",
+                    "value": {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD)",
+                        "type": "COPY"
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_payments,PROD),payment_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD),payment_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_payments,PROD),order_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD),order_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_payments,PROD),payment_method)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD),payment_method)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_payments,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD),amount)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_customers,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_customers,PROD)",
+                    "value": {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_customers,PROD)",
+                        "type": "COPY"
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_customers,PROD),id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_customers,PROD),id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_customers,PROD),first_name)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_customers,PROD),first_name)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_customers,PROD),last_name)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_customers,PROD),last_name)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_orders,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_orders,PROD)",
+                    "value": {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_orders,PROD)",
+                        "type": "COPY"
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_orders,PROD),id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_orders,PROD),id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_orders,PROD),user_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_orders,PROD),user_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_orders,PROD),order_date)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_orders,PROD),order_date)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_orders,PROD),status)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_orders,PROD),status)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_payments,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_payments,PROD)",
+                    "value": {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_payments,PROD)",
+                        "type": "COPY"
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_payments,PROD),id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_payments,PROD),id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_payments,PROD),order_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_payments,PROD),order_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_payments,PROD),payment_method)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_payments,PROD),payment_method)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_payments,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_payments,PROD),amount)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b052a324c05327985f3b579a19ad7579",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b052a324c05327985f3b579a19ad7579",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3",
+                    "dbt_test_upstream_unique_id": "model.jaffle_shop.orders",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
+                    "manifest_version": "1.1.0",
+                    "manifest_adapter": "bigquery",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.1.0"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
                     "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
-                    "type": "COPY"
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.orders,PROD),order_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),order_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.orders,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),customer_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.orders,PROD),order_date)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),order_date)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.orders,PROD),status)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),status)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.orders,PROD),credit_card_amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),credit_card_amount)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.orders,PROD),coupon_amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),coupon_amount)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.orders,PROD),bank_transfer_amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),bank_transfer_amount)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.orders,PROD),gift_card_amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),gift_card_amount)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.orders,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),amount)",
-                "value": {
-                    "confidenceScore": 1.0
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),status)"
+                    ],
+                    "aggregation": "IDENTITY",
+                    "operator": "IN",
+                    "parameters": {
+                        "value": {
+                            "value": "[\"placed\", \"shipped\", \"completed\", \"return_pending\", \"returned\"]",
+                            "type": "SET"
+                        }
+                    },
+                    "nativeType": "accepted_values_orders_status__placed__shipped__completed__return_pending__returned",
+                    "nativeParameters": {
+                        "values": "['placed', 'shipped', 'completed', 'return_pending', 'returned']",
+                        "column_name": "status",
+                        "model": "{{ get_where_subquery(ref('orders')) }}"
+                    }
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
             }
-        ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_customers,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_customers,PROD)",
-                "value": {
-                    "auditStamp": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
-                    },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_customers,PROD)",
-                    "type": "COPY"
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_customers,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_customers,PROD),customer_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_customers,PROD),first_name)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_customers,PROD),first_name)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_customers,PROD),last_name)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_customers,PROD),last_name)",
-                "value": {
-                    "confidenceScore": 1.0
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b052a324c05327985f3b579a19ad7579",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1655565131058,
+                "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
+                },
+                "assertionUrn": "urn:li:assertion:b052a324c05327985f3b579a19ad7579",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
             }
-        ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_orders,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD)",
-                "value": {
-                    "auditStamp": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
-                    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:da743330013b7e3e3707ac6e526ab408",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:da743330013b7e3e3707ac6e526ab408",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad",
+                    "dbt_test_upstream_unique_id": "model.jaffle_shop.stg_orders",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
+                    "manifest_version": "1.1.0",
+                    "manifest_adapter": "bigquery",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.1.0"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
                     "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD)",
-                    "type": "COPY"
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_orders,PROD),order_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD),order_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_orders,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD),customer_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_orders,PROD),order_date)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD),order_date)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_orders,PROD),status)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD),status)",
-                "value": {
-                    "confidenceScore": 1.0
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD),status)"
+                    ],
+                    "aggregation": "IDENTITY",
+                    "operator": "IN",
+                    "parameters": {
+                        "value": {
+                            "value": "[\"placed\", \"shipped\", \"completed\", \"return_pending\", \"returned\"]",
+                            "type": "SET"
+                        }
+                    },
+                    "nativeType": "accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned",
+                    "nativeParameters": {
+                        "values": "['placed', 'shipped', 'completed', 'return_pending', 'returned']",
+                        "column_name": "status",
+                        "model": "{{ get_where_subquery(ref('stg_orders')) }}"
+                    }
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
             }
-        ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_payments,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD)",
-                "value": {
-                    "auditStamp": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
-                    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:da743330013b7e3e3707ac6e526ab408",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1655565131075,
+                "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
+                },
+                "assertionUrn": "urn:li:assertion:da743330013b7e3e3707ac6e526ab408",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:2887b9c826e0be6296a37833bdc380bd",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:2887b9c826e0be6296a37833bdc380bd",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278",
+                    "dbt_test_upstream_unique_id": "model.jaffle_shop.stg_payments",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
+                    "manifest_version": "1.1.0",
+                    "manifest_adapter": "bigquery",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.1.0"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
                     "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD)",
-                    "type": "COPY"
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_payments,PROD),payment_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD),payment_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_payments,PROD),order_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD),order_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_payments,PROD),payment_method)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD),payment_method)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_payments,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD),amount)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_customers,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_customers,PROD)",
-                "value": {
-                    "auditStamp": {
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD),payment_method)"
+                    ],
+                    "aggregation": "IDENTITY",
+                    "operator": "IN",
+                    "parameters": {
+                        "value": {
+                            "value": "[\"credit_card\", \"coupon\", \"bank_transfer\", \"gift_card\"]",
+                            "type": "SET"
+                        }
+                    },
+                    "nativeType": "accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card",
+                    "nativeParameters": {
+                        "values": "['credit_card', 'coupon', 'bank_transfer', 'gift_card']",
+                        "column_name": "payment_method",
+                        "model": "{{ get_where_subquery(ref('stg_payments')) }}"
+                    }
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
                         "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
-                    },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_customers,PROD)",
-                    "type": "COPY"
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_customers,PROD),id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_customers,PROD),id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_customers,PROD),first_name)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_customers,PROD),first_name)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_customers,PROD),last_name)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_customers,PROD),last_name)",
-                "value": {
-                    "confidenceScore": 1.0
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
             }
-        ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_orders,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_orders,PROD)",
-                "value": {
-                    "auditStamp": {
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:2887b9c826e0be6296a37833bdc380bd",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1655565131073,
+                "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
+                },
+                "assertionUrn": "urn:li:assertion:2887b9c826e0be6296a37833bdc380bd",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:591d8dc8939e0cf9bf0fd03264ad1a0e",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:591d8dc8939e0cf9bf0fd03264ad1a0e",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.jaffle_shop.assert_total_payment_amount_is_positive",
+                    "dbt_test_upstream_unique_id": "model.jaffle_shop.orders",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
+                    "manifest_version": "1.1.0",
+                    "manifest_adapter": "bigquery",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.1.0"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
+                    "scope": "DATASET_ROWS",
+                    "aggregation": "_NATIVE_",
+                    "operator": "_NATIVE_",
+                    "nativeType": "assert_total_payment_amount_is_positive",
+                    "nativeParameters": {},
+                    "logic": "-- Refunds have a negative amount, so the total amount should always be >= 0.\n-- Therefore return records where this isn't true to make the test fail\nselect\n    order_id,\n    sum(amount) as total_amount\nfrom `calm-pagoda-323403`.`jaffle_shop`.`orders`\ngroup by 1\nhaving not(total_amount >= 0)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
                         "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
-                    },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_orders,PROD)",
-                    "type": "COPY"
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_orders,PROD),id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_orders,PROD),id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_orders,PROD),user_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_orders,PROD),user_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_orders,PROD),order_date)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_orders,PROD),order_date)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_orders,PROD),status)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_orders,PROD),status)",
-                "value": {
-                    "confidenceScore": 1.0
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
             }
-        ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_payments,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_payments,PROD)",
-                "value": {
-                    "auditStamp": {
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:591d8dc8939e0cf9bf0fd03264ad1a0e",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1655565131077,
+                "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
+                },
+                "assertionUrn": "urn:li:assertion:591d8dc8939e0cf9bf0fd03264ad1a0e",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:2ff754df689ea951ed2e12cbe356708f",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:2ff754df689ea951ed2e12cbe356708f",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.jaffle_shop.dbt_expectations_expect_column_values_to_be_between_customers_customer_id__2000000__0__customer_id_is_not_null__False.e67667298f",
+                    "dbt_test_upstream_unique_id": "model.jaffle_shop.customers",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
+                    "manifest_version": "1.1.0",
+                    "manifest_adapter": "bigquery",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.1.0"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD)",
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD),customer_id)"
+                    ],
+                    "aggregation": "IDENTITY",
+                    "operator": "BETWEEN",
+                    "parameters": {
+                        "maxValue": {
+                            "value": "2000000",
+                            "type": "NUMBER"
+                        },
+                        "minValue": {
+                            "value": "0",
+                            "type": "NUMBER"
+                        }
+                    },
+                    "nativeType": "dbt_expectations_expect_column_values_to_be_between_customers_customer_id__2000000__0__customer_id_is_not_null__False",
+                    "nativeParameters": {
+                        "min_value": "0",
+                        "max_value": "2000000",
+                        "row_condition": "customer_id is not null",
+                        "strictly": "False",
+                        "column_name": "customer_id",
+                        "model": "{{ get_where_subquery(ref('customers')) }}"
+                    }
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
                         "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bf7fd2b46d2c32ee9bb036acd1559782",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bf7fd2b46d2c32ee9bb036acd1559782",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.jaffle_shop.dbt_expectations_expect_column_values_to_be_in_set_customers_customer_id__customer_id_is_not_null__0__1__2.81450cfcd8",
+                    "dbt_test_upstream_unique_id": "model.jaffle_shop.customers",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
+                    "manifest_version": "1.1.0",
+                    "manifest_adapter": "bigquery",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.1.0"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD)",
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD),customer_id)"
+                    ],
+                    "aggregation": "IDENTITY",
+                    "operator": "IN",
+                    "parameters": {
+                        "value": {
+                            "value": "[\"0\", \"1\", \"2\"]",
+                            "type": "SET"
+                        }
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_payments,PROD)",
-                    "type": "COPY"
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_payments,PROD),id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_payments,PROD),id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_payments,PROD),order_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_payments,PROD),order_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_payments,PROD),payment_method)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_payments,PROD),payment_method)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_payments,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_payments,PROD),amount)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b052a324c05327985f3b579a19ad7579",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b052a324c05327985f3b579a19ad7579",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3",
-                "dbt_test_upstream_unique_id": "model.jaffle_shop.orders",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
-                "manifest_version": "1.1.0",
-                "manifest_adapter": "bigquery",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.1.0"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),status)"
-                ],
-                "aggregation": "IDENTITY",
-                "operator": "IN",
-                "parameters": {
-                    "value": {
-                        "value": "[\"placed\", \"shipped\", \"completed\", \"return_pending\", \"returned\"]",
-                        "type": "SET"
+                    "nativeType": "dbt_expectations_expect_column_values_to_be_in_set_customers_customer_id__customer_id_is_not_null__0__1__2",
+                    "nativeParameters": {
+                        "value_set": "['0', '1', '2']",
+                        "row_condition": "customer_id is not null",
+                        "column_name": "customer_id",
+                        "model": "{{ get_where_subquery(ref('customers')) }}"
                     }
                 },
-                "nativeType": "accepted_values_orders_status__placed__shipped__completed__return_pending__returned",
-                "nativeParameters": {
-                    "values": "['placed', 'shipped', 'completed', 'return_pending', 'returned']",
-                    "column_name": "status",
-                    "model": "{{ get_where_subquery(ref('orders')) }}"
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b052a324c05327985f3b579a19ad7579",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1655565131058,
-            "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:b052a324c05327985f3b579a19ad7579",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:da743330013b7e3e3707ac6e526ab408",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:da743330013b7e3e3707ac6e526ab408",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad",
-                "dbt_test_upstream_unique_id": "model.jaffle_shop.stg_orders",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
-                "manifest_version": "1.1.0",
-                "manifest_adapter": "bigquery",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.1.0"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD),status)"
-                ],
-                "aggregation": "IDENTITY",
-                "operator": "IN",
-                "parameters": {
-                    "value": {
-                        "value": "[\"placed\", \"shipped\", \"completed\", \"return_pending\", \"returned\"]",
-                        "type": "SET"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bf7fd2b46d2c32ee9bb036acd1559782",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1655565137668,
+                "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "FAILURE",
+                    "nativeResults": {
+                        "message": "Database Error in test dbt_expectations_expect_column_values_to_be_in_set_customers_customer_id__customer_id_is_not_null__0__1__2 (models/schema.yml)\n  No matching signature for operator = for argument types: INT64, STRING. Supported signature: ANY = ANY at [46:25]\n  compiled SQL at target/run/jaffle_shop/models/schema.yml/dbt_expectations_expect_column_e42202dc29e1149de0f5c3966219796d.sql"
                     }
                 },
-                "nativeType": "accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned",
-                "nativeParameters": {
-                    "values": "['placed', 'shipped', 'completed', 'return_pending', 'returned']",
-                    "column_name": "status",
-                    "model": "{{ get_where_subquery(ref('stg_orders')) }}"
+                "assertionUrn": "urn:li:assertion:bf7fd2b46d2c32ee9bb036acd1559782",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:da743330013b7e3e3707ac6e526ab408",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1655565131075,
-            "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:da743330013b7e3e3707ac6e526ab408",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:1c217b7587a0cad47a07a09bfe154055",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:2887b9c826e0be6296a37833bdc380bd",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:2887b9c826e0be6296a37833bdc380bd",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278",
-                "dbt_test_upstream_unique_id": "model.jaffle_shop.stg_payments",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
-                "manifest_version": "1.1.0",
-                "manifest_adapter": "bigquery",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.1.0"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD),payment_method)"
-                ],
-                "aggregation": "IDENTITY",
-                "operator": "IN",
-                "parameters": {
-                    "value": {
-                        "value": "[\"credit_card\", \"coupon\", \"bank_transfer\", \"gift_card\"]",
-                        "type": "SET"
-                    }
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:1c217b7587a0cad47a07a09bfe154055",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.jaffle_shop.dbt_expectations_expect_column_values_to_not_be_in_set_orders_credit_card_amount__credit_card_amount_is_not_null__0.888b06036c",
+                    "dbt_test_upstream_unique_id": "model.jaffle_shop.orders",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
+                    "manifest_version": "1.1.0",
+                    "manifest_adapter": "bigquery",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.1.0"
                 },
-                "nativeType": "accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card",
-                "nativeParameters": {
-                    "values": "['credit_card', 'coupon', 'bank_transfer', 'gift_card']",
-                    "column_name": "payment_method",
-                    "model": "{{ get_where_subquery(ref('stg_payments')) }}"
-                }
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:2887b9c826e0be6296a37833bdc380bd",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1655565131073,
-            "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:2887b9c826e0be6296a37833bdc380bd",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:591d8dc8939e0cf9bf0fd03264ad1a0e",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:591d8dc8939e0cf9bf0fd03264ad1a0e",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.jaffle_shop.assert_total_payment_amount_is_positive",
-                "dbt_test_upstream_unique_id": "model.jaffle_shop.orders",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
-                "manifest_version": "1.1.0",
-                "manifest_adapter": "bigquery",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.1.0"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
-                "scope": "DATASET_ROWS",
-                "aggregation": "_NATIVE_",
-                "operator": "_NATIVE_",
-                "nativeType": "assert_total_payment_amount_is_positive",
-                "nativeParameters": {},
-                "logic": "-- Refunds have a negative amount, so the total amount should always be >= 0.\n-- Therefore return records where this isn't true to make the test fail\nselect\n    order_id,\n    sum(amount) as total_amount\nfrom `calm-pagoda-323403`.`jaffle_shop`.`orders`\ngroup by 1\nhaving not(total_amount >= 0)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:591d8dc8939e0cf9bf0fd03264ad1a0e",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1655565131077,
-            "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:591d8dc8939e0cf9bf0fd03264ad1a0e",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:2ff754df689ea951ed2e12cbe356708f",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:2ff754df689ea951ed2e12cbe356708f",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.jaffle_shop.dbt_expectations_expect_column_values_to_be_between_customers_customer_id__2000000__0__customer_id_is_not_null__False.e67667298f",
-                "dbt_test_upstream_unique_id": "model.jaffle_shop.customers",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
-                "manifest_version": "1.1.0",
-                "manifest_adapter": "bigquery",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.1.0"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD),customer_id)"
-                ],
-                "aggregation": "IDENTITY",
-                "operator": "BETWEEN",
-                "parameters": {
-                    "maxValue": {
-                        "value": "2000000",
-                        "type": "NUMBER"
+                "type": "DATASET",
+                "datasetAssertion": {
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),credit_card_amount)"
+                    ],
+                    "aggregation": "_NATIVE_",
+                    "operator": "_NATIVE_",
+                    "nativeType": "dbt_expectations_expect_column_values_to_not_be_in_set_orders_credit_card_amount__credit_card_amount_is_not_null__0",
+                    "nativeParameters": {
+                        "value_set": "['0']",
+                        "row_condition": "credit_card_amount is not null",
+                        "column_name": "credit_card_amount",
+                        "model": "{{ get_where_subquery(ref('orders')) }}"
                     },
-                    "minValue": {
-                        "value": "0",
-                        "type": "NUMBER"
+                    "logic": "\n\nwith all_values as (\n\n    select\n        credit_card_amount as value_field\n\n    from `calm-pagoda-323403`.`jaffle_shop`.`orders`\n    \n    where credit_card_amount is not null\n    \n\n),\nset_values as (\n\n    select\n        cast('0' as \n    string\n) as value_field\n    \n    \n),\nvalidation_errors as (\n    -- values from the model that match the set\n    select\n        v.value_field\n    from\n        all_values v\n        join\n        set_values s on v.value_field = s.value_field\n\n)\n\nselect *\nfrom validation_errors\n\n"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:1c217b7587a0cad47a07a09bfe154055",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1655565137668,
+                "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "FAILURE",
+                    "nativeResults": {
+                        "message": "Database Error in test dbt_expectations_expect_column_values_to_not_be_in_set_orders_credit_card_amount__credit_card_amount_is_not_null__0 (models/schema.yml)\n  No matching signature for operator = for argument types: FLOAT64, STRING. Supported signature: ANY = ANY at [36:25]\n  compiled SQL at target/run/jaffle_shop/models/schema.yml/dbt_expectations_expect_column_fdf581b1071168614662824120d65b90.sql"
                     }
                 },
-                "nativeType": "dbt_expectations_expect_column_values_to_be_between_customers_customer_id__2000000__0__customer_id_is_not_null__False",
-                "nativeParameters": {
-                    "min_value": "0",
-                    "max_value": "2000000",
-                    "row_condition": "customer_id is not null",
-                    "strictly": "False",
-                    "column_name": "customer_id",
-                    "model": "{{ get_where_subquery(ref('customers')) }}"
+                "assertionUrn": "urn:li:assertion:1c217b7587a0cad47a07a09bfe154055",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bf7fd2b46d2c32ee9bb036acd1559782",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:44519aa345bf3ea896179f9f352ae946",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bf7fd2b46d2c32ee9bb036acd1559782",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.jaffle_shop.dbt_expectations_expect_column_values_to_be_in_set_customers_customer_id__customer_id_is_not_null__0__1__2.81450cfcd8",
-                "dbt_test_upstream_unique_id": "model.jaffle_shop.customers",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
-                "manifest_version": "1.1.0",
-                "manifest_adapter": "bigquery",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.1.0"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD),customer_id)"
-                ],
-                "aggregation": "IDENTITY",
-                "operator": "IN",
-                "parameters": {
-                    "value": {
-                        "value": "[\"0\", \"1\", \"2\"]",
-                        "type": "SET"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:44519aa345bf3ea896179f9f352ae946",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.jaffle_shop.not_null_customers_customer_id.5c9bf9911d",
+                    "dbt_test_upstream_unique_id": "model.jaffle_shop.customers",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
+                    "manifest_version": "1.1.0",
+                    "manifest_adapter": "bigquery",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.1.0"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD)",
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD),customer_id)"
+                    ],
+                    "aggregation": "IDENTITY",
+                    "operator": "NOT_NULL",
+                    "nativeType": "not_null_customers_customer_id",
+                    "nativeParameters": {
+                        "column_name": "customer_id",
+                        "model": "{{ get_where_subquery(ref('customers')) }}"
                     }
                 },
-                "nativeType": "dbt_expectations_expect_column_values_to_be_in_set_customers_customer_id__customer_id_is_not_null__0__1__2",
-                "nativeParameters": {
-                    "value_set": "['0', '1', '2']",
-                    "row_condition": "customer_id is not null",
-                    "column_name": "customer_id",
-                    "model": "{{ get_where_subquery(ref('customers')) }}"
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bf7fd2b46d2c32ee9bb036acd1559782",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1655565137668,
-            "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "FAILURE",
-                "nativeResults": {
-                    "message": "Database Error in test dbt_expectations_expect_column_values_to_be_in_set_customers_customer_id__customer_id_is_not_null__0__1__2 (models/schema.yml)\n  No matching signature for operator = for argument types: INT64, STRING. Supported signature: ANY = ANY at [46:25]\n  compiled SQL at target/run/jaffle_shop/models/schema.yml/dbt_expectations_expect_column_e42202dc29e1149de0f5c3966219796d.sql"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:bf7fd2b46d2c32ee9bb036acd1559782",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:1c217b7587a0cad47a07a09bfe154055",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:1c217b7587a0cad47a07a09bfe154055",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.jaffle_shop.dbt_expectations_expect_column_values_to_not_be_in_set_orders_credit_card_amount__credit_card_amount_is_not_null__0.888b06036c",
-                "dbt_test_upstream_unique_id": "model.jaffle_shop.orders",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
-                "manifest_version": "1.1.0",
-                "manifest_adapter": "bigquery",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.1.0"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),credit_card_amount)"
-                ],
-                "aggregation": "_NATIVE_",
-                "operator": "_NATIVE_",
-                "nativeType": "dbt_expectations_expect_column_values_to_not_be_in_set_orders_credit_card_amount__credit_card_amount_is_not_null__0",
-                "nativeParameters": {
-                    "value_set": "['0']",
-                    "row_condition": "credit_card_amount is not null",
-                    "column_name": "credit_card_amount",
-                    "model": "{{ get_where_subquery(ref('orders')) }}"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:44519aa345bf3ea896179f9f352ae946",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1655565132560,
+                "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
                 },
-                "logic": "\n\nwith all_values as (\n\n    select\n        credit_card_amount as value_field\n\n    from `calm-pagoda-323403`.`jaffle_shop`.`orders`\n    \n    where credit_card_amount is not null\n    \n\n),\nset_values as (\n\n    select\n        cast('0' as \n    string\n) as value_field\n    \n    \n),\nvalidation_errors as (\n    -- values from the model that match the set\n    select\n        v.value_field\n    from\n        all_values v\n        join\n        set_values s on v.value_field = s.value_field\n\n)\n\nselect *\nfrom validation_errors\n\n"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:1c217b7587a0cad47a07a09bfe154055",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1655565137668,
-            "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "FAILURE",
-                "nativeResults": {
-                    "message": "Database Error in test dbt_expectations_expect_column_values_to_not_be_in_set_orders_credit_card_amount__credit_card_amount_is_not_null__0 (models/schema.yml)\n  No matching signature for operator = for argument types: FLOAT64, STRING. Supported signature: ANY = ANY at [36:25]\n  compiled SQL at target/run/jaffle_shop/models/schema.yml/dbt_expectations_expect_column_fdf581b1071168614662824120d65b90.sql"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:1c217b7587a0cad47a07a09bfe154055",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:44519aa345bf3ea896179f9f352ae946",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:44519aa345bf3ea896179f9f352ae946",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.jaffle_shop.not_null_customers_customer_id.5c9bf9911d",
-                "dbt_test_upstream_unique_id": "model.jaffle_shop.customers",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
-                "manifest_version": "1.1.0",
-                "manifest_adapter": "bigquery",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.1.0"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD),customer_id)"
-                ],
-                "aggregation": "IDENTITY",
-                "operator": "NOT_NULL",
-                "nativeType": "not_null_customers_customer_id",
-                "nativeParameters": {
-                    "column_name": "customer_id",
-                    "model": "{{ get_where_subquery(ref('customers')) }}"
+                "assertionUrn": "urn:li:assertion:44519aa345bf3ea896179f9f352ae946",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:44519aa345bf3ea896179f9f352ae946",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1655565132560,
-            "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:44519aa345bf3ea896179f9f352ae946",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bbd78a070092f54313153abec49f6f31",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bbd78a070092f54313153abec49f6f31",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bbd78a070092f54313153abec49f6f31",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.jaffle_shop.not_null_orders_amount.106140f9fd",
-                "dbt_test_upstream_unique_id": "model.jaffle_shop.orders",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
-                "manifest_version": "1.1.0",
-                "manifest_adapter": "bigquery",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.1.0"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),amount)"
-                ],
-                "aggregation": "IDENTITY",
-                "operator": "NOT_NULL",
-                "nativeType": "not_null_orders_amount",
-                "nativeParameters": {
-                    "column_name": "amount",
-                    "model": "{{ get_where_subquery(ref('orders')) }}"
-                }
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bbd78a070092f54313153abec49f6f31",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1655565133585,
-            "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:bbd78a070092f54313153abec49f6f31",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:52d06197762e3608d94609e96f03a0a7",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:52d06197762e3608d94609e96f03a0a7",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.jaffle_shop.not_null_orders_bank_transfer_amount.7743500c49",
-                "dbt_test_upstream_unique_id": "model.jaffle_shop.orders",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
-                "manifest_version": "1.1.0",
-                "manifest_adapter": "bigquery",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.1.0"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),bank_transfer_amount)"
-                ],
-                "aggregation": "IDENTITY",
-                "operator": "NOT_NULL",
-                "nativeType": "not_null_orders_bank_transfer_amount",
-                "nativeParameters": {
-                    "column_name": "bank_transfer_amount",
-                    "model": "{{ get_where_subquery(ref('orders')) }}"
-                }
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:52d06197762e3608d94609e96f03a0a7",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1655565133591,
-            "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:52d06197762e3608d94609e96f03a0a7",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ca065a99637630468f688717590beeab",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ca065a99637630468f688717590beeab",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.jaffle_shop.not_null_orders_coupon_amount.ab90c90625",
-                "dbt_test_upstream_unique_id": "model.jaffle_shop.orders",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
-                "manifest_version": "1.1.0",
-                "manifest_adapter": "bigquery",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.1.0"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),coupon_amount)"
-                ],
-                "aggregation": "IDENTITY",
-                "operator": "NOT_NULL",
-                "nativeType": "not_null_orders_coupon_amount",
-                "nativeParameters": {
-                    "column_name": "coupon_amount",
-                    "model": "{{ get_where_subquery(ref('orders')) }}"
-                }
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ca065a99637630468f688717590beeab",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1655565133595,
-            "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:ca065a99637630468f688717590beeab",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:7a305acc5fc049dc9bbd141b814461d0",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:7a305acc5fc049dc9bbd141b814461d0",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.jaffle_shop.not_null_orders_credit_card_amount.d3ca593b59",
-                "dbt_test_upstream_unique_id": "model.jaffle_shop.orders",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
-                "manifest_version": "1.1.0",
-                "manifest_adapter": "bigquery",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.1.0"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),credit_card_amount)"
-                ],
-                "aggregation": "IDENTITY",
-                "operator": "NOT_NULL",
-                "nativeType": "not_null_orders_credit_card_amount",
-                "nativeParameters": {
-                    "column_name": "credit_card_amount",
-                    "model": "{{ get_where_subquery(ref('orders')) }}"
-                }
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:7a305acc5fc049dc9bbd141b814461d0",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1655565134031,
-            "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:7a305acc5fc049dc9bbd141b814461d0",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:11087a3d7ae178df22c42922ac8ef8ad",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:11087a3d7ae178df22c42922ac8ef8ad",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.jaffle_shop.not_null_orders_customer_id.c5f02694af",
-                "dbt_test_upstream_unique_id": "model.jaffle_shop.orders",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
-                "manifest_version": "1.1.0",
-                "manifest_adapter": "bigquery",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.1.0"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),customer_id)"
-                ],
-                "aggregation": "IDENTITY",
-                "operator": "NOT_NULL",
-                "nativeType": "not_null_orders_customer_id",
-                "nativeParameters": {
-                    "column_name": "customer_id",
-                    "model": "{{ get_where_subquery(ref('orders')) }}"
-                }
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:11087a3d7ae178df22c42922ac8ef8ad",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1655565134482,
-            "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:11087a3d7ae178df22c42922ac8ef8ad",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b301bb47cc4ebce4e78a194b3de11f25",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b301bb47cc4ebce4e78a194b3de11f25",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.jaffle_shop.not_null_orders_gift_card_amount.413a0d2d7a",
-                "dbt_test_upstream_unique_id": "model.jaffle_shop.orders",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
-                "manifest_version": "1.1.0",
-                "manifest_adapter": "bigquery",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.1.0"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),gift_card_amount)"
-                ],
-                "aggregation": "IDENTITY",
-                "operator": "NOT_NULL",
-                "nativeType": "not_null_orders_gift_card_amount",
-                "nativeParameters": {
-                    "column_name": "gift_card_amount",
-                    "model": "{{ get_where_subquery(ref('orders')) }}"
-                }
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b301bb47cc4ebce4e78a194b3de11f25",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1655565134485,
-            "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:b301bb47cc4ebce4e78a194b3de11f25",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:2e9117138dcc9facda66f1efd55a8cd7",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:2e9117138dcc9facda66f1efd55a8cd7",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.jaffle_shop.not_null_orders_order_id.cf6c17daed",
-                "dbt_test_upstream_unique_id": "model.jaffle_shop.orders",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
-                "manifest_version": "1.1.0",
-                "manifest_adapter": "bigquery",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.1.0"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),order_id)"
-                ],
-                "aggregation": "IDENTITY",
-                "operator": "NOT_NULL",
-                "nativeType": "not_null_orders_order_id",
-                "nativeParameters": {
-                    "column_name": "order_id",
-                    "model": "{{ get_where_subquery(ref('orders')) }}"
-                }
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:2e9117138dcc9facda66f1efd55a8cd7",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1655565134493,
-            "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:2e9117138dcc9facda66f1efd55a8cd7",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:25ebf4faa9b1654ef54c46d975ca0a81",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:25ebf4faa9b1654ef54c46d975ca0a81",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa",
-                "dbt_test_upstream_unique_id": "model.jaffle_shop.stg_customers",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
-                "manifest_version": "1.1.0",
-                "manifest_adapter": "bigquery",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.1.0"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_customers,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_customers,PROD),customer_id)"
-                ],
-                "aggregation": "IDENTITY",
-                "operator": "NOT_NULL",
-                "nativeType": "not_null_stg_customers_customer_id",
-                "nativeParameters": {
-                    "column_name": "customer_id",
-                    "model": "{{ get_where_subquery(ref('stg_customers')) }}"
-                }
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:25ebf4faa9b1654ef54c46d975ca0a81",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1655565134966,
-            "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_customers,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:25ebf4faa9b1654ef54c46d975ca0a81",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b03abcc447aac70bbebb22a8a9d7dbbe",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b03abcc447aac70bbebb22a8a9d7dbbe",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64",
-                "dbt_test_upstream_unique_id": "model.jaffle_shop.stg_orders",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
-                "manifest_version": "1.1.0",
-                "manifest_adapter": "bigquery",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.1.0"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD),order_id)"
-                ],
-                "aggregation": "IDENTITY",
-                "operator": "NOT_NULL",
-                "nativeType": "not_null_stg_orders_order_id",
-                "nativeParameters": {
-                    "column_name": "order_id",
-                    "model": "{{ get_where_subquery(ref('stg_orders')) }}"
-                }
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b03abcc447aac70bbebb22a8a9d7dbbe",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1655565135368,
-            "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:b03abcc447aac70bbebb22a8a9d7dbbe",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:c1eebc71f36690e4523adca30314e927",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:c1eebc71f36690e4523adca30314e927",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.jaffle_shop.not_null_stg_payments_payment_id.c19cc50075",
-                "dbt_test_upstream_unique_id": "model.jaffle_shop.stg_payments",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
-                "manifest_version": "1.1.0",
-                "manifest_adapter": "bigquery",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.1.0"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD),payment_id)"
-                ],
-                "aggregation": "IDENTITY",
-                "operator": "NOT_NULL",
-                "nativeType": "not_null_stg_payments_payment_id",
-                "nativeParameters": {
-                    "column_name": "payment_id",
-                    "model": "{{ get_where_subquery(ref('stg_payments')) }}"
-                }
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:c1eebc71f36690e4523adca30314e927",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1655565135377,
-            "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:c1eebc71f36690e4523adca30314e927",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:3191c2851901165afc07c3bd7f5f590a",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:3191c2851901165afc07c3bd7f5f590a",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_.c6ec7f58f2",
-                "dbt_test_upstream_unique_id": "model.jaffle_shop.customers",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
-                "manifest_version": "1.1.0",
-                "manifest_adapter": "bigquery",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.1.0"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD),customer_id)"
-                ],
-                "aggregation": "IDENTITY",
-                "operator": "_NATIVE_",
-                "parameters": {
-                    "value": {
-                        "value": "null",
-                        "type": "SET"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bbd78a070092f54313153abec49f6f31",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.jaffle_shop.not_null_orders_amount.106140f9fd",
+                    "dbt_test_upstream_unique_id": "model.jaffle_shop.orders",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
+                    "manifest_version": "1.1.0",
+                    "manifest_adapter": "bigquery",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.1.0"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),amount)"
+                    ],
+                    "aggregation": "IDENTITY",
+                    "operator": "NOT_NULL",
+                    "nativeType": "not_null_orders_amount",
+                    "nativeParameters": {
+                        "column_name": "amount",
+                        "model": "{{ get_where_subquery(ref('orders')) }}"
                     }
                 },
-                "nativeType": "relationships_orders_customer_id__customer_id__ref_customers_",
-                "nativeParameters": {
-                    "to": "ref('customers')",
-                    "field": "customer_id",
-                    "column_name": "customer_id",
-                    "model": "{{ get_where_subquery(ref('orders')) }}"
-                },
-                "logic": "orders.customer_id referential integrity to customers.customer_id"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:3191c2851901165afc07c3bd7f5f590a",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1655565135510,
-            "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:3191c2851901165afc07c3bd7f5f590a",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0331fa8a77015ca1a48d3a2fc90948fb",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0331fa8a77015ca1a48d3a2fc90948fb",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_.c6ec7f58f2",
-                "dbt_test_upstream_unique_id": "model.jaffle_shop.orders",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
-                "manifest_version": "1.1.0",
-                "manifest_adapter": "bigquery",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.1.0"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),customer_id)"
-                ],
-                "aggregation": "IDENTITY",
-                "operator": "_NATIVE_",
-                "parameters": {
-                    "value": {
-                        "value": "null",
-                        "type": "SET"
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
                     }
-                },
-                "nativeType": "relationships_orders_customer_id__customer_id__ref_customers_",
-                "nativeParameters": {
-                    "to": "ref('customers')",
-                    "field": "customer_id",
-                    "column_name": "customer_id",
-                    "model": "{{ get_where_subquery(ref('orders')) }}"
-                },
-                "logic": "orders.customer_id referential integrity to customers.customer_id"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0331fa8a77015ca1a48d3a2fc90948fb",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1655565135510,
-            "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:0331fa8a77015ca1a48d3a2fc90948fb",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:c51ca9c4b5a1f964bef748f0b8968e71",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:c51ca9c4b5a1f964bef748f0b8968e71",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.jaffle_shop.unique_customers_customer_id.c5af1ff4b1",
-                "dbt_test_upstream_unique_id": "model.jaffle_shop.customers",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
-                "manifest_version": "1.1.0",
-                "manifest_adapter": "bigquery",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.1.0"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD),customer_id)"
-                ],
-                "aggregation": "UNIQUE_PROPOTION",
-                "operator": "EQUAL_TO",
-                "parameters": {
-                    "value": {
-                        "value": "1.0",
-                        "type": "NUMBER"
-                    }
-                },
-                "nativeType": "unique_customers_customer_id",
-                "nativeParameters": {
-                    "column_name": "customer_id",
-                    "model": "{{ get_where_subquery(ref('customers')) }}"
                 }
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:c51ca9c4b5a1f964bef748f0b8968e71",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1655565135836,
-            "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:c51ca9c4b5a1f964bef748f0b8968e71",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:caa9b8060e214cecab88a92dc39c2e60",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:caa9b8060e214cecab88a92dc39c2e60",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.jaffle_shop.unique_orders_order_id.fed79b3a6e",
-                "dbt_test_upstream_unique_id": "model.jaffle_shop.orders",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
-                "manifest_version": "1.1.0",
-                "manifest_adapter": "bigquery",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.1.0"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),order_id)"
-                ],
-                "aggregation": "UNIQUE_PROPOTION",
-                "operator": "EQUAL_TO",
-                "parameters": {
-                    "value": {
-                        "value": "1.0",
-                        "type": "NUMBER"
-                    }
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bbd78a070092f54313153abec49f6f31",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1655565133585,
+                "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
                 },
-                "nativeType": "unique_orders_order_id",
-                "nativeParameters": {
-                    "column_name": "order_id",
-                    "model": "{{ get_where_subquery(ref('orders')) }}"
+                "assertionUrn": "urn:li:assertion:bbd78a070092f54313153abec49f6f31",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:caa9b8060e214cecab88a92dc39c2e60",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1655565136269,
-            "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:caa9b8060e214cecab88a92dc39c2e60",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:52d06197762e3608d94609e96f03a0a7",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:54bac90e6785bdefd8685ebf8814c429",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:54bac90e6785bdefd8685ebf8814c429",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.jaffle_shop.unique_stg_customers_customer_id.c7614daada",
-                "dbt_test_upstream_unique_id": "model.jaffle_shop.stg_customers",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
-                "manifest_version": "1.1.0",
-                "manifest_adapter": "bigquery",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.1.0"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_customers,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_customers,PROD),customer_id)"
-                ],
-                "aggregation": "UNIQUE_PROPOTION",
-                "operator": "EQUAL_TO",
-                "parameters": {
-                    "value": {
-                        "value": "1.0",
-                        "type": "NUMBER"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:52d06197762e3608d94609e96f03a0a7",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.jaffle_shop.not_null_orders_bank_transfer_amount.7743500c49",
+                    "dbt_test_upstream_unique_id": "model.jaffle_shop.orders",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
+                    "manifest_version": "1.1.0",
+                    "manifest_adapter": "bigquery",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.1.0"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),bank_transfer_amount)"
+                    ],
+                    "aggregation": "IDENTITY",
+                    "operator": "NOT_NULL",
+                    "nativeType": "not_null_orders_bank_transfer_amount",
+                    "nativeParameters": {
+                        "column_name": "bank_transfer_amount",
+                        "model": "{{ get_where_subquery(ref('orders')) }}"
                     }
                 },
-                "nativeType": "unique_stg_customers_customer_id",
-                "nativeParameters": {
-                    "column_name": "customer_id",
-                    "model": "{{ get_where_subquery(ref('stg_customers')) }}"
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:54bac90e6785bdefd8685ebf8814c429",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1655565136230,
-            "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_customers,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:54bac90e6785bdefd8685ebf8814c429",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:52d06197762e3608d94609e96f03a0a7",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1655565133591,
+                "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
+                },
+                "assertionUrn": "urn:li:assertion:52d06197762e3608d94609e96f03a0a7",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:815963e1332b46a203504ba46ebfab24",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ca065a99637630468f688717590beeab",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:815963e1332b46a203504ba46ebfab24",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a",
-                "dbt_test_upstream_unique_id": "model.jaffle_shop.stg_orders",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
-                "manifest_version": "1.1.0",
-                "manifest_adapter": "bigquery",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.1.0"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD),order_id)"
-                ],
-                "aggregation": "UNIQUE_PROPOTION",
-                "operator": "EQUAL_TO",
-                "parameters": {
-                    "value": {
-                        "value": "1.0",
-                        "type": "NUMBER"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ca065a99637630468f688717590beeab",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.jaffle_shop.not_null_orders_coupon_amount.ab90c90625",
+                    "dbt_test_upstream_unique_id": "model.jaffle_shop.orders",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
+                    "manifest_version": "1.1.0",
+                    "manifest_adapter": "bigquery",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.1.0"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),coupon_amount)"
+                    ],
+                    "aggregation": "IDENTITY",
+                    "operator": "NOT_NULL",
+                    "nativeType": "not_null_orders_coupon_amount",
+                    "nativeParameters": {
+                        "column_name": "coupon_amount",
+                        "model": "{{ get_where_subquery(ref('orders')) }}"
                     }
                 },
-                "nativeType": "unique_stg_orders_order_id",
-                "nativeParameters": {
-                    "column_name": "order_id",
-                    "model": "{{ get_where_subquery(ref('stg_orders')) }}"
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:815963e1332b46a203504ba46ebfab24",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1655565136395,
-            "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:815963e1332b46a203504ba46ebfab24",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ca065a99637630468f688717590beeab",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1655565133595,
+                "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
+                },
+                "assertionUrn": "urn:li:assertion:ca065a99637630468f688717590beeab",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:fac27f352406b941125292413afa8096",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:7a305acc5fc049dc9bbd141b814461d0",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:fac27f352406b941125292413afa8096",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.jaffle_shop.unique_stg_payments_payment_id.3744510712",
-                "dbt_test_upstream_unique_id": "model.jaffle_shop.stg_payments",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
-                "manifest_version": "1.1.0",
-                "manifest_adapter": "bigquery",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.1.0"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD),payment_id)"
-                ],
-                "aggregation": "UNIQUE_PROPOTION",
-                "operator": "EQUAL_TO",
-                "parameters": {
-                    "value": {
-                        "value": "1.0",
-                        "type": "NUMBER"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:7a305acc5fc049dc9bbd141b814461d0",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.jaffle_shop.not_null_orders_credit_card_amount.d3ca593b59",
+                    "dbt_test_upstream_unique_id": "model.jaffle_shop.orders",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
+                    "manifest_version": "1.1.0",
+                    "manifest_adapter": "bigquery",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.1.0"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),credit_card_amount)"
+                    ],
+                    "aggregation": "IDENTITY",
+                    "operator": "NOT_NULL",
+                    "nativeType": "not_null_orders_credit_card_amount",
+                    "nativeParameters": {
+                        "column_name": "credit_card_amount",
+                        "model": "{{ get_where_subquery(ref('orders')) }}"
                     }
                 },
-                "nativeType": "unique_stg_payments_payment_id",
-                "nativeParameters": {
-                    "column_name": "payment_id",
-                    "model": "{{ get_where_subquery(ref('stg_payments')) }}"
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:fac27f352406b941125292413afa8096",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1655565136719,
-            "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:fac27f352406b941125292413afa8096",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:7a305acc5fc049dc9bbd141b814461d0",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1655565134031,
+                "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
+                },
+                "assertionUrn": "urn:li:assertion:7a305acc5fc049dc9bbd141b814461d0",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0331fa8a77015ca1a48d3a2fc90948fb",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:11087a3d7ae178df22c42922ac8ef8ad",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:11087a3d7ae178df22c42922ac8ef8ad",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:11087a3d7ae178df22c42922ac8ef8ad",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.jaffle_shop.not_null_orders_customer_id.c5f02694af",
+                    "dbt_test_upstream_unique_id": "model.jaffle_shop.orders",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
+                    "manifest_version": "1.1.0",
+                    "manifest_adapter": "bigquery",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.1.0"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),customer_id)"
+                    ],
+                    "aggregation": "IDENTITY",
+                    "operator": "NOT_NULL",
+                    "nativeType": "not_null_orders_customer_id",
+                    "nativeParameters": {
+                        "column_name": "customer_id",
+                        "model": "{{ get_where_subquery(ref('orders')) }}"
+                    }
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:1c217b7587a0cad47a07a09bfe154055",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:11087a3d7ae178df22c42922ac8ef8ad",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1655565134482,
+                "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
+                },
+                "assertionUrn": "urn:li:assertion:11087a3d7ae178df22c42922ac8ef8ad",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:25ebf4faa9b1654ef54c46d975ca0a81",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b301bb47cc4ebce4e78a194b3de11f25",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:2887b9c826e0be6296a37833bdc380bd",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b301bb47cc4ebce4e78a194b3de11f25",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.jaffle_shop.not_null_orders_gift_card_amount.413a0d2d7a",
+                    "dbt_test_upstream_unique_id": "model.jaffle_shop.orders",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
+                    "manifest_version": "1.1.0",
+                    "manifest_adapter": "bigquery",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.1.0"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),gift_card_amount)"
+                    ],
+                    "aggregation": "IDENTITY",
+                    "operator": "NOT_NULL",
+                    "nativeType": "not_null_orders_gift_card_amount",
+                    "nativeParameters": {
+                        "column_name": "gift_card_amount",
+                        "model": "{{ get_where_subquery(ref('orders')) }}"
+                    }
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:2e9117138dcc9facda66f1efd55a8cd7",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b301bb47cc4ebce4e78a194b3de11f25",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1655565134485,
+                "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
+                },
+                "assertionUrn": "urn:li:assertion:b301bb47cc4ebce4e78a194b3de11f25",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:2ff754df689ea951ed2e12cbe356708f",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:2e9117138dcc9facda66f1efd55a8cd7",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:3191c2851901165afc07c3bd7f5f590a",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:2e9117138dcc9facda66f1efd55a8cd7",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.jaffle_shop.not_null_orders_order_id.cf6c17daed",
+                    "dbt_test_upstream_unique_id": "model.jaffle_shop.orders",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
+                    "manifest_version": "1.1.0",
+                    "manifest_adapter": "bigquery",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.1.0"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),order_id)"
+                    ],
+                    "aggregation": "IDENTITY",
+                    "operator": "NOT_NULL",
+                    "nativeType": "not_null_orders_order_id",
+                    "nativeParameters": {
+                        "column_name": "order_id",
+                        "model": "{{ get_where_subquery(ref('orders')) }}"
+                    }
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:44519aa345bf3ea896179f9f352ae946",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:2e9117138dcc9facda66f1efd55a8cd7",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1655565134493,
+                "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
+                },
+                "assertionUrn": "urn:li:assertion:2e9117138dcc9facda66f1efd55a8cd7",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:52d06197762e3608d94609e96f03a0a7",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:25ebf4faa9b1654ef54c46d975ca0a81",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:54bac90e6785bdefd8685ebf8814c429",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:25ebf4faa9b1654ef54c46d975ca0a81",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa",
+                    "dbt_test_upstream_unique_id": "model.jaffle_shop.stg_customers",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
+                    "manifest_version": "1.1.0",
+                    "manifest_adapter": "bigquery",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.1.0"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_customers,PROD)",
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_customers,PROD),customer_id)"
+                    ],
+                    "aggregation": "IDENTITY",
+                    "operator": "NOT_NULL",
+                    "nativeType": "not_null_stg_customers_customer_id",
+                    "nativeParameters": {
+                        "column_name": "customer_id",
+                        "model": "{{ get_where_subquery(ref('stg_customers')) }}"
+                    }
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:591d8dc8939e0cf9bf0fd03264ad1a0e",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:25ebf4faa9b1654ef54c46d975ca0a81",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1655565134966,
+                "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_customers,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
+                },
+                "assertionUrn": "urn:li:assertion:25ebf4faa9b1654ef54c46d975ca0a81",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:7a305acc5fc049dc9bbd141b814461d0",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b03abcc447aac70bbebb22a8a9d7dbbe",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:815963e1332b46a203504ba46ebfab24",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b03abcc447aac70bbebb22a8a9d7dbbe",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64",
+                    "dbt_test_upstream_unique_id": "model.jaffle_shop.stg_orders",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
+                    "manifest_version": "1.1.0",
+                    "manifest_adapter": "bigquery",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.1.0"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD)",
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD),order_id)"
+                    ],
+                    "aggregation": "IDENTITY",
+                    "operator": "NOT_NULL",
+                    "nativeType": "not_null_stg_orders_order_id",
+                    "nativeParameters": {
+                        "column_name": "order_id",
+                        "model": "{{ get_where_subquery(ref('stg_orders')) }}"
+                    }
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b03abcc447aac70bbebb22a8a9d7dbbe",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b03abcc447aac70bbebb22a8a9d7dbbe",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1655565135368,
+                "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
+                },
+                "assertionUrn": "urn:li:assertion:b03abcc447aac70bbebb22a8a9d7dbbe",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b052a324c05327985f3b579a19ad7579",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:c1eebc71f36690e4523adca30314e927",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b301bb47cc4ebce4e78a194b3de11f25",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:c1eebc71f36690e4523adca30314e927",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.jaffle_shop.not_null_stg_payments_payment_id.c19cc50075",
+                    "dbt_test_upstream_unique_id": "model.jaffle_shop.stg_payments",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
+                    "manifest_version": "1.1.0",
+                    "manifest_adapter": "bigquery",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.1.0"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD)",
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD),payment_id)"
+                    ],
+                    "aggregation": "IDENTITY",
+                    "operator": "NOT_NULL",
+                    "nativeType": "not_null_stg_payments_payment_id",
+                    "nativeParameters": {
+                        "column_name": "payment_id",
+                        "model": "{{ get_where_subquery(ref('stg_payments')) }}"
+                    }
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bbd78a070092f54313153abec49f6f31",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:c1eebc71f36690e4523adca30314e927",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1655565135377,
+                "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
+                },
+                "assertionUrn": "urn:li:assertion:c1eebc71f36690e4523adca30314e927",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bf7fd2b46d2c32ee9bb036acd1559782",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:3191c2851901165afc07c3bd7f5f590a",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:c1eebc71f36690e4523adca30314e927",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:3191c2851901165afc07c3bd7f5f590a",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_.c6ec7f58f2",
+                    "dbt_test_upstream_unique_id": "model.jaffle_shop.customers",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
+                    "manifest_version": "1.1.0",
+                    "manifest_adapter": "bigquery",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.1.0"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD)",
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD),customer_id)"
+                    ],
+                    "aggregation": "IDENTITY",
+                    "operator": "_NATIVE_",
+                    "parameters": {
+                        "value": {
+                            "value": "null",
+                            "type": "SET"
+                        }
+                    },
+                    "nativeType": "relationships_orders_customer_id__customer_id__ref_customers_",
+                    "nativeParameters": {
+                        "to": "ref('customers')",
+                        "field": "customer_id",
+                        "column_name": "customer_id",
+                        "model": "{{ get_where_subquery(ref('orders')) }}"
+                    },
+                    "logic": "orders.customer_id referential integrity to customers.customer_id"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:c51ca9c4b5a1f964bef748f0b8968e71",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:3191c2851901165afc07c3bd7f5f590a",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1655565135510,
+                "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
+                },
+                "assertionUrn": "urn:li:assertion:3191c2851901165afc07c3bd7f5f590a",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ca065a99637630468f688717590beeab",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0331fa8a77015ca1a48d3a2fc90948fb",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:caa9b8060e214cecab88a92dc39c2e60",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0331fa8a77015ca1a48d3a2fc90948fb",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_.c6ec7f58f2",
+                    "dbt_test_upstream_unique_id": "model.jaffle_shop.orders",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
+                    "manifest_version": "1.1.0",
+                    "manifest_adapter": "bigquery",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.1.0"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),customer_id)"
+                    ],
+                    "aggregation": "IDENTITY",
+                    "operator": "_NATIVE_",
+                    "parameters": {
+                        "value": {
+                            "value": "null",
+                            "type": "SET"
+                        }
+                    },
+                    "nativeType": "relationships_orders_customer_id__customer_id__ref_customers_",
+                    "nativeParameters": {
+                        "to": "ref('customers')",
+                        "field": "customer_id",
+                        "column_name": "customer_id",
+                        "model": "{{ get_where_subquery(ref('orders')) }}"
+                    },
+                    "logic": "orders.customer_id referential integrity to customers.customer_id"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:da743330013b7e3e3707ac6e526ab408",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0331fa8a77015ca1a48d3a2fc90948fb",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1655565135510,
+                "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
+                },
+                "assertionUrn": "urn:li:assertion:0331fa8a77015ca1a48d3a2fc90948fb",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:fac27f352406b941125292413afa8096",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:c51ca9c4b5a1f964bef748f0b8968e71",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:c51ca9c4b5a1f964bef748f0b8968e71",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.jaffle_shop.unique_customers_customer_id.c5af1ff4b1",
+                    "dbt_test_upstream_unique_id": "model.jaffle_shop.customers",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
+                    "manifest_version": "1.1.0",
+                    "manifest_adapter": "bigquery",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.1.0"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD)",
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD),customer_id)"
+                    ],
+                    "aggregation": "UNIQUE_PROPOTION",
+                    "operator": "EQUAL_TO",
+                    "parameters": {
+                        "value": {
+                            "value": "1.0",
+                            "type": "NUMBER"
+                        }
+                    },
+                    "nativeType": "unique_customers_customer_id",
+                    "nativeParameters": {
+                        "column_name": "customer_id",
+                        "model": "{{ get_where_subquery(ref('customers')) }}"
+                    }
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:c51ca9c4b5a1f964bef748f0b8968e71",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1655565135836,
+                "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
+                },
+                "assertionUrn": "urn:li:assertion:c51ca9c4b5a1f964bef748f0b8968e71",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:caa9b8060e214cecab88a92dc39c2e60",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:caa9b8060e214cecab88a92dc39c2e60",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.jaffle_shop.unique_orders_order_id.fed79b3a6e",
+                    "dbt_test_upstream_unique_id": "model.jaffle_shop.orders",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
+                    "manifest_version": "1.1.0",
+                    "manifest_adapter": "bigquery",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.1.0"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),order_id)"
+                    ],
+                    "aggregation": "UNIQUE_PROPOTION",
+                    "operator": "EQUAL_TO",
+                    "parameters": {
+                        "value": {
+                            "value": "1.0",
+                            "type": "NUMBER"
+                        }
+                    },
+                    "nativeType": "unique_orders_order_id",
+                    "nativeParameters": {
+                        "column_name": "order_id",
+                        "model": "{{ get_where_subquery(ref('orders')) }}"
+                    }
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:caa9b8060e214cecab88a92dc39c2e60",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1655565136269,
+                "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
+                },
+                "assertionUrn": "urn:li:assertion:caa9b8060e214cecab88a92dc39c2e60",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:54bac90e6785bdefd8685ebf8814c429",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:54bac90e6785bdefd8685ebf8814c429",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.jaffle_shop.unique_stg_customers_customer_id.c7614daada",
+                    "dbt_test_upstream_unique_id": "model.jaffle_shop.stg_customers",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
+                    "manifest_version": "1.1.0",
+                    "manifest_adapter": "bigquery",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.1.0"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_customers,PROD)",
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_customers,PROD),customer_id)"
+                    ],
+                    "aggregation": "UNIQUE_PROPOTION",
+                    "operator": "EQUAL_TO",
+                    "parameters": {
+                        "value": {
+                            "value": "1.0",
+                            "type": "NUMBER"
+                        }
+                    },
+                    "nativeType": "unique_stg_customers_customer_id",
+                    "nativeParameters": {
+                        "column_name": "customer_id",
+                        "model": "{{ get_where_subquery(ref('stg_customers')) }}"
+                    }
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:54bac90e6785bdefd8685ebf8814c429",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1655565136230,
+                "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_customers,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
+                },
+                "assertionUrn": "urn:li:assertion:54bac90e6785bdefd8685ebf8814c429",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:815963e1332b46a203504ba46ebfab24",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:815963e1332b46a203504ba46ebfab24",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a",
+                    "dbt_test_upstream_unique_id": "model.jaffle_shop.stg_orders",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
+                    "manifest_version": "1.1.0",
+                    "manifest_adapter": "bigquery",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.1.0"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD)",
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD),order_id)"
+                    ],
+                    "aggregation": "UNIQUE_PROPOTION",
+                    "operator": "EQUAL_TO",
+                    "parameters": {
+                        "value": {
+                            "value": "1.0",
+                            "type": "NUMBER"
+                        }
+                    },
+                    "nativeType": "unique_stg_orders_order_id",
+                    "nativeParameters": {
+                        "column_name": "order_id",
+                        "model": "{{ get_where_subquery(ref('stg_orders')) }}"
+                    }
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:815963e1332b46a203504ba46ebfab24",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1655565136395,
+                "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
+                },
+                "assertionUrn": "urn:li:assertion:815963e1332b46a203504ba46ebfab24",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:fac27f352406b941125292413afa8096",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:fac27f352406b941125292413afa8096",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.jaffle_shop.unique_stg_payments_payment_id.3744510712",
+                    "dbt_test_upstream_unique_id": "model.jaffle_shop.stg_payments",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
+                    "manifest_version": "1.1.0",
+                    "manifest_adapter": "bigquery",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.1.0"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD)",
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD),payment_id)"
+                    ],
+                    "aggregation": "UNIQUE_PROPOTION",
+                    "operator": "EQUAL_TO",
+                    "parameters": {
+                        "value": {
+                            "value": "1.0",
+                            "type": "NUMBER"
+                        }
+                    },
+                    "nativeType": "unique_stg_payments_payment_id",
+                    "nativeParameters": {
+                        "column_name": "payment_id",
+                        "model": "{{ get_where_subquery(ref('stg_payments')) }}"
+                    }
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:fac27f352406b941125292413afa8096",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1655565136719,
+                "runId": "c7a6b778-0e0f-4789-b567-ca7e124a6840",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
+                },
+                "assertionUrn": "urn:li:assertion:fac27f352406b941125292413afa8096",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0331fa8a77015ca1a48d3a2fc90948fb",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:11087a3d7ae178df22c42922ac8ef8ad",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:1c217b7587a0cad47a07a09bfe154055",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:25ebf4faa9b1654ef54c46d975ca0a81",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:2887b9c826e0be6296a37833bdc380bd",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:2e9117138dcc9facda66f1efd55a8cd7",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:2ff754df689ea951ed2e12cbe356708f",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:3191c2851901165afc07c3bd7f5f590a",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:44519aa345bf3ea896179f9f352ae946",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:52d06197762e3608d94609e96f03a0a7",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:54bac90e6785bdefd8685ebf8814c429",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:591d8dc8939e0cf9bf0fd03264ad1a0e",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:7a305acc5fc049dc9bbd141b814461d0",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:815963e1332b46a203504ba46ebfab24",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b03abcc447aac70bbebb22a8a9d7dbbe",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b052a324c05327985f3b579a19ad7579",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b301bb47cc4ebce4e78a194b3de11f25",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bbd78a070092f54313153abec49f6f31",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bf7fd2b46d2c32ee9bb036acd1559782",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:c1eebc71f36690e4523adca30314e927",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:c51ca9c4b5a1f964bef748f0b8968e71",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ca065a99637630468f688717590beeab",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:caa9b8060e214cecab88a92dc39c2e60",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:da743330013b7e3e3707ac6e526ab408",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:fac27f352406b941125292413afa8096",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-2022_02_03-07_00_00",
+            "lastRunId": "no-run-id-provided"
+        }
     }
-}
 ]

--- a/metadata-ingestion/tests/integration/dbt/dbt_test_prefer_sql_parser_lineage_golden.json
+++ b/metadata-ingestion/tests/integration/dbt/dbt_test_prefer_sql_parser_lineage_golden.json
@@ -1,6545 +1,6685 @@
 [
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "model",
-                            "materialization": "ephemeral",
-                            "dbt_file_path": "models/transform/customer_details.sql",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.customer_details",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                            "manifest_version": "1.7.3",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.7.3"
-                        },
-                        "name": "customer_details",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.customer_details",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "INT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "full_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "VARCHAR",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "initial_full_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "VARCHAR",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "email",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "city",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "postal_code",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "phone",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),first_name)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),full_name)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),first_name)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),last_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),initial_full_name)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),email)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),email)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),address)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),city)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),city)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),postal_code)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),postal_code)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),phone)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),phone)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": false,
-                        "viewLogic": "{{ config(\n    materialized = \"ephemeral\",\n) }}\n\nSELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name as \"full_name\",\n    (\n        select cs.first_name || ' ' || cs.last_name\n        from {{ ref('customer_snapshot') }} cs where cs.customer_id = c.customer_id\n        order by dbt_valid_from desc\n        limit 1\n    ) as \"initial_full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\nFROM\n    {{ source('pagila', 'customer')}} c\n    left outer join {{ source('pagila', 'address')}} a on c.address_id = a.address_id\n    left outer join {{ source('pagila', 'city') }} m on a.city_id = m.city_id",
-                        "formattedViewLogic": "SELECT\n  c.customer_id,\n  c.first_name || ' ' || c.last_name AS \"full_name\",\n  (\n    SELECT\n      cs.first_name || ' ' || cs.last_name\n    FROM \"pagila\".\"public\".\"customer_snapshot\" AS cs\n    WHERE\n      cs.customer_id = c.customer_id\n    ORDER BY\n      dbt_valid_from DESC\n    LIMIT 1\n  ) AS \"initial_full_name\",\n  c.email,\n  a.address,\n  m.city,\n  a.postal_code,\n  a.phone\nFROM \"pagila\".\"public\".\"customer\" AS c\nLEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n  ON c.address_id = a.address_id\nLEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n  ON a.city_id = m.city_id",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "model",
-                            "materialization": "table",
-                            "dbt_file_path": "models/billing/monthly_billing_with_cust.sql",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.monthly_billing_with_cust",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                            "manifest_version": "1.7.3",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.7.3"
-                        },
-                        "name": "an-aliased-view-for-monthly-billing",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.monthly_billing_with_cust",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "billing_month",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "email",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payments_by_customer_by_month,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payments_by_customer_by_month,PROD),BillingMonth)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),billing_month)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payments_by_customer_by_month,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payments_by_customer_by_month,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),amount)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),email)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),email)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": true,
-                        "viewLogic": "{{ config(\n    materialized = \"table\",\n    alias='an-aliased-view-for-monthly-billing'\n) }}\n\nSELECT \n    pbc.\"BillingMonth\" as billing_month,\n    pbc.customer_id,\n    pbc.amount,\n    cust.email\nFROM\n    {{ ref('payments_by_customer_by_month')}} pbc\n    left outer join {{ ref('customer_details')}} cust on pbc.customer_id = cust.customer_id\nORDER BY\n    pbc.\"BillingMonth\"",
-                        "formattedViewLogic": "WITH __dbt__cte__customer_details AS (\n  SELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name AS \"full_name\",\n    (\n      SELECT\n        cs.first_name || ' ' || cs.last_name\n      FROM \"pagila\".\"public\".\"customer_snapshot\" AS cs\n      WHERE\n        cs.customer_id = c.customer_id\n      ORDER BY\n        dbt_valid_from DESC\n      LIMIT 1\n    ) AS \"initial_full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\n  FROM \"pagila\".\"public\".\"customer\" AS c\n  LEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n    ON c.address_id = a.address_id\n  LEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n    ON a.city_id = m.city_id\n)\nSELECT\n  pbc.\"BillingMonth\" AS billing_month,\n  pbc.customer_id,\n  pbc.amount,\n  cust.email\nFROM \"pagila\".\"public\".\"payments_by_customer_by_month\" AS pbc\nLEFT OUTER JOIN __dbt__cte__customer_details AS cust\n  ON pbc.customer_id = cust.customer_id\nORDER BY\n  pbc.\"BillingMonth\"",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:a42a5b1bee156e45972e12d4156fb7a2",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceProperties",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_name": "model.sample_dbt.monthly_billing_with_cust",
-                "dbt_urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)"
-            },
-            "name": "just-some-random-id_urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
-            "type": "BATCH_SCHEDULED",
-            "created": {
-                "time": 1663355198239,
-                "actor": "urn:li:corpuser:datahub"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:a42a5b1bee156e45972e12d4156fb7a2",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceRelationships",
-    "aspect": {
-        "json": {
-            "parentTemplate": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
-            "upstreamInstances": []
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:a42a5b1bee156e45972e12d4156fb7a2",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceInput",
-    "aspect": {
-        "json": {
-            "inputs": [
-                "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD)",
-                "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payments_by_customer_by_month,PROD)"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:a42a5b1bee156e45972e12d4156fb7a2",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceOutput",
-    "aspect": {
-        "json": {
-            "outputs": [
-                "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:a42a5b1bee156e45972e12d4156fb7a2",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1663355198239,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "status": "STARTED"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:a42a5b1bee156e45972e12d4156fb7a2",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1663355198241,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResultType": "success"
-            },
-            "durationMillis": 2
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "model",
-                            "materialization": "view",
-                            "dbt_file_path": "models/base/payments_base.sql",
-                            "catalog_type": "VIEW",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.payments_base",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                            "manifest_version": "1.7.3",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.7.3"
-                        },
-                        "name": "an_aliased_view_for_payments",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.payments_base",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),amount)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": false,
-                        "viewLogic": "{{ config(\n    materialized=\"view\",\n    alias='an_aliased_view_for_payments'\n) }}\n\nwith payments as (\n\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_01')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_03')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_04')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_05')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_06')}}\n)\n\nselect *\nfrom payments",
-                        "formattedViewLogic": "WITH payments AS (\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_01\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_03\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_04\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_05\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_06\"\n)\nSELECT\n  *\nFROM payments",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:fc6268f0be68fd04c310705b65efd6fe",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceProperties",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_name": "model.sample_dbt.payments_base",
-                "dbt_urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD)"
-            },
-            "name": "just-some-random-id_urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD)",
-            "type": "BATCH_SCHEDULED",
-            "created": {
-                "time": 1663355198239,
-                "actor": "urn:li:corpuser:datahub"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:fc6268f0be68fd04c310705b65efd6fe",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceRelationships",
-    "aspect": {
-        "json": {
-            "parentTemplate": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD)",
-            "upstreamInstances": []
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:fc6268f0be68fd04c310705b65efd6fe",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceInput",
-    "aspect": {
-        "json": {
-            "inputs": [
-                "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
-                "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
-                "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
-                "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
-                "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
-                "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:fc6268f0be68fd04c310705b65efd6fe",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceOutput",
-    "aspect": {
-        "json": {
-            "outputs": [
-                "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD)"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:fc6268f0be68fd04c310705b65efd6fe",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1663355198239,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "status": "STARTED"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:fc6268f0be68fd04c310705b65efd6fe",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1663355198241,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResultType": "success"
-            },
-            "durationMillis": 2
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "model",
-                            "materialization": "table",
-                            "dbt_file_path": "models/transform/payments_by_customer_by_month.sql",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.payments_by_customer_by_month",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                            "manifest_version": "1.7.3",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.7.3"
-                        },
-                        "name": "payments_by_customer_by_month",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.payments_by_customer_by_month",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "BillingMonth",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "model",
+                                "materialization": "ephemeral",
+                                "dbt_file_path": "models/transform/customer_details.sql",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.customer_details",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                                "manifest_version": "1.7.3",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.7.3"
                             },
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric",
-                                "recursive": false,
-                                "isPartOfKey": false
+                            "name": "customer_details",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.customer_details",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
                             },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "description": "description for customer_id from dbt",
-                                "type": {
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "globalTags": {
-                                    "tags": [
-                                        {
-                                            "tag": "urn:li:tag:dbt:tag_from_dbt"
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
                                         }
-                                    ]
+                                    },
+                                    "nativeDataType": "INT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD),BillingMonth)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD),amount)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": true,
-                        "viewLogic": "{{ config(\n    materialized = \"table\",\n) }}\n\nSELECT\n    date_trunc('month', payment_date) as \"BillingMonth\",\n    customer_id,\n    sum(amount) as \"amount\"\nFROM\n    {{ ref('payments_base')}}\nGROUP BY\n    \"BillingMonth\",\n    customer_id",
-                        "formattedViewLogic": "SELECT\n  DATE_TRUNC('MONTH', payment_date) AS \"BillingMonth\",\n  customer_id,\n  SUM(amount) AS \"amount\"\nFROM \"pagila\".\"public\".\"an_aliased_view_for_payments\"\nGROUP BY\n  \"BillingMonth\",\n  customer_id",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:57aa623f096cf3a28af70fe94b713907",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceProperties",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_name": "model.sample_dbt.payments_by_customer_by_month",
-                "dbt_urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD)"
-            },
-            "name": "just-some-random-id_urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD)",
-            "type": "BATCH_SCHEDULED",
-            "created": {
-                "time": 1663355198239,
-                "actor": "urn:li:corpuser:datahub"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:57aa623f096cf3a28af70fe94b713907",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceRelationships",
-    "aspect": {
-        "json": {
-            "parentTemplate": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD)",
-            "upstreamInstances": []
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:57aa623f096cf3a28af70fe94b713907",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceInput",
-    "aspect": {
-        "json": {
-            "inputs": [
-                "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD)"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:57aa623f096cf3a28af70fe94b713907",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceOutput",
-    "aspect": {
-        "json": {
-            "outputs": [
-                "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD)"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:57aa623f096cf3a28af70fe94b713907",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1663355198239,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "status": "STARTED"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:57aa623f096cf3a28af70fe94b713907",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1663355198241,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResultType": "success"
-            },
-            "durationMillis": 2
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Snapshot"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "snapshot",
-                            "materialization": "snapshot",
-                            "dbt_file_path": "snapshots/customer_snapshot.sql",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "snapshot.sample_dbt.customer_snapshot",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                            "manifest_version": "1.7.3",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.7.3"
-                        },
-                        "name": "customer_snapshot",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "snapshot.sample_dbt.customer_snapshot",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "active",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "full_name",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "VARCHAR",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "activebool",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "initial_full_name",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.BooleanType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "VARCHAR",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "boolean",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address_id",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "email",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "create_date",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "address",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.DateType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "date",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "city",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "dbt_scd_id",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "postal_code",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "dbt_updated_at",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "phone",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "dbt_valid_from",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "dbt_valid_to",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "email",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "first_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "store_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),active)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),active)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),activebool)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),activebool)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),address_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),address_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),create_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),create_date)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),email)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),email)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),first_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),first_name)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),last_name)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),last_update)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),store_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),store_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": true,
-                        "viewLogic": "\n\n{{\n    config(\n      target_database='pagila',\n      target_schema='public',\n      unique_key='customer_id',\n\n      strategy='timestamp',\n      updated_at='last_update',\n    )\n}}\n\nselect * from {{ source('pagila', 'customer') }}\n\n",
-                        "formattedViewLogic": "SELECT\n  *\nFROM \"pagila\".\"public\".\"customer\"",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:36225e795a4597b2376996774a803b0d",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceProperties",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_name": "snapshot.sample_dbt.customer_snapshot",
-                "dbt_urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD)"
-            },
-            "name": "just-some-random-id_urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD)",
-            "type": "BATCH_SCHEDULED",
-            "created": {
-                "time": 1663355198239,
-                "actor": "urn:li:corpuser:datahub"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:36225e795a4597b2376996774a803b0d",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceRelationships",
-    "aspect": {
-        "json": {
-            "parentTemplate": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD)",
-            "upstreamInstances": []
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:36225e795a4597b2376996774a803b0d",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceInput",
-    "aspect": {
-        "json": {
-            "inputs": [
-                "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:36225e795a4597b2376996774a803b0d",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceOutput",
-    "aspect": {
-        "json": {
-            "outputs": [
-                "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD)"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:36225e795a4597b2376996774a803b0d",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1663355198239,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "status": "STARTED"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:36225e795a4597b2376996774a803b0d",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1663355198241,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResultType": "success"
-            },
-            "durationMillis": 2
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "model_maturity": "in dev",
-                            "owner": "@alice",
-                            "some_other_property": "test 1",
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.actor",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                            "manifest_version": "1.7.3",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.7.3"
-                        },
-                        "name": "actor",
-                        "description": "description for actor table from dbt",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:@alice",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
                         }
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.actor",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1581759273000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "actor_id",
-                                "nullable": false,
-                                "description": "description for actor_id column from dbt",
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "first_name",
-                                "nullable": false,
-                                "description": "dbt comment: Actors column \u2013 from postgres\n\ndbt model description: description for first_name from dbt",
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_name",
-                                "nullable": false,
-                                "description": "description for last_name from dbt",
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "description": "description for last_update from dbt",
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
-                                "type": "COPY"
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.address",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                            "manifest_version": "1.7.3",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.7.3"
-                        },
-                        "name": "address",
-                        "description": "a user's address",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.address",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1581759930000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "address",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address2",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "city_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "district",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "phone",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "postal_code",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
-                                "type": "COPY"
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.category",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                            "manifest_version": "1.7.3",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.7.3"
-                        },
-                        "name": "category",
-                        "description": "a user's category",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.category",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1581759987000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "category_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
-                                "type": "COPY"
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.city",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                            "manifest_version": "1.7.3",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.7.3"
-                        },
-                        "name": "city",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.city",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1581759925000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "city",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "city_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "country_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
-                                "type": "COPY"
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "model_maturity": "in prod",
-                            "owner": "@bob",
-                            "some_other_property": "test 2",
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.country",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                            "manifest_version": "1.7.3",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.7.3"
-                        },
-                        "name": "country",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:@bob",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        }
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.country",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1581759840000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "country",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "country_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
-                                "type": "COPY"
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.customer",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                            "manifest_version": "1.7.3",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.7.3"
-                        },
-                        "name": "customer",
-                        "description": "description for customer table from dbt",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.customer",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1581760640000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "active",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "activebool",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.BooleanType": {}
-                                    }
-                                },
-                                "nativeDataType": "boolean",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "create_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.DateType": {}
-                                    }
-                                },
-                                "nativeDataType": "date",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "email",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "first_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "store_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
-                                "type": "COPY"
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                            "manifest_version": "1.7.3",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.7.3"
-                        },
-                        "name": "payment_p2020_01",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_01",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1580505371996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
-                                "type": "COPY"
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "an_array_property": "['alpha', 'beta', 'charlie']",
-                            "model_maturity": "in prod",
-                            "owner": "@charles",
-                            "some_other_property": "test 3",
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                            "manifest_version": "1.7.3",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.7.3"
-                        },
-                        "name": "payment_p2020_02",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:@charles",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        }
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_02",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1582319845996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
-                                "type": "COPY"
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                            "manifest_version": "1.7.3",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.7.3"
-                        },
-                        "name": "payment_p2020_03",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_03",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1584998318996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
-                                "type": "COPY"
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                            "manifest_version": "1.7.3",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.7.3"
-                        },
-                        "name": "payment_p2020_04",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_04",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1588287228996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
-                                "type": "COPY"
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                            "manifest_version": "1.7.3",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.7.3"
-                        },
-                        "name": "payment_p2020_05",
-                        "description": "a payment",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_05",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1589460269996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
-                                "type": "COPY"
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                            "manifest_version": "1.7.3",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.7.3"
-                        },
-                        "name": "payment_p2020_06",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_06",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": -62135596800000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
-                                "type": "COPY"
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
-                "value": {
-                    "auditStamp": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
                     },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),first_name)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),full_name)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),first_name)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),last_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),initial_full_name)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),email)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),email)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),address)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),city)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),city)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),postal_code)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),postal_code)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),phone)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),phone)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": false,
+                            "viewLogic": "{{ config(\n    materialized = \"ephemeral\",\n) }}\n\nSELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name as \"full_name\",\n    (\n        select cs.first_name || ' ' || cs.last_name\n        from {{ ref('customer_snapshot') }} cs where cs.customer_id = c.customer_id\n        order by dbt_valid_from desc\n        limit 1\n    ) as \"initial_full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\nFROM\n    {{ source('pagila', 'customer')}} c\n    left outer join {{ source('pagila', 'address')}} a on c.address_id = a.address_id\n    left outer join {{ source('pagila', 'city') }} m on a.city_id = m.city_id",
+                            "formattedViewLogic": "SELECT\n  c.customer_id,\n  c.first_name || ' ' || c.last_name AS \"full_name\",\n  (\n    SELECT\n      cs.first_name || ' ' || cs.last_name\n    FROM \"pagila\".\"public\".\"customer_snapshot\" AS cs\n    WHERE\n      cs.customer_id = c.customer_id\n    ORDER BY\n      dbt_valid_from DESC\n    LIMIT 1\n  ) AS \"initial_full_name\",\n  c.email,\n  a.address,\n  m.city,\n  a.postal_code,\n  a.phone\nFROM \"pagila\".\"public\".\"customer\" AS c\nLEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n  ON c.address_id = a.address_id\nLEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n  ON a.city_id = m.city_id",
+                            "viewLanguage": "SQL"
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "model",
+                                "materialization": "table",
+                                "dbt_file_path": "models/billing/monthly_billing_with_cust.sql",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.monthly_billing_with_cust",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                                "manifest_version": "1.7.3",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.7.3"
+                            },
+                            "name": "an-aliased-view-for-monthly-billing",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.monthly_billing_with_cust",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "billing_month",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "email",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payments_by_customer_by_month,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payments_by_customer_by_month,PROD),BillingMonth)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),billing_month)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payments_by_customer_by_month,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payments_by_customer_by_month,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),email)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),email)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": true,
+                            "viewLogic": "{{ config(\n    materialized = \"table\",\n    alias='an-aliased-view-for-monthly-billing'\n) }}\n\nSELECT \n    pbc.\"BillingMonth\" as billing_month,\n    pbc.customer_id,\n    pbc.amount,\n    cust.email\nFROM\n    {{ ref('payments_by_customer_by_month')}} pbc\n    left outer join {{ ref('customer_details')}} cust on pbc.customer_id = cust.customer_id\nORDER BY\n    pbc.\"BillingMonth\"",
+                            "formattedViewLogic": "WITH __dbt__cte__customer_details AS (\n  SELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name AS \"full_name\",\n    (\n      SELECT\n        cs.first_name || ' ' || cs.last_name\n      FROM \"pagila\".\"public\".\"customer_snapshot\" AS cs\n      WHERE\n        cs.customer_id = c.customer_id\n      ORDER BY\n        dbt_valid_from DESC\n      LIMIT 1\n    ) AS \"initial_full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\n  FROM \"pagila\".\"public\".\"customer\" AS c\n  LEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n    ON c.address_id = a.address_id\n  LEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n    ON a.city_id = m.city_id\n)\nSELECT\n  pbc.\"BillingMonth\" AS billing_month,\n  pbc.customer_id,\n  pbc.amount,\n  cust.email\nFROM \"pagila\".\"public\".\"payments_by_customer_by_month\" AS pbc\nLEFT OUTER JOIN __dbt__cte__customer_details AS cust\n  ON pbc.customer_id = cust.customer_id\nORDER BY\n  pbc.\"BillingMonth\"",
+                            "viewLanguage": "SQL"
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:a42a5b1bee156e45972e12d4156fb7a2",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceProperties",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_name": "model.sample_dbt.monthly_billing_with_cust",
+                    "dbt_urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)"
+                },
+                "name": "just-some-random-id_urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
+                "type": "BATCH_SCHEDULED",
+                "created": {
+                    "time": 1663355198239,
+                    "actor": "urn:li:corpuser:datahub"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:a42a5b1bee156e45972e12d4156fb7a2",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceRelationships",
+        "aspect": {
+            "json": {
+                "parentTemplate": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
+                "upstreamInstances": []
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:a42a5b1bee156e45972e12d4156fb7a2",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceInput",
+        "aspect": {
+            "json": {
+                "inputs": [
+                    "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD)",
+                    "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payments_by_customer_by_month,PROD)"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:a42a5b1bee156e45972e12d4156fb7a2",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceOutput",
+        "aspect": {
+            "json": {
+                "outputs": [
+                    "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:a42a5b1bee156e45972e12d4156fb7a2",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1663355198239,
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                },
+                "status": "STARTED"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:a42a5b1bee156e45972e12d4156fb7a2",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1663355198241,
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                },
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResultType": "success"
+                },
+                "durationMillis": 2
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "model",
+                                "materialization": "view",
+                                "dbt_file_path": "models/base/payments_base.sql",
+                                "catalog_type": "VIEW",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.payments_base",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                                "manifest_version": "1.7.3",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.7.3"
+                            },
+                            "name": "an_aliased_view_for_payments",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.payments_base",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": false,
+                            "viewLogic": "{{ config(\n    materialized=\"view\",\n    alias='an_aliased_view_for_payments'\n) }}\n\nwith payments as (\n\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_01')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_03')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_04')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_05')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_06')}}\n)\n\nselect *\nfrom payments",
+                            "formattedViewLogic": "WITH payments AS (\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_01\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_03\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_04\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_05\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_06\"\n)\nSELECT\n  *\nFROM payments",
+                            "viewLanguage": "SQL"
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:fc6268f0be68fd04c310705b65efd6fe",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceProperties",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_name": "model.sample_dbt.payments_base",
+                    "dbt_urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD)"
+                },
+                "name": "just-some-random-id_urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD)",
+                "type": "BATCH_SCHEDULED",
+                "created": {
+                    "time": 1663355198239,
+                    "actor": "urn:li:corpuser:datahub"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:fc6268f0be68fd04c310705b65efd6fe",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceRelationships",
+        "aspect": {
+            "json": {
+                "parentTemplate": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD)",
+                "upstreamInstances": []
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:fc6268f0be68fd04c310705b65efd6fe",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceInput",
+        "aspect": {
+            "json": {
+                "inputs": [
+                    "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
+                    "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
+                    "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
+                    "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
+                    "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
+                    "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:fc6268f0be68fd04c310705b65efd6fe",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceOutput",
+        "aspect": {
+            "json": {
+                "outputs": [
+                    "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD)"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:fc6268f0be68fd04c310705b65efd6fe",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1663355198239,
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                },
+                "status": "STARTED"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:fc6268f0be68fd04c310705b65efd6fe",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1663355198241,
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                },
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResultType": "success"
+                },
+                "durationMillis": 2
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "model",
+                                "materialization": "table",
+                                "dbt_file_path": "models/transform/payments_by_customer_by_month.sql",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.payments_by_customer_by_month",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                                "manifest_version": "1.7.3",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.7.3"
+                            },
+                            "name": "payments_by_customer_by_month",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.payments_by_customer_by_month",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "BillingMonth",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "description": "description for customer_id from dbt",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "globalTags": {
+                                        "tags": [
+                                            {
+                                                "tag": "urn:li:tag:dbt:tag_from_dbt"
+                                            }
+                                        ]
+                                    },
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD),BillingMonth)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": true,
+                            "viewLogic": "{{ config(\n    materialized = \"table\",\n) }}\n\nSELECT\n    date_trunc('month', payment_date) as \"BillingMonth\",\n    customer_id,\n    sum(amount) as \"amount\"\nFROM\n    {{ ref('payments_base')}}\nGROUP BY\n    \"BillingMonth\",\n    customer_id",
+                            "formattedViewLogic": "SELECT\n  DATE_TRUNC('MONTH', payment_date) AS \"BillingMonth\",\n  customer_id,\n  SUM(amount) AS \"amount\"\nFROM \"pagila\".\"public\".\"an_aliased_view_for_payments\"\nGROUP BY\n  \"BillingMonth\",\n  customer_id",
+                            "viewLanguage": "SQL"
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:57aa623f096cf3a28af70fe94b713907",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceProperties",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_name": "model.sample_dbt.payments_by_customer_by_month",
+                    "dbt_urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD)"
+                },
+                "name": "just-some-random-id_urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD)",
+                "type": "BATCH_SCHEDULED",
+                "created": {
+                    "time": 1663355198239,
+                    "actor": "urn:li:corpuser:datahub"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:57aa623f096cf3a28af70fe94b713907",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceRelationships",
+        "aspect": {
+            "json": {
+                "parentTemplate": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD)",
+                "upstreamInstances": []
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:57aa623f096cf3a28af70fe94b713907",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceInput",
+        "aspect": {
+            "json": {
+                "inputs": [
+                    "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD)"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:57aa623f096cf3a28af70fe94b713907",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceOutput",
+        "aspect": {
+            "json": {
+                "outputs": [
+                    "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD)"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:57aa623f096cf3a28af70fe94b713907",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1663355198239,
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                },
+                "status": "STARTED"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:57aa623f096cf3a28af70fe94b713907",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1663355198241,
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                },
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResultType": "success"
+                },
+                "durationMillis": 2
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Snapshot"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "snapshot",
+                                "materialization": "snapshot",
+                                "dbt_file_path": "snapshots/customer_snapshot.sql",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "snapshot.sample_dbt.customer_snapshot",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                                "manifest_version": "1.7.3",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.7.3"
+                            },
+                            "name": "customer_snapshot",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "snapshot.sample_dbt.customer_snapshot",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "active",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "activebool",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.BooleanType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "boolean",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "address_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "create_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.DateType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "date",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "dbt_scd_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "dbt_updated_at",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "dbt_valid_from",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "dbt_valid_to",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "email",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "first_name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "store_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),active)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),active)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),activebool)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),activebool)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),address_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),address_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),create_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),create_date)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),email)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),email)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),first_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),first_name)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),last_name)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),store_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),store_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": true,
+                            "viewLogic": "\n\n{{\n    config(\n      target_database='pagila',\n      target_schema='public',\n      unique_key='customer_id',\n\n      strategy='timestamp',\n      updated_at='last_update',\n    )\n}}\n\nselect * from {{ source('pagila', 'customer') }}\n\n",
+                            "formattedViewLogic": "SELECT\n  *\nFROM \"pagila\".\"public\".\"customer\"",
+                            "viewLanguage": "SQL"
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:36225e795a4597b2376996774a803b0d",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceProperties",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_name": "snapshot.sample_dbt.customer_snapshot",
+                    "dbt_urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD)"
+                },
+                "name": "just-some-random-id_urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD)",
+                "type": "BATCH_SCHEDULED",
+                "created": {
+                    "time": 1663355198239,
+                    "actor": "urn:li:corpuser:datahub"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:36225e795a4597b2376996774a803b0d",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceRelationships",
+        "aspect": {
+            "json": {
+                "parentTemplate": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD)",
+                "upstreamInstances": []
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:36225e795a4597b2376996774a803b0d",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceInput",
+        "aspect": {
+            "json": {
+                "inputs": [
+                    "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:36225e795a4597b2376996774a803b0d",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceOutput",
+        "aspect": {
+            "json": {
+                "outputs": [
+                    "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD)"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:36225e795a4597b2376996774a803b0d",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1663355198239,
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                },
+                "status": "STARTED"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:36225e795a4597b2376996774a803b0d",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1663355198241,
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                },
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResultType": "success"
+                },
+                "durationMillis": 2
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "model_maturity": "in dev",
+                                "owner": "@alice",
+                                "some_other_property": "test 1",
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.actor",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                                "manifest_version": "1.7.3",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.7.3"
+                            },
+                            "name": "actor",
+                            "description": "description for actor table from dbt",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:@alice",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.actor",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1581759273000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "actor_id",
+                                    "nullable": false,
+                                    "description": "description for actor_id column from dbt",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "first_name",
+                                    "nullable": false,
+                                    "description": "dbt comment: Actors column \u2013 from postgres\n\ndbt model description: description for first_name from dbt",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_name",
+                                    "nullable": false,
+                                    "description": "description for last_name from dbt",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "description": "description for last_update from dbt",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
+                                    "type": "COPY"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.address",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                                "manifest_version": "1.7.3",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.7.3"
+                            },
+                            "name": "address",
+                            "description": "a user's address",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.address",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1581759930000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "address",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "address2",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "address_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "city_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "district",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "phone",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "postal_code",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
+                                    "type": "COPY"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.category",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                                "manifest_version": "1.7.3",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.7.3"
+                            },
+                            "name": "category",
+                            "description": "a user's category",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.category",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1581759987000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "category_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
+                                    "type": "COPY"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.city",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                                "manifest_version": "1.7.3",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.7.3"
+                            },
+                            "name": "city",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.city",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1581759925000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "city",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "city_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "country_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
+                                    "type": "COPY"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "model_maturity": "in prod",
+                                "owner": "@bob",
+                                "some_other_property": "test 2",
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.country",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                                "manifest_version": "1.7.3",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.7.3"
+                            },
+                            "name": "country",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:@bob",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.country",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1581759840000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "country",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "country_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
+                                    "type": "COPY"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.customer",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                                "manifest_version": "1.7.3",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.7.3"
+                            },
+                            "name": "customer",
+                            "description": "description for customer table from dbt",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.customer",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1581760640000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "active",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "activebool",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.BooleanType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "boolean",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "address_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "create_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.DateType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "date",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "email",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "first_name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "store_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
+                                    "type": "COPY"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                                "manifest_version": "1.7.3",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.7.3"
+                            },
+                            "name": "payment_p2020_01",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_01",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1580505371996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
+                                    "type": "COPY"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "an_array_property": "['alpha', 'beta', 'charlie']",
+                                "model_maturity": "in prod",
+                                "owner": "@charles",
+                                "some_other_property": "test 3",
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                                "manifest_version": "1.7.3",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.7.3"
+                            },
+                            "name": "payment_p2020_02",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:@charles",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_02",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1582319845996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
+                                    "type": "COPY"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                                "manifest_version": "1.7.3",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.7.3"
+                            },
+                            "name": "payment_p2020_03",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_03",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1584998318996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
+                                    "type": "COPY"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                                "manifest_version": "1.7.3",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.7.3"
+                            },
+                            "name": "payment_p2020_04",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_04",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1588287228996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
+                                    "type": "COPY"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                                "manifest_version": "1.7.3",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.7.3"
+                            },
+                            "name": "payment_p2020_05",
+                            "description": "a payment",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_05",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1589460269996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
+                                    "type": "COPY"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                                "manifest_version": "1.7.3",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.7.3"
+                            },
+                            "name": "payment_p2020_06",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_06",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": -62135596800000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
+                                    "type": "COPY"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
+                    "value": {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
+                        "type": "COPY"
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an-aliased-view-for-monthly-billing,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),amount)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an-aliased-view-for-monthly-billing,PROD),billing_month)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),billing_month)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an-aliased-view-for-monthly-billing,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),customer_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an-aliased-view-for-monthly-billing,PROD),email)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),email)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD)",
+                    "value": {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD)",
+                        "type": "COPY"
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),amount)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),customer_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD),payment_date)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),payment_date)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD),payment_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),payment_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD),rental_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),rental_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD),staff_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),staff_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payments_by_customer_by_month,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD)",
+                    "value": {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD)",
+                        "type": "COPY"
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payments_by_customer_by_month,PROD),BillingMonth)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD),BillingMonth)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payments_by_customer_by_month,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD),amount)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payments_by_customer_by_month,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD),customer_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD)",
+                    "value": {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD)",
+                        "type": "COPY"
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),active)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),active)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),activebool)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),activebool)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),address_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),address_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),create_date)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),create_date)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),customer_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),dbt_scd_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),dbt_scd_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),dbt_updated_at)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),dbt_updated_at)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),dbt_valid_from)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),dbt_valid_from)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),dbt_valid_to)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),dbt_valid_to)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),email)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),email)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),first_name)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),first_name)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),last_name)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),last_name)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),last_update)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),last_update)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),store_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),store_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ba2c6ba830d407d539452f4cf46c92a6",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ba2c6ba830d407d539452f4cf46c92a6",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.sample_dbt.assert_source_actor_last_update_is_recent",
+                    "dbt_test_upstream_unique_id": "source.sample_dbt.pagila.actor",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+                    "scope": "DATASET_ROWS",
+                    "aggregation": "_NATIVE_",
+                    "operator": "_NATIVE_",
+                    "nativeType": "assert_source_actor_last_update_is_recent",
+                    "nativeParameters": {},
+                    "logic": "select\n    *\nfrom \"pagila\".\"public\".\"actor\"\nwhere last_update < (now() - interval '100 years')"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ba2c6ba830d407d539452f4cf46c92a6",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1663355198239,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
+                },
+                "assertionUrn": "urn:li:assertion:ba2c6ba830d407d539452f4cf46c92a6",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:10f2a119dedcaab43afc47ff13d9cb5b",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:10f2a119dedcaab43afc47ff13d9cb5b",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.sample_dbt.is_email_monthly_billing_with_cust_email.57a935ce99",
+                    "dbt_test_upstream_unique_id": "model.sample_dbt.monthly_billing_with_cust",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
                     "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
-                    "type": "COPY"
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an-aliased-view-for-monthly-billing,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),amount)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an-aliased-view-for-monthly-billing,PROD),billing_month)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),billing_month)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an-aliased-view-for-monthly-billing,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),customer_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an-aliased-view-for-monthly-billing,PROD),email)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),email)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD)",
-                "value": {
-                    "auditStamp": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),email)"
+                    ],
+                    "aggregation": "_NATIVE_",
+                    "operator": "_NATIVE_",
+                    "nativeType": "is_email_monthly_billing_with_cust_email",
+                    "nativeParameters": {
+                        "column_name": "email",
+                        "model": "{{ get_where_subquery(ref('monthly_billing_with_cust')) }}"
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD)",
-                    "type": "COPY"
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),amount)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),customer_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD),payment_date)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),payment_date)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD),payment_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),payment_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD),rental_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),rental_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD),staff_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),staff_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payments_by_customer_by_month,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD)",
-                "value": {
-                    "auditStamp": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
-                    },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD)",
-                    "type": "COPY"
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payments_by_customer_by_month,PROD),BillingMonth)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD),BillingMonth)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payments_by_customer_by_month,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD),amount)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payments_by_customer_by_month,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD),customer_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD)",
-                "value": {
-                    "auditStamp": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
-                    },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD)",
-                    "type": "COPY"
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),active)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),active)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),activebool)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),activebool)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),address_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),address_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),create_date)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),create_date)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),customer_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),dbt_scd_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),dbt_scd_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),dbt_updated_at)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),dbt_updated_at)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),dbt_valid_from)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),dbt_valid_from)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),dbt_valid_to)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),dbt_valid_to)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),email)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),email)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),first_name)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),first_name)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),last_name)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),last_name)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),last_update)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),last_update)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),store_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),store_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ba2c6ba830d407d539452f4cf46c92a6",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ba2c6ba830d407d539452f4cf46c92a6",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.sample_dbt.assert_source_actor_last_update_is_recent",
-                "dbt_test_upstream_unique_id": "source.sample_dbt.pagila.actor",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-                "scope": "DATASET_ROWS",
-                "aggregation": "_NATIVE_",
-                "operator": "_NATIVE_",
-                "nativeType": "assert_source_actor_last_update_is_recent",
-                "nativeParameters": {},
-                "logic": "select\n    *\nfrom \"pagila\".\"public\".\"actor\"\nwhere last_update < (now() - interval '100 years')"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ba2c6ba830d407d539452f4cf46c92a6",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1663355198239,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:ba2c6ba830d407d539452f4cf46c92a6",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:10f2a119dedcaab43afc47ff13d9cb5b",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:10f2a119dedcaab43afc47ff13d9cb5b",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.sample_dbt.is_email_monthly_billing_with_cust_email.57a935ce99",
-                "dbt_test_upstream_unique_id": "model.sample_dbt.monthly_billing_with_cust",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),email)"
-                ],
-                "aggregation": "_NATIVE_",
-                "operator": "_NATIVE_",
-                "nativeType": "is_email_monthly_billing_with_cust_email",
-                "nativeParameters": {
-                    "column_name": "email",
-                    "model": "{{ get_where_subquery(ref('monthly_billing_with_cust')) }}"
+                    "logic": "\n\n    select *\n    from \"pagila\".\"public\".\"an-aliased-view-for-monthly-billing\"\n    where email not like '%@%'\n\n"
                 },
-                "logic": "\n\n    select *\n    from \"pagila\".\"public\".\"an-aliased-view-for-monthly-billing\"\n    where email not like '%@%'\n\n"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:10f2a119dedcaab43afc47ff13d9cb5b",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1663355198239,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:10f2a119dedcaab43afc47ff13d9cb5b",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:c456eccf6440c6e3388c584689a74d91",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:c456eccf6440c6e3388c584689a74d91",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.sample_dbt.not_null_monthly_billing_with_cust_billing_month.19ce54289b",
-                "dbt_test_upstream_unique_id": "model.sample_dbt.monthly_billing_with_cust",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),billing_month)"
-                ],
-                "aggregation": "IDENTITY",
-                "operator": "NOT_NULL",
-                "nativeType": "not_null_monthly_billing_with_cust_billing_month",
-                "nativeParameters": {
-                    "column_name": "billing_month",
-                    "model": "{{ get_where_subquery(ref('monthly_billing_with_cust')) }}"
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:c456eccf6440c6e3388c584689a74d91",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1663355198239,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:c456eccf6440c6e3388c584689a74d91",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:f812b73477d81e6af283d918cb59e7bf",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:f812b73477d81e6af283d918cb59e7bf",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.sample_dbt.not_null_monthly_billing_with_cust_email.d405c2cc13",
-                "dbt_test_upstream_unique_id": "model.sample_dbt.monthly_billing_with_cust",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),email)"
-                ],
-                "aggregation": "IDENTITY",
-                "operator": "NOT_NULL",
-                "nativeType": "not_null_monthly_billing_with_cust_email",
-                "nativeParameters": {
-                    "column_name": "email",
-                    "model": "{{ get_where_subquery(ref('monthly_billing_with_cust')) }}"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:10f2a119dedcaab43afc47ff13d9cb5b",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1663355198239,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
+                },
+                "assertionUrn": "urn:li:assertion:10f2a119dedcaab43afc47ff13d9cb5b",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:f812b73477d81e6af283d918cb59e7bf",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1663355198239,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:f812b73477d81e6af283d918cb59e7bf",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:c456eccf6440c6e3388c584689a74d91",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:1f37cbfd95ea2a1d46b8e94828805eb1",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:1f37cbfd95ea2a1d46b8e94828805eb1",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.sample_dbt.relationships_monthly_billing_with_cust_customer_id__customer_id__ref_customer_details_.653e08a90b",
-                "dbt_test_upstream_unique_id": "model.sample_dbt.customer_details",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),customer_id)"
-                ],
-                "aggregation": "IDENTITY",
-                "operator": "_NATIVE_",
-                "parameters": {
-                    "value": {
-                        "value": "null",
-                        "type": "SET"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:c456eccf6440c6e3388c584689a74d91",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.sample_dbt.not_null_monthly_billing_with_cust_billing_month.19ce54289b",
+                    "dbt_test_upstream_unique_id": "model.sample_dbt.monthly_billing_with_cust",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),billing_month)"
+                    ],
+                    "aggregation": "IDENTITY",
+                    "operator": "NOT_NULL",
+                    "nativeType": "not_null_monthly_billing_with_cust_billing_month",
+                    "nativeParameters": {
+                        "column_name": "billing_month",
+                        "model": "{{ get_where_subquery(ref('monthly_billing_with_cust')) }}"
                     }
                 },
-                "nativeType": "relationships_monthly_billing_with_cust_customer_id__customer_id__ref_customer_details_",
-                "nativeParameters": {
-                    "column_name": "customer_id",
-                    "field": "customer_id",
-                    "model": "{{ get_where_subquery(ref('monthly_billing_with_cust')) }}",
-                    "to": "ref('customer_details')"
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:c456eccf6440c6e3388c584689a74d91",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1663355198239,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
                 },
-                "logic": "monthly_billing_with_cust.customer_id referential integrity to customer_details.customer_id"
+                "assertionUrn": "urn:li:assertion:c456eccf6440c6e3388c584689a74d91",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:1f37cbfd95ea2a1d46b8e94828805eb1",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1663355198239,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:1f37cbfd95ea2a1d46b8e94828805eb1",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:f812b73477d81e6af283d918cb59e7bf",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:f3a0dbf71b6cbf7112ff44925f475ff5",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:f3a0dbf71b6cbf7112ff44925f475ff5",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.sample_dbt.relationships_monthly_billing_with_cust_customer_id__customer_id__ref_customer_details_.653e08a90b",
-                "dbt_test_upstream_unique_id": "model.sample_dbt.monthly_billing_with_cust",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),customer_id)"
-                ],
-                "aggregation": "IDENTITY",
-                "operator": "_NATIVE_",
-                "parameters": {
-                    "value": {
-                        "value": "null",
-                        "type": "SET"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:f812b73477d81e6af283d918cb59e7bf",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.sample_dbt.not_null_monthly_billing_with_cust_email.d405c2cc13",
+                    "dbt_test_upstream_unique_id": "model.sample_dbt.monthly_billing_with_cust",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),email)"
+                    ],
+                    "aggregation": "IDENTITY",
+                    "operator": "NOT_NULL",
+                    "nativeType": "not_null_monthly_billing_with_cust_email",
+                    "nativeParameters": {
+                        "column_name": "email",
+                        "model": "{{ get_where_subquery(ref('monthly_billing_with_cust')) }}"
                     }
                 },
-                "nativeType": "relationships_monthly_billing_with_cust_customer_id__customer_id__ref_customer_details_",
-                "nativeParameters": {
-                    "column_name": "customer_id",
-                    "field": "customer_id",
-                    "model": "{{ get_where_subquery(ref('monthly_billing_with_cust')) }}",
-                    "to": "ref('customer_details')"
-                },
-                "logic": "monthly_billing_with_cust.customer_id referential integrity to customer_details.customer_id"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:f3a0dbf71b6cbf7112ff44925f475ff5",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1663355198239,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:f3a0dbf71b6cbf7112ff44925f475ff5",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:f6a1fde3ab4919abcc04bdee93144958",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:f6a1fde3ab4919abcc04bdee93144958",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.sample_dbt.source_not_null_pagila_actor_actor_id.ad63829d3e",
-                "dbt_test_upstream_unique_id": "source.sample_dbt.pagila.actor",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),actor_id)"
-                ],
-                "aggregation": "IDENTITY",
-                "operator": "NOT_NULL",
-                "nativeType": "source_not_null_pagila_actor_actor_id",
-                "nativeParameters": {
-                    "column_name": "actor_id",
-                    "model": "{{ get_where_subquery(source('pagila', 'actor')) }}"
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:f6a1fde3ab4919abcc04bdee93144958",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1663355198239,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:f6a1fde3ab4919abcc04bdee93144958",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:f812b73477d81e6af283d918cb59e7bf",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1663355198239,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
+                },
+                "assertionUrn": "urn:li:assertion:f812b73477d81e6af283d918cb59e7bf",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:60ce4aad7ff6dbff7004da0f2258c9df",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:1f37cbfd95ea2a1d46b8e94828805eb1",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:60ce4aad7ff6dbff7004da0f2258c9df",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.sample_dbt.source_unique_pagila_actor_actor_id.76aff1935a",
-                "dbt_test_upstream_unique_id": "source.sample_dbt.pagila.actor",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),actor_id)"
-                ],
-                "aggregation": "UNIQUE_PROPOTION",
-                "operator": "EQUAL_TO",
-                "parameters": {
-                    "value": {
-                        "value": "1.0",
-                        "type": "NUMBER"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:1f37cbfd95ea2a1d46b8e94828805eb1",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.sample_dbt.relationships_monthly_billing_with_cust_customer_id__customer_id__ref_customer_details_.653e08a90b",
+                    "dbt_test_upstream_unique_id": "model.sample_dbt.customer_details",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD)",
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),customer_id)"
+                    ],
+                    "aggregation": "IDENTITY",
+                    "operator": "_NATIVE_",
+                    "parameters": {
+                        "value": {
+                            "value": "null",
+                            "type": "SET"
+                        }
+                    },
+                    "nativeType": "relationships_monthly_billing_with_cust_customer_id__customer_id__ref_customer_details_",
+                    "nativeParameters": {
+                        "column_name": "customer_id",
+                        "field": "customer_id",
+                        "model": "{{ get_where_subquery(ref('monthly_billing_with_cust')) }}",
+                        "to": "ref('customer_details')"
+                    },
+                    "logic": "monthly_billing_with_cust.customer_id referential integrity to customer_details.customer_id"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:1f37cbfd95ea2a1d46b8e94828805eb1",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1663355198239,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
+                },
+                "assertionUrn": "urn:li:assertion:1f37cbfd95ea2a1d46b8e94828805eb1",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:f3a0dbf71b6cbf7112ff44925f475ff5",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:f3a0dbf71b6cbf7112ff44925f475ff5",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.sample_dbt.relationships_monthly_billing_with_cust_customer_id__customer_id__ref_customer_details_.653e08a90b",
+                    "dbt_test_upstream_unique_id": "model.sample_dbt.monthly_billing_with_cust",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),customer_id)"
+                    ],
+                    "aggregation": "IDENTITY",
+                    "operator": "_NATIVE_",
+                    "parameters": {
+                        "value": {
+                            "value": "null",
+                            "type": "SET"
+                        }
+                    },
+                    "nativeType": "relationships_monthly_billing_with_cust_customer_id__customer_id__ref_customer_details_",
+                    "nativeParameters": {
+                        "column_name": "customer_id",
+                        "field": "customer_id",
+                        "model": "{{ get_where_subquery(ref('monthly_billing_with_cust')) }}",
+                        "to": "ref('customer_details')"
+                    },
+                    "logic": "monthly_billing_with_cust.customer_id referential integrity to customer_details.customer_id"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:f3a0dbf71b6cbf7112ff44925f475ff5",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1663355198239,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
+                },
+                "assertionUrn": "urn:li:assertion:f3a0dbf71b6cbf7112ff44925f475ff5",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:f6a1fde3ab4919abcc04bdee93144958",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:f6a1fde3ab4919abcc04bdee93144958",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.sample_dbt.source_not_null_pagila_actor_actor_id.ad63829d3e",
+                    "dbt_test_upstream_unique_id": "source.sample_dbt.pagila.actor",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),actor_id)"
+                    ],
+                    "aggregation": "IDENTITY",
+                    "operator": "NOT_NULL",
+                    "nativeType": "source_not_null_pagila_actor_actor_id",
+                    "nativeParameters": {
+                        "column_name": "actor_id",
+                        "model": "{{ get_where_subquery(source('pagila', 'actor')) }}"
                     }
                 },
-                "nativeType": "source_unique_pagila_actor_actor_id",
-                "nativeParameters": {
-                    "column_name": "actor_id",
-                    "model": "{{ get_where_subquery(source('pagila', 'actor')) }}"
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:60ce4aad7ff6dbff7004da0f2258c9df",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1663355198239,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:60ce4aad7ff6dbff7004da0f2258c9df",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.actor",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-15T09:34:33+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:f6a1fde3ab4919abcc04bdee93144958",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1663355198239,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
+                },
+                "assertionUrn": "urn:li:assertion:f6a1fde3ab4919abcc04bdee93144958",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
-            },
-            "assertionUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.address",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:60ce4aad7ff6dbff7004da0f2258c9df",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-15T09:45:30+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:60ce4aad7ff6dbff7004da0f2258c9df",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.sample_dbt.source_unique_pagila_actor_actor_id.76aff1935a",
+                    "dbt_test_upstream_unique_id": "source.sample_dbt.pagila.actor",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),actor_id)"
+                    ],
+                    "aggregation": "UNIQUE_PROPOTION",
+                    "operator": "EQUAL_TO",
+                    "parameters": {
+                        "value": {
+                            "value": "1.0",
+                            "type": "NUMBER"
+                        }
+                    },
+                    "nativeType": "source_unique_pagila_actor_actor_id",
+                    "nativeParameters": {
+                        "column_name": "actor_id",
+                        "model": "{{ get_where_subquery(source('pagila', 'actor')) }}"
+                    }
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
-            },
-            "assertionUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.category",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-15T09:46:27+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:60ce4aad7ff6dbff7004da0f2258c9df",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1663355198239,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
+                },
+                "assertionUrn": "urn:li:assertion:60ce4aad7ff6dbff7004da0f2258c9df",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
-            },
-            "assertionUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.city",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-15T09:45:25+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.actor",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
-            },
-            "assertionUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.country",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-15T09:44:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-15T09:34:33+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
-            },
-            "assertionUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.customer",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-15T09:57:20+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.address",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
-            },
-            "assertionUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-01-31T21:16:11.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-15T09:45:30+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
-            },
-            "assertionUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-21T21:17:25.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.category",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
-            },
-            "assertionUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-03-23T21:18:38.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-15T09:46:27+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
-            },
-            "assertionUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-04-30T22:53:48.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.city",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
-            },
-            "assertionUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-05-14T12:44:29.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-15T09:45:25+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
-            },
-            "assertionUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "0001-01-01T00:00:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.country",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
-            },
-            "assertionUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-15T09:44:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:10f2a119dedcaab43afc47ff13d9cb5b",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:1f37cbfd95ea2a1d46b8e94828805eb1",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.customer",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-15T09:57:20+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:60ce4aad7ff6dbff7004da0f2258c9df",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-01-31T21:16:11.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-21T21:17:25.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ba2c6ba830d407d539452f4cf46c92a6",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-03-23T21:18:38.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:c456eccf6440c6e3388c584689a74d91",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-04-30T22:53:48.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:f3a0dbf71b6cbf7112ff44925f475ff5",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:f6a1fde3ab4919abcc04bdee93144958",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-05-14T12:44:29.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:f812b73477d81e6af283d918cb59e7bf",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:36225e795a4597b2376996774a803b0d",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:57aa623f096cf3a28af70fe94b713907",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "0001-01-01T00:00:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:a42a5b1bee156e45972e12d4156fb7a2",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:fc6268f0be68fd04c310705b65efd6fe",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:10f2a119dedcaab43afc47ff13d9cb5b",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:tag_from_dbt",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:tag_from_dbt"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:1f37cbfd95ea2a1d46b8e94828805eb1",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:60ce4aad7ff6dbff7004da0f2258c9df",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ba2c6ba830d407d539452f4cf46c92a6",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:c456eccf6440c6e3388c584689a74d91",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:f3a0dbf71b6cbf7112ff44925f475ff5",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:f6a1fde3ab4919abcc04bdee93144958",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:f812b73477d81e6af283d918cb59e7bf",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:36225e795a4597b2376996774a803b0d",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:57aa623f096cf3a28af70fe94b713907",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:a42a5b1bee156e45972e12d4156fb7a2",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:fc6268f0be68fd04c310705b65efd6fe",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:tag_from_dbt",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:tag_from_dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-prefer-sql-parser-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
     }
-}
 ]

--- a/metadata-ingestion/tests/integration/dbt/dbt_test_query_entity_emission_golden.json
+++ b/metadata-ingestion/tests/integration/dbt/dbt_test_query_entity_emission_golden.json
@@ -1,5632 +1,5716 @@
 [
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "owner": "@alice2",
-                            "business_owner": "jdoe.last@gmail.com",
-                            "data_governance.team_owner": "Finance",
-                            "has_pii": "True",
-                            "int_property": "1",
-                            "double_property": "2.5",
-                            "node_type": "model",
-                            "materialization": "ephemeral",
-                            "dbt_file_path": "models/transform/customer_details.sql",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.customer_details",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "customer_details",
-                        "description": "",
-                        "tags": [
-                            "dbt:test_tag"
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:@alice2",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "owner": "@alice2",
+                                "business_owner": "jdoe.last@gmail.com",
+                                "data_governance.team_owner": "Finance",
+                                "has_pii": "True",
+                                "int_property": "1",
+                                "double_property": "2.5",
+                                "node_type": "model",
+                                "materialization": "ephemeral",
+                                "dbt_file_path": "models/transform/customer_details.sql",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.customer_details",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "customer_details",
+                            "description": "",
+                            "tags": [
+                                "dbt:test_tag"
+                            ]
                         }
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.GlobalTags": {
-                        "tags": [
-                            {
-                                "tag": "urn:li:tag:dbt:test_tag"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.customer_details",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "INT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "full_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "VARCHAR",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "email",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "city",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "postal_code",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "phone",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),full_name)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),email)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),address)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),city)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),postal_code)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),postal_code)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),phone)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),phone)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": false,
-                        "viewLogic": "{{ config(\n    materialized = \"ephemeral\",\n) }}\n\nSELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name as \"full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\nFROM\n    {{ source('pagila', 'customer')}} c\n    left outer join {{ source('pagila', 'address')}} a on c.address_id = a.address_id\n    left outer join {{ source('pagila', 'city') }} m on a.city_id = m.city_id",
-                        "formattedViewLogic": "SELECT\n  c.customer_id,\n  c.first_name || ' ' || c.last_name AS \"full_name\",\n  c.email,\n  a.address,\n  m.city,\n  a.postal_code,\n  a.phone\nFROM \"pagila\".\"public\".\"customer\" AS c\nLEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n  ON c.address_id = a.address_id\nLEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n  ON a.city_id = m.city_id",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "business_owner": "jdoe.last",
-                            "data_governance.team_owner": "Sales",
-                            "has_pii": "False",
-                            "int_property": "2",
-                            "double_property": "3.5",
-                            "queries": "[{'name': 'Monthly billing summary', 'description': 'Standard report for monthly billing aggregation', 'sql': 'SELECT * FROM monthly_billing_with_cust WHERE billing_month >= DATE_TRUNC(\"month\", CURRENT_DATE - INTERVAL \"90 days\")', 'tags': ['production', 'finance'], 'terms': ['FinancialData', 'BillingMetrics']}, {'name': 'Customer revenue trends', 'sql': 'SELECT customer_id, SUM(amount) as total_revenue FROM monthly_billing_with_cust GROUP BY customer_id ORDER BY total_revenue DESC'}]",
-                            "node_type": "model",
-                            "materialization": "table",
-                            "dbt_file_path": "models/billing/monthly_billing_with_cust.sql",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.monthly_billing_with_cust",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "an-aliased-view-for-monthly-billing",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.monthly_billing_with_cust",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "billing_month",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "email",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": true,
-                        "viewLogic": "{{ config(\n    materialized = \"table\",\n    alias='an-aliased-view-for-monthly-billing'\n) }}\n\nSELECT \n    pbc.billing_month,\n    pbc.customer_id,\n    pbc.amount,\n    cust.email\nFROM\n    {{ ref('payments_by_customer_by_month')}} pbc\n    left outer join {{ ref('customer_details')}} cust on pbc.customer_id = cust.customer_id\nORDER BY\n    pbc.billing_month",
-                        "formattedViewLogic": "WITH __dbt__CTE__customer_details AS (\n  SELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name AS \"full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\n  FROM \"pagila\".\"public\".\"customer\" AS c\n  LEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n    ON c.address_id = a.address_id\n  LEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n    ON a.city_id = m.city_id\n)\nSELECT\n  pbc.billing_month,\n  pbc.customer_id,\n  pbc.amount,\n  cust.email\nFROM \"pagila\".\"dbt_postgres\".\"payments_by_customer_by_month\" AS pbc\nLEFT OUTER JOIN __dbt__CTE__customer_details AS cust\n  ON pbc.customer_id = cust.customer_id\nORDER BY\n  pbc.billing_month",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "queries": "[{'name': 'Recent payments', 'sql': 'SELECT * FROM payments_base WHERE payment_date > CURRENT_DATE - 30', 'tags': ['operations']}]",
-                            "node_type": "model",
-                            "materialization": "view",
-                            "dbt_file_path": "models/base/payments_base.sql",
-                            "catalog_type": "VIEW",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.payments_base",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "an-aliased-view-for-payments",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.payments_base",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": false,
-                        "viewLogic": "{{ config(\n    materialized=\"view\",\n    alias='an-aliased-view-for-payments'\n) }}\n\nwith payments as (\n\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_01')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_03')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_04')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_05')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_06')}}\n)\n\nselect *\nfrom payments",
-                        "formattedViewLogic": "WITH payments AS (\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_01\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_03\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_04\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_05\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_06\"\n)\nSELECT\n  *\nFROM payments",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "model",
-                            "materialization": "table",
-                            "dbt_file_path": "models/transform/payments_by_customer_by_month.sql",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.payments_by_customer_by_month",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payments_by_customer_by_month",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.payments_by_customer_by_month",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "billing_month",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": true,
-                        "viewLogic": "{{ config(\n    materialized = \"table\",\n) }}\n\nSELECT\n    date_trunc('month', payment_date) as \"billing_month\",\n    customer_id,\n    sum(amount) as \"amount\"\nFROM\n    {{ ref('payments_base')}}\nGROUP BY\n    billing_month,\n    customer_id",
-                        "formattedViewLogic": "SELECT\n  DATE_TRUNC('MONTH', payment_date) AS \"billing_month\",\n  customer_id,\n  SUM(amount) AS \"amount\"\nFROM \"pagila\".\"dbt_postgres\".\"an-aliased-view-for-payments\"\nGROUP BY\n  billing_month,\n  customer_id",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "model_maturity": "in dev",
-                            "some_other_property": "test 1",
-                            "owner": "@alice1",
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.actor",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "actor",
-                        "description": "description for actor table from dbt",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:@alice1",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
                         }
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.actor",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1581759273000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:@alice2",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
                             }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "actor_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.GlobalTags": {
+                            "tags": [
+                                {
+                                    "tag": "urn:li:tag:dbt:test_tag"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.customer_details",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
                             },
-                            {
-                                "fieldPath": "first_name",
-                                "nullable": false,
-                                "description": "dbt comment: Actors column \u2013 from postgres\n\ndbt model description: description for first_name from dbt",
-                                "type": {
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "globalTags": {
-                                    "tags": [
-                                        {
-                                            "tag": "urn:li:tag:dbt:column_tag"
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
                                         }
-                                    ]
+                                    },
+                                    "nativeDataType": "INT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_name",
-                                "nullable": false,
-                                "description": "description for last_name from dbt",
-                                "type": {
+                                {
+                                    "fieldPath": "full_name",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "VARCHAR",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "description": "description for last_update from dbt",
-                                "type": {
+                                {
+                                    "fieldPath": "email",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),actor_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),actor_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),first_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),first_name)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),last_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),last_name)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.address",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "address",
-                        "description": "a user's address",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.address",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1623751200000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "address",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "address",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address2",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "city",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address_id",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "postal_code",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "city_id",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "phone",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+                                    "type": "TRANSFORMED"
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "district",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+                                    "type": "TRANSFORMED"
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "phone",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),full_name)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "postal_code",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),email)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),address)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address2)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address2)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),city_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),city_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),district)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),district)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),phone)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),phone)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),postal_code)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),postal_code)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.category",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "category",
-                        "description": "a user's category",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.category",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1623319200000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "category_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),city)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),postal_code)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),postal_code)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),category_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),category_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),name)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.city",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "city",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.city",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1581759925000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "city",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "city_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "country_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),city)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),city_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),country_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),country_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "model_maturity": "in prod",
-                            "owner": "@bob",
-                            "some_other_property": "test 2",
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.country",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "country",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:@bob",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),phone)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),phone)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": false,
+                            "viewLogic": "{{ config(\n    materialized = \"ephemeral\",\n) }}\n\nSELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name as \"full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\nFROM\n    {{ source('pagila', 'customer')}} c\n    left outer join {{ source('pagila', 'address')}} a on c.address_id = a.address_id\n    left outer join {{ source('pagila', 'city') }} m on a.city_id = m.city_id",
+                            "formattedViewLogic": "SELECT\n  c.customer_id,\n  c.first_name || ' ' || c.last_name AS \"full_name\",\n  c.email,\n  a.address,\n  m.city,\n  a.postal_code,\n  a.phone\nFROM \"pagila\".\"public\".\"customer\" AS c\nLEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n  ON c.address_id = a.address_id\nLEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n  ON a.city_id = m.city_id",
+                            "viewLanguage": "SQL"
                         }
                     }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.country",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1624033800000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "country",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "country_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),country)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),country)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),country_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),country_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.customer",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "customer",
-                        "description": "description for customer table from dbt",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.customer",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1624032000000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "active",
-                                "nullable": false,
-                                "type": {
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "business_owner": "jdoe.last",
+                                "data_governance.team_owner": "Sales",
+                                "has_pii": "False",
+                                "int_property": "2",
+                                "double_property": "3.5",
+                                "queries": "[{'name': 'Monthly billing summary', 'description': 'Standard report for monthly billing aggregation', 'sql': 'SELECT * FROM monthly_billing_with_cust WHERE billing_month >= DATE_TRUNC(\"month\", CURRENT_DATE - INTERVAL \"90 days\")', 'tags': ['production', 'finance'], 'terms': ['FinancialData', 'BillingMetrics']}, {'name': 'Customer revenue trends', 'sql': 'SELECT customer_id, SUM(amount) as total_revenue FROM monthly_billing_with_cust GROUP BY customer_id ORDER BY total_revenue DESC'}]",
+                                "node_type": "model",
+                                "materialization": "table",
+                                "dbt_file_path": "models/billing/monthly_billing_with_cust.sql",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.monthly_billing_with_cust",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "an-aliased-view-for-monthly-billing",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.monthly_billing_with_cust",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "activebool",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "billing_month",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.BooleanType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "boolean",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address_id",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "create_date",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "email",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.DateType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+                                    "type": "TRANSFORMED"
                                 },
-                                "nativeDataType": "date",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "email",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "first_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "store_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),active)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),active)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),activebool)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),activebool)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),address_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),address_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),create_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),create_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),email)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),first_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),store_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),store_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_01",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_01",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1580505371996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "an_array_property": "['alpha', 'beta', 'charlie']",
-                            "model_maturity": "in prod",
-                            "owner": "@charles",
-                            "some_other_property": "test 3",
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_02",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:@charles",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": true,
+                            "viewLogic": "{{ config(\n    materialized = \"table\",\n    alias='an-aliased-view-for-monthly-billing'\n) }}\n\nSELECT \n    pbc.billing_month,\n    pbc.customer_id,\n    pbc.amount,\n    cust.email\nFROM\n    {{ ref('payments_by_customer_by_month')}} pbc\n    left outer join {{ ref('customer_details')}} cust on pbc.customer_id = cust.customer_id\nORDER BY\n    pbc.billing_month",
+                            "formattedViewLogic": "WITH __dbt__CTE__customer_details AS (\n  SELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name AS \"full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\n  FROM \"pagila\".\"public\".\"customer\" AS c\n  LEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n    ON c.address_id = a.address_id\n  LEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n    ON a.city_id = m.city_id\n)\nSELECT\n  pbc.billing_month,\n  pbc.customer_id,\n  pbc.amount,\n  cust.email\nFROM \"pagila\".\"dbt_postgres\".\"payments_by_customer_by_month\" AS pbc\nLEFT OUTER JOIN __dbt__CTE__customer_details AS cust\n  ON pbc.customer_id = cust.customer_id\nORDER BY\n  pbc.billing_month",
+                            "viewLanguage": "SQL"
                         }
                     }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_02",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1582319845996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_03",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_03",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1584998318996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "queries": "[{'name': 'Recent payments', 'sql': 'SELECT * FROM payments_base WHERE payment_date > CURRENT_DATE - 30', 'tags': ['operations']}]",
+                                "node_type": "model",
+                                "materialization": "view",
+                                "dbt_file_path": "models/base/payments_base.sql",
+                                "catalog_type": "VIEW",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.payments_base",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
                             },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_04",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_04",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1588287228996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_05",
-                        "description": "a payment",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_05",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1589460269996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_06",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_06",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": -62135596800000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:model.sample_dbt.monthly_billing_with_cust_Monthly_billing_summary",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "tags": "production, finance",
-                "terms": "FinancialData, BillingMetrics"
-            },
-            "statement": {
-                "value": "SELECT * FROM monthly_billing_with_cust WHERE billing_month >= DATE_TRUNC(\"month\", CURRENT_DATE - INTERVAL \"90 days\")",
-                "language": "SQL"
-            },
-            "source": "MANUAL",
-            "name": "Monthly billing summary",
-            "description": "Standard report for monthly billing aggregation",
-            "created": {
-                "time": 1624052316384,
-                "actor": "urn:li:corpuser:dbt_executor"
-            },
-            "lastModified": {
-                "time": 1624052316384,
-                "actor": "urn:li:corpuser:dbt_executor"
-            },
-            "origin": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:model.sample_dbt.monthly_billing_with_cust_Monthly_billing_summary",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:model.sample_dbt.monthly_billing_with_cust_Customer_revenue_trends",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "customProperties": {},
-            "statement": {
-                "value": "SELECT customer_id, SUM(amount) as total_revenue FROM monthly_billing_with_cust GROUP BY customer_id ORDER BY total_revenue DESC",
-                "language": "SQL"
-            },
-            "source": "MANUAL",
-            "name": "Customer revenue trends",
-            "created": {
-                "time": 1624052316384,
-                "actor": "urn:li:corpuser:dbt_executor"
-            },
-            "lastModified": {
-                "time": 1624052316384,
-                "actor": "urn:li:corpuser:dbt_executor"
-            },
-            "origin": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:model.sample_dbt.monthly_billing_with_cust_Customer_revenue_trends",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-                "value": {
-                    "auditStamp": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
+                            "name": "an-aliased-view-for-payments",
+                            "description": "",
+                            "tags": []
+                        }
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-                    "type": "COPY"
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),email)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),email)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.payments_base",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": false,
+                            "viewLogic": "{{ config(\n    materialized=\"view\",\n    alias='an-aliased-view-for-payments'\n) }}\n\nwith payments as (\n\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_01')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_03')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_04')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_05')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_06')}}\n)\n\nselect *\nfrom payments",
+                            "formattedViewLogic": "WITH payments AS (\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_01\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_03\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_04\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_05\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_06\"\n)\nSELECT\n  *\nFROM payments",
+                            "viewLanguage": "SQL"
+                        }
+                    }
+                ]
             }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:model.sample_dbt.payments_base_Recent_payments",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "tags": "operations"
-            },
-            "statement": {
-                "value": "SELECT * FROM payments_base WHERE payment_date > CURRENT_DATE - 30",
-                "language": "SQL"
-            },
-            "source": "MANUAL",
-            "name": "Recent payments",
-            "created": {
-                "time": 1624052316384,
-                "actor": "urn:li:corpuser:dbt_executor"
-            },
-            "lastModified": {
-                "time": 1624052316384,
-                "actor": "urn:li:corpuser:dbt_executor"
-            },
-            "origin": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)"
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:model.sample_dbt.payments_base_Recent_payments",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "model",
+                                "materialization": "table",
+                                "dbt_file_path": "models/transform/payments_by_customer_by_month.sql",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.payments_by_customer_by_month",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payments_by_customer_by_month",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.payments_by_customer_by_month",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "billing_month",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": true,
+                            "viewLogic": "{{ config(\n    materialized = \"table\",\n) }}\n\nSELECT\n    date_trunc('month', payment_date) as \"billing_month\",\n    customer_id,\n    sum(amount) as \"amount\"\nFROM\n    {{ ref('payments_base')}}\nGROUP BY\n    billing_month,\n    customer_id",
+                            "formattedViewLogic": "SELECT\n  DATE_TRUNC('MONTH', payment_date) AS \"billing_month\",\n  customer_id,\n  SUM(amount) AS \"amount\"\nFROM \"pagila\".\"dbt_postgres\".\"an-aliased-view-for-payments\"\nGROUP BY\n  billing_month,\n  customer_id",
+                            "viewLanguage": "SQL"
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "model_maturity": "in dev",
+                                "some_other_property": "test 1",
+                                "owner": "@alice1",
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.actor",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "actor",
+                            "description": "description for actor table from dbt",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:@alice1",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.actor",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1581759273000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "actor_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "first_name",
+                                    "nullable": false,
+                                    "description": "dbt comment: Actors column \u2013 from postgres\n\ndbt model description: description for first_name from dbt",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "globalTags": {
+                                        "tags": [
+                                            {
+                                                "tag": "urn:li:tag:dbt:column_tag"
+                                            }
+                                        ]
+                                    },
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_name",
+                                    "nullable": false,
+                                    "description": "description for last_name from dbt",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "description": "description for last_update from dbt",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),actor_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),actor_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),first_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),first_name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),last_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),last_name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.address",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "address",
+                            "description": "a user's address",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.address",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1623751200000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "address",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "address2",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "address_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "city_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "district",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "phone",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "postal_code",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address2)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address2)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),city_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),city_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),district)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),district)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),phone)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),phone)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),postal_code)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),postal_code)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.category",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "category",
+                            "description": "a user's category",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.category",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1623319200000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "category_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),category_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),category_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.city",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "city",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.city",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1581759925000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "city",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "city_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "country_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),city)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),city_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),country_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),country_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "model_maturity": "in prod",
+                                "owner": "@bob",
+                                "some_other_property": "test 2",
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.country",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "country",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:@bob",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.country",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1624033800000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "country",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "country_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),country)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),country)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),country_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),country_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.customer",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "customer",
+                            "description": "description for customer table from dbt",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.customer",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1624032000000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "active",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "activebool",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.BooleanType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "boolean",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "address_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "create_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.DateType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "date",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "email",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "first_name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "store_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),active)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),active)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),activebool)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),activebool)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),address_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),address_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),create_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),create_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),email)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),first_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),store_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),store_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_01",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_01",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1580505371996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "an_array_property": "['alpha', 'beta', 'charlie']",
+                                "model_maturity": "in prod",
+                                "owner": "@charles",
+                                "some_other_property": "test 3",
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_02",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:@charles",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_02",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1582319845996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_03",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_03",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1584998318996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_04",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_04",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1588287228996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_05",
+                            "description": "a payment",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_05",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1589460269996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_06",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_06",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": -62135596800000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "query",
+        "entityUrn": "urn:li:query:model.sample_dbt.monthly_billing_with_cust_Monthly_billing_summary",
+        "changeType": "UPSERT",
+        "aspectName": "queryProperties",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "tags": "production, finance",
+                    "terms": "FinancialData, BillingMetrics"
+                },
+                "statement": {
+                    "value": "SELECT * FROM monthly_billing_with_cust WHERE billing_month >= DATE_TRUNC(\"month\", CURRENT_DATE - INTERVAL \"90 days\")",
+                    "language": "SQL"
+                },
+                "source": "MANUAL",
+                "name": "Monthly billing summary",
+                "description": "Standard report for monthly billing aggregation",
+                "created": {
+                    "time": 1624052316384,
+                    "actor": "urn:li:corpuser:dbt_executor"
+                },
+                "lastModified": {
+                    "time": 1624052316384,
+                    "actor": "urn:li:corpuser:dbt_executor"
+                },
+                "origin": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "query",
+        "entityUrn": "urn:li:query:model.sample_dbt.monthly_billing_with_cust_Monthly_billing_summary",
+        "changeType": "UPSERT",
+        "aspectName": "querySubjects",
+        "aspect": {
+            "json": {
+                "subjects": [
+                    {
+                        "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)"
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "query",
+        "entityUrn": "urn:li:query:model.sample_dbt.monthly_billing_with_cust_Customer_revenue_trends",
+        "changeType": "UPSERT",
+        "aspectName": "queryProperties",
+        "aspect": {
+            "json": {
+                "customProperties": {},
+                "statement": {
+                    "value": "SELECT customer_id, SUM(amount) as total_revenue FROM monthly_billing_with_cust GROUP BY customer_id ORDER BY total_revenue DESC",
+                    "language": "SQL"
+                },
+                "source": "MANUAL",
+                "name": "Customer revenue trends",
+                "created": {
+                    "time": 1624052316384,
+                    "actor": "urn:li:corpuser:dbt_executor"
+                },
+                "lastModified": {
+                    "time": 1624052316384,
+                    "actor": "urn:li:corpuser:dbt_executor"
+                },
+                "origin": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "query",
+        "entityUrn": "urn:li:query:model.sample_dbt.monthly_billing_with_cust_Customer_revenue_trends",
+        "changeType": "UPSERT",
+        "aspectName": "querySubjects",
+        "aspect": {
+            "json": {
+                "subjects": [
+                    {
+                        "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)"
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
                 {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)"
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+                    "value": {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+                        "type": "COPY"
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),email)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),email)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
                 }
             ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-                "value": {
-                    "auditStamp": {
+    {
+        "entityType": "query",
+        "entityUrn": "urn:li:query:model.sample_dbt.payments_base_Recent_payments",
+        "changeType": "UPSERT",
+        "aspectName": "queryProperties",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "tags": "operations"
+                },
+                "statement": {
+                    "value": "SELECT * FROM payments_base WHERE payment_date > CURRENT_DATE - 30",
+                    "language": "SQL"
+                },
+                "source": "MANUAL",
+                "name": "Recent payments",
+                "created": {
+                    "time": 1624052316384,
+                    "actor": "urn:li:corpuser:dbt_executor"
+                },
+                "lastModified": {
+                    "time": 1624052316384,
+                    "actor": "urn:li:corpuser:dbt_executor"
+                },
+                "origin": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "query",
+        "entityUrn": "urn:li:query:model.sample_dbt.payments_base_Recent_payments",
+        "changeType": "UPSERT",
+        "aspectName": "querySubjects",
+        "aspect": {
+            "json": {
+                "subjects": [
+                    {
+                        "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)"
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+                    "value": {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+                        "type": "COPY"
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+                    "value": {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+                        "type": "COPY"
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.actor",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
                         "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
-                    },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-                    "type": "COPY"
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)",
-                "value": {
-                    "confidenceScore": 1.0
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
             }
-        ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-                "value": {
-                    "auditStamp": {
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-15T09:34:33+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.address",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
                         "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
-                    },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-                    "type": "COPY"
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)",
-                "value": {
-                    "confidenceScore": 1.0
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
             }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.actor",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-15T09:34:33+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "warn",
+                        "max_loaded_at": "2021-06-15T10:00:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "259200.0"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
-            },
-            "assertionUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.address",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "warn",
-                    "max_loaded_at": "2021-06-15T10:00:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "259200.0"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.category",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
-            },
-            "assertionUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.category",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "FAILURE",
-                "nativeResults": {
-                    "status": "error",
-                    "max_loaded_at": "2021-06-10T10:00:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "691200.0"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "FAILURE",
+                    "nativeResults": {
+                        "status": "error",
+                        "max_loaded_at": "2021-06-10T10:00:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "691200.0"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
-            },
-            "assertionUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.city",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "error_after_count": "1",
-                "error_after_period": "day"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-15T09:45:25+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.city",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "error_after_count": "1",
+                    "error_after_period": "day"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
-            },
-            "assertionUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.country",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "30",
-                "warn_after_period": "minute"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2021-06-18T16:30:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "2335.925443"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-15T09:45:25+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
-            },
-            "assertionUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.customer",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "1",
-                "warn_after_period": "day",
-                "error_after_count": "2",
-                "error_after_period": "day"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2021-06-18T16:00:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "4085.925443"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.country",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "30",
+                    "warn_after_period": "minute"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
-            },
-            "assertionUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "3",
-                "warn_after_period": "day",
-                "error_after_count": "7",
-                "error_after_period": "day"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-01-31T21:16:11.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2021-06-18T16:30:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "2335.925443"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
-            },
-            "assertionUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-21T21:17:25.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.customer",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "1",
+                    "warn_after_period": "day",
+                    "error_after_count": "2",
+                    "error_after_period": "day"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
-            },
-            "assertionUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-03-23T21:18:38.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2021-06-18T16:00:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "4085.925443"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
-            },
-            "assertionUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-04-30T22:53:48.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "3",
+                    "warn_after_period": "day",
+                    "error_after_count": "7",
+                    "error_after_period": "day"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
-            },
-            "assertionUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-05-14T12:44:29.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-01-31T21:16:11.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
-            },
-            "assertionUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "0001-01-01T00:00:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
-            },
-            "assertionUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-21T21:17:25.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-03-23T21:18:38.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-04-30T22:53:48.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-05-14T12:44:29.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:model.sample_dbt.monthly_billing_with_cust_Customer_revenue_trends",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "0001-01-01T00:00:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:model.sample_dbt.monthly_billing_with_cust_Monthly_billing_summary",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:model.sample_dbt.payments_base_Recent_payments",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:column_tag",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:column_tag"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:test_tag",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:test_tag"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-query-entity-emission",
-        "lastRunId": "no-run-id-provided"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "query",
+        "entityUrn": "urn:li:query:model.sample_dbt.monthly_billing_with_cust_Customer_revenue_trends",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "query",
+        "entityUrn": "urn:li:query:model.sample_dbt.monthly_billing_with_cust_Monthly_billing_summary",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "query",
+        "entityUrn": "urn:li:query:model.sample_dbt.payments_base_Recent_payments",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:column_tag",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:column_tag"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:test_tag",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:test_tag"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-query-entity-emission",
+            "lastRunId": "no-run-id-provided"
+        }
     }
-}
 ]

--- a/metadata-ingestion/tests/integration/dbt/dbt_test_target_platform_primary_siblings_golden.json
+++ b/metadata-ingestion/tests/integration/dbt/dbt_test_target_platform_primary_siblings_golden.json
@@ -1,6427 +1,6511 @@
 [
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "owner": "@alice2",
-                            "business_owner": "jdoe.last@gmail.com",
-                            "data_governance.team_owner": "Finance",
-                            "has_pii": "True",
-                            "int_property": "1",
-                            "double_property": "2.5",
-                            "node_type": "model",
-                            "materialization": "ephemeral",
-                            "dbt_file_path": "models/transform/customer_details.sql",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.customer_details",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "customer_details",
-                        "description": "",
-                        "tags": [
-                            "dbt:test_tag"
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:@alice2",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "owner": "@alice2",
+                                "business_owner": "jdoe.last@gmail.com",
+                                "data_governance.team_owner": "Finance",
+                                "has_pii": "True",
+                                "int_property": "1",
+                                "double_property": "2.5",
+                                "node_type": "model",
+                                "materialization": "ephemeral",
+                                "dbt_file_path": "models/transform/customer_details.sql",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.customer_details",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "customer_details",
+                            "description": "",
+                            "tags": [
+                                "dbt:test_tag"
+                            ]
                         }
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.GlobalTags": {
-                        "tags": [
-                            {
-                                "tag": "urn:li:tag:dbt:test_tag"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.customer_details",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "INT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "full_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "VARCHAR",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "email",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "city",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "postal_code",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "phone",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),full_name)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),email)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),address)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),city)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),postal_code)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),postal_code)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),phone)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),phone)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": false,
-                        "viewLogic": "{{ config(\n    materialized = \"ephemeral\",\n) }}\n\nSELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name as \"full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\nFROM\n    {{ source('pagila', 'customer')}} c\n    left outer join {{ source('pagila', 'address')}} a on c.address_id = a.address_id\n    left outer join {{ source('pagila', 'city') }} m on a.city_id = m.city_id",
-                        "formattedViewLogic": "SELECT\n  c.customer_id,\n  c.first_name || ' ' || c.last_name AS \"full_name\",\n  c.email,\n  a.address,\n  m.city,\n  a.postal_code,\n  a.phone\nFROM \"pagila\".\"public\".\"customer\" AS c\nLEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n  ON c.address_id = a.address_id\nLEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n  ON a.city_id = m.city_id",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": {
-            "siblings": [
-                "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)"
-            ],
-            "primary": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "business_owner": "jdoe.last",
-                            "data_governance.team_owner": "Sales",
-                            "has_pii": "False",
-                            "int_property": "2",
-                            "double_property": "3.5",
-                            "node_type": "model",
-                            "materialization": "table",
-                            "dbt_file_path": "models/billing/monthly_billing_with_cust.sql",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.monthly_billing_with_cust",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "an-aliased-view-for-monthly-billing",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.monthly_billing_with_cust",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "billing_month",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "email",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": true,
-                        "viewLogic": "{{ config(\n    materialized = \"table\",\n    alias='an-aliased-view-for-monthly-billing'\n) }}\n\nSELECT \n    pbc.billing_month,\n    pbc.customer_id,\n    pbc.amount,\n    cust.email\nFROM\n    {{ ref('payments_by_customer_by_month')}} pbc\n    left outer join {{ ref('customer_details')}} cust on pbc.customer_id = cust.customer_id\nORDER BY\n    pbc.billing_month",
-                        "formattedViewLogic": "WITH __dbt__CTE__customer_details AS (\n  SELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name AS \"full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\n  FROM \"pagila\".\"public\".\"customer\" AS c\n  LEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n    ON c.address_id = a.address_id\n  LEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n    ON a.city_id = m.city_id\n)\nSELECT\n  pbc.billing_month,\n  pbc.customer_id,\n  pbc.amount,\n  cust.email\nFROM \"pagila\".\"dbt_postgres\".\"payments_by_customer_by_month\" AS pbc\nLEFT OUTER JOIN __dbt__CTE__customer_details AS cust\n  ON pbc.customer_id = cust.customer_id\nORDER BY\n  pbc.billing_month",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": {
-            "siblings": [
-                "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)"
-            ],
-            "primary": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "model",
-                            "materialization": "view",
-                            "dbt_file_path": "models/base/payments_base.sql",
-                            "catalog_type": "VIEW",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.payments_base",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "an-aliased-view-for-payments",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.payments_base",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": false,
-                        "viewLogic": "{{ config(\n    materialized=\"view\",\n    alias='an-aliased-view-for-payments'\n) }}\n\nwith payments as (\n\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_01')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_03')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_04')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_05')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_06')}}\n)\n\nselect *\nfrom payments",
-                        "formattedViewLogic": "WITH payments AS (\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_01\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_03\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_04\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_05\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_06\"\n)\nSELECT\n  *\nFROM payments",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": {
-            "siblings": [
-                "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD)"
-            ],
-            "primary": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "model",
-                            "materialization": "table",
-                            "dbt_file_path": "models/transform/payments_by_customer_by_month.sql",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.payments_by_customer_by_month",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payments_by_customer_by_month",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.payments_by_customer_by_month",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "billing_month",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": true,
-                        "viewLogic": "{{ config(\n    materialized = \"table\",\n) }}\n\nSELECT\n    date_trunc('month', payment_date) as \"billing_month\",\n    customer_id,\n    sum(amount) as \"amount\"\nFROM\n    {{ ref('payments_base')}}\nGROUP BY\n    billing_month,\n    customer_id",
-                        "formattedViewLogic": "SELECT\n  DATE_TRUNC('MONTH', payment_date) AS \"billing_month\",\n  customer_id,\n  SUM(amount) AS \"amount\"\nFROM \"pagila\".\"dbt_postgres\".\"an-aliased-view-for-payments\"\nGROUP BY\n  billing_month,\n  customer_id",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": {
-            "siblings": [
-                "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)"
-            ],
-            "primary": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "model_maturity": "in dev",
-                            "some_other_property": "test 1",
-                            "owner": "@alice1",
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.actor",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "actor",
-                        "description": "description for actor table from dbt",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:@alice1",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
                         }
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.actor",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1581759273000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:@alice2",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
                             }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "actor_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.GlobalTags": {
+                            "tags": [
+                                {
+                                    "tag": "urn:li:tag:dbt:test_tag"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.customer_details",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
                             },
-                            {
-                                "fieldPath": "first_name",
-                                "nullable": false,
-                                "description": "dbt comment: Actors column \u2013 from postgres\n\ndbt model description: description for first_name from dbt",
-                                "type": {
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "globalTags": {
-                                    "tags": [
-                                        {
-                                            "tag": "urn:li:tag:dbt:column_tag"
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
                                         }
-                                    ]
+                                    },
+                                    "nativeDataType": "INT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_name",
-                                "nullable": false,
-                                "description": "description for last_name from dbt",
-                                "type": {
+                                {
+                                    "fieldPath": "full_name",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "VARCHAR",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "description": "description for last_update from dbt",
-                                "type": {
+                                {
+                                    "fieldPath": "email",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),actor_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),actor_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),first_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),first_name)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),last_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),last_name)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": {
-            "siblings": [
-                "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)"
-            ],
-            "primary": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.address",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "address",
-                        "description": "a user's address",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.address",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1623751200000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "address",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "address",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address2",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "city",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address_id",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "postal_code",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "city_id",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "phone",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+                                    "type": "TRANSFORMED"
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "district",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+                                    "type": "TRANSFORMED"
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "phone",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),full_name)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "postal_code",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),email)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),address)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address2)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address2)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),city_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),city_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),district)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),district)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),phone)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),phone)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),postal_code)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),postal_code)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": {
-            "siblings": [
-                "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)"
-            ],
-            "primary": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.category",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "category",
-                        "description": "a user's category",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.category",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1623319200000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "category_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),city)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),postal_code)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),postal_code)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),category_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),category_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),name)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": {
-            "siblings": [
-                "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)"
-            ],
-            "primary": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.city",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "city",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.city",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1581759925000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "city",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "city_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "country_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),city)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),city_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),country_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),country_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": {
-            "siblings": [
-                "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)"
-            ],
-            "primary": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "model_maturity": "in prod",
-                            "owner": "@bob",
-                            "some_other_property": "test 2",
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.country",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "country",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:@bob",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),phone)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),phone)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": false,
+                            "viewLogic": "{{ config(\n    materialized = \"ephemeral\",\n) }}\n\nSELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name as \"full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\nFROM\n    {{ source('pagila', 'customer')}} c\n    left outer join {{ source('pagila', 'address')}} a on c.address_id = a.address_id\n    left outer join {{ source('pagila', 'city') }} m on a.city_id = m.city_id",
+                            "formattedViewLogic": "SELECT\n  c.customer_id,\n  c.first_name || ' ' || c.last_name AS \"full_name\",\n  c.email,\n  a.address,\n  m.city,\n  a.postal_code,\n  a.phone\nFROM \"pagila\".\"public\".\"customer\" AS c\nLEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n  ON c.address_id = a.address_id\nLEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n  ON a.city_id = m.city_id",
+                            "viewLanguage": "SQL"
                         }
                     }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.country",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1624033800000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "country",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "country_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),country)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),country)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),country_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),country_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": {
-            "siblings": [
-                "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)"
-            ],
-            "primary": false
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "siblings",
+        "aspect": {
+            "json": {
+                "siblings": [
+                    "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)"
+                ],
+                "primary": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.customer",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "customer",
-                        "description": "description for customer table from dbt",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.customer",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1624032000000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "active",
-                                "nullable": false,
-                                "type": {
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "business_owner": "jdoe.last",
+                                "data_governance.team_owner": "Sales",
+                                "has_pii": "False",
+                                "int_property": "2",
+                                "double_property": "3.5",
+                                "node_type": "model",
+                                "materialization": "table",
+                                "dbt_file_path": "models/billing/monthly_billing_with_cust.sql",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.monthly_billing_with_cust",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "an-aliased-view-for-monthly-billing",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.monthly_billing_with_cust",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "activebool",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "billing_month",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.BooleanType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "boolean",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address_id",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "create_date",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "email",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.DateType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+                                    "type": "TRANSFORMED"
                                 },
-                                "nativeDataType": "date",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "email",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "first_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "store_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),active)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),active)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),activebool)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),activebool)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),address_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),address_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),create_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),create_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),email)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),first_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),store_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),store_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": {
-            "siblings": [
-                "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)"
-            ],
-            "primary": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_01",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_01",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1580505371996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": {
-            "siblings": [
-                "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)"
-            ],
-            "primary": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "an_array_property": "['alpha', 'beta', 'charlie']",
-                            "model_maturity": "in prod",
-                            "owner": "@charles",
-                            "some_other_property": "test 3",
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_02",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:@charles",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": true,
+                            "viewLogic": "{{ config(\n    materialized = \"table\",\n    alias='an-aliased-view-for-monthly-billing'\n) }}\n\nSELECT \n    pbc.billing_month,\n    pbc.customer_id,\n    pbc.amount,\n    cust.email\nFROM\n    {{ ref('payments_by_customer_by_month')}} pbc\n    left outer join {{ ref('customer_details')}} cust on pbc.customer_id = cust.customer_id\nORDER BY\n    pbc.billing_month",
+                            "formattedViewLogic": "WITH __dbt__CTE__customer_details AS (\n  SELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name AS \"full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\n  FROM \"pagila\".\"public\".\"customer\" AS c\n  LEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n    ON c.address_id = a.address_id\n  LEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n    ON a.city_id = m.city_id\n)\nSELECT\n  pbc.billing_month,\n  pbc.customer_id,\n  pbc.amount,\n  cust.email\nFROM \"pagila\".\"dbt_postgres\".\"payments_by_customer_by_month\" AS pbc\nLEFT OUTER JOIN __dbt__CTE__customer_details AS cust\n  ON pbc.customer_id = cust.customer_id\nORDER BY\n  pbc.billing_month",
+                            "viewLanguage": "SQL"
                         }
                     }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_02",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1582319845996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": {
-            "siblings": [
-                "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)"
-            ],
-            "primary": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_03",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_03",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1584998318996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": {
-            "siblings": [
-                "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)"
-            ],
-            "primary": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_04",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_04",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1588287228996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": {
-            "siblings": [
-                "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)"
-            ],
-            "primary": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_05",
-                        "description": "a payment",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_05",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1589460269996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": {
-            "siblings": [
-                "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)"
-            ],
-            "primary": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_06",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_06",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": -62135596800000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)"
-            },
-            {
-                "op": "add",
-                "path": "/primary",
-                "value": true
+                ]
             }
-        ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-                "value": {
-                    "auditStamp": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "siblings",
+        "aspect": {
+            "json": {
+                "siblings": [
+                    "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)"
+                ],
+                "primary": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "model",
+                                "materialization": "view",
+                                "dbt_file_path": "models/base/payments_base.sql",
+                                "catalog_type": "VIEW",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.payments_base",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "an-aliased-view-for-payments",
+                            "description": "",
+                            "tags": []
+                        }
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-                    "type": "COPY"
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),email)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),email)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)"
-            },
-            {
-                "op": "add",
-                "path": "/primary",
-                "value": true
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-                "value": {
-                    "auditStamp": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-                    "type": "COPY"
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)"
-            },
-            {
-                "op": "add",
-                "path": "/primary",
-                "value": true
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-                "value": {
-                    "auditStamp": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.payments_base",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-                    "type": "COPY"
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": false,
+                            "viewLogic": "{{ config(\n    materialized=\"view\",\n    alias='an-aliased-view-for-payments'\n) }}\n\nwith payments as (\n\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_01')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_03')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_04')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_05')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_06')}}\n)\n\nselect *\nfrom payments",
+                            "formattedViewLogic": "WITH payments AS (\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_01\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_03\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_04\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_05\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_06\"\n)\nSELECT\n  *\nFROM payments",
+                            "viewLanguage": "SQL"
+                        }
+                    }
+                ]
             }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)"
-            },
-            {
-                "op": "add",
-                "path": "/primary",
-                "value": true
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)"
-            },
-            {
-                "op": "add",
-                "path": "/primary",
-                "value": true
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
-                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)"
-            },
-            {
-                "op": "add",
-                "path": "/primary",
-                "value": true
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)"
-            },
-            {
-                "op": "add",
-                "path": "/primary",
-                "value": true
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
-                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)"
-            },
-            {
-                "op": "add",
-                "path": "/primary",
-                "value": true
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)"
-            },
-            {
-                "op": "add",
-                "path": "/primary",
-                "value": true
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)"
-            },
-            {
-                "op": "add",
-                "path": "/primary",
-                "value": true
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)"
-            },
-            {
-                "op": "add",
-                "path": "/primary",
-                "value": true
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)"
-            },
-            {
-                "op": "add",
-                "path": "/primary",
-                "value": true
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)"
-            },
-            {
-                "op": "add",
-                "path": "/primary",
-                "value": true
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)"
-            },
-            {
-                "op": "add",
-                "path": "/primary",
-                "value": true
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)"
-            },
-            {
-                "op": "add",
-                "path": "/primary",
-                "value": true
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.actor",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-15T09:34:33+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.address",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "siblings",
+        "aspect": {
+            "json": {
+                "siblings": [
+                    "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD)"
+                ],
+                "primary": false
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "warn",
-                    "max_loaded_at": "2021-06-15T10:00:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "259200.0"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "model",
+                                "materialization": "table",
+                                "dbt_file_path": "models/transform/payments_by_customer_by_month.sql",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.payments_by_customer_by_month",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payments_by_customer_by_month",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.payments_by_customer_by_month",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "billing_month",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": true,
+                            "viewLogic": "{{ config(\n    materialized = \"table\",\n) }}\n\nSELECT\n    date_trunc('month', payment_date) as \"billing_month\",\n    customer_id,\n    sum(amount) as \"amount\"\nFROM\n    {{ ref('payments_base')}}\nGROUP BY\n    billing_month,\n    customer_id",
+                            "formattedViewLogic": "SELECT\n  DATE_TRUNC('MONTH', payment_date) AS \"billing_month\",\n  customer_id,\n  SUM(amount) AS \"amount\"\nFROM \"pagila\".\"dbt_postgres\".\"an-aliased-view-for-payments\"\nGROUP BY\n  billing_month,\n  customer_id",
+                            "viewLanguage": "SQL"
+                        }
+                    }
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.category",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "FAILURE",
-                "nativeResults": {
-                    "status": "error",
-                    "max_loaded_at": "2021-06-10T10:00:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "691200.0"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.city",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "error_after_count": "1",
-                "error_after_period": "day"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "siblings",
+        "aspect": {
+            "json": {
+                "siblings": [
+                    "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)"
+                ],
+                "primary": false
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-15T09:45:25+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "model_maturity": "in dev",
+                                "some_other_property": "test 1",
+                                "owner": "@alice1",
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.actor",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "actor",
+                            "description": "description for actor table from dbt",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:@alice1",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.actor",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1581759273000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "actor_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "first_name",
+                                    "nullable": false,
+                                    "description": "dbt comment: Actors column \u2013 from postgres\n\ndbt model description: description for first_name from dbt",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "globalTags": {
+                                        "tags": [
+                                            {
+                                                "tag": "urn:li:tag:dbt:column_tag"
+                                            }
+                                        ]
+                                    },
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_name",
+                                    "nullable": false,
+                                    "description": "description for last_name from dbt",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "description": "description for last_update from dbt",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),actor_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),actor_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),first_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),first_name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),last_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),last_name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.country",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "30",
-                "warn_after_period": "minute"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2021-06-18T16:30:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "2335.925443"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.customer",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "1",
-                "warn_after_period": "day",
-                "error_after_count": "2",
-                "error_after_period": "day"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "siblings",
+        "aspect": {
+            "json": {
+                "siblings": [
+                    "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)"
+                ],
+                "primary": false
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2021-06-18T16:00:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "4085.925443"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.address",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "address",
+                            "description": "a user's address",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.address",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1623751200000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "address",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "address2",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "address_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "city_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "district",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "phone",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "postal_code",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address2)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address2)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),city_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),city_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),district)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),district)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),phone)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),phone)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),postal_code)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),postal_code)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "3",
-                "warn_after_period": "day",
-                "error_after_count": "7",
-                "error_after_period": "day"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-01-31T21:16:11.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "siblings",
+        "aspect": {
+            "json": {
+                "siblings": [
+                    "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)"
+                ],
+                "primary": false
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-21T21:17:25.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.category",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "category",
+                            "description": "a user's category",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.category",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1623319200000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "category_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),category_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),category_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-03-23T21:18:38.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "siblings",
+        "aspect": {
+            "json": {
+                "siblings": [
+                    "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)"
+                ],
+                "primary": false
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-04-30T22:53:48.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.city",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "city",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.city",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1581759925000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "city",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "city_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "country_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),city)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),city_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),country_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),country_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-05-14T12:44:29.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "siblings",
+        "aspect": {
+            "json": {
+                "siblings": [
+                    "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)"
+                ],
+                "primary": false
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "0001-01-01T00:00:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "model_maturity": "in prod",
+                                "owner": "@bob",
+                                "some_other_property": "test 2",
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.country",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "country",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:@bob",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.country",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1624033800000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "country",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "country_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),country)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),country)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),country_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),country_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
-    "changeType": "UPSERT",
-    "aspectName": "dashboardInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "exposure.sample_dbt.customer_dashboard",
-                "exposure_type": "dashboard",
-                "maturity": "high",
-                "dbt_package_name": "sample_dbt",
-                "dbt_file_path": "models/exposures.yml",
-                "team": "analytics"
-            },
-            "externalUrl": "https://bi.example.com/dashboards/customer",
-            "title": "customer_dashboard",
-            "description": "Dashboard showing customer details and billing",
-            "charts": [],
-            "datasets": [
-                "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-                "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)"
-            ],
-            "dashboards": [],
-            "lastModified": {
-                "created": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:dbt_ingestion"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "siblings",
+        "aspect": {
+            "json": {
+                "siblings": [
+                    "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)"
+                ],
+                "primary": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.customer",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "customer",
+                            "description": "description for customer table from dbt",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.customer",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1624032000000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "active",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "activebool",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.BooleanType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "boolean",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "address_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "create_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.DateType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "date",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "email",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "first_name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "store_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),active)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),active)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),activebool)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),activebool)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),address_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),address_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),create_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),create_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),email)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),first_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),store_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),store_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "siblings",
+        "aspect": {
+            "json": {
+                "siblings": [
+                    "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)"
+                ],
+                "primary": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_01",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_01",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1580505371996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "siblings",
+        "aspect": {
+            "json": {
+                "siblings": [
+                    "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)"
+                ],
+                "primary": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "an_array_property": "['alpha', 'beta', 'charlie']",
+                                "model_maturity": "in prod",
+                                "owner": "@charles",
+                                "some_other_property": "test 3",
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_02",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:@charles",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_02",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1582319845996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "siblings",
+        "aspect": {
+            "json": {
+                "siblings": [
+                    "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)"
+                ],
+                "primary": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_03",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_03",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1584998318996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "siblings",
+        "aspect": {
+            "json": {
+                "siblings": [
+                    "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)"
+                ],
+                "primary": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_04",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_04",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1588287228996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "siblings",
+        "aspect": {
+            "json": {
+                "siblings": [
+                    "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)"
+                ],
+                "primary": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_05",
+                            "description": "a payment",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_05",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1589460269996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "siblings",
+        "aspect": {
+            "json": {
+                "siblings": [
+                    "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)"
+                ],
+                "primary": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_06",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_06",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": -62135596800000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "siblings",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+                    "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)"
                 },
+                {
+                    "op": "add",
+                    "path": "/primary",
+                    "value": true
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+                    "value": {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+                        "type": "COPY"
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),email)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),email)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "siblings",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+                    "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)"
+                },
+                {
+                    "op": "add",
+                    "path": "/primary",
+                    "value": true
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+                    "value": {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+                        "type": "COPY"
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "siblings",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+                    "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)"
+                },
+                {
+                    "op": "add",
+                    "path": "/primary",
+                    "value": true
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+                    "value": {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+                        "type": "COPY"
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "siblings",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+                    "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)"
+                },
+                {
+                    "op": "add",
+                    "path": "/primary",
+                    "value": true
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "siblings",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+                    "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)"
+                },
+                {
+                    "op": "add",
+                    "path": "/primary",
+                    "value": true
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "siblings",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
+                    "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)"
+                },
+                {
+                    "op": "add",
+                    "path": "/primary",
+                    "value": true
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "siblings",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+                    "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)"
+                },
+                {
+                    "op": "add",
+                    "path": "/primary",
+                    "value": true
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "siblings",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
+                    "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)"
+                },
+                {
+                    "op": "add",
+                    "path": "/primary",
+                    "value": true
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "siblings",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+                    "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)"
+                },
+                {
+                    "op": "add",
+                    "path": "/primary",
+                    "value": true
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "siblings",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+                    "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)"
+                },
+                {
+                    "op": "add",
+                    "path": "/primary",
+                    "value": true
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "siblings",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+                    "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)"
+                },
+                {
+                    "op": "add",
+                    "path": "/primary",
+                    "value": true
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "siblings",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+                    "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)"
+                },
+                {
+                    "op": "add",
+                    "path": "/primary",
+                    "value": true
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "siblings",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+                    "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)"
+                },
+                {
+                    "op": "add",
+                    "path": "/primary",
+                    "value": true
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "siblings",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+                    "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)"
+                },
+                {
+                    "op": "add",
+                    "path": "/primary",
+                    "value": true
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "siblings",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+                    "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)"
+                },
+                {
+                    "op": "add",
+                    "path": "/primary",
+                    "value": true
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.actor",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-15T09:34:33+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.address",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "warn",
+                        "max_loaded_at": "2021-06-15T10:00:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "259200.0"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.category",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "FAILURE",
+                    "nativeResults": {
+                        "status": "error",
+                        "max_loaded_at": "2021-06-10T10:00:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "691200.0"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.city",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "error_after_count": "1",
+                    "error_after_period": "day"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-15T09:45:25+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.country",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "30",
+                    "warn_after_period": "minute"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2021-06-18T16:30:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "2335.925443"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.customer",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "1",
+                    "warn_after_period": "day",
+                    "error_after_count": "2",
+                    "error_after_period": "day"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2021-06-18T16:00:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "4085.925443"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "3",
+                    "warn_after_period": "day",
+                    "error_after_count": "7",
+                    "error_after_period": "day"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-01-31T21:16:11.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-21T21:17:25.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-03-23T21:18:38.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-04-30T22:53:48.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-05-14T12:44:29.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "0001-01-01T00:00:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
+        "changeType": "UPSERT",
+        "aspectName": "dashboardInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "exposure.sample_dbt.customer_dashboard",
+                    "exposure_type": "dashboard",
+                    "maturity": "high",
+                    "dbt_package_name": "sample_dbt",
+                    "dbt_file_path": "models/exposures.yml",
+                    "team": "analytics"
+                },
+                "externalUrl": "https://bi.example.com/dashboards/customer",
+                "title": "customer_dashboard",
+                "description": "Dashboard showing customer details and billing",
+                "charts": [],
+                "datasets": [
+                    "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+                    "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)"
+                ],
+                "dashboards": [],
                 "lastModified": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:dbt_ingestion"
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:dbt_ingestion"
+                    },
+                    "lastModified": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:dbt_ingestion"
+                    }
                 }
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Dashboard"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
-    "changeType": "UPSERT",
-    "aspectName": "ownership",
-    "aspect": {
-        "json": {
-            "owners": [
-                {
-                    "owner": "urn:li:corpuser:analytics@example.com",
-                    "type": "DATAOWNER"
-                }
-            ],
-            "ownerTypes": {},
-            "lastModified": {
-                "time": 0,
-                "actor": "urn:li:corpuser:unknown"
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
-    "changeType": "UPSERT",
-    "aspectName": "globalTags",
-    "aspect": {
-        "json": {
-            "tags": [
-                {
-                    "tag": "urn:li:tag:dbt:executive"
-                },
-                {
-                    "tag": "urn:li:tag:dbt:customer"
-                }
-            ]
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Dashboard"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
-    "changeType": "UPSERT",
-    "aspectName": "dashboardInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "exposure.sample_dbt.payments_ml_model",
-                "exposure_type": "ml",
-                "maturity": "medium",
-                "dbt_package_name": "sample_dbt",
-                "dbt_file_path": "models/exposures.yml"
-            },
-            "externalUrl": "https://mlflow.example.com/models/payments",
-            "title": "payments_ml_model",
-            "description": "ML model for payment predictions",
-            "charts": [],
-            "datasets": [
-                "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)"
-            ],
-            "dashboards": [],
-            "lastModified": {
-                "created": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:dbt_ingestion"
-                },
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
+        "changeType": "UPSERT",
+        "aspectName": "ownership",
+        "aspect": {
+            "json": {
+                "owners": [
+                    {
+                        "owner": "urn:li:corpuser:analytics@example.com",
+                        "type": "DATAOWNER"
+                    }
+                ],
+                "ownerTypes": {},
                 "lastModified": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:dbt_ingestion"
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
                 }
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "ML Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
-    "changeType": "UPSERT",
-    "aspectName": "ownership",
-    "aspect": {
-        "json": {
-            "owners": [
-                {
-                    "owner": "urn:li:corpuser:ds@example.com",
-                    "type": "DATAOWNER"
-                }
-            ],
-            "ownerTypes": {},
-            "lastModified": {
-                "time": 0,
-                "actor": "urn:li:corpuser:unknown"
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
+        "changeType": "UPSERT",
+        "aspectName": "globalTags",
+        "aspect": {
+            "json": {
+                "tags": [
+                    {
+                        "tag": "urn:li:tag:dbt:executive"
+                    },
+                    {
+                        "tag": "urn:li:tag:dbt:customer"
+                    }
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
-    "changeType": "UPSERT",
-    "aspectName": "globalTags",
-    "aspect": {
-        "json": {
-            "tags": [
-                {
-                    "tag": "urn:li:tag:dbt:ml"
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
+        "changeType": "UPSERT",
+        "aspectName": "dashboardInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "exposure.sample_dbt.payments_ml_model",
+                    "exposure_type": "ml",
+                    "maturity": "medium",
+                    "dbt_package_name": "sample_dbt",
+                    "dbt_file_path": "models/exposures.yml"
                 },
-                {
-                    "tag": "urn:li:tag:dbt:payments"
+                "externalUrl": "https://mlflow.example.com/models/payments",
+                "title": "payments_ml_model",
+                "description": "ML model for payment predictions",
+                "charts": [],
+                "datasets": [
+                    "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)"
+                ],
+                "dashboards": [],
+                "lastModified": {
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:dbt_ingestion"
+                    },
+                    "lastModified": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:dbt_ingestion"
+                    }
                 }
-            ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "ML Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
+        "changeType": "UPSERT",
+        "aspectName": "ownership",
+        "aspect": {
+            "json": {
+                "owners": [
+                    {
+                        "owner": "urn:li:corpuser:ds@example.com",
+                        "type": "DATAOWNER"
+                    }
+                ],
+                "ownerTypes": {},
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
+        "changeType": "UPSERT",
+        "aspectName": "globalTags",
+        "aspect": {
+            "json": {
+                "tags": [
+                    {
+                        "tag": "urn:li:tag:dbt:ml"
+                    },
+                    {
+                        "tag": "urn:li:tag:dbt:payments"
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:column_tag",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:column_tag"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:customer",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:customer"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:executive",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:executive"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:ml",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:ml"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:payments",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:payments"
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:column_tag",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:column_tag"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:test_tag",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:test_tag"
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:customer",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:customer"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:executive",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:executive"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:ml",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:ml"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:payments",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:payments"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:test_tag",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:test_tag"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-target-platform-primary-siblings",
+            "lastRunId": "no-run-id-provided"
+        }
     }
-}
 ]

--- a/metadata-ingestion/tests/integration/dbt/dbt_test_test_model_performance_golden.json
+++ b/metadata-ingestion/tests/integration/dbt/dbt_test_test_model_performance_golden.json
@@ -1,7317 +1,7457 @@
 [
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "model",
-                            "materialization": "ephemeral",
-                            "dbt_file_path": "models/transform/customer_details.sql",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.customer_details",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                            "manifest_version": "1.7.3",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.7.3"
-                        },
-                        "name": "customer_details",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.customer_details",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "INT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "full_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "VARCHAR",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "initial_full_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "VARCHAR",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "email",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "city",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "postal_code",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "phone",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),full_name)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),first_name)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),last_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),initial_full_name)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),email)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),address)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),city)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),postal_code)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),postal_code)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),phone)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),phone)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": false,
-                        "viewLogic": "{{ config(\n    materialized = \"ephemeral\",\n) }}\n\nSELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name as \"full_name\",\n    (\n        select cs.first_name || ' ' || cs.last_name\n        from {{ ref('customer_snapshot') }} cs where cs.customer_id = c.customer_id\n        order by dbt_valid_from desc\n        limit 1\n    ) as \"initial_full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\nFROM\n    {{ source('pagila', 'customer')}} c\n    left outer join {{ source('pagila', 'address')}} a on c.address_id = a.address_id\n    left outer join {{ source('pagila', 'city') }} m on a.city_id = m.city_id",
-                        "formattedViewLogic": "SELECT\n  c.customer_id,\n  c.first_name || ' ' || c.last_name AS \"full_name\",\n  (\n    SELECT\n      cs.first_name || ' ' || cs.last_name\n    FROM \"pagila\".\"public\".\"customer_snapshot\" AS cs\n    WHERE\n      cs.customer_id = c.customer_id\n    ORDER BY\n      dbt_valid_from DESC\n    LIMIT 1\n  ) AS \"initial_full_name\",\n  c.email,\n  a.address,\n  m.city,\n  a.postal_code,\n  a.phone\nFROM \"pagila\".\"public\".\"customer\" AS c\nLEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n  ON c.address_id = a.address_id\nLEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n  ON a.city_id = m.city_id",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "model",
-                            "materialization": "table",
-                            "dbt_file_path": "models/billing/monthly_billing_with_cust.sql",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.monthly_billing_with_cust",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                            "manifest_version": "1.7.3",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.7.3"
-                        },
-                        "name": "an-aliased-view-for-monthly-billing",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.monthly_billing_with_cust",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "billing_month",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "email",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payments_by_customer_by_month,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payments_by_customer_by_month,PROD),BillingMonth)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),billing_month)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payments_by_customer_by_month,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payments_by_customer_by_month,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),amount)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),email)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),email)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": true,
-                        "viewLogic": "{{ config(\n    materialized = \"table\",\n    alias='an-aliased-view-for-monthly-billing'\n) }}\n\nSELECT \n    pbc.\"BillingMonth\" as billing_month,\n    pbc.customer_id,\n    pbc.amount,\n    cust.email\nFROM\n    {{ ref('payments_by_customer_by_month')}} pbc\n    left outer join {{ ref('customer_details')}} cust on pbc.customer_id = cust.customer_id\nORDER BY\n    pbc.\"BillingMonth\"",
-                        "formattedViewLogic": "WITH __dbt__cte__customer_details AS (\n  SELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name AS \"full_name\",\n    (\n      SELECT\n        cs.first_name || ' ' || cs.last_name\n      FROM \"pagila\".\"public\".\"customer_snapshot\" AS cs\n      WHERE\n        cs.customer_id = c.customer_id\n      ORDER BY\n        dbt_valid_from DESC\n      LIMIT 1\n    ) AS \"initial_full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\n  FROM \"pagila\".\"public\".\"customer\" AS c\n  LEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n    ON c.address_id = a.address_id\n  LEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n    ON a.city_id = m.city_id\n)\nSELECT\n  pbc.\"BillingMonth\" AS billing_month,\n  pbc.customer_id,\n  pbc.amount,\n  cust.email\nFROM \"pagila\".\"public\".\"payments_by_customer_by_month\" AS pbc\nLEFT OUTER JOIN __dbt__cte__customer_details AS cust\n  ON pbc.customer_id = cust.customer_id\nORDER BY\n  pbc.\"BillingMonth\"",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:a42a5b1bee156e45972e12d4156fb7a2",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceProperties",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_name": "model.sample_dbt.monthly_billing_with_cust",
-                "dbt_urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)"
-            },
-            "name": "just-some-random-id_urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
-            "type": "BATCH_SCHEDULED",
-            "created": {
-                "time": 1663355198239,
-                "actor": "urn:li:corpuser:datahub"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:a42a5b1bee156e45972e12d4156fb7a2",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceRelationships",
-    "aspect": {
-        "json": {
-            "parentTemplate": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
-            "upstreamInstances": []
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:a42a5b1bee156e45972e12d4156fb7a2",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceInput",
-    "aspect": {
-        "json": {
-            "inputs": [
-                "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD)",
-                "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payments_by_customer_by_month,PROD)"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:a42a5b1bee156e45972e12d4156fb7a2",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceOutput",
-    "aspect": {
-        "json": {
-            "outputs": [
-                "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:a42a5b1bee156e45972e12d4156fb7a2",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1663355198239,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "status": "STARTED"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:a42a5b1bee156e45972e12d4156fb7a2",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1663355198241,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResultType": "success"
-            },
-            "durationMillis": 2
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "model",
-                            "materialization": "view",
-                            "dbt_file_path": "models/base/payments_base.sql",
-                            "catalog_type": "VIEW",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.payments_base",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                            "manifest_version": "1.7.3",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.7.3"
-                        },
-                        "name": "an_aliased_view_for_payments",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.payments_base",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),amount)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": false,
-                        "viewLogic": "{{ config(\n    materialized=\"view\",\n    alias='an_aliased_view_for_payments'\n) }}\n\nwith payments as (\n\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_01')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_03')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_04')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_05')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_06')}}\n)\n\nselect *\nfrom payments",
-                        "formattedViewLogic": "WITH payments AS (\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_01\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_03\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_04\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_05\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_06\"\n)\nSELECT\n  *\nFROM payments",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:fc6268f0be68fd04c310705b65efd6fe",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceProperties",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_name": "model.sample_dbt.payments_base",
-                "dbt_urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD)"
-            },
-            "name": "just-some-random-id_urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD)",
-            "type": "BATCH_SCHEDULED",
-            "created": {
-                "time": 1663355198239,
-                "actor": "urn:li:corpuser:datahub"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:fc6268f0be68fd04c310705b65efd6fe",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceRelationships",
-    "aspect": {
-        "json": {
-            "parentTemplate": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD)",
-            "upstreamInstances": []
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:fc6268f0be68fd04c310705b65efd6fe",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceInput",
-    "aspect": {
-        "json": {
-            "inputs": [
-                "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-                "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-                "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-                "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-                "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-                "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:fc6268f0be68fd04c310705b65efd6fe",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceOutput",
-    "aspect": {
-        "json": {
-            "outputs": [
-                "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD)"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:fc6268f0be68fd04c310705b65efd6fe",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1663355198239,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "status": "STARTED"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:fc6268f0be68fd04c310705b65efd6fe",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1663355198241,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResultType": "success"
-            },
-            "durationMillis": 2
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "model",
-                            "materialization": "table",
-                            "dbt_file_path": "models/transform/payments_by_customer_by_month.sql",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.payments_by_customer_by_month",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                            "manifest_version": "1.7.3",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.7.3"
-                        },
-                        "name": "payments_by_customer_by_month",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.payments_by_customer_by_month",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "BillingMonth",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "model",
+                                "materialization": "ephemeral",
+                                "dbt_file_path": "models/transform/customer_details.sql",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.customer_details",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                                "manifest_version": "1.7.3",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.7.3"
                             },
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric",
-                                "recursive": false,
-                                "isPartOfKey": false
+                            "name": "customer_details",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.customer_details",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
                             },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "description": "description for customer_id from dbt",
-                                "type": {
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "globalTags": {
-                                    "tags": [
-                                        {
-                                            "tag": "urn:li:tag:dbt:tag_from_dbt"
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
                                         }
-                                    ]
+                                    },
+                                    "nativeDataType": "INT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD),BillingMonth)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD),amount)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": true,
-                        "viewLogic": "{{ config(\n    materialized = \"table\",\n) }}\n\nSELECT\n    date_trunc('month', payment_date) as \"BillingMonth\",\n    customer_id,\n    sum(amount) as \"amount\"\nFROM\n    {{ ref('payments_base')}}\nGROUP BY\n    \"BillingMonth\",\n    customer_id",
-                        "formattedViewLogic": "SELECT\n  DATE_TRUNC('MONTH', payment_date) AS \"BillingMonth\",\n  customer_id,\n  SUM(amount) AS \"amount\"\nFROM \"pagila\".\"public\".\"an_aliased_view_for_payments\"\nGROUP BY\n  \"BillingMonth\",\n  customer_id",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:57aa623f096cf3a28af70fe94b713907",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceProperties",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_name": "model.sample_dbt.payments_by_customer_by_month",
-                "dbt_urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD)"
-            },
-            "name": "just-some-random-id_urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD)",
-            "type": "BATCH_SCHEDULED",
-            "created": {
-                "time": 1663355198239,
-                "actor": "urn:li:corpuser:datahub"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:57aa623f096cf3a28af70fe94b713907",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceRelationships",
-    "aspect": {
-        "json": {
-            "parentTemplate": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD)",
-            "upstreamInstances": []
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:57aa623f096cf3a28af70fe94b713907",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceInput",
-    "aspect": {
-        "json": {
-            "inputs": [
-                "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD)"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:57aa623f096cf3a28af70fe94b713907",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceOutput",
-    "aspect": {
-        "json": {
-            "outputs": [
-                "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD)"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:57aa623f096cf3a28af70fe94b713907",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1663355198239,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "status": "STARTED"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:57aa623f096cf3a28af70fe94b713907",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1663355198241,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResultType": "success"
-            },
-            "durationMillis": 2
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Snapshot"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "snapshot",
-                            "materialization": "snapshot",
-                            "dbt_file_path": "snapshots/customer_snapshot.sql",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "snapshot.sample_dbt.customer_snapshot",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                            "manifest_version": "1.7.3",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.7.3"
-                        },
-                        "name": "customer_snapshot",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "snapshot.sample_dbt.customer_snapshot",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "active",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "full_name",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "VARCHAR",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "activebool",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "initial_full_name",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.BooleanType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "VARCHAR",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "boolean",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address_id",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "email",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "create_date",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "address",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.DateType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "date",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "city",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "dbt_scd_id",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "postal_code",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "dbt_updated_at",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "phone",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "dbt_valid_from",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "dbt_valid_to",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "email",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "first_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "store_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),active)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),active)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),activebool)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),activebool)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),address_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),address_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),create_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),create_date)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),email)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),first_name)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),last_name)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),last_update)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),store_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),store_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": true,
-                        "viewLogic": "\n\n{{\n    config(\n      target_database='pagila',\n      target_schema='public',\n      unique_key='customer_id',\n\n      strategy='timestamp',\n      updated_at='last_update',\n    )\n}}\n\nselect * from {{ source('pagila', 'customer') }}\n\n",
-                        "formattedViewLogic": "SELECT\n  *\nFROM \"pagila\".\"public\".\"customer\"",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:36225e795a4597b2376996774a803b0d",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceProperties",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_name": "snapshot.sample_dbt.customer_snapshot",
-                "dbt_urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD)"
-            },
-            "name": "just-some-random-id_urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD)",
-            "type": "BATCH_SCHEDULED",
-            "created": {
-                "time": 1663355198239,
-                "actor": "urn:li:corpuser:datahub"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:36225e795a4597b2376996774a803b0d",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceRelationships",
-    "aspect": {
-        "json": {
-            "parentTemplate": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD)",
-            "upstreamInstances": []
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:36225e795a4597b2376996774a803b0d",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceInput",
-    "aspect": {
-        "json": {
-            "inputs": [
-                "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:36225e795a4597b2376996774a803b0d",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceOutput",
-    "aspect": {
-        "json": {
-            "outputs": [
-                "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD)"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:36225e795a4597b2376996774a803b0d",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1663355198239,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "status": "STARTED"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:36225e795a4597b2376996774a803b0d",
-    "changeType": "UPSERT",
-    "aspectName": "dataProcessInstanceRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1663355198241,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResultType": "success"
-            },
-            "durationMillis": 2
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "model_maturity": "in dev",
-                            "owner": "@alice",
-                            "some_other_property": "test 1",
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.actor",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                            "manifest_version": "1.7.3",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.7.3"
-                        },
-                        "name": "actor",
-                        "description": "description for actor table from dbt",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:@alice",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
                         }
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.actor",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1581759273000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "actor_id",
-                                "nullable": false,
-                                "description": "description for actor_id column from dbt",
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "first_name",
-                                "nullable": false,
-                                "description": "dbt comment: Actors column \u2013 from postgres\n\ndbt model description: description for first_name from dbt",
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_name",
-                                "nullable": false,
-                                "description": "description for last_name from dbt",
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "description": "description for last_update from dbt",
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),actor_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),actor_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),first_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),first_name)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),last_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),last_name)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.address",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                            "manifest_version": "1.7.3",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.7.3"
-                        },
-                        "name": "address",
-                        "description": "a user's address",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.address",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1581759930000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "address",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address2",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "city_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "district",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "phone",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "postal_code",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address2)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address2)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),city_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),city_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),district)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),district)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),phone)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),phone)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),postal_code)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),postal_code)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.category",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                            "manifest_version": "1.7.3",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.7.3"
-                        },
-                        "name": "category",
-                        "description": "a user's category",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.category",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1581759987000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "category_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),category_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),category_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),name)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.city",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                            "manifest_version": "1.7.3",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.7.3"
-                        },
-                        "name": "city",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.city",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1581759925000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "city",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "city_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "country_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),city)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),city_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),country_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),country_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "model_maturity": "in prod",
-                            "owner": "@bob",
-                            "some_other_property": "test 2",
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.country",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                            "manifest_version": "1.7.3",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.7.3"
-                        },
-                        "name": "country",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:@bob",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        }
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.country",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1581759840000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "country",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "country_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),country)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),country)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),country_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),country_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.customer",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                            "manifest_version": "1.7.3",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.7.3"
-                        },
-                        "name": "customer",
-                        "description": "description for customer table from dbt",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.customer",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1581760640000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "active",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "activebool",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.BooleanType": {}
-                                    }
-                                },
-                                "nativeDataType": "boolean",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "create_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.DateType": {}
-                                    }
-                                },
-                                "nativeDataType": "date",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "email",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "first_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "store_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),active)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),active)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),activebool)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),activebool)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),address_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),address_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),create_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),create_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),email)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),first_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),store_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),store_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                            "manifest_version": "1.7.3",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.7.3"
-                        },
-                        "name": "payment_p2020_01",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_01",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1580505371996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "an_array_property": "['alpha', 'beta', 'charlie']",
-                            "model_maturity": "in prod",
-                            "owner": "@charles",
-                            "some_other_property": "test 3",
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                            "manifest_version": "1.7.3",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.7.3"
-                        },
-                        "name": "payment_p2020_02",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:@charles",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        }
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_02",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1582319845996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                            "manifest_version": "1.7.3",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.7.3"
-                        },
-                        "name": "payment_p2020_03",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_03",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1584998318996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                            "manifest_version": "1.7.3",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.7.3"
-                        },
-                        "name": "payment_p2020_04",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_04",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1588287228996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                            "manifest_version": "1.7.3",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.7.3"
-                        },
-                        "name": "payment_p2020_05",
-                        "description": "a payment",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_05",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1589460269996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                            "manifest_version": "1.7.3",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "1.7.3"
-                        },
-                        "name": "payment_p2020_06",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_06",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": -62135596800000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
-                "value": {
-                    "auditStamp": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
                     },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),full_name)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),first_name)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),last_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),initial_full_name)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),email)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),address)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),city)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),postal_code)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),postal_code)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),phone)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),phone)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": false,
+                            "viewLogic": "{{ config(\n    materialized = \"ephemeral\",\n) }}\n\nSELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name as \"full_name\",\n    (\n        select cs.first_name || ' ' || cs.last_name\n        from {{ ref('customer_snapshot') }} cs where cs.customer_id = c.customer_id\n        order by dbt_valid_from desc\n        limit 1\n    ) as \"initial_full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\nFROM\n    {{ source('pagila', 'customer')}} c\n    left outer join {{ source('pagila', 'address')}} a on c.address_id = a.address_id\n    left outer join {{ source('pagila', 'city') }} m on a.city_id = m.city_id",
+                            "formattedViewLogic": "SELECT\n  c.customer_id,\n  c.first_name || ' ' || c.last_name AS \"full_name\",\n  (\n    SELECT\n      cs.first_name || ' ' || cs.last_name\n    FROM \"pagila\".\"public\".\"customer_snapshot\" AS cs\n    WHERE\n      cs.customer_id = c.customer_id\n    ORDER BY\n      dbt_valid_from DESC\n    LIMIT 1\n  ) AS \"initial_full_name\",\n  c.email,\n  a.address,\n  m.city,\n  a.postal_code,\n  a.phone\nFROM \"pagila\".\"public\".\"customer\" AS c\nLEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n  ON c.address_id = a.address_id\nLEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n  ON a.city_id = m.city_id",
+                            "viewLanguage": "SQL"
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "model",
+                                "materialization": "table",
+                                "dbt_file_path": "models/billing/monthly_billing_with_cust.sql",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.monthly_billing_with_cust",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                                "manifest_version": "1.7.3",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.7.3"
+                            },
+                            "name": "an-aliased-view-for-monthly-billing",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.monthly_billing_with_cust",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "billing_month",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "email",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payments_by_customer_by_month,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payments_by_customer_by_month,PROD),BillingMonth)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),billing_month)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payments_by_customer_by_month,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payments_by_customer_by_month,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),email)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),email)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": true,
+                            "viewLogic": "{{ config(\n    materialized = \"table\",\n    alias='an-aliased-view-for-monthly-billing'\n) }}\n\nSELECT \n    pbc.\"BillingMonth\" as billing_month,\n    pbc.customer_id,\n    pbc.amount,\n    cust.email\nFROM\n    {{ ref('payments_by_customer_by_month')}} pbc\n    left outer join {{ ref('customer_details')}} cust on pbc.customer_id = cust.customer_id\nORDER BY\n    pbc.\"BillingMonth\"",
+                            "formattedViewLogic": "WITH __dbt__cte__customer_details AS (\n  SELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name AS \"full_name\",\n    (\n      SELECT\n        cs.first_name || ' ' || cs.last_name\n      FROM \"pagila\".\"public\".\"customer_snapshot\" AS cs\n      WHERE\n        cs.customer_id = c.customer_id\n      ORDER BY\n        dbt_valid_from DESC\n      LIMIT 1\n    ) AS \"initial_full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\n  FROM \"pagila\".\"public\".\"customer\" AS c\n  LEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n    ON c.address_id = a.address_id\n  LEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n    ON a.city_id = m.city_id\n)\nSELECT\n  pbc.\"BillingMonth\" AS billing_month,\n  pbc.customer_id,\n  pbc.amount,\n  cust.email\nFROM \"pagila\".\"public\".\"payments_by_customer_by_month\" AS pbc\nLEFT OUTER JOIN __dbt__cte__customer_details AS cust\n  ON pbc.customer_id = cust.customer_id\nORDER BY\n  pbc.\"BillingMonth\"",
+                            "viewLanguage": "SQL"
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:a42a5b1bee156e45972e12d4156fb7a2",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceProperties",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_name": "model.sample_dbt.monthly_billing_with_cust",
+                    "dbt_urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)"
+                },
+                "name": "just-some-random-id_urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
+                "type": "BATCH_SCHEDULED",
+                "created": {
+                    "time": 1663355198239,
+                    "actor": "urn:li:corpuser:datahub"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:a42a5b1bee156e45972e12d4156fb7a2",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceRelationships",
+        "aspect": {
+            "json": {
+                "parentTemplate": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
+                "upstreamInstances": []
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:a42a5b1bee156e45972e12d4156fb7a2",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceInput",
+        "aspect": {
+            "json": {
+                "inputs": [
+                    "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD)",
+                    "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payments_by_customer_by_month,PROD)"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:a42a5b1bee156e45972e12d4156fb7a2",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceOutput",
+        "aspect": {
+            "json": {
+                "outputs": [
+                    "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:a42a5b1bee156e45972e12d4156fb7a2",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1663355198239,
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                },
+                "status": "STARTED"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:a42a5b1bee156e45972e12d4156fb7a2",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1663355198241,
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                },
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResultType": "success"
+                },
+                "durationMillis": 2
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "model",
+                                "materialization": "view",
+                                "dbt_file_path": "models/base/payments_base.sql",
+                                "catalog_type": "VIEW",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.payments_base",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                                "manifest_version": "1.7.3",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.7.3"
+                            },
+                            "name": "an_aliased_view_for_payments",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.payments_base",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": false,
+                            "viewLogic": "{{ config(\n    materialized=\"view\",\n    alias='an_aliased_view_for_payments'\n) }}\n\nwith payments as (\n\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_01')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_03')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_04')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_05')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_06')}}\n)\n\nselect *\nfrom payments",
+                            "formattedViewLogic": "WITH payments AS (\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_01\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_03\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_04\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_05\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_06\"\n)\nSELECT\n  *\nFROM payments",
+                            "viewLanguage": "SQL"
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:fc6268f0be68fd04c310705b65efd6fe",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceProperties",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_name": "model.sample_dbt.payments_base",
+                    "dbt_urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD)"
+                },
+                "name": "just-some-random-id_urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD)",
+                "type": "BATCH_SCHEDULED",
+                "created": {
+                    "time": 1663355198239,
+                    "actor": "urn:li:corpuser:datahub"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:fc6268f0be68fd04c310705b65efd6fe",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceRelationships",
+        "aspect": {
+            "json": {
+                "parentTemplate": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD)",
+                "upstreamInstances": []
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:fc6268f0be68fd04c310705b65efd6fe",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceInput",
+        "aspect": {
+            "json": {
+                "inputs": [
+                    "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+                    "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+                    "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+                    "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+                    "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+                    "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:fc6268f0be68fd04c310705b65efd6fe",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceOutput",
+        "aspect": {
+            "json": {
+                "outputs": [
+                    "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD)"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:fc6268f0be68fd04c310705b65efd6fe",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1663355198239,
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                },
+                "status": "STARTED"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:fc6268f0be68fd04c310705b65efd6fe",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1663355198241,
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                },
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResultType": "success"
+                },
+                "durationMillis": 2
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "model",
+                                "materialization": "table",
+                                "dbt_file_path": "models/transform/payments_by_customer_by_month.sql",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.payments_by_customer_by_month",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                                "manifest_version": "1.7.3",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.7.3"
+                            },
+                            "name": "payments_by_customer_by_month",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.payments_by_customer_by_month",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "BillingMonth",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "description": "description for customer_id from dbt",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "globalTags": {
+                                        "tags": [
+                                            {
+                                                "tag": "urn:li:tag:dbt:tag_from_dbt"
+                                            }
+                                        ]
+                                    },
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD),BillingMonth)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": true,
+                            "viewLogic": "{{ config(\n    materialized = \"table\",\n) }}\n\nSELECT\n    date_trunc('month', payment_date) as \"BillingMonth\",\n    customer_id,\n    sum(amount) as \"amount\"\nFROM\n    {{ ref('payments_base')}}\nGROUP BY\n    \"BillingMonth\",\n    customer_id",
+                            "formattedViewLogic": "SELECT\n  DATE_TRUNC('MONTH', payment_date) AS \"BillingMonth\",\n  customer_id,\n  SUM(amount) AS \"amount\"\nFROM \"pagila\".\"public\".\"an_aliased_view_for_payments\"\nGROUP BY\n  \"BillingMonth\",\n  customer_id",
+                            "viewLanguage": "SQL"
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:57aa623f096cf3a28af70fe94b713907",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceProperties",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_name": "model.sample_dbt.payments_by_customer_by_month",
+                    "dbt_urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD)"
+                },
+                "name": "just-some-random-id_urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD)",
+                "type": "BATCH_SCHEDULED",
+                "created": {
+                    "time": 1663355198239,
+                    "actor": "urn:li:corpuser:datahub"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:57aa623f096cf3a28af70fe94b713907",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceRelationships",
+        "aspect": {
+            "json": {
+                "parentTemplate": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD)",
+                "upstreamInstances": []
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:57aa623f096cf3a28af70fe94b713907",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceInput",
+        "aspect": {
+            "json": {
+                "inputs": [
+                    "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD)"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:57aa623f096cf3a28af70fe94b713907",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceOutput",
+        "aspect": {
+            "json": {
+                "outputs": [
+                    "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD)"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:57aa623f096cf3a28af70fe94b713907",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1663355198239,
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                },
+                "status": "STARTED"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:57aa623f096cf3a28af70fe94b713907",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1663355198241,
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                },
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResultType": "success"
+                },
+                "durationMillis": 2
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Snapshot"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "snapshot",
+                                "materialization": "snapshot",
+                                "dbt_file_path": "snapshots/customer_snapshot.sql",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "snapshot.sample_dbt.customer_snapshot",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                                "manifest_version": "1.7.3",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.7.3"
+                            },
+                            "name": "customer_snapshot",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "snapshot.sample_dbt.customer_snapshot",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "active",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "activebool",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.BooleanType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "boolean",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "address_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "create_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.DateType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "date",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "dbt_scd_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "dbt_updated_at",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "dbt_valid_from",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "dbt_valid_to",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "email",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "first_name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "store_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),active)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),active)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),activebool)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),activebool)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),address_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),address_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),create_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),create_date)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),email)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),first_name)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),last_name)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),store_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),store_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": true,
+                            "viewLogic": "\n\n{{\n    config(\n      target_database='pagila',\n      target_schema='public',\n      unique_key='customer_id',\n\n      strategy='timestamp',\n      updated_at='last_update',\n    )\n}}\n\nselect * from {{ source('pagila', 'customer') }}\n\n",
+                            "formattedViewLogic": "SELECT\n  *\nFROM \"pagila\".\"public\".\"customer\"",
+                            "viewLanguage": "SQL"
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:36225e795a4597b2376996774a803b0d",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceProperties",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_name": "snapshot.sample_dbt.customer_snapshot",
+                    "dbt_urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD)"
+                },
+                "name": "just-some-random-id_urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD)",
+                "type": "BATCH_SCHEDULED",
+                "created": {
+                    "time": 1663355198239,
+                    "actor": "urn:li:corpuser:datahub"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:36225e795a4597b2376996774a803b0d",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceRelationships",
+        "aspect": {
+            "json": {
+                "parentTemplate": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD)",
+                "upstreamInstances": []
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:36225e795a4597b2376996774a803b0d",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceInput",
+        "aspect": {
+            "json": {
+                "inputs": [
+                    "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:36225e795a4597b2376996774a803b0d",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceOutput",
+        "aspect": {
+            "json": {
+                "outputs": [
+                    "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD)"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:36225e795a4597b2376996774a803b0d",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1663355198239,
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                },
+                "status": "STARTED"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:36225e795a4597b2376996774a803b0d",
+        "changeType": "UPSERT",
+        "aspectName": "dataProcessInstanceRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1663355198241,
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                },
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResultType": "success"
+                },
+                "durationMillis": 2
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "model_maturity": "in dev",
+                                "owner": "@alice",
+                                "some_other_property": "test 1",
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.actor",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                                "manifest_version": "1.7.3",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.7.3"
+                            },
+                            "name": "actor",
+                            "description": "description for actor table from dbt",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:@alice",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.actor",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1581759273000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "actor_id",
+                                    "nullable": false,
+                                    "description": "description for actor_id column from dbt",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "first_name",
+                                    "nullable": false,
+                                    "description": "dbt comment: Actors column \u2013 from postgres\n\ndbt model description: description for first_name from dbt",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_name",
+                                    "nullable": false,
+                                    "description": "description for last_name from dbt",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "description": "description for last_update from dbt",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),actor_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),actor_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),first_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),first_name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),last_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),last_name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.address",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                                "manifest_version": "1.7.3",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.7.3"
+                            },
+                            "name": "address",
+                            "description": "a user's address",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.address",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1581759930000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "address",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "address2",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "address_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "city_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "district",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "phone",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "postal_code",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address2)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address2)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),city_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),city_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),district)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),district)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),phone)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),phone)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),postal_code)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),postal_code)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.category",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                                "manifest_version": "1.7.3",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.7.3"
+                            },
+                            "name": "category",
+                            "description": "a user's category",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.category",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1581759987000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "category_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),category_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),category_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.city",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                                "manifest_version": "1.7.3",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.7.3"
+                            },
+                            "name": "city",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.city",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1581759925000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "city",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "city_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "country_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),city)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),city_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),country_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),country_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "model_maturity": "in prod",
+                                "owner": "@bob",
+                                "some_other_property": "test 2",
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.country",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                                "manifest_version": "1.7.3",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.7.3"
+                            },
+                            "name": "country",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:@bob",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.country",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1581759840000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "country",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "country_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),country)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),country)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),country_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),country_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.customer",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                                "manifest_version": "1.7.3",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.7.3"
+                            },
+                            "name": "customer",
+                            "description": "description for customer table from dbt",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.customer",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1581760640000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "active",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "activebool",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.BooleanType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "boolean",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "address_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "create_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.DateType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "date",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "email",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "first_name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "store_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),active)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),active)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),activebool)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),activebool)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),address_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),address_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),create_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),create_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),email)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),first_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),store_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),store_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                                "manifest_version": "1.7.3",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.7.3"
+                            },
+                            "name": "payment_p2020_01",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_01",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1580505371996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "an_array_property": "['alpha', 'beta', 'charlie']",
+                                "model_maturity": "in prod",
+                                "owner": "@charles",
+                                "some_other_property": "test 3",
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                                "manifest_version": "1.7.3",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.7.3"
+                            },
+                            "name": "payment_p2020_02",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:@charles",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_02",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1582319845996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                                "manifest_version": "1.7.3",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.7.3"
+                            },
+                            "name": "payment_p2020_03",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_03",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1584998318996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                                "manifest_version": "1.7.3",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.7.3"
+                            },
+                            "name": "payment_p2020_04",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_04",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1588287228996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                                "manifest_version": "1.7.3",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.7.3"
+                            },
+                            "name": "payment_p2020_05",
+                            "description": "a payment",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_05",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1589460269996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                                "manifest_version": "1.7.3",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "1.7.3"
+                            },
+                            "name": "payment_p2020_06",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_06",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": -62135596800000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
+                    "value": {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
+                        "type": "COPY"
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an-aliased-view-for-monthly-billing,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),amount)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an-aliased-view-for-monthly-billing,PROD),billing_month)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),billing_month)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an-aliased-view-for-monthly-billing,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),customer_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an-aliased-view-for-monthly-billing,PROD),email)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),email)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD)",
+                    "value": {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD)",
+                        "type": "COPY"
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),amount)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),customer_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD),payment_date)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),payment_date)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD),payment_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),payment_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD),rental_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),rental_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD),staff_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),staff_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payments_by_customer_by_month,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD)",
+                    "value": {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD)",
+                        "type": "COPY"
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payments_by_customer_by_month,PROD),BillingMonth)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD),BillingMonth)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payments_by_customer_by_month,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD),amount)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payments_by_customer_by_month,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD),customer_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD)",
+                    "value": {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD)",
+                        "type": "COPY"
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),active)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),active)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),activebool)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),activebool)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),address_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),address_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),create_date)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),create_date)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),customer_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),dbt_scd_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),dbt_scd_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),dbt_updated_at)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),dbt_updated_at)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),dbt_valid_from)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),dbt_valid_from)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),dbt_valid_to)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),dbt_valid_to)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),email)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),email)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),first_name)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),first_name)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),last_name)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),last_name)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),last_update)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),last_update)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),store_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),store_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ba2c6ba830d407d539452f4cf46c92a6",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ba2c6ba830d407d539452f4cf46c92a6",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.sample_dbt.assert_source_actor_last_update_is_recent",
+                    "dbt_test_upstream_unique_id": "source.sample_dbt.pagila.actor",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+                    "scope": "DATASET_ROWS",
+                    "aggregation": "_NATIVE_",
+                    "operator": "_NATIVE_",
+                    "nativeType": "assert_source_actor_last_update_is_recent",
+                    "nativeParameters": {},
+                    "logic": "select\n    *\nfrom \"pagila\".\"public\".\"actor\"\nwhere last_update < (now() - interval '100 years')"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ba2c6ba830d407d539452f4cf46c92a6",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1663355198239,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
+                },
+                "assertionUrn": "urn:li:assertion:ba2c6ba830d407d539452f4cf46c92a6",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:10f2a119dedcaab43afc47ff13d9cb5b",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:10f2a119dedcaab43afc47ff13d9cb5b",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.sample_dbt.is_email_monthly_billing_with_cust_email.57a935ce99",
+                    "dbt_test_upstream_unique_id": "model.sample_dbt.monthly_billing_with_cust",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
                     "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
-                    "type": "COPY"
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an-aliased-view-for-monthly-billing,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),amount)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an-aliased-view-for-monthly-billing,PROD),billing_month)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),billing_month)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an-aliased-view-for-monthly-billing,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),customer_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an-aliased-view-for-monthly-billing,PROD),email)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),email)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD)",
-                "value": {
-                    "auditStamp": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),email)"
+                    ],
+                    "aggregation": "_NATIVE_",
+                    "operator": "_NATIVE_",
+                    "nativeType": "is_email_monthly_billing_with_cust_email",
+                    "nativeParameters": {
+                        "column_name": "email",
+                        "model": "{{ get_where_subquery(ref('monthly_billing_with_cust')) }}"
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD)",
-                    "type": "COPY"
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),amount)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),customer_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD),payment_date)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),payment_date)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD),payment_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),payment_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD),rental_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),rental_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.an_aliased_view_for_payments,PROD),staff_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an_aliased_view_for_payments,PROD),staff_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payments_by_customer_by_month,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD)",
-                "value": {
-                    "auditStamp": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
-                    },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD)",
-                    "type": "COPY"
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payments_by_customer_by_month,PROD),BillingMonth)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD),BillingMonth)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payments_by_customer_by_month,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD),amount)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payments_by_customer_by_month,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payments_by_customer_by_month,PROD),customer_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD)",
-                "value": {
-                    "auditStamp": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
-                    },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD)",
-                    "type": "COPY"
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),active)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),active)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),activebool)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),activebool)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),address_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),address_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),create_date)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),create_date)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),customer_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),dbt_scd_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),dbt_scd_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),dbt_updated_at)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),dbt_updated_at)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),dbt_valid_from)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),dbt_valid_from)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),dbt_valid_to)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),dbt_valid_to)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),email)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),email)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),first_name)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),first_name)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),last_name)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),last_name)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),last_update)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),last_update)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer_snapshot,PROD),store_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_snapshot,PROD),store_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ba2c6ba830d407d539452f4cf46c92a6",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ba2c6ba830d407d539452f4cf46c92a6",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.sample_dbt.assert_source_actor_last_update_is_recent",
-                "dbt_test_upstream_unique_id": "source.sample_dbt.pagila.actor",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-                "scope": "DATASET_ROWS",
-                "aggregation": "_NATIVE_",
-                "operator": "_NATIVE_",
-                "nativeType": "assert_source_actor_last_update_is_recent",
-                "nativeParameters": {},
-                "logic": "select\n    *\nfrom \"pagila\".\"public\".\"actor\"\nwhere last_update < (now() - interval '100 years')"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ba2c6ba830d407d539452f4cf46c92a6",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1663355198239,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:ba2c6ba830d407d539452f4cf46c92a6",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:10f2a119dedcaab43afc47ff13d9cb5b",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:10f2a119dedcaab43afc47ff13d9cb5b",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.sample_dbt.is_email_monthly_billing_with_cust_email.57a935ce99",
-                "dbt_test_upstream_unique_id": "model.sample_dbt.monthly_billing_with_cust",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),email)"
-                ],
-                "aggregation": "_NATIVE_",
-                "operator": "_NATIVE_",
-                "nativeType": "is_email_monthly_billing_with_cust_email",
-                "nativeParameters": {
-                    "column_name": "email",
-                    "model": "{{ get_where_subquery(ref('monthly_billing_with_cust')) }}"
+                    "logic": "\n\n    select *\n    from \"pagila\".\"public\".\"an-aliased-view-for-monthly-billing\"\n    where email not like '%@%'\n\n"
                 },
-                "logic": "\n\n    select *\n    from \"pagila\".\"public\".\"an-aliased-view-for-monthly-billing\"\n    where email not like '%@%'\n\n"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:10f2a119dedcaab43afc47ff13d9cb5b",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1663355198239,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:10f2a119dedcaab43afc47ff13d9cb5b",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:c456eccf6440c6e3388c584689a74d91",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:c456eccf6440c6e3388c584689a74d91",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.sample_dbt.not_null_monthly_billing_with_cust_billing_month.19ce54289b",
-                "dbt_test_upstream_unique_id": "model.sample_dbt.monthly_billing_with_cust",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),billing_month)"
-                ],
-                "aggregation": "IDENTITY",
-                "operator": "NOT_NULL",
-                "nativeType": "not_null_monthly_billing_with_cust_billing_month",
-                "nativeParameters": {
-                    "column_name": "billing_month",
-                    "model": "{{ get_where_subquery(ref('monthly_billing_with_cust')) }}"
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:c456eccf6440c6e3388c584689a74d91",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1663355198239,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:c456eccf6440c6e3388c584689a74d91",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:f812b73477d81e6af283d918cb59e7bf",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:f812b73477d81e6af283d918cb59e7bf",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.sample_dbt.not_null_monthly_billing_with_cust_email.d405c2cc13",
-                "dbt_test_upstream_unique_id": "model.sample_dbt.monthly_billing_with_cust",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),email)"
-                ],
-                "aggregation": "IDENTITY",
-                "operator": "NOT_NULL",
-                "nativeType": "not_null_monthly_billing_with_cust_email",
-                "nativeParameters": {
-                    "column_name": "email",
-                    "model": "{{ get_where_subquery(ref('monthly_billing_with_cust')) }}"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:10f2a119dedcaab43afc47ff13d9cb5b",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1663355198239,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
+                },
+                "assertionUrn": "urn:li:assertion:10f2a119dedcaab43afc47ff13d9cb5b",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:f812b73477d81e6af283d918cb59e7bf",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1663355198239,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:f812b73477d81e6af283d918cb59e7bf",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:c456eccf6440c6e3388c584689a74d91",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:1f37cbfd95ea2a1d46b8e94828805eb1",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:1f37cbfd95ea2a1d46b8e94828805eb1",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.sample_dbt.relationships_monthly_billing_with_cust_customer_id__customer_id__ref_customer_details_.653e08a90b",
-                "dbt_test_upstream_unique_id": "model.sample_dbt.customer_details",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),customer_id)"
-                ],
-                "aggregation": "IDENTITY",
-                "operator": "_NATIVE_",
-                "parameters": {
-                    "value": {
-                        "value": "null",
-                        "type": "SET"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:c456eccf6440c6e3388c584689a74d91",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.sample_dbt.not_null_monthly_billing_with_cust_billing_month.19ce54289b",
+                    "dbt_test_upstream_unique_id": "model.sample_dbt.monthly_billing_with_cust",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),billing_month)"
+                    ],
+                    "aggregation": "IDENTITY",
+                    "operator": "NOT_NULL",
+                    "nativeType": "not_null_monthly_billing_with_cust_billing_month",
+                    "nativeParameters": {
+                        "column_name": "billing_month",
+                        "model": "{{ get_where_subquery(ref('monthly_billing_with_cust')) }}"
                     }
                 },
-                "nativeType": "relationships_monthly_billing_with_cust_customer_id__customer_id__ref_customer_details_",
-                "nativeParameters": {
-                    "column_name": "customer_id",
-                    "field": "customer_id",
-                    "model": "{{ get_where_subquery(ref('monthly_billing_with_cust')) }}",
-                    "to": "ref('customer_details')"
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:c456eccf6440c6e3388c584689a74d91",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1663355198239,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
                 },
-                "logic": "monthly_billing_with_cust.customer_id referential integrity to customer_details.customer_id"
+                "assertionUrn": "urn:li:assertion:c456eccf6440c6e3388c584689a74d91",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:1f37cbfd95ea2a1d46b8e94828805eb1",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1663355198239,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:1f37cbfd95ea2a1d46b8e94828805eb1",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:f812b73477d81e6af283d918cb59e7bf",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:f3a0dbf71b6cbf7112ff44925f475ff5",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:f3a0dbf71b6cbf7112ff44925f475ff5",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.sample_dbt.relationships_monthly_billing_with_cust_customer_id__customer_id__ref_customer_details_.653e08a90b",
-                "dbt_test_upstream_unique_id": "model.sample_dbt.monthly_billing_with_cust",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),customer_id)"
-                ],
-                "aggregation": "IDENTITY",
-                "operator": "_NATIVE_",
-                "parameters": {
-                    "value": {
-                        "value": "null",
-                        "type": "SET"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:f812b73477d81e6af283d918cb59e7bf",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.sample_dbt.not_null_monthly_billing_with_cust_email.d405c2cc13",
+                    "dbt_test_upstream_unique_id": "model.sample_dbt.monthly_billing_with_cust",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),email)"
+                    ],
+                    "aggregation": "IDENTITY",
+                    "operator": "NOT_NULL",
+                    "nativeType": "not_null_monthly_billing_with_cust_email",
+                    "nativeParameters": {
+                        "column_name": "email",
+                        "model": "{{ get_where_subquery(ref('monthly_billing_with_cust')) }}"
                     }
                 },
-                "nativeType": "relationships_monthly_billing_with_cust_customer_id__customer_id__ref_customer_details_",
-                "nativeParameters": {
-                    "column_name": "customer_id",
-                    "field": "customer_id",
-                    "model": "{{ get_where_subquery(ref('monthly_billing_with_cust')) }}",
-                    "to": "ref('customer_details')"
-                },
-                "logic": "monthly_billing_with_cust.customer_id referential integrity to customer_details.customer_id"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:f3a0dbf71b6cbf7112ff44925f475ff5",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1663355198239,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:f3a0dbf71b6cbf7112ff44925f475ff5",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:f6a1fde3ab4919abcc04bdee93144958",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:f6a1fde3ab4919abcc04bdee93144958",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.sample_dbt.source_not_null_pagila_actor_actor_id.ad63829d3e",
-                "dbt_test_upstream_unique_id": "source.sample_dbt.pagila.actor",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),actor_id)"
-                ],
-                "aggregation": "IDENTITY",
-                "operator": "NOT_NULL",
-                "nativeType": "source_not_null_pagila_actor_actor_id",
-                "nativeParameters": {
-                    "column_name": "actor_id",
-                    "model": "{{ get_where_subquery(source('pagila', 'actor')) }}"
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:f6a1fde3ab4919abcc04bdee93144958",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1663355198239,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:f6a1fde3ab4919abcc04bdee93144958",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:f812b73477d81e6af283d918cb59e7bf",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1663355198239,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
+                },
+                "assertionUrn": "urn:li:assertion:f812b73477d81e6af283d918cb59e7bf",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:60ce4aad7ff6dbff7004da0f2258c9df",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:1f37cbfd95ea2a1d46b8e94828805eb1",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:60ce4aad7ff6dbff7004da0f2258c9df",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "test.sample_dbt.source_unique_pagila_actor_actor_id.76aff1935a",
-                "dbt_test_upstream_unique_id": "source.sample_dbt.pagila.actor",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),actor_id)"
-                ],
-                "aggregation": "UNIQUE_PROPOTION",
-                "operator": "EQUAL_TO",
-                "parameters": {
-                    "value": {
-                        "value": "1.0",
-                        "type": "NUMBER"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:1f37cbfd95ea2a1d46b8e94828805eb1",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.sample_dbt.relationships_monthly_billing_with_cust_customer_id__customer_id__ref_customer_details_.653e08a90b",
+                    "dbt_test_upstream_unique_id": "model.sample_dbt.customer_details",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD)",
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD),customer_id)"
+                    ],
+                    "aggregation": "IDENTITY",
+                    "operator": "_NATIVE_",
+                    "parameters": {
+                        "value": {
+                            "value": "null",
+                            "type": "SET"
+                        }
+                    },
+                    "nativeType": "relationships_monthly_billing_with_cust_customer_id__customer_id__ref_customer_details_",
+                    "nativeParameters": {
+                        "column_name": "customer_id",
+                        "field": "customer_id",
+                        "model": "{{ get_where_subquery(ref('monthly_billing_with_cust')) }}",
+                        "to": "ref('customer_details')"
+                    },
+                    "logic": "monthly_billing_with_cust.customer_id referential integrity to customer_details.customer_id"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:1f37cbfd95ea2a1d46b8e94828805eb1",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1663355198239,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer_details,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
+                },
+                "assertionUrn": "urn:li:assertion:1f37cbfd95ea2a1d46b8e94828805eb1",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:f3a0dbf71b6cbf7112ff44925f475ff5",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:f3a0dbf71b6cbf7112ff44925f475ff5",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.sample_dbt.relationships_monthly_billing_with_cust_customer_id__customer_id__ref_customer_details_.653e08a90b",
+                    "dbt_test_upstream_unique_id": "model.sample_dbt.monthly_billing_with_cust",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),customer_id)"
+                    ],
+                    "aggregation": "IDENTITY",
+                    "operator": "_NATIVE_",
+                    "parameters": {
+                        "value": {
+                            "value": "null",
+                            "type": "SET"
+                        }
+                    },
+                    "nativeType": "relationships_monthly_billing_with_cust_customer_id__customer_id__ref_customer_details_",
+                    "nativeParameters": {
+                        "column_name": "customer_id",
+                        "field": "customer_id",
+                        "model": "{{ get_where_subquery(ref('monthly_billing_with_cust')) }}",
+                        "to": "ref('customer_details')"
+                    },
+                    "logic": "monthly_billing_with_cust.customer_id referential integrity to customer_details.customer_id"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:f3a0dbf71b6cbf7112ff44925f475ff5",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1663355198239,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
+                },
+                "assertionUrn": "urn:li:assertion:f3a0dbf71b6cbf7112ff44925f475ff5",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:f6a1fde3ab4919abcc04bdee93144958",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:f6a1fde3ab4919abcc04bdee93144958",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.sample_dbt.source_not_null_pagila_actor_actor_id.ad63829d3e",
+                    "dbt_test_upstream_unique_id": "source.sample_dbt.pagila.actor",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),actor_id)"
+                    ],
+                    "aggregation": "IDENTITY",
+                    "operator": "NOT_NULL",
+                    "nativeType": "source_not_null_pagila_actor_actor_id",
+                    "nativeParameters": {
+                        "column_name": "actor_id",
+                        "model": "{{ get_where_subquery(source('pagila', 'actor')) }}"
                     }
                 },
-                "nativeType": "source_unique_pagila_actor_actor_id",
-                "nativeParameters": {
-                    "column_name": "actor_id",
-                    "model": "{{ get_where_subquery(source('pagila', 'actor')) }}"
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:60ce4aad7ff6dbff7004da0f2258c9df",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1663355198239,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:60ce4aad7ff6dbff7004da0f2258c9df",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.actor",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-15T09:34:33+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:f6a1fde3ab4919abcc04bdee93144958",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1663355198239,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
+                },
+                "assertionUrn": "urn:li:assertion:f6a1fde3ab4919abcc04bdee93144958",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
-            },
-            "assertionUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.address",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:60ce4aad7ff6dbff7004da0f2258c9df",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-15T09:45:30+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:60ce4aad7ff6dbff7004da0f2258c9df",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "test.sample_dbt.source_unique_pagila_actor_actor_id.76aff1935a",
+                    "dbt_test_upstream_unique_id": "source.sample_dbt.pagila.actor",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3"
+                },
+                "type": "DATASET",
+                "datasetAssertion": {
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+                    "scope": "DATASET_COLUMN",
+                    "fields": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),actor_id)"
+                    ],
+                    "aggregation": "UNIQUE_PROPOTION",
+                    "operator": "EQUAL_TO",
+                    "parameters": {
+                        "value": {
+                            "value": "1.0",
+                            "type": "NUMBER"
+                        }
+                    },
+                    "nativeType": "source_unique_pagila_actor_actor_id",
+                    "nativeParameters": {
+                        "column_name": "actor_id",
+                        "model": "{{ get_where_subquery(source('pagila', 'actor')) }}"
+                    }
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
-            },
-            "assertionUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.category",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-15T09:46:27+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:60ce4aad7ff6dbff7004da0f2258c9df",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1663355198239,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {}
+                },
+                "assertionUrn": "urn:li:assertion:60ce4aad7ff6dbff7004da0f2258c9df",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
-            },
-            "assertionUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.city",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-15T09:45:25+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.actor",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
-            },
-            "assertionUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.country",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-15T09:44:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-15T09:34:33+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
-            },
-            "assertionUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.customer",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-15T09:57:20+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.address",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
-            },
-            "assertionUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-01-31T21:16:11.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-15T09:45:30+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
-            },
-            "assertionUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-21T21:17:25.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.category",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
-            },
-            "assertionUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-03-23T21:18:38.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-15T09:46:27+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
-            },
-            "assertionUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-04-30T22:53:48.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.city",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
-            },
-            "assertionUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-05-14T12:44:29.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-15T09:45:25+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
-            },
-            "assertionUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "0001-01-01T00:00:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.country",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
-            },
-            "assertionUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-15T09:44:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:10f2a119dedcaab43afc47ff13d9cb5b",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:1f37cbfd95ea2a1d46b8e94828805eb1",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.customer",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-15T09:57:20+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:60ce4aad7ff6dbff7004da0f2258c9df",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-01-31T21:16:11.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-21T21:17:25.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ba2c6ba830d407d539452f4cf46c92a6",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-03-23T21:18:38.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:c456eccf6440c6e3388c584689a74d91",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-04-30T22:53:48.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:f3a0dbf71b6cbf7112ff44925f475ff5",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:f6a1fde3ab4919abcc04bdee93144958",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-05-14T12:44:29.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:f812b73477d81e6af283d918cb59e7bf",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:36225e795a4597b2376996774a803b0d",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                    "manifest_version": "1.7.3",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "1.7.3",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:57aa623f096cf3a28af70fe94b713907",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "0001-01-01T00:00:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:a42a5b1bee156e45972e12d4156fb7a2",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:fc6268f0be68fd04c310705b65efd6fe",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:10f2a119dedcaab43afc47ff13d9cb5b",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:tag_from_dbt",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:tag_from_dbt"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:1f37cbfd95ea2a1d46b8e94828805eb1",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:60ce4aad7ff6dbff7004da0f2258c9df",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ba2c6ba830d407d539452f4cf46c92a6",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:c456eccf6440c6e3388c584689a74d91",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:f3a0dbf71b6cbf7112ff44925f475ff5",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:f6a1fde3ab4919abcc04bdee93144958",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:f812b73477d81e6af283d918cb59e7bf",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:36225e795a4597b2376996774a803b0d",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:57aa623f096cf3a28af70fe94b713907",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:a42a5b1bee156e45972e12d4156fb7a2",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataProcessInstance",
+        "entityUrn": "urn:li:dataProcessInstance:fc6268f0be68fd04c310705b65efd6fe",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:tag_from_dbt",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:tag_from_dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-model-performance",
+            "lastRunId": "no-run-id-provided"
+        }
     }
-}
 ]

--- a/metadata-ingestion/tests/integration/dbt/dbt_test_with_complex_owner_patterns_mces_golden.json
+++ b/metadata-ingestion/tests/integration/dbt/dbt_test_with_complex_owner_patterns_mces_golden.json
@@ -1,5074 +1,5151 @@
 [
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "business_owner": "jdoe.last@gmail.com",
-                            "data_governance.team_owner": "Finance",
-                            "has_pii": "True",
-                            "int_property": "1",
-                            "double_property": "2.5",
-                            "node_type": "model",
-                            "materialization": "ephemeral",
-                            "dbt_file_path": "models/transform/customer_details.sql",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.customer_details",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "customer_details",
-                        "description": "",
-                        "tags": [
-                            "dbt:test_tag"
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:alice2",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "business_owner": "jdoe.last@gmail.com",
+                                "data_governance.team_owner": "Finance",
+                                "has_pii": "True",
+                                "int_property": "1",
+                                "double_property": "2.5",
+                                "node_type": "model",
+                                "materialization": "ephemeral",
+                                "dbt_file_path": "models/transform/customer_details.sql",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.customer_details",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "customer_details",
+                            "description": "",
+                            "tags": [
+                                "dbt:test_tag"
+                            ]
                         }
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.GlobalTags": {
-                        "tags": [
-                            {
-                                "tag": "urn:li:tag:dbt:test_tag"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.customer_details",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "INT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "full_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "VARCHAR",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "email",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "city",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "postal_code",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "phone",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),full_name)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),email)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),address)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),city)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),postal_code)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),postal_code)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),phone)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),phone)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": false,
-                        "viewLogic": "{{ config(\n    materialized = \"ephemeral\",\n) }}\n\nSELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name as \"full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\nFROM\n    {{ source('pagila', 'customer')}} c\n    left outer join {{ source('pagila', 'address')}} a on c.address_id = a.address_id\n    left outer join {{ source('pagila', 'city') }} m on a.city_id = m.city_id",
-                        "formattedViewLogic": "SELECT\n  c.customer_id,\n  c.first_name || ' ' || c.last_name AS \"full_name\",\n  c.email,\n  a.address,\n  m.city,\n  a.postal_code,\n  a.phone\nFROM \"pagila\".\"public\".\"customer\" AS c\nLEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n  ON c.address_id = a.address_id\nLEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n  ON a.city_id = m.city_id",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "business_owner": "jdoe.last",
-                            "data_governance.team_owner": "Sales",
-                            "has_pii": "False",
-                            "int_property": "2",
-                            "double_property": "3.5",
-                            "node_type": "model",
-                            "materialization": "table",
-                            "dbt_file_path": "models/billing/monthly_billing_with_cust.sql",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.monthly_billing_with_cust",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "an-aliased-view-for-monthly-billing",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.monthly_billing_with_cust",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "billing_month",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "email",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": true,
-                        "viewLogic": "{{ config(\n    materialized = \"table\",\n    alias='an-aliased-view-for-monthly-billing'\n) }}\n\nSELECT \n    pbc.billing_month,\n    pbc.customer_id,\n    pbc.amount,\n    cust.email\nFROM\n    {{ ref('payments_by_customer_by_month')}} pbc\n    left outer join {{ ref('customer_details')}} cust on pbc.customer_id = cust.customer_id\nORDER BY\n    pbc.billing_month",
-                        "formattedViewLogic": "WITH __dbt__CTE__customer_details AS (\n  SELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name AS \"full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\n  FROM \"pagila\".\"public\".\"customer\" AS c\n  LEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n    ON c.address_id = a.address_id\n  LEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n    ON a.city_id = m.city_id\n)\nSELECT\n  pbc.billing_month,\n  pbc.customer_id,\n  pbc.amount,\n  cust.email\nFROM \"pagila\".\"dbt_postgres\".\"payments_by_customer_by_month\" AS pbc\nLEFT OUTER JOIN __dbt__CTE__customer_details AS cust\n  ON pbc.customer_id = cust.customer_id\nORDER BY\n  pbc.billing_month",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "model",
-                            "materialization": "view",
-                            "dbt_file_path": "models/base/payments_base.sql",
-                            "catalog_type": "VIEW",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.payments_base",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "an-aliased-view-for-payments",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.payments_base",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": false,
-                        "viewLogic": "{{ config(\n    materialized=\"view\",\n    alias='an-aliased-view-for-payments'\n) }}\n\nwith payments as (\n\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_01')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_03')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_04')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_05')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_06')}}\n)\n\nselect *\nfrom payments",
-                        "formattedViewLogic": "WITH payments AS (\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_01\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_03\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_04\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_05\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_06\"\n)\nSELECT\n  *\nFROM payments",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "model",
-                            "materialization": "table",
-                            "dbt_file_path": "models/transform/payments_by_customer_by_month.sql",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.payments_by_customer_by_month",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payments_by_customer_by_month",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.payments_by_customer_by_month",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "billing_month",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": true,
-                        "viewLogic": "{{ config(\n    materialized = \"table\",\n) }}\n\nSELECT\n    date_trunc('month', payment_date) as \"billing_month\",\n    customer_id,\n    sum(amount) as \"amount\"\nFROM\n    {{ ref('payments_base')}}\nGROUP BY\n    billing_month,\n    customer_id",
-                        "formattedViewLogic": "SELECT\n  DATE_TRUNC('MONTH', payment_date) AS \"billing_month\",\n  customer_id,\n  SUM(amount) AS \"amount\"\nFROM \"pagila\".\"dbt_postgres\".\"an-aliased-view-for-payments\"\nGROUP BY\n  billing_month,\n  customer_id",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "model_maturity": "in dev",
-                            "some_other_property": "test 1",
-                            "owner": "ML User(alice1@gmail.com)",
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.actor",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "actor",
-                        "description": "description for actor table from dbt",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:alice1",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
                         }
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.actor",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1581759273000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:alice2",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
                             }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "actor_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.GlobalTags": {
+                            "tags": [
+                                {
+                                    "tag": "urn:li:tag:dbt:test_tag"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.customer_details",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
                             },
-                            {
-                                "fieldPath": "first_name",
-                                "nullable": false,
-                                "description": "dbt comment: Actors column \u2013 from postgres\n\ndbt model description: description for first_name from dbt",
-                                "type": {
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "globalTags": {
-                                    "tags": [
-                                        {
-                                            "tag": "urn:li:tag:dbt:column_tag"
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
                                         }
-                                    ]
+                                    },
+                                    "nativeDataType": "INT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_name",
-                                "nullable": false,
-                                "description": "description for last_name from dbt",
-                                "type": {
+                                {
+                                    "fieldPath": "full_name",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "VARCHAR",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "description": "description for last_update from dbt",
-                                "type": {
+                                {
+                                    "fieldPath": "email",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),actor_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),actor_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),first_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),first_name)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),last_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),last_name)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.address",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "address",
-                        "description": "a user's address",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.address",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1623751200000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "address",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "address",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address2",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "city",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address_id",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "postal_code",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "city_id",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "phone",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+                                    "type": "TRANSFORMED"
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "district",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+                                    "type": "TRANSFORMED"
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "phone",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),full_name)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "postal_code",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),email)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),address)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address2)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address2)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),city_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),city_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),district)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),district)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),phone)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),phone)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),postal_code)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),postal_code)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.category",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "category",
-                        "description": "a user's category",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.category",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1623319200000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "category_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),city)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),postal_code)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),postal_code)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),category_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),category_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),name)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.city",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "city",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.city",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1581759925000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "city",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "city_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "country_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),city)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),city_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),country_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),country_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "model_maturity": "in prod",
-                            "owner": "bob@gmail.com",
-                            "some_other_property": "test 2",
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.country",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "country",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:bob",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),phone)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),phone)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": false,
+                            "viewLogic": "{{ config(\n    materialized = \"ephemeral\",\n) }}\n\nSELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name as \"full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\nFROM\n    {{ source('pagila', 'customer')}} c\n    left outer join {{ source('pagila', 'address')}} a on c.address_id = a.address_id\n    left outer join {{ source('pagila', 'city') }} m on a.city_id = m.city_id",
+                            "formattedViewLogic": "SELECT\n  c.customer_id,\n  c.first_name || ' ' || c.last_name AS \"full_name\",\n  c.email,\n  a.address,\n  m.city,\n  a.postal_code,\n  a.phone\nFROM \"pagila\".\"public\".\"customer\" AS c\nLEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n  ON c.address_id = a.address_id\nLEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n  ON a.city_id = m.city_id",
+                            "viewLanguage": "SQL"
                         }
                     }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.country",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1624033800000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "country",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "country_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),country)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),country)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),country_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),country_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.customer",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "customer",
-                        "description": "description for customer table from dbt",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.customer",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1624032000000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "active",
-                                "nullable": false,
-                                "type": {
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "business_owner": "jdoe.last",
+                                "data_governance.team_owner": "Sales",
+                                "has_pii": "False",
+                                "int_property": "2",
+                                "double_property": "3.5",
+                                "node_type": "model",
+                                "materialization": "table",
+                                "dbt_file_path": "models/billing/monthly_billing_with_cust.sql",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.monthly_billing_with_cust",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "an-aliased-view-for-monthly-billing",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.monthly_billing_with_cust",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "activebool",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "billing_month",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.BooleanType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "boolean",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address_id",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "create_date",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "email",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.DateType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+                                    "type": "TRANSFORMED"
                                 },
-                                "nativeDataType": "date",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "email",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "first_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "store_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),active)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),active)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),activebool)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),activebool)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),address_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),address_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),create_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),create_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),email)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),first_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),store_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),store_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_01",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_01",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1580505371996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "an_array_property": "['alpha', 'beta', 'charlie']",
-                            "model_maturity": "in prod",
-                            "owner": "Analytics User(charles@gmail.com)",
-                            "some_other_property": "test 3",
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_02",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:charles",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": true,
+                            "viewLogic": "{{ config(\n    materialized = \"table\",\n    alias='an-aliased-view-for-monthly-billing'\n) }}\n\nSELECT \n    pbc.billing_month,\n    pbc.customer_id,\n    pbc.amount,\n    cust.email\nFROM\n    {{ ref('payments_by_customer_by_month')}} pbc\n    left outer join {{ ref('customer_details')}} cust on pbc.customer_id = cust.customer_id\nORDER BY\n    pbc.billing_month",
+                            "formattedViewLogic": "WITH __dbt__CTE__customer_details AS (\n  SELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name AS \"full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\n  FROM \"pagila\".\"public\".\"customer\" AS c\n  LEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n    ON c.address_id = a.address_id\n  LEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n    ON a.city_id = m.city_id\n)\nSELECT\n  pbc.billing_month,\n  pbc.customer_id,\n  pbc.amount,\n  cust.email\nFROM \"pagila\".\"dbt_postgres\".\"payments_by_customer_by_month\" AS pbc\nLEFT OUTER JOIN __dbt__CTE__customer_details AS cust\n  ON pbc.customer_id = cust.customer_id\nORDER BY\n  pbc.billing_month",
+                            "viewLanguage": "SQL"
                         }
                     }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_02",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1582319845996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_03",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_03",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1584998318996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "model",
+                                "materialization": "view",
+                                "dbt_file_path": "models/base/payments_base.sql",
+                                "catalog_type": "VIEW",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.payments_base",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
                             },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_04",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_04",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1588287228996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_05",
-                        "description": "a payment",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_05",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1589460269996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-                "value": {
-                    "auditStamp": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
+                            "name": "an-aliased-view-for-payments",
+                            "description": "",
+                            "tags": []
+                        }
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-                    "type": "COPY"
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),email)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),email)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-                "value": {
-                    "auditStamp": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-                    "type": "COPY"
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-                "value": {
-                    "auditStamp": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.payments_base",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-                    "type": "COPY"
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": false,
+                            "viewLogic": "{{ config(\n    materialized=\"view\",\n    alias='an-aliased-view-for-payments'\n) }}\n\nwith payments as (\n\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_01')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_03')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_04')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_05')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_06')}}\n)\n\nselect *\nfrom payments",
+                            "formattedViewLogic": "WITH payments AS (\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_01\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_03\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_04\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_05\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_06\"\n)\nSELECT\n  *\nFROM payments",
+                            "viewLanguage": "SQL"
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "model",
+                                "materialization": "table",
+                                "dbt_file_path": "models/transform/payments_by_customer_by_month.sql",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.payments_by_customer_by_month",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payments_by_customer_by_month",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.payments_by_customer_by_month",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "billing_month",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": true,
+                            "viewLogic": "{{ config(\n    materialized = \"table\",\n) }}\n\nSELECT\n    date_trunc('month', payment_date) as \"billing_month\",\n    customer_id,\n    sum(amount) as \"amount\"\nFROM\n    {{ ref('payments_base')}}\nGROUP BY\n    billing_month,\n    customer_id",
+                            "formattedViewLogic": "SELECT\n  DATE_TRUNC('MONTH', payment_date) AS \"billing_month\",\n  customer_id,\n  SUM(amount) AS \"amount\"\nFROM \"pagila\".\"dbt_postgres\".\"an-aliased-view-for-payments\"\nGROUP BY\n  billing_month,\n  customer_id",
+                            "viewLanguage": "SQL"
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "model_maturity": "in dev",
+                                "some_other_property": "test 1",
+                                "owner": "ML User(alice1@gmail.com)",
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.actor",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "actor",
+                            "description": "description for actor table from dbt",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:alice1",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.actor",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1581759273000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "actor_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "first_name",
+                                    "nullable": false,
+                                    "description": "dbt comment: Actors column \u2013 from postgres\n\ndbt model description: description for first_name from dbt",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "globalTags": {
+                                        "tags": [
+                                            {
+                                                "tag": "urn:li:tag:dbt:column_tag"
+                                            }
+                                        ]
+                                    },
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_name",
+                                    "nullable": false,
+                                    "description": "description for last_name from dbt",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "description": "description for last_update from dbt",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),actor_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),actor_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),first_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),first_name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),last_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),last_name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.address",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "address",
+                            "description": "a user's address",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.address",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1623751200000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "address",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "address2",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "address_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "city_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "district",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "phone",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "postal_code",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address2)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address2)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),city_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),city_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),district)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),district)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),phone)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),phone)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),postal_code)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),postal_code)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.category",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "category",
+                            "description": "a user's category",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.category",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1623319200000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "category_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),category_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),category_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.city",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "city",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.city",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1581759925000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "city",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "city_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "country_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),city)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),city_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),country_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),country_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "model_maturity": "in prod",
+                                "owner": "bob@gmail.com",
+                                "some_other_property": "test 2",
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.country",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "country",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:bob",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.country",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1624033800000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "country",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "country_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),country)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),country)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),country_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),country_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.customer",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "customer",
+                            "description": "description for customer table from dbt",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.customer",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1624032000000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "active",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "activebool",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.BooleanType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "boolean",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "address_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "create_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.DateType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "date",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "email",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "first_name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "store_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),active)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),active)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),activebool)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),activebool)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),address_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),address_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),create_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),create_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),email)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),first_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),store_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),store_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_01",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_01",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1580505371996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "an_array_property": "['alpha', 'beta', 'charlie']",
+                                "model_maturity": "in prod",
+                                "owner": "Analytics User(charles@gmail.com)",
+                                "some_other_property": "test 3",
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_02",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:charles",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_02",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1582319845996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_03",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_03",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1584998318996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_04",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_04",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1588287228996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_05",
+                            "description": "a payment",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_05",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1589460269996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+                    "value": {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+                        "type": "COPY"
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),email)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),email)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
                 }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)",
-                "value": {
-                    "confidenceScore": 1.0
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+                    "value": {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+                        "type": "COPY"
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
                 }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)",
-                "value": {
-                    "confidenceScore": 1.0
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+                    "value": {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+                        "type": "COPY"
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
                 }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)",
-                "value": {
-                    "confidenceScore": 1.0
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.actor",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
             }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.actor",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-15T09:34:33+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-15T09:34:33+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
-            },
-            "assertionUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.address",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "warn",
-                    "max_loaded_at": "2021-06-15T10:00:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "259200.0"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.address",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
-            },
-            "assertionUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.category",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "FAILURE",
-                "nativeResults": {
-                    "status": "error",
-                    "max_loaded_at": "2021-06-10T10:00:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "691200.0"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "warn",
+                        "max_loaded_at": "2021-06-15T10:00:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "259200.0"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
-            },
-            "assertionUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.city",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "error_after_count": "1",
-                "error_after_period": "day"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-15T09:45:25+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.category",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
-            },
-            "assertionUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.country",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "30",
-                "warn_after_period": "minute"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2021-06-18T16:30:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "2335.925443"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "FAILURE",
+                    "nativeResults": {
+                        "status": "error",
+                        "max_loaded_at": "2021-06-10T10:00:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "691200.0"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
-            },
-            "assertionUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.customer",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "1",
-                "warn_after_period": "day",
-                "error_after_count": "2",
-                "error_after_period": "day"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2021-06-18T16:00:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "4085.925443"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.city",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "error_after_count": "1",
+                    "error_after_period": "day"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
-            },
-            "assertionUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "3",
-                "warn_after_period": "day",
-                "error_after_count": "7",
-                "error_after_period": "day"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-01-31T21:16:11.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-15T09:45:25+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
-            },
-            "assertionUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-21T21:17:25.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.country",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "30",
+                    "warn_after_period": "minute"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
-            },
-            "assertionUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-03-23T21:18:38.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2021-06-18T16:30:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "2335.925443"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
-            },
-            "assertionUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-04-30T22:53:48.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.customer",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "1",
+                    "warn_after_period": "day",
+                    "error_after_count": "2",
+                    "error_after_period": "day"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
-            },
-            "assertionUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-05-14T12:44:29.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2021-06-18T16:00:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "4085.925443"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
-            },
-            "assertionUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "3",
+                    "warn_after_period": "day",
+                    "error_after_count": "7",
+                    "error_after_period": "day"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-01-31T21:16:11.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-21T21:17:25.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-03-23T21:18:38.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:column_tag",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:column_tag"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-04-30T22:53:48.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:test_tag",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:test_tag"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-complex-owner-patterns",
-        "lastRunId": "no-run-id-provided"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-05-14T12:44:29.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:column_tag",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:column_tag"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:test_tag",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:test_tag"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-complex-owner-patterns",
+            "lastRunId": "no-run-id-provided"
+        }
     }
-}
 ]

--- a/metadata-ingestion/tests/integration/dbt/dbt_test_with_data_platform_instance_mces_golden.json
+++ b/metadata-ingestion/tests/integration/dbt/dbt_test_with_data_platform_instance_mces_golden.json
@@ -1,5797 +1,5881 @@
 [
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.customer_details,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.customer_details,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.customer_details,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt",
-            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.customer_details,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt",
+                "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.customer_details,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "owner": "@alice2",
-                            "business_owner": "jdoe.last@gmail.com",
-                            "data_governance.team_owner": "Finance",
-                            "has_pii": "True",
-                            "int_property": "1",
-                            "double_property": "2.5",
-                            "node_type": "model",
-                            "materialization": "ephemeral",
-                            "dbt_file_path": "models/transform/customer_details.sql",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.customer_details",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "customer_details",
-                        "description": "",
-                        "tags": [
-                            "dbt:test_tag"
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:@alice2",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.customer_details,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "owner": "@alice2",
+                                "business_owner": "jdoe.last@gmail.com",
+                                "data_governance.team_owner": "Finance",
+                                "has_pii": "True",
+                                "int_property": "1",
+                                "double_property": "2.5",
+                                "node_type": "model",
+                                "materialization": "ephemeral",
+                                "dbt_file_path": "models/transform/customer_details.sql",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.customer_details",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "customer_details",
+                            "description": "",
+                            "tags": [
+                                "dbt:test_tag"
+                            ]
                         }
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.GlobalTags": {
-                        "tags": [
-                            {
-                                "tag": "urn:li:tag:dbt:test_tag"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.customer_details",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "INT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "full_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "VARCHAR",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "email",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "city",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "postal_code",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "phone",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.address,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.city,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.customer,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.customer,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.customer_details,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.customer,PROD),first_name)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.customer,PROD),last_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.customer_details,PROD),full_name)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.customer,PROD),email)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.customer_details,PROD),email)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.address,PROD),address)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.customer_details,PROD),address)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.city,PROD),city)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.customer_details,PROD),city)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.address,PROD),postal_code)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.customer_details,PROD),postal_code)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.address,PROD),phone)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.customer_details,PROD),phone)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": false,
-                        "viewLogic": "{{ config(\n    materialized = \"ephemeral\",\n) }}\n\nSELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name as \"full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\nFROM\n    {{ source('pagila', 'customer')}} c\n    left outer join {{ source('pagila', 'address')}} a on c.address_id = a.address_id\n    left outer join {{ source('pagila', 'city') }} m on a.city_id = m.city_id",
-                        "formattedViewLogic": "SELECT\n  c.customer_id,\n  c.first_name || ' ' || c.last_name AS \"full_name\",\n  c.email,\n  a.address,\n  m.city,\n  a.postal_code,\n  a.phone\nFROM \"pagila\".\"public\".\"customer\" AS c\nLEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n  ON c.address_id = a.address_id\nLEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n  ON a.city_id = m.city_id",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt",
-            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "business_owner": "jdoe.last",
-                            "data_governance.team_owner": "Sales",
-                            "has_pii": "False",
-                            "int_property": "2",
-                            "double_property": "3.5",
-                            "node_type": "model",
-                            "materialization": "table",
-                            "dbt_file_path": "models/billing/monthly_billing_with_cust.sql",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.monthly_billing_with_cust",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "an-aliased-view-for-monthly-billing",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.monthly_billing_with_cust",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "billing_month",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "email",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.customer_details,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": true,
-                        "viewLogic": "{{ config(\n    materialized = \"table\",\n    alias='an-aliased-view-for-monthly-billing'\n) }}\n\nSELECT \n    pbc.billing_month,\n    pbc.customer_id,\n    pbc.amount,\n    cust.email\nFROM\n    {{ ref('payments_by_customer_by_month')}} pbc\n    left outer join {{ ref('customer_details')}} cust on pbc.customer_id = cust.customer_id\nORDER BY\n    pbc.billing_month",
-                        "formattedViewLogic": "WITH __dbt__CTE__customer_details AS (\n  SELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name AS \"full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\n  FROM \"pagila\".\"public\".\"customer\" AS c\n  LEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n    ON c.address_id = a.address_id\n  LEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n    ON a.city_id = m.city_id\n)\nSELECT\n  pbc.billing_month,\n  pbc.customer_id,\n  pbc.amount,\n  cust.email\nFROM \"pagila\".\"dbt_postgres\".\"payments_by_customer_by_month\" AS pbc\nLEFT OUTER JOIN __dbt__CTE__customer_details AS cust\n  ON pbc.customer_id = cust.customer_id\nORDER BY\n  pbc.billing_month",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt",
-            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "model",
-                            "materialization": "view",
-                            "dbt_file_path": "models/base/payments_base.sql",
-                            "catalog_type": "VIEW",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.payments_base",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "an-aliased-view-for-payments",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.payments_base",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_01,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_02,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_02,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_03,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_04,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_05,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_06,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_01,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_02,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_03,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_04,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_05,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_06,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_01,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_02,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_03,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_04,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_05,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_06,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_01,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_02,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_03,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_04,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_05,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_06,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_01,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_02,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_03,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_04,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_05,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_06,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_01,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_02,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_03,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_04,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_05,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_06,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_01,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_02,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_03,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_04,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_05,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_06,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": false,
-                        "viewLogic": "{{ config(\n    materialized=\"view\",\n    alias='an-aliased-view-for-payments'\n) }}\n\nwith payments as (\n\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_01')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_03')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_04')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_05')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_06')}}\n)\n\nselect *\nfrom payments",
-                        "formattedViewLogic": "WITH payments AS (\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_01\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_03\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_04\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_05\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_06\"\n)\nSELECT\n  *\nFROM payments",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt",
-            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "model",
-                            "materialization": "table",
-                            "dbt_file_path": "models/transform/payments_by_customer_by_month.sql",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.payments_by_customer_by_month",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payments_by_customer_by_month",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.payments_by_customer_by_month",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "billing_month",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": true,
-                        "viewLogic": "{{ config(\n    materialized = \"table\",\n) }}\n\nSELECT\n    date_trunc('month', payment_date) as \"billing_month\",\n    customer_id,\n    sum(amount) as \"amount\"\nFROM\n    {{ ref('payments_base')}}\nGROUP BY\n    billing_month,\n    customer_id",
-                        "formattedViewLogic": "SELECT\n  DATE_TRUNC('MONTH', payment_date) AS \"billing_month\",\n  customer_id,\n  SUM(amount) AS \"amount\"\nFROM \"pagila\".\"dbt_postgres\".\"an-aliased-view-for-payments\"\nGROUP BY\n  billing_month,\n  customer_id",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.actor,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.actor,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt",
-            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.actor,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "model_maturity": "in dev",
-                            "some_other_property": "test 1",
-                            "owner": "@alice1",
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.actor",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "actor",
-                        "description": "description for actor table from dbt",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:@alice1",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
                         }
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.actor",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1581759273000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:@alice2",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
                             }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "actor_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.GlobalTags": {
+                            "tags": [
+                                {
+                                    "tag": "urn:li:tag:dbt:test_tag"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.customer_details",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
                             },
-                            {
-                                "fieldPath": "first_name",
-                                "nullable": false,
-                                "description": "dbt comment: Actors column \u2013 from postgres\n\ndbt model description: description for first_name from dbt",
-                                "type": {
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "globalTags": {
-                                    "tags": [
-                                        {
-                                            "tag": "urn:li:tag:dbt:column_tag"
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
                                         }
-                                    ]
+                                    },
+                                    "nativeDataType": "INT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_name",
-                                "nullable": false,
-                                "description": "description for last_name from dbt",
-                                "type": {
+                                {
+                                    "fieldPath": "full_name",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "VARCHAR",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "description": "description for last_update from dbt",
-                                "type": {
+                                {
+                                    "fieldPath": "email",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),actor_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.actor,PROD),actor_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),first_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.actor,PROD),first_name)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),last_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.actor,PROD),last_name)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.actor,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.address,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.address,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt",
-            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.address,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.address",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "address",
-                        "description": "a user's address",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.address",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1623751200000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "address",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "address",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address2",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "city",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address_id",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "postal_code",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "city_id",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "phone",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.address,PROD)",
+                                    "type": "TRANSFORMED"
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "district",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.city,PROD)",
+                                    "type": "TRANSFORMED"
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.customer,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.customer,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.customer_details,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "phone",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.customer,PROD),first_name)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.customer,PROD),last_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.customer_details,PROD),full_name)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "postal_code",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.customer,PROD),email)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.customer_details,PROD),email)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.address,PROD),address)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.customer_details,PROD),address)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.address,PROD),address)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address2)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.address,PROD),address2)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.address,PROD),address_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),city_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.address,PROD),city_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),district)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.address,PROD),district)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.address,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),phone)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.address,PROD),phone)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),postal_code)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.address,PROD),postal_code)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.category,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.category,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt",
-            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.category,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.category",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "category",
-                        "description": "a user's category",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.category",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1623319200000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "category_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.city,PROD),city)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.customer_details,PROD),city)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.address,PROD),postal_code)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.customer_details,PROD),postal_code)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),category_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.category,PROD),category_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.category,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.category,PROD),name)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.city,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.city,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt",
-            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.city,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.city",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "city",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.city",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1581759925000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "city",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "city_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "country_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),city)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.city,PROD),city)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),city_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.city,PROD),city_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),country_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.city,PROD),country_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.city,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.country,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.country,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt",
-            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.country,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "model_maturity": "in prod",
-                            "owner": "@bob",
-                            "some_other_property": "test 2",
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.country",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "country",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:@bob",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.address,PROD),phone)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.customer_details,PROD),phone)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": false,
+                            "viewLogic": "{{ config(\n    materialized = \"ephemeral\",\n) }}\n\nSELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name as \"full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\nFROM\n    {{ source('pagila', 'customer')}} c\n    left outer join {{ source('pagila', 'address')}} a on c.address_id = a.address_id\n    left outer join {{ source('pagila', 'city') }} m on a.city_id = m.city_id",
+                            "formattedViewLogic": "SELECT\n  c.customer_id,\n  c.first_name || ' ' || c.last_name AS \"full_name\",\n  c.email,\n  a.address,\n  m.city,\n  a.postal_code,\n  a.phone\nFROM \"pagila\".\"public\".\"customer\" AS c\nLEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n  ON c.address_id = a.address_id\nLEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n  ON a.city_id = m.city_id",
+                            "viewLanguage": "SQL"
                         }
                     }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.country",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1624033800000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "country",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "country_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),country)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.country,PROD),country)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),country_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.country,PROD),country_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.country,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.customer,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.customer,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt",
-            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt",
+                "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.customer,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.customer",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "customer",
-                        "description": "description for customer table from dbt",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.customer",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1624032000000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "active",
-                                "nullable": false,
-                                "type": {
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "business_owner": "jdoe.last",
+                                "data_governance.team_owner": "Sales",
+                                "has_pii": "False",
+                                "int_property": "2",
+                                "double_property": "3.5",
+                                "node_type": "model",
+                                "materialization": "table",
+                                "dbt_file_path": "models/billing/monthly_billing_with_cust.sql",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.monthly_billing_with_cust",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "an-aliased-view-for-monthly-billing",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.monthly_billing_with_cust",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "activebool",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "billing_month",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.BooleanType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "boolean",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address_id",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "create_date",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "email",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.DateType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.customer_details,PROD)",
+                                    "type": "TRANSFORMED"
                                 },
-                                "nativeDataType": "date",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "email",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "first_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "store_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),active)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.customer,PROD),active)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),activebool)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.customer,PROD),activebool)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),address_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.customer,PROD),address_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),create_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.customer,PROD),create_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.customer,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),email)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.customer,PROD),email)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),first_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.customer,PROD),first_name)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.customer,PROD),last_name)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.customer,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),store_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.customer,PROD),store_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_01,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_01,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt",
-            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_01,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_01",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_01",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1580505371996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_01,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_01,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_01,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_01,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_01,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_01,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_02,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_02,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt",
-            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_02,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "an_array_property": "['alpha', 'beta', 'charlie']",
-                            "model_maturity": "in prod",
-                            "owner": "@charles",
-                            "some_other_property": "test 3",
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_02",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:@charles",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": true,
+                            "viewLogic": "{{ config(\n    materialized = \"table\",\n    alias='an-aliased-view-for-monthly-billing'\n) }}\n\nSELECT \n    pbc.billing_month,\n    pbc.customer_id,\n    pbc.amount,\n    cust.email\nFROM\n    {{ ref('payments_by_customer_by_month')}} pbc\n    left outer join {{ ref('customer_details')}} cust on pbc.customer_id = cust.customer_id\nORDER BY\n    pbc.billing_month",
+                            "formattedViewLogic": "WITH __dbt__CTE__customer_details AS (\n  SELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name AS \"full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\n  FROM \"pagila\".\"public\".\"customer\" AS c\n  LEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n    ON c.address_id = a.address_id\n  LEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n    ON a.city_id = m.city_id\n)\nSELECT\n  pbc.billing_month,\n  pbc.customer_id,\n  pbc.amount,\n  cust.email\nFROM \"pagila\".\"dbt_postgres\".\"payments_by_customer_by_month\" AS pbc\nLEFT OUTER JOIN __dbt__CTE__customer_details AS cust\n  ON pbc.customer_id = cust.customer_id\nORDER BY\n  pbc.billing_month",
+                            "viewLanguage": "SQL"
                         }
                     }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_02",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1582319845996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_02,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_02,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_02,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_02,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_02,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_02,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_03,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_03,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt",
-            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt",
+                "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_03,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_03",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_03",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1584998318996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "model",
+                                "materialization": "view",
+                                "dbt_file_path": "models/base/payments_base.sql",
+                                "catalog_type": "VIEW",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.payments_base",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
                             },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_03,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_03,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_03,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_03,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_03,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_03,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_04,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_04,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt",
-            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_04,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_04",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_04",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1588287228996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_04,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_04,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_04,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_04,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_04,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_04,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_05,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_05,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt",
-            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_05,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_05",
-                        "description": "a payment",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_05",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1589460269996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_05,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_05,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_05,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_05,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_05,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_05,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_06,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_06,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt",
-            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_06,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_06",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_06",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": -62135596800000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_06,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_06,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_06,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_06,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_06,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_06,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-                "value": {
-                    "auditStamp": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
+                            "name": "an-aliased-view-for-payments",
+                            "description": "",
+                            "tags": []
+                        }
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-                    "type": "COPY"
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),email)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),email)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-                "value": {
-                    "auditStamp": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-                    "type": "COPY"
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-                "value": {
-                    "auditStamp": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.payments_base",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-                    "type": "COPY"
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_01,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_02,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_02,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_03,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_04,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_05,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_06,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_01,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_02,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_03,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_04,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_05,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_06,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_01,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_02,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_03,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_04,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_05,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_06,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_01,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_02,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_03,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_04,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_05,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_06,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_01,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_02,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_03,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_04,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_05,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_06,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_01,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_02,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_03,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_04,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_05,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_06,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_01,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_02,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_03,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_04,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_05,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_06,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": false,
+                            "viewLogic": "{{ config(\n    materialized=\"view\",\n    alias='an-aliased-view-for-payments'\n) }}\n\nwith payments as (\n\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_01')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_03')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_04')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_05')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_06')}}\n)\n\nselect *\nfrom payments",
+                            "formattedViewLogic": "WITH payments AS (\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_01\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_03\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_04\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_05\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_06\"\n)\nSELECT\n  *\nFROM payments",
+                            "viewLanguage": "SQL"
+                        }
+                    }
+                ]
             }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:114b26676391b0d4bc7143f090aa2092",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt",
-            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:114b26676391b0d4bc7143f090aa2092",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.actor",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.actor,PROD)"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:114b26676391b0d4bc7143f090aa2092",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.actor,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-15T09:34:33+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:114b26676391b0d4bc7143f090aa2092",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt",
+                "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:f33d16bca24e0a4b25f05fc2a93c9124",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt",
-            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:f33d16bca24e0a4b25f05fc2a93c9124",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.address",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.address,PROD)"
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "model",
+                                "materialization": "table",
+                                "dbt_file_path": "models/transform/payments_by_customer_by_month.sql",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.payments_by_customer_by_month",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payments_by_customer_by_month",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.payments_by_customer_by_month",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "billing_month",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": true,
+                            "viewLogic": "{{ config(\n    materialized = \"table\",\n) }}\n\nSELECT\n    date_trunc('month', payment_date) as \"billing_month\",\n    customer_id,\n    sum(amount) as \"amount\"\nFROM\n    {{ ref('payments_base')}}\nGROUP BY\n    billing_month,\n    customer_id",
+                            "formattedViewLogic": "SELECT\n  DATE_TRUNC('MONTH', payment_date) AS \"billing_month\",\n  customer_id,\n  SUM(amount) AS \"amount\"\nFROM \"pagila\".\"dbt_postgres\".\"an-aliased-view-for-payments\"\nGROUP BY\n  billing_month,\n  customer_id",
+                            "viewLanguage": "SQL"
+                        }
+                    }
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:f33d16bca24e0a4b25f05fc2a93c9124",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.address,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "warn",
-                    "max_loaded_at": "2021-06-15T10:00:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "259200.0"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:f33d16bca24e0a4b25f05fc2a93c9124",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.actor,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:d1c318d2d5b710066a75f0451adc9d00",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt",
-            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:d1c318d2d5b710066a75f0451adc9d00",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.category",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.category,PROD)"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.actor,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt",
+                "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:d1c318d2d5b710066a75f0451adc9d00",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.category,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "FAILURE",
-                "nativeResults": {
-                    "status": "error",
-                    "max_loaded_at": "2021-06-10T10:00:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "691200.0"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:d1c318d2d5b710066a75f0451adc9d00",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.actor,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "model_maturity": "in dev",
+                                "some_other_property": "test 1",
+                                "owner": "@alice1",
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.actor",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "actor",
+                            "description": "description for actor table from dbt",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:@alice1",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.actor",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1581759273000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "actor_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "first_name",
+                                    "nullable": false,
+                                    "description": "dbt comment: Actors column \u2013 from postgres\n\ndbt model description: description for first_name from dbt",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "globalTags": {
+                                        "tags": [
+                                            {
+                                                "tag": "urn:li:tag:dbt:column_tag"
+                                            }
+                                        ]
+                                    },
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_name",
+                                    "nullable": false,
+                                    "description": "description for last_name from dbt",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "description": "description for last_update from dbt",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),actor_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.actor,PROD),actor_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),first_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.actor,PROD),first_name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),last_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.actor,PROD),last_name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.actor,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:deb7bd9eb9d2806806bb5496853ea01d",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt",
-            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:deb7bd9eb9d2806806bb5496853ea01d",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.city",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "error_after_count": "1",
-                "error_after_period": "day"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.city,PROD)"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.address,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:deb7bd9eb9d2806806bb5496853ea01d",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.city,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-15T09:45:25+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:deb7bd9eb9d2806806bb5496853ea01d",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.address,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt",
+                "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:d607430fab76cb43e7b2c5e0106849d1",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt",
-            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:d607430fab76cb43e7b2c5e0106849d1",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.country",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "30",
-                "warn_after_period": "minute"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.country,PROD)"
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.address,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.address",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "address",
+                            "description": "a user's address",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.address",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1623751200000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "address",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "address2",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "address_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "city_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "district",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "phone",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "postal_code",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.address,PROD),address)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address2)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.address,PROD),address2)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.address,PROD),address_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),city_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.address,PROD),city_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),district)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.address,PROD),district)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.address,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),phone)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.address,PROD),phone)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),postal_code)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.address,PROD),postal_code)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:d607430fab76cb43e7b2c5e0106849d1",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.country,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2021-06-18T16:30:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "2335.925443"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:d607430fab76cb43e7b2c5e0106849d1",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.category,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:7dc3c97ede9287646994b3b955afecd7",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt",
-            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:7dc3c97ede9287646994b3b955afecd7",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.customer",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "1",
-                "warn_after_period": "day",
-                "error_after_count": "2",
-                "error_after_period": "day"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.customer,PROD)"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.category,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt",
+                "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:7dc3c97ede9287646994b3b955afecd7",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.customer,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2021-06-18T16:00:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "4085.925443"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:7dc3c97ede9287646994b3b955afecd7",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.category,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.category",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "category",
+                            "description": "a user's category",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.category",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1623319200000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "category_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),category_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.category,PROD),category_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.category,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.category,PROD),name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:6dafa476c7e3f886e89c0448bf6b3756",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt",
-            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:6dafa476c7e3f886e89c0448bf6b3756",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "3",
-                "warn_after_period": "day",
-                "error_after_count": "7",
-                "error_after_period": "day"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.payment_p2020_01,PROD)"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.city,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:6dafa476c7e3f886e89c0448bf6b3756",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.payment_p2020_01,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-01-31T21:16:11.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:6dafa476c7e3f886e89c0448bf6b3756",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.city,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt",
+                "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:6caf326d9f2e14e2b05e487a61da0282",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt",
-            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:6caf326d9f2e14e2b05e487a61da0282",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.payment_p2020_02,PROD)"
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.city,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.city",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "city",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.city",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1581759925000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "city",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "city_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "country_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),city)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.city,PROD),city)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),city_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.city,PROD),city_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),country_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.city,PROD),country_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.city,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:6caf326d9f2e14e2b05e487a61da0282",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.payment_p2020_02,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-21T21:17:25.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:6caf326d9f2e14e2b05e487a61da0282",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.country,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:26edbe8ed47e1675145a09ec0867207c",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt",
-            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:26edbe8ed47e1675145a09ec0867207c",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.payment_p2020_03,PROD)"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.country,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt",
+                "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:26edbe8ed47e1675145a09ec0867207c",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.payment_p2020_03,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-03-23T21:18:38.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:26edbe8ed47e1675145a09ec0867207c",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.country,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "model_maturity": "in prod",
+                                "owner": "@bob",
+                                "some_other_property": "test 2",
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.country",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "country",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:@bob",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.country",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1624033800000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "country",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "country_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),country)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.country,PROD),country)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),country_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.country,PROD),country_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.country,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8161adb9a5a93baa4f9ce0396812db1b",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt",
-            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8161adb9a5a93baa4f9ce0396812db1b",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.payment_p2020_04,PROD)"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.customer,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8161adb9a5a93baa4f9ce0396812db1b",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.payment_p2020_04,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-04-30T22:53:48.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:8161adb9a5a93baa4f9ce0396812db1b",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.customer,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt",
+                "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:08eec22f4bafbf8bc076998b83a4d06e",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt",
-            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:08eec22f4bafbf8bc076998b83a4d06e",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.payment_p2020_05,PROD)"
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.customer,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.customer",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "customer",
+                            "description": "description for customer table from dbt",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.customer",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1624032000000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "active",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "activebool",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.BooleanType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "boolean",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "address_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "create_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.DateType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "date",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "email",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "first_name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "store_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),active)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.customer,PROD),active)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),activebool)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.customer,PROD),activebool)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),address_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.customer,PROD),address_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),create_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.customer,PROD),create_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.customer,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),email)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.customer,PROD),email)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),first_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.customer,PROD),first_name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.customer,PROD),last_name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.customer,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),store_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.customer,PROD),store_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:08eec22f4bafbf8bc076998b83a4d06e",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.payment_p2020_05,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-05-14T12:44:29.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:08eec22f4bafbf8bc076998b83a4d06e",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_01,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:31628ac3818b105279e9063edbaccc05",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt",
-            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:31628ac3818b105279e9063edbaccc05",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.payment_p2020_06,PROD)"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_01,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt",
+                "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:31628ac3818b105279e9063edbaccc05",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.payment_p2020_06,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "0001-01-01T00:00:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:31628ac3818b105279e9063edbaccc05",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_01,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_01",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_01",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1580505371996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_01,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_01,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_01,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_01,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_01,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_01,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,dbt-instance-1.exposure.sample_dbt.customer_dashboard)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt",
-            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_02,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,dbt-instance-1.exposure.sample_dbt.customer_dashboard)",
-    "changeType": "UPSERT",
-    "aspectName": "dashboardInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "exposure.sample_dbt.customer_dashboard",
-                "exposure_type": "dashboard",
-                "maturity": "high",
-                "dbt_package_name": "sample_dbt",
-                "dbt_file_path": "models/exposures.yml",
-                "team": "analytics"
-            },
-            "externalUrl": "https://bi.example.com/dashboards/customer",
-            "title": "customer_dashboard",
-            "description": "Dashboard showing customer details and billing",
-            "charts": [],
-            "datasets": [
-                "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.customer_details,PROD)",
-                "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)"
-            ],
-            "dashboards": [],
-            "lastModified": {
-                "created": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:dbt_ingestion"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_02,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt",
+                "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_02,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "an_array_property": "['alpha', 'beta', 'charlie']",
+                                "model_maturity": "in prod",
+                                "owner": "@charles",
+                                "some_other_property": "test 3",
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_02",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:@charles",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_02",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1582319845996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_02,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_02,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_02,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_02,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_02,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_02,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_03,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_03,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt",
+                "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_03,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_03",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_03",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1584998318996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_03,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_03,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_03,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_03,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_03,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_03,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_04,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_04,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt",
+                "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_04,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_04",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_04",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1588287228996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_04,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_04,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_04,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_04,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_04,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_04,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_05,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_05,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt",
+                "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_05,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_05",
+                            "description": "a payment",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_05",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1589460269996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_05,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_05,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_05,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_05,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_05,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_05,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_06,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_06,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt",
+                "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_06,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_06",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_06",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": -62135596800000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_06,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_06,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_06,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_06,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_06,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.public.payment_p2020_06,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+                    "value": {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+                        "type": "COPY"
+                    }
                 },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),email)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),email)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+                    "value": {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+                        "type": "COPY"
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+                    "value": {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+                        "type": "COPY"
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:114b26676391b0d4bc7143f090aa2092",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt",
+                "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:114b26676391b0d4bc7143f090aa2092",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.actor",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.actor,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:114b26676391b0d4bc7143f090aa2092",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.actor,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-15T09:34:33+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:114b26676391b0d4bc7143f090aa2092",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:f33d16bca24e0a4b25f05fc2a93c9124",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt",
+                "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:f33d16bca24e0a4b25f05fc2a93c9124",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.address",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.address,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:f33d16bca24e0a4b25f05fc2a93c9124",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.address,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "warn",
+                        "max_loaded_at": "2021-06-15T10:00:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "259200.0"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:f33d16bca24e0a4b25f05fc2a93c9124",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:d1c318d2d5b710066a75f0451adc9d00",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt",
+                "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:d1c318d2d5b710066a75f0451adc9d00",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.category",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.category,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:d1c318d2d5b710066a75f0451adc9d00",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.category,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "FAILURE",
+                    "nativeResults": {
+                        "status": "error",
+                        "max_loaded_at": "2021-06-10T10:00:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "691200.0"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:d1c318d2d5b710066a75f0451adc9d00",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:deb7bd9eb9d2806806bb5496853ea01d",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt",
+                "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:deb7bd9eb9d2806806bb5496853ea01d",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.city",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "error_after_count": "1",
+                    "error_after_period": "day"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.city,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:deb7bd9eb9d2806806bb5496853ea01d",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.city,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-15T09:45:25+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:deb7bd9eb9d2806806bb5496853ea01d",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:d607430fab76cb43e7b2c5e0106849d1",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt",
+                "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:d607430fab76cb43e7b2c5e0106849d1",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.country",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "30",
+                    "warn_after_period": "minute"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.country,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:d607430fab76cb43e7b2c5e0106849d1",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.country,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2021-06-18T16:30:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "2335.925443"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:d607430fab76cb43e7b2c5e0106849d1",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:7dc3c97ede9287646994b3b955afecd7",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt",
+                "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:7dc3c97ede9287646994b3b955afecd7",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.customer",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "1",
+                    "warn_after_period": "day",
+                    "error_after_count": "2",
+                    "error_after_period": "day"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.customer,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:7dc3c97ede9287646994b3b955afecd7",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.customer,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2021-06-18T16:00:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "4085.925443"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:7dc3c97ede9287646994b3b955afecd7",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:6dafa476c7e3f886e89c0448bf6b3756",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt",
+                "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:6dafa476c7e3f886e89c0448bf6b3756",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "3",
+                    "warn_after_period": "day",
+                    "error_after_count": "7",
+                    "error_after_period": "day"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.payment_p2020_01,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:6dafa476c7e3f886e89c0448bf6b3756",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.payment_p2020_01,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-01-31T21:16:11.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:6dafa476c7e3f886e89c0448bf6b3756",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:6caf326d9f2e14e2b05e487a61da0282",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt",
+                "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:6caf326d9f2e14e2b05e487a61da0282",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.payment_p2020_02,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:6caf326d9f2e14e2b05e487a61da0282",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.payment_p2020_02,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-21T21:17:25.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:6caf326d9f2e14e2b05e487a61da0282",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:26edbe8ed47e1675145a09ec0867207c",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt",
+                "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:26edbe8ed47e1675145a09ec0867207c",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.payment_p2020_03,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:26edbe8ed47e1675145a09ec0867207c",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.payment_p2020_03,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-03-23T21:18:38.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:26edbe8ed47e1675145a09ec0867207c",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8161adb9a5a93baa4f9ce0396812db1b",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt",
+                "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8161adb9a5a93baa4f9ce0396812db1b",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.payment_p2020_04,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8161adb9a5a93baa4f9ce0396812db1b",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.payment_p2020_04,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-04-30T22:53:48.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:8161adb9a5a93baa4f9ce0396812db1b",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:08eec22f4bafbf8bc076998b83a4d06e",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt",
+                "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:08eec22f4bafbf8bc076998b83a4d06e",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.payment_p2020_05,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:08eec22f4bafbf8bc076998b83a4d06e",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.payment_p2020_05,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-05-14T12:44:29.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:08eec22f4bafbf8bc076998b83a4d06e",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:31628ac3818b105279e9063edbaccc05",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt",
+                "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:31628ac3818b105279e9063edbaccc05",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.payment_p2020_06,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:31628ac3818b105279e9063edbaccc05",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.payment_p2020_06,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "0001-01-01T00:00:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:31628ac3818b105279e9063edbaccc05",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,dbt-instance-1.exposure.sample_dbt.customer_dashboard)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt",
+                "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,dbt-instance-1.exposure.sample_dbt.customer_dashboard)",
+        "changeType": "UPSERT",
+        "aspectName": "dashboardInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "exposure.sample_dbt.customer_dashboard",
+                    "exposure_type": "dashboard",
+                    "maturity": "high",
+                    "dbt_package_name": "sample_dbt",
+                    "dbt_file_path": "models/exposures.yml",
+                    "team": "analytics"
+                },
+                "externalUrl": "https://bi.example.com/dashboards/customer",
+                "title": "customer_dashboard",
+                "description": "Dashboard showing customer details and billing",
+                "charts": [],
+                "datasets": [
+                    "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.customer_details,PROD)",
+                    "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)"
+                ],
+                "dashboards": [],
                 "lastModified": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:dbt_ingestion"
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:dbt_ingestion"
+                    },
+                    "lastModified": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:dbt_ingestion"
+                    }
                 }
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,dbt-instance-1.exposure.sample_dbt.customer_dashboard)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,dbt-instance-1.exposure.sample_dbt.customer_dashboard)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Dashboard"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,dbt-instance-1.exposure.sample_dbt.customer_dashboard)",
-    "changeType": "UPSERT",
-    "aspectName": "ownership",
-    "aspect": {
-        "json": {
-            "owners": [
-                {
-                    "owner": "urn:li:corpuser:analytics@example.com",
-                    "type": "DATAOWNER"
-                }
-            ],
-            "ownerTypes": {},
-            "lastModified": {
-                "time": 0,
-                "actor": "urn:li:corpuser:unknown"
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,dbt-instance-1.exposure.sample_dbt.customer_dashboard)",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,dbt-instance-1.exposure.sample_dbt.customer_dashboard)",
-    "changeType": "UPSERT",
-    "aspectName": "globalTags",
-    "aspect": {
-        "json": {
-            "tags": [
-                {
-                    "tag": "urn:li:tag:dbt:executive"
-                },
-                {
-                    "tag": "urn:li:tag:dbt:customer"
-                }
-            ]
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,dbt-instance-1.exposure.sample_dbt.customer_dashboard)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Dashboard"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,dbt-instance-1.exposure.sample_dbt.payments_ml_model)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt",
-            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,dbt-instance-1.exposure.sample_dbt.payments_ml_model)",
-    "changeType": "UPSERT",
-    "aspectName": "dashboardInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "exposure.sample_dbt.payments_ml_model",
-                "exposure_type": "ml",
-                "maturity": "medium",
-                "dbt_package_name": "sample_dbt",
-                "dbt_file_path": "models/exposures.yml"
-            },
-            "externalUrl": "https://mlflow.example.com/models/payments",
-            "title": "payments_ml_model",
-            "description": "ML model for payment predictions",
-            "charts": [],
-            "datasets": [
-                "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD)"
-            ],
-            "dashboards": [],
-            "lastModified": {
-                "created": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:dbt_ingestion"
-                },
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,dbt-instance-1.exposure.sample_dbt.customer_dashboard)",
+        "changeType": "UPSERT",
+        "aspectName": "ownership",
+        "aspect": {
+            "json": {
+                "owners": [
+                    {
+                        "owner": "urn:li:corpuser:analytics@example.com",
+                        "type": "DATAOWNER"
+                    }
+                ],
+                "ownerTypes": {},
                 "lastModified": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:dbt_ingestion"
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
                 }
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,dbt-instance-1.exposure.sample_dbt.payments_ml_model)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,dbt-instance-1.exposure.sample_dbt.payments_ml_model)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "ML Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,dbt-instance-1.exposure.sample_dbt.payments_ml_model)",
-    "changeType": "UPSERT",
-    "aspectName": "ownership",
-    "aspect": {
-        "json": {
-            "owners": [
-                {
-                    "owner": "urn:li:corpuser:ds@example.com",
-                    "type": "DATAOWNER"
-                }
-            ],
-            "ownerTypes": {},
-            "lastModified": {
-                "time": 0,
-                "actor": "urn:li:corpuser:unknown"
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,dbt-instance-1.exposure.sample_dbt.customer_dashboard)",
+        "changeType": "UPSERT",
+        "aspectName": "globalTags",
+        "aspect": {
+            "json": {
+                "tags": [
+                    {
+                        "tag": "urn:li:tag:dbt:executive"
+                    },
+                    {
+                        "tag": "urn:li:tag:dbt:customer"
+                    }
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,dbt-instance-1.exposure.sample_dbt.payments_ml_model)",
-    "changeType": "UPSERT",
-    "aspectName": "globalTags",
-    "aspect": {
-        "json": {
-            "tags": [
-                {
-                    "tag": "urn:li:tag:dbt:ml"
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,dbt-instance-1.exposure.sample_dbt.payments_ml_model)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt",
+                "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,dbt-instance-1.exposure.sample_dbt.payments_ml_model)",
+        "changeType": "UPSERT",
+        "aspectName": "dashboardInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "exposure.sample_dbt.payments_ml_model",
+                    "exposure_type": "ml",
+                    "maturity": "medium",
+                    "dbt_package_name": "sample_dbt",
+                    "dbt_file_path": "models/exposures.yml"
                 },
-                {
-                    "tag": "urn:li:tag:dbt:payments"
+                "externalUrl": "https://mlflow.example.com/models/payments",
+                "title": "payments_ml_model",
+                "description": "ML model for payment predictions",
+                "charts": [],
+                "datasets": [
+                    "urn:li:dataset:(urn:li:dataPlatform:dbt,dbt-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD)"
+                ],
+                "dashboards": [],
+                "lastModified": {
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:dbt_ingestion"
+                    },
+                    "lastModified": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:dbt_ingestion"
+                    }
                 }
-            ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:08eec22f4bafbf8bc076998b83a4d06e",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,dbt-instance-1.exposure.sample_dbt.payments_ml_model)",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:114b26676391b0d4bc7143f090aa2092",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,dbt-instance-1.exposure.sample_dbt.payments_ml_model)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "ML Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:26edbe8ed47e1675145a09ec0867207c",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,dbt-instance-1.exposure.sample_dbt.payments_ml_model)",
+        "changeType": "UPSERT",
+        "aspectName": "ownership",
+        "aspect": {
+            "json": {
+                "owners": [
+                    {
+                        "owner": "urn:li:corpuser:ds@example.com",
+                        "type": "DATAOWNER"
+                    }
+                ],
+                "ownerTypes": {},
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:31628ac3818b105279e9063edbaccc05",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,dbt-instance-1.exposure.sample_dbt.payments_ml_model)",
+        "changeType": "UPSERT",
+        "aspectName": "globalTags",
+        "aspect": {
+            "json": {
+                "tags": [
+                    {
+                        "tag": "urn:li:tag:dbt:ml"
+                    },
+                    {
+                        "tag": "urn:li:tag:dbt:payments"
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:6caf326d9f2e14e2b05e487a61da0282",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:08eec22f4bafbf8bc076998b83a4d06e",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:6dafa476c7e3f886e89c0448bf6b3756",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:114b26676391b0d4bc7143f090aa2092",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:7dc3c97ede9287646994b3b955afecd7",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:26edbe8ed47e1675145a09ec0867207c",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8161adb9a5a93baa4f9ce0396812db1b",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:31628ac3818b105279e9063edbaccc05",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:d1c318d2d5b710066a75f0451adc9d00",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:6caf326d9f2e14e2b05e487a61da0282",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:d607430fab76cb43e7b2c5e0106849d1",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:6dafa476c7e3f886e89c0448bf6b3756",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:deb7bd9eb9d2806806bb5496853ea01d",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:7dc3c97ede9287646994b3b955afecd7",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:f33d16bca24e0a4b25f05fc2a93c9124",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8161adb9a5a93baa4f9ce0396812db1b",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:column_tag",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:column_tag"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:d1c318d2d5b710066a75f0451adc9d00",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:customer",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:customer"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:d607430fab76cb43e7b2c5e0106849d1",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:executive",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:executive"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:deb7bd9eb9d2806806bb5496853ea01d",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:ml",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:ml"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:f33d16bca24e0a4b25f05fc2a93c9124",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:payments",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:payments"
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:column_tag",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:column_tag"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:test_tag",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:test_tag"
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:customer",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:customer"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-data-platform-instance",
-        "lastRunId": "no-run-id-provided"
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:executive",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:executive"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:ml",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:ml"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:payments",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:payments"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:test_tag",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:test_tag"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-data-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
     }
-}
 ]

--- a/metadata-ingestion/tests/integration/dbt/dbt_test_with_non_incremental_lineage_mces_golden.json
+++ b/metadata-ingestion/tests/integration/dbt/dbt_test_with_non_incremental_lineage_mces_golden.json
@@ -1,5819 +1,5903 @@
 [
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "owner": "@alice2",
-                            "business_owner": "jdoe.last@gmail.com",
-                            "data_governance.team_owner": "Finance",
-                            "has_pii": "True",
-                            "int_property": "1",
-                            "double_property": "2.5",
-                            "node_type": "model",
-                            "materialization": "ephemeral",
-                            "dbt_file_path": "models/transform/customer_details.sql",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.customer_details",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "customer_details",
-                        "description": "",
-                        "tags": [
-                            "dbt:test_tag"
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:@alice2",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "owner": "@alice2",
+                                "business_owner": "jdoe.last@gmail.com",
+                                "data_governance.team_owner": "Finance",
+                                "has_pii": "True",
+                                "int_property": "1",
+                                "double_property": "2.5",
+                                "node_type": "model",
+                                "materialization": "ephemeral",
+                                "dbt_file_path": "models/transform/customer_details.sql",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.customer_details",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "customer_details",
+                            "description": "",
+                            "tags": [
+                                "dbt:test_tag"
+                            ]
                         }
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.GlobalTags": {
-                        "tags": [
-                            {
-                                "tag": "urn:li:tag:dbt:test_tag"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.customer_details",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "INT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "full_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "VARCHAR",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "email",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "city",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "postal_code",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "phone",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),full_name)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),email)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),address)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),city)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),postal_code)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),postal_code)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),phone)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),phone)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": false,
-                        "viewLogic": "{{ config(\n    materialized = \"ephemeral\",\n) }}\n\nSELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name as \"full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\nFROM\n    {{ source('pagila', 'customer')}} c\n    left outer join {{ source('pagila', 'address')}} a on c.address_id = a.address_id\n    left outer join {{ source('pagila', 'city') }} m on a.city_id = m.city_id",
-                        "formattedViewLogic": "SELECT\n  c.customer_id,\n  c.first_name || ' ' || c.last_name AS \"full_name\",\n  c.email,\n  a.address,\n  m.city,\n  a.postal_code,\n  a.phone\nFROM \"pagila\".\"public\".\"customer\" AS c\nLEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n  ON c.address_id = a.address_id\nLEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n  ON a.city_id = m.city_id",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "business_owner": "jdoe.last",
-                            "data_governance.team_owner": "Sales",
-                            "has_pii": "False",
-                            "int_property": "2",
-                            "double_property": "3.5",
-                            "node_type": "model",
-                            "materialization": "table",
-                            "dbt_file_path": "models/billing/monthly_billing_with_cust.sql",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.monthly_billing_with_cust",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "an-aliased-view-for-monthly-billing",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.monthly_billing_with_cust",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "billing_month",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "email",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": true,
-                        "viewLogic": "{{ config(\n    materialized = \"table\",\n    alias='an-aliased-view-for-monthly-billing'\n) }}\n\nSELECT \n    pbc.billing_month,\n    pbc.customer_id,\n    pbc.amount,\n    cust.email\nFROM\n    {{ ref('payments_by_customer_by_month')}} pbc\n    left outer join {{ ref('customer_details')}} cust on pbc.customer_id = cust.customer_id\nORDER BY\n    pbc.billing_month",
-                        "formattedViewLogic": "WITH __dbt__CTE__customer_details AS (\n  SELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name AS \"full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\n  FROM \"pagila\".\"public\".\"customer\" AS c\n  LEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n    ON c.address_id = a.address_id\n  LEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n    ON a.city_id = m.city_id\n)\nSELECT\n  pbc.billing_month,\n  pbc.customer_id,\n  pbc.amount,\n  cust.email\nFROM \"pagila\".\"dbt_postgres\".\"payments_by_customer_by_month\" AS pbc\nLEFT OUTER JOIN __dbt__CTE__customer_details AS cust\n  ON pbc.customer_id = cust.customer_id\nORDER BY\n  pbc.billing_month",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "model",
-                            "materialization": "view",
-                            "dbt_file_path": "models/base/payments_base.sql",
-                            "catalog_type": "VIEW",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.payments_base",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "an-aliased-view-for-payments",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.payments_base",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": false,
-                        "viewLogic": "{{ config(\n    materialized=\"view\",\n    alias='an-aliased-view-for-payments'\n) }}\n\nwith payments as (\n\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_01')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_03')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_04')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_05')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_06')}}\n)\n\nselect *\nfrom payments",
-                        "formattedViewLogic": "WITH payments AS (\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_01\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_03\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_04\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_05\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_06\"\n)\nSELECT\n  *\nFROM payments",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "model",
-                            "materialization": "table",
-                            "dbt_file_path": "models/transform/payments_by_customer_by_month.sql",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.payments_by_customer_by_month",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payments_by_customer_by_month",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.payments_by_customer_by_month",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "billing_month",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": true,
-                        "viewLogic": "{{ config(\n    materialized = \"table\",\n) }}\n\nSELECT\n    date_trunc('month', payment_date) as \"billing_month\",\n    customer_id,\n    sum(amount) as \"amount\"\nFROM\n    {{ ref('payments_base')}}\nGROUP BY\n    billing_month,\n    customer_id",
-                        "formattedViewLogic": "SELECT\n  DATE_TRUNC('MONTH', payment_date) AS \"billing_month\",\n  customer_id,\n  SUM(amount) AS \"amount\"\nFROM \"pagila\".\"dbt_postgres\".\"an-aliased-view-for-payments\"\nGROUP BY\n  billing_month,\n  customer_id",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "model_maturity": "in dev",
-                            "some_other_property": "test 1",
-                            "owner": "@alice1",
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.actor",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "actor",
-                        "description": "description for actor table from dbt",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:@alice1",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
                         }
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.actor",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1581759273000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:@alice2",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
                             }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "actor_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.GlobalTags": {
+                            "tags": [
+                                {
+                                    "tag": "urn:li:tag:dbt:test_tag"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.customer_details",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
                             },
-                            {
-                                "fieldPath": "first_name",
-                                "nullable": false,
-                                "description": "dbt comment: Actors column \u2013 from postgres\n\ndbt model description: description for first_name from dbt",
-                                "type": {
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "globalTags": {
-                                    "tags": [
-                                        {
-                                            "tag": "urn:li:tag:dbt:column_tag"
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
                                         }
-                                    ]
+                                    },
+                                    "nativeDataType": "INT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_name",
-                                "nullable": false,
-                                "description": "description for last_name from dbt",
-                                "type": {
+                                {
+                                    "fieldPath": "full_name",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "VARCHAR",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "description": "description for last_update from dbt",
-                                "type": {
+                                {
+                                    "fieldPath": "email",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),actor_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),actor_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),first_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),first_name)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),last_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),last_name)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.address",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "address",
-                        "description": "a user's address",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.address",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1623751200000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "address",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "address",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address2",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "city",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address_id",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "postal_code",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "city_id",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "phone",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+                                    "type": "TRANSFORMED"
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "district",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+                                    "type": "TRANSFORMED"
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "phone",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),full_name)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "postal_code",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),email)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),address)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address2)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address2)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),city_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),city_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),district)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),district)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),phone)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),phone)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),postal_code)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),postal_code)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.category",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "category",
-                        "description": "a user's category",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.category",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1623319200000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "category_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),city)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),postal_code)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),postal_code)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),category_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),category_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),name)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.city",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "city",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.city",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1581759925000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "city",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "city_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "country_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),city)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),city_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),country_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),country_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "model_maturity": "in prod",
-                            "owner": "@bob",
-                            "some_other_property": "test 2",
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.country",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "country",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:@bob",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),phone)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),phone)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": false,
+                            "viewLogic": "{{ config(\n    materialized = \"ephemeral\",\n) }}\n\nSELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name as \"full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\nFROM\n    {{ source('pagila', 'customer')}} c\n    left outer join {{ source('pagila', 'address')}} a on c.address_id = a.address_id\n    left outer join {{ source('pagila', 'city') }} m on a.city_id = m.city_id",
+                            "formattedViewLogic": "SELECT\n  c.customer_id,\n  c.first_name || ' ' || c.last_name AS \"full_name\",\n  c.email,\n  a.address,\n  m.city,\n  a.postal_code,\n  a.phone\nFROM \"pagila\".\"public\".\"customer\" AS c\nLEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n  ON c.address_id = a.address_id\nLEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n  ON a.city_id = m.city_id",
+                            "viewLanguage": "SQL"
                         }
                     }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.country",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1624033800000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "country",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "country_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),country)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),country)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),country_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),country_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.customer",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "customer",
-                        "description": "description for customer table from dbt",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.customer",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1624032000000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "active",
-                                "nullable": false,
-                                "type": {
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "business_owner": "jdoe.last",
+                                "data_governance.team_owner": "Sales",
+                                "has_pii": "False",
+                                "int_property": "2",
+                                "double_property": "3.5",
+                                "node_type": "model",
+                                "materialization": "table",
+                                "dbt_file_path": "models/billing/monthly_billing_with_cust.sql",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.monthly_billing_with_cust",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "an-aliased-view-for-monthly-billing",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.monthly_billing_with_cust",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "activebool",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "billing_month",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.BooleanType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "boolean",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address_id",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "create_date",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "email",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.DateType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+                                    "type": "TRANSFORMED"
                                 },
-                                "nativeDataType": "date",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "email",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "first_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "store_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),active)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),active)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),activebool)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),activebool)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),address_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),address_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),create_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),create_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),email)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),first_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),store_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),store_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_01",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_01",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1580505371996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "an_array_property": "['alpha', 'beta', 'charlie']",
-                            "model_maturity": "in prod",
-                            "owner": "@charles",
-                            "some_other_property": "test 3",
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_02",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:@charles",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": true,
+                            "viewLogic": "{{ config(\n    materialized = \"table\",\n    alias='an-aliased-view-for-monthly-billing'\n) }}\n\nSELECT \n    pbc.billing_month,\n    pbc.customer_id,\n    pbc.amount,\n    cust.email\nFROM\n    {{ ref('payments_by_customer_by_month')}} pbc\n    left outer join {{ ref('customer_details')}} cust on pbc.customer_id = cust.customer_id\nORDER BY\n    pbc.billing_month",
+                            "formattedViewLogic": "WITH __dbt__CTE__customer_details AS (\n  SELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name AS \"full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\n  FROM \"pagila\".\"public\".\"customer\" AS c\n  LEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n    ON c.address_id = a.address_id\n  LEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n    ON a.city_id = m.city_id\n)\nSELECT\n  pbc.billing_month,\n  pbc.customer_id,\n  pbc.amount,\n  cust.email\nFROM \"pagila\".\"dbt_postgres\".\"payments_by_customer_by_month\" AS pbc\nLEFT OUTER JOIN __dbt__CTE__customer_details AS cust\n  ON pbc.customer_id = cust.customer_id\nORDER BY\n  pbc.billing_month",
+                            "viewLanguage": "SQL"
                         }
                     }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_02",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1582319845996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_03",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_03",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1584998318996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "model",
+                                "materialization": "view",
+                                "dbt_file_path": "models/base/payments_base.sql",
+                                "catalog_type": "VIEW",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.payments_base",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
                             },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_04",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_04",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1588287228996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_05",
-                        "description": "a payment",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_05",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1589460269996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_06",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_06",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": -62135596800000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": {
-            "upstreams": [
-                {
-                    "auditStamp": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
+                            "name": "an-aliased-view-for-payments",
+                            "description": "",
+                            "tags": []
+                        }
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-                    "type": "COPY"
-                }
-            ],
-            "fineGrainedLineages": [
-                {
-                    "upstreamType": "FIELD_SET",
-                    "upstreams": [
-                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)"
-                    ],
-                    "downstreamType": "FIELD",
-                    "downstreams": [
-                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)"
-                    ],
-                    "confidenceScore": 1.0
-                },
-                {
-                    "upstreamType": "FIELD_SET",
-                    "upstreams": [
-                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)"
-                    ],
-                    "downstreamType": "FIELD",
-                    "downstreams": [
-                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)"
-                    ],
-                    "confidenceScore": 1.0
-                },
-                {
-                    "upstreamType": "FIELD_SET",
-                    "upstreams": [
-                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)"
-                    ],
-                    "downstreamType": "FIELD",
-                    "downstreams": [
-                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)"
-                    ],
-                    "confidenceScore": 1.0
-                },
-                {
-                    "upstreamType": "FIELD_SET",
-                    "upstreams": [
-                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),email)"
-                    ],
-                    "downstreamType": "FIELD",
-                    "downstreams": [
-                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),email)"
-                    ],
-                    "confidenceScore": 1.0
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": {
-            "upstreams": [
-                {
-                    "auditStamp": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-                    "type": "COPY"
-                }
-            ],
-            "fineGrainedLineages": [
-                {
-                    "upstreamType": "FIELD_SET",
-                    "upstreams": [
-                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
-                    ],
-                    "downstreamType": "FIELD",
-                    "downstreams": [
-                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
-                    ],
-                    "confidenceScore": 1.0
-                },
-                {
-                    "upstreamType": "FIELD_SET",
-                    "upstreams": [
-                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
-                    ],
-                    "downstreamType": "FIELD",
-                    "downstreams": [
-                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
-                    ],
-                    "confidenceScore": 1.0
-                },
-                {
-                    "upstreamType": "FIELD_SET",
-                    "upstreams": [
-                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
-                    ],
-                    "downstreamType": "FIELD",
-                    "downstreams": [
-                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
-                    ],
-                    "confidenceScore": 1.0
-                },
-                {
-                    "upstreamType": "FIELD_SET",
-                    "upstreams": [
-                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)"
-                    ],
-                    "downstreamType": "FIELD",
-                    "downstreams": [
-                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)"
-                    ],
-                    "confidenceScore": 1.0
-                },
-                {
-                    "upstreamType": "FIELD_SET",
-                    "upstreams": [
-                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)"
-                    ],
-                    "downstreamType": "FIELD",
-                    "downstreams": [
-                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)"
-                    ],
-                    "confidenceScore": 1.0
-                },
-                {
-                    "upstreamType": "FIELD_SET",
-                    "upstreams": [
-                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)"
-                    ],
-                    "downstreamType": "FIELD",
-                    "downstreams": [
-                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)"
-                    ],
-                    "confidenceScore": 1.0
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": {
-            "upstreams": [
-                {
-                    "auditStamp": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.payments_base",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-                    "type": "COPY"
-                }
-            ],
-            "fineGrainedLineages": [
-                {
-                    "upstreamType": "FIELD_SET",
-                    "upstreams": [
-                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
-                    ],
-                    "downstreamType": "FIELD",
-                    "downstreams": [
-                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
-                    ],
-                    "confidenceScore": 1.0
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": false,
+                            "viewLogic": "{{ config(\n    materialized=\"view\",\n    alias='an-aliased-view-for-payments'\n) }}\n\nwith payments as (\n\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_01')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_03')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_04')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_05')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_06')}}\n)\n\nselect *\nfrom payments",
+                            "formattedViewLogic": "WITH payments AS (\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_01\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_03\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_04\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_05\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_06\"\n)\nSELECT\n  *\nFROM payments",
+                            "viewLanguage": "SQL"
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "model",
+                                "materialization": "table",
+                                "dbt_file_path": "models/transform/payments_by_customer_by_month.sql",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.payments_by_customer_by_month",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payments_by_customer_by_month",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.payments_by_customer_by_month",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "billing_month",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": true,
+                            "viewLogic": "{{ config(\n    materialized = \"table\",\n) }}\n\nSELECT\n    date_trunc('month', payment_date) as \"billing_month\",\n    customer_id,\n    sum(amount) as \"amount\"\nFROM\n    {{ ref('payments_base')}}\nGROUP BY\n    billing_month,\n    customer_id",
+                            "formattedViewLogic": "SELECT\n  DATE_TRUNC('MONTH', payment_date) AS \"billing_month\",\n  customer_id,\n  SUM(amount) AS \"amount\"\nFROM \"pagila\".\"dbt_postgres\".\"an-aliased-view-for-payments\"\nGROUP BY\n  billing_month,\n  customer_id",
+                            "viewLanguage": "SQL"
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "model_maturity": "in dev",
+                                "some_other_property": "test 1",
+                                "owner": "@alice1",
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.actor",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "actor",
+                            "description": "description for actor table from dbt",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:@alice1",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.actor",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1581759273000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "actor_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "first_name",
+                                    "nullable": false,
+                                    "description": "dbt comment: Actors column \u2013 from postgres\n\ndbt model description: description for first_name from dbt",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "globalTags": {
+                                        "tags": [
+                                            {
+                                                "tag": "urn:li:tag:dbt:column_tag"
+                                            }
+                                        ]
+                                    },
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_name",
+                                    "nullable": false,
+                                    "description": "description for last_name from dbt",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "description": "description for last_update from dbt",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),actor_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),actor_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),first_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),first_name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),last_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),last_name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.address",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "address",
+                            "description": "a user's address",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.address",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1623751200000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "address",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "address2",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "address_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "city_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "district",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "phone",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "postal_code",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address2)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address2)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),city_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),city_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),district)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),district)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),phone)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),phone)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),postal_code)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),postal_code)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.category",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "category",
+                            "description": "a user's category",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.category",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1623319200000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "category_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),category_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),category_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.city",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "city",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.city",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1581759925000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "city",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "city_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "country_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),city)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),city_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),country_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),country_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "model_maturity": "in prod",
+                                "owner": "@bob",
+                                "some_other_property": "test 2",
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.country",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "country",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:@bob",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.country",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1624033800000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "country",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "country_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),country)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),country)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),country_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),country_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.customer",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "customer",
+                            "description": "description for customer table from dbt",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.customer",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1624032000000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "active",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "activebool",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.BooleanType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "boolean",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "address_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "create_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.DateType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "date",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "email",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "first_name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "store_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),active)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),active)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),activebool)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),activebool)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),address_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),address_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),create_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),create_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),email)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),first_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),store_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),store_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_01",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_01",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1580505371996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "an_array_property": "['alpha', 'beta', 'charlie']",
+                                "model_maturity": "in prod",
+                                "owner": "@charles",
+                                "some_other_property": "test 3",
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_02",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:@charles",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_02",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1582319845996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_03",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_03",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1584998318996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_04",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_04",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1588287228996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_05",
+                            "description": "a payment",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_05",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1589460269996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_06",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_06",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": -62135596800000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": {
+                "upstreams": [
+                    {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+                        "type": "COPY"
+                    }
+                ],
+                "fineGrainedLineages": [
+                    {
+                        "upstreamType": "FIELD_SET",
+                        "upstreams": [
+                            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)"
+                        ],
+                        "downstreamType": "FIELD",
+                        "downstreams": [
+                            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)"
+                        ],
+                        "confidenceScore": 1.0
+                    },
+                    {
+                        "upstreamType": "FIELD_SET",
+                        "upstreams": [
+                            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)"
+                        ],
+                        "downstreamType": "FIELD",
+                        "downstreams": [
+                            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)"
+                        ],
+                        "confidenceScore": 1.0
+                    },
+                    {
+                        "upstreamType": "FIELD_SET",
+                        "upstreams": [
+                            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)"
+                        ],
+                        "downstreamType": "FIELD",
+                        "downstreams": [
+                            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)"
+                        ],
+                        "confidenceScore": 1.0
+                    },
+                    {
+                        "upstreamType": "FIELD_SET",
+                        "upstreams": [
+                            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),email)"
+                        ],
+                        "downstreamType": "FIELD",
+                        "downstreams": [
+                            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),email)"
+                        ],
+                        "confidenceScore": 1.0
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": {
+                "upstreams": [
+                    {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+                        "type": "COPY"
+                    }
+                ],
+                "fineGrainedLineages": [
+                    {
+                        "upstreamType": "FIELD_SET",
+                        "upstreams": [
+                            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
+                        ],
+                        "downstreamType": "FIELD",
+                        "downstreams": [
+                            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
+                        ],
+                        "confidenceScore": 1.0
+                    },
+                    {
+                        "upstreamType": "FIELD_SET",
+                        "upstreams": [
+                            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
+                        ],
+                        "downstreamType": "FIELD",
+                        "downstreams": [
+                            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
+                        ],
+                        "confidenceScore": 1.0
+                    },
+                    {
+                        "upstreamType": "FIELD_SET",
+                        "upstreams": [
+                            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
+                        ],
+                        "downstreamType": "FIELD",
+                        "downstreams": [
+                            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
+                        ],
+                        "confidenceScore": 1.0
+                    },
+                    {
+                        "upstreamType": "FIELD_SET",
+                        "upstreams": [
+                            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)"
+                        ],
+                        "downstreamType": "FIELD",
+                        "downstreams": [
+                            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)"
+                        ],
+                        "confidenceScore": 1.0
+                    },
+                    {
+                        "upstreamType": "FIELD_SET",
+                        "upstreams": [
+                            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)"
+                        ],
+                        "downstreamType": "FIELD",
+                        "downstreams": [
+                            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)"
+                        ],
+                        "confidenceScore": 1.0
+                    },
+                    {
+                        "upstreamType": "FIELD_SET",
+                        "upstreams": [
+                            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)"
+                        ],
+                        "downstreamType": "FIELD",
+                        "downstreams": [
+                            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)"
+                        ],
+                        "confidenceScore": 1.0
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": {
+                "upstreams": [
+                    {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+                        "type": "COPY"
+                    }
+                ],
+                "fineGrainedLineages": [
+                    {
+                        "upstreamType": "FIELD_SET",
+                        "upstreams": [
+                            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
+                        ],
+                        "downstreamType": "FIELD",
+                        "downstreams": [
+                            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
+                        ],
+                        "confidenceScore": 1.0
+                    },
+                    {
+                        "upstreamType": "FIELD_SET",
+                        "upstreams": [
+                            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
+                        ],
+                        "downstreamType": "FIELD",
+                        "downstreams": [
+                            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
+                        ],
+                        "confidenceScore": 1.0
+                    },
+                    {
+                        "upstreamType": "FIELD_SET",
+                        "upstreams": [
+                            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
+                        ],
+                        "downstreamType": "FIELD",
+                        "downstreams": [
+                            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
+                        ],
+                        "confidenceScore": 1.0
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.actor",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
                 },
-                {
-                    "upstreamType": "FIELD_SET",
-                    "upstreams": [
-                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
-                    ],
-                    "downstreamType": "FIELD",
-                    "downstreams": [
-                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
-                    ],
-                    "confidenceScore": 1.0
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)"
                 },
-                {
-                    "upstreamType": "FIELD_SET",
-                    "upstreams": [
-                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
-                    ],
-                    "downstreamType": "FIELD",
-                    "downstreams": [
-                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
-                    ],
-                    "confidenceScore": 1.0
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.actor",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-15T09:34:33+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.address",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "warn",
-                    "max_loaded_at": "2021-06-15T10:00:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "259200.0"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.category",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "FAILURE",
-                "nativeResults": {
-                    "status": "error",
-                    "max_loaded_at": "2021-06-10T10:00:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "691200.0"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.city",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "error_after_count": "1",
-                "error_after_period": "day"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-15T09:45:25+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.country",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "30",
-                "warn_after_period": "minute"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2021-06-18T16:30:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "2335.925443"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.customer",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "1",
-                "warn_after_period": "day",
-                "error_after_count": "2",
-                "error_after_period": "day"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2021-06-18T16:00:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "4085.925443"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "3",
-                "warn_after_period": "day",
-                "error_after_count": "7",
-                "error_after_period": "day"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-01-31T21:16:11.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-21T21:17:25.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-03-23T21:18:38.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-04-30T22:53:48.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-05-14T12:44:29.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "0001-01-01T00:00:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
-    "changeType": "UPSERT",
-    "aspectName": "dashboardInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "exposure.sample_dbt.customer_dashboard",
-                "exposure_type": "dashboard",
-                "maturity": "high",
-                "dbt_package_name": "sample_dbt",
-                "dbt_file_path": "models/exposures.yml",
-                "team": "analytics"
-            },
-            "externalUrl": "https://bi.example.com/dashboards/customer",
-            "title": "customer_dashboard",
-            "description": "Dashboard showing customer details and billing",
-            "charts": [],
-            "datasets": [
-                "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-                "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)"
-            ],
-            "dashboards": [],
-            "lastModified": {
-                "created": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:dbt_ingestion"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-15T09:34:33+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
                 },
+                "assertionUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.address",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "warn",
+                        "max_loaded_at": "2021-06-15T10:00:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "259200.0"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.category",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "FAILURE",
+                    "nativeResults": {
+                        "status": "error",
+                        "max_loaded_at": "2021-06-10T10:00:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "691200.0"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.city",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "error_after_count": "1",
+                    "error_after_period": "day"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-15T09:45:25+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.country",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "30",
+                    "warn_after_period": "minute"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2021-06-18T16:30:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "2335.925443"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.customer",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "1",
+                    "warn_after_period": "day",
+                    "error_after_count": "2",
+                    "error_after_period": "day"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2021-06-18T16:00:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "4085.925443"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "3",
+                    "warn_after_period": "day",
+                    "error_after_count": "7",
+                    "error_after_period": "day"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-01-31T21:16:11.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-21T21:17:25.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-03-23T21:18:38.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-04-30T22:53:48.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-05-14T12:44:29.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "0001-01-01T00:00:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
+        "changeType": "UPSERT",
+        "aspectName": "dashboardInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "exposure.sample_dbt.customer_dashboard",
+                    "exposure_type": "dashboard",
+                    "maturity": "high",
+                    "dbt_package_name": "sample_dbt",
+                    "dbt_file_path": "models/exposures.yml",
+                    "team": "analytics"
+                },
+                "externalUrl": "https://bi.example.com/dashboards/customer",
+                "title": "customer_dashboard",
+                "description": "Dashboard showing customer details and billing",
+                "charts": [],
+                "datasets": [
+                    "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+                    "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)"
+                ],
+                "dashboards": [],
                 "lastModified": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:dbt_ingestion"
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:dbt_ingestion"
+                    },
+                    "lastModified": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:dbt_ingestion"
+                    }
                 }
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Dashboard"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
-    "changeType": "UPSERT",
-    "aspectName": "ownership",
-    "aspect": {
-        "json": {
-            "owners": [
-                {
-                    "owner": "urn:li:corpuser:analytics@example.com",
-                    "type": "DATAOWNER"
-                }
-            ],
-            "ownerTypes": {},
-            "lastModified": {
-                "time": 0,
-                "actor": "urn:li:corpuser:unknown"
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
-    "changeType": "UPSERT",
-    "aspectName": "globalTags",
-    "aspect": {
-        "json": {
-            "tags": [
-                {
-                    "tag": "urn:li:tag:dbt:executive"
-                },
-                {
-                    "tag": "urn:li:tag:dbt:customer"
-                }
-            ]
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Dashboard"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
-    "changeType": "UPSERT",
-    "aspectName": "dashboardInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "exposure.sample_dbt.payments_ml_model",
-                "exposure_type": "ml",
-                "maturity": "medium",
-                "dbt_package_name": "sample_dbt",
-                "dbt_file_path": "models/exposures.yml"
-            },
-            "externalUrl": "https://mlflow.example.com/models/payments",
-            "title": "payments_ml_model",
-            "description": "ML model for payment predictions",
-            "charts": [],
-            "datasets": [
-                "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)"
-            ],
-            "dashboards": [],
-            "lastModified": {
-                "created": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:dbt_ingestion"
-                },
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
+        "changeType": "UPSERT",
+        "aspectName": "ownership",
+        "aspect": {
+            "json": {
+                "owners": [
+                    {
+                        "owner": "urn:li:corpuser:analytics@example.com",
+                        "type": "DATAOWNER"
+                    }
+                ],
+                "ownerTypes": {},
                 "lastModified": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:dbt_ingestion"
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
                 }
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "ML Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
-    "changeType": "UPSERT",
-    "aspectName": "ownership",
-    "aspect": {
-        "json": {
-            "owners": [
-                {
-                    "owner": "urn:li:corpuser:ds@example.com",
-                    "type": "DATAOWNER"
-                }
-            ],
-            "ownerTypes": {},
-            "lastModified": {
-                "time": 0,
-                "actor": "urn:li:corpuser:unknown"
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
+        "changeType": "UPSERT",
+        "aspectName": "globalTags",
+        "aspect": {
+            "json": {
+                "tags": [
+                    {
+                        "tag": "urn:li:tag:dbt:executive"
+                    },
+                    {
+                        "tag": "urn:li:tag:dbt:customer"
+                    }
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
-    "changeType": "UPSERT",
-    "aspectName": "globalTags",
-    "aspect": {
-        "json": {
-            "tags": [
-                {
-                    "tag": "urn:li:tag:dbt:ml"
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
+        "changeType": "UPSERT",
+        "aspectName": "dashboardInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "exposure.sample_dbt.payments_ml_model",
+                    "exposure_type": "ml",
+                    "maturity": "medium",
+                    "dbt_package_name": "sample_dbt",
+                    "dbt_file_path": "models/exposures.yml"
                 },
-                {
-                    "tag": "urn:li:tag:dbt:payments"
+                "externalUrl": "https://mlflow.example.com/models/payments",
+                "title": "payments_ml_model",
+                "description": "ML model for payment predictions",
+                "charts": [],
+                "datasets": [
+                    "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)"
+                ],
+                "dashboards": [],
+                "lastModified": {
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:dbt_ingestion"
+                    },
+                    "lastModified": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:dbt_ingestion"
+                    }
                 }
-            ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "ML Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
+        "changeType": "UPSERT",
+        "aspectName": "ownership",
+        "aspect": {
+            "json": {
+                "owners": [
+                    {
+                        "owner": "urn:li:corpuser:ds@example.com",
+                        "type": "DATAOWNER"
+                    }
+                ],
+                "ownerTypes": {},
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
+        "changeType": "UPSERT",
+        "aspectName": "globalTags",
+        "aspect": {
+            "json": {
+                "tags": [
+                    {
+                        "tag": "urn:li:tag:dbt:ml"
+                    },
+                    {
+                        "tag": "urn:li:tag:dbt:payments"
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:column_tag",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:column_tag"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:customer",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:customer"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:executive",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:executive"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:ml",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:ml"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:payments",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:payments"
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:column_tag",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:column_tag"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:test_tag",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:test_tag"
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:customer",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:customer"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-non-incremental-lineage",
-        "lastRunId": "no-run-id-provided"
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:executive",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:executive"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:ml",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:ml"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:payments",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:payments"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:test_tag",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:test_tag"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-non-incremental-lineage",
+            "lastRunId": "no-run-id-provided"
+        }
     }
-}
 ]

--- a/metadata-ingestion/tests/integration/dbt/dbt_test_with_source_database_pattern_mces_golden.json
+++ b/metadata-ingestion/tests/integration/dbt/dbt_test_with_source_database_pattern_mces_golden.json
@@ -1,5422 +1,5506 @@
 [
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "business_owner": "jdoe.last@gmail.com",
-                            "data_governance.team_owner": "Finance",
-                            "has_pii": "True",
-                            "int_property": "1",
-                            "double_property": "2.5",
-                            "node_type": "model",
-                            "materialization": "ephemeral",
-                            "dbt_file_path": "models/transform/customer_details.sql",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.customer_details",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "customer_details",
-                        "description": "",
-                        "tags": [
-                            "dbt:test_tag"
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:alice2",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "business_owner": "jdoe.last@gmail.com",
+                                "data_governance.team_owner": "Finance",
+                                "has_pii": "True",
+                                "int_property": "1",
+                                "double_property": "2.5",
+                                "node_type": "model",
+                                "materialization": "ephemeral",
+                                "dbt_file_path": "models/transform/customer_details.sql",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.customer_details",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "customer_details",
+                            "description": "",
+                            "tags": [
+                                "dbt:test_tag"
+                            ]
                         }
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.GlobalTags": {
-                        "tags": [
-                            {
-                                "tag": "urn:li:tag:dbt:test_tag"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.customer_details",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "INT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "full_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "VARCHAR",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "email",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "city",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "postal_code",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "phone",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),full_name)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),email)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),address)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),city)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),postal_code)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),postal_code)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),phone)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),phone)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": false,
-                        "viewLogic": "{{ config(\n    materialized = \"ephemeral\",\n) }}\n\nSELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name as \"full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\nFROM\n    {{ source('pagila', 'customer')}} c\n    left outer join {{ source('pagila', 'address')}} a on c.address_id = a.address_id\n    left outer join {{ source('pagila', 'city') }} m on a.city_id = m.city_id",
-                        "formattedViewLogic": "SELECT\n  c.customer_id,\n  c.first_name || ' ' || c.last_name AS \"full_name\",\n  c.email,\n  a.address,\n  m.city,\n  a.postal_code,\n  a.phone\nFROM \"pagila\".\"public\".\"customer\" AS c\nLEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n  ON c.address_id = a.address_id\nLEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n  ON a.city_id = m.city_id",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "business_owner": "jdoe.last",
-                            "data_governance.team_owner": "Sales",
-                            "has_pii": "False",
-                            "int_property": "2",
-                            "double_property": "3.5",
-                            "node_type": "model",
-                            "materialization": "table",
-                            "dbt_file_path": "models/billing/monthly_billing_with_cust.sql",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.monthly_billing_with_cust",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "an-aliased-view-for-monthly-billing",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.monthly_billing_with_cust",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "billing_month",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "email",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": true,
-                        "viewLogic": "{{ config(\n    materialized = \"table\",\n    alias='an-aliased-view-for-monthly-billing'\n) }}\n\nSELECT \n    pbc.billing_month,\n    pbc.customer_id,\n    pbc.amount,\n    cust.email\nFROM\n    {{ ref('payments_by_customer_by_month')}} pbc\n    left outer join {{ ref('customer_details')}} cust on pbc.customer_id = cust.customer_id\nORDER BY\n    pbc.billing_month",
-                        "formattedViewLogic": "WITH __dbt__CTE__customer_details AS (\n  SELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name AS \"full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\n  FROM \"pagila\".\"public\".\"customer\" AS c\n  LEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n    ON c.address_id = a.address_id\n  LEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n    ON a.city_id = m.city_id\n)\nSELECT\n  pbc.billing_month,\n  pbc.customer_id,\n  pbc.amount,\n  cust.email\nFROM \"pagila\".\"dbt_postgres\".\"payments_by_customer_by_month\" AS pbc\nLEFT OUTER JOIN __dbt__CTE__customer_details AS cust\n  ON pbc.customer_id = cust.customer_id\nORDER BY\n  pbc.billing_month",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "model",
-                            "materialization": "view",
-                            "dbt_file_path": "models/base/payments_base.sql",
-                            "catalog_type": "VIEW",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.payments_base",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "an-aliased-view-for-payments",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.payments_base",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": false,
-                        "viewLogic": "{{ config(\n    materialized=\"view\",\n    alias='an-aliased-view-for-payments'\n) }}\n\nwith payments as (\n\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_01')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_03')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_04')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_05')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_06')}}\n)\n\nselect *\nfrom payments",
-                        "formattedViewLogic": "WITH payments AS (\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_01\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_03\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_04\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_05\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_06\"\n)\nSELECT\n  *\nFROM payments",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "model",
-                            "materialization": "table",
-                            "dbt_file_path": "models/transform/payments_by_customer_by_month.sql",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.payments_by_customer_by_month",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payments_by_customer_by_month",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.payments_by_customer_by_month",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "billing_month",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": true,
-                        "viewLogic": "{{ config(\n    materialized = \"table\",\n) }}\n\nSELECT\n    date_trunc('month', payment_date) as \"billing_month\",\n    customer_id,\n    sum(amount) as \"amount\"\nFROM\n    {{ ref('payments_base')}}\nGROUP BY\n    billing_month,\n    customer_id",
-                        "formattedViewLogic": "SELECT\n  DATE_TRUNC('MONTH', payment_date) AS \"billing_month\",\n  customer_id,\n  SUM(amount) AS \"amount\"\nFROM \"pagila\".\"dbt_postgres\".\"an-aliased-view-for-payments\"\nGROUP BY\n  billing_month,\n  customer_id",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "model_maturity": "in dev",
-                            "some_other_property": "test 1",
-                            "owner": "ML User(alice1@gmail.com)",
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.actor",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "actor",
-                        "description": "description for actor table from dbt",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:ML User%28alice1@gmail.com%29",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
                         }
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.actor",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1581759273000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:alice2",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
                             }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "actor_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.GlobalTags": {
+                            "tags": [
+                                {
+                                    "tag": "urn:li:tag:dbt:test_tag"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.customer_details",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
                             },
-                            {
-                                "fieldPath": "first_name",
-                                "nullable": false,
-                                "description": "dbt comment: Actors column \u2013 from postgres\n\ndbt model description: description for first_name from dbt",
-                                "type": {
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "globalTags": {
-                                    "tags": [
-                                        {
-                                            "tag": "urn:li:tag:dbt:column_tag"
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
                                         }
-                                    ]
+                                    },
+                                    "nativeDataType": "INT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_name",
-                                "nullable": false,
-                                "description": "description for last_name from dbt",
-                                "type": {
+                                {
+                                    "fieldPath": "full_name",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "VARCHAR",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "description": "description for last_update from dbt",
-                                "type": {
+                                {
+                                    "fieldPath": "email",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),actor_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),actor_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),first_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),first_name)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),last_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),last_name)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.address",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "address",
-                        "description": "a user's address",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.address",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1623751200000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "address",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "address",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address2",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "city",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address_id",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "postal_code",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "city_id",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "phone",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+                                    "type": "TRANSFORMED"
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "district",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+                                    "type": "TRANSFORMED"
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "phone",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),full_name)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "postal_code",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),email)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),address)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address2)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address2)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),city_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),city_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),district)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),district)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),phone)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),phone)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),postal_code)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),postal_code)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.category",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "category",
-                        "description": "a user's category",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.category",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1623319200000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "category_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),city)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),postal_code)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),postal_code)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),category_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),category_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),name)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.city",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "city",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.city",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1581759925000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "city",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "city_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "country_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),city)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),city_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),country_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),country_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "model_maturity": "in prod",
-                            "owner": "bob@gmail.com",
-                            "some_other_property": "test 2",
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.country",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "country",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:bob@gmail.com",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),phone)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),phone)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": false,
+                            "viewLogic": "{{ config(\n    materialized = \"ephemeral\",\n) }}\n\nSELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name as \"full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\nFROM\n    {{ source('pagila', 'customer')}} c\n    left outer join {{ source('pagila', 'address')}} a on c.address_id = a.address_id\n    left outer join {{ source('pagila', 'city') }} m on a.city_id = m.city_id",
+                            "formattedViewLogic": "SELECT\n  c.customer_id,\n  c.first_name || ' ' || c.last_name AS \"full_name\",\n  c.email,\n  a.address,\n  m.city,\n  a.postal_code,\n  a.phone\nFROM \"pagila\".\"public\".\"customer\" AS c\nLEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n  ON c.address_id = a.address_id\nLEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n  ON a.city_id = m.city_id",
+                            "viewLanguage": "SQL"
                         }
                     }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.country",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1624033800000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "country",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "country_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),country)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),country)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),country_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),country_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.customer",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "customer",
-                        "description": "description for customer table from dbt",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.customer",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1624032000000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "active",
-                                "nullable": false,
-                                "type": {
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "business_owner": "jdoe.last",
+                                "data_governance.team_owner": "Sales",
+                                "has_pii": "False",
+                                "int_property": "2",
+                                "double_property": "3.5",
+                                "node_type": "model",
+                                "materialization": "table",
+                                "dbt_file_path": "models/billing/monthly_billing_with_cust.sql",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.monthly_billing_with_cust",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "an-aliased-view-for-monthly-billing",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.monthly_billing_with_cust",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "activebool",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "billing_month",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.BooleanType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "boolean",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address_id",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "create_date",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "email",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.DateType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+                                    "type": "TRANSFORMED"
                                 },
-                                "nativeDataType": "date",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "email",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "first_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "store_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),active)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),active)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),activebool)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),activebool)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),address_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),address_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),create_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),create_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),email)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),first_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),store_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),store_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_01",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_01",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1580505371996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "an_array_property": "['alpha', 'beta', 'charlie']",
-                            "model_maturity": "in prod",
-                            "owner": "Analytics User(charles@gmail.com)",
-                            "some_other_property": "test 3",
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_02",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:Analytics User%28charles@gmail.com%29",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": true,
+                            "viewLogic": "{{ config(\n    materialized = \"table\",\n    alias='an-aliased-view-for-monthly-billing'\n) }}\n\nSELECT \n    pbc.billing_month,\n    pbc.customer_id,\n    pbc.amount,\n    cust.email\nFROM\n    {{ ref('payments_by_customer_by_month')}} pbc\n    left outer join {{ ref('customer_details')}} cust on pbc.customer_id = cust.customer_id\nORDER BY\n    pbc.billing_month",
+                            "formattedViewLogic": "WITH __dbt__CTE__customer_details AS (\n  SELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name AS \"full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\n  FROM \"pagila\".\"public\".\"customer\" AS c\n  LEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n    ON c.address_id = a.address_id\n  LEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n    ON a.city_id = m.city_id\n)\nSELECT\n  pbc.billing_month,\n  pbc.customer_id,\n  pbc.amount,\n  cust.email\nFROM \"pagila\".\"dbt_postgres\".\"payments_by_customer_by_month\" AS pbc\nLEFT OUTER JOIN __dbt__CTE__customer_details AS cust\n  ON pbc.customer_id = cust.customer_id\nORDER BY\n  pbc.billing_month",
+                            "viewLanguage": "SQL"
                         }
                     }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_02",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1582319845996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_03",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_03",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1584998318996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "model",
+                                "materialization": "view",
+                                "dbt_file_path": "models/base/payments_base.sql",
+                                "catalog_type": "VIEW",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.payments_base",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
                             },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_04",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_04",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1588287228996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_05",
-                        "description": "a payment",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_05",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1589460269996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_06",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_06",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": -62135596800000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-                "value": {
-                    "auditStamp": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
+                            "name": "an-aliased-view-for-payments",
+                            "description": "",
+                            "tags": []
+                        }
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-                    "type": "COPY"
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),email)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),email)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-                "value": {
-                    "auditStamp": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-                    "type": "COPY"
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-                "value": {
-                    "auditStamp": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.payments_base",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-                    "type": "COPY"
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": false,
+                            "viewLogic": "{{ config(\n    materialized=\"view\",\n    alias='an-aliased-view-for-payments'\n) }}\n\nwith payments as (\n\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_01')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_03')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_04')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_05')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_06')}}\n)\n\nselect *\nfrom payments",
+                            "formattedViewLogic": "WITH payments AS (\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_01\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_03\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_04\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_05\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_06\"\n)\nSELECT\n  *\nFROM payments",
+                            "viewLanguage": "SQL"
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "model",
+                                "materialization": "table",
+                                "dbt_file_path": "models/transform/payments_by_customer_by_month.sql",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.payments_by_customer_by_month",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payments_by_customer_by_month",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.payments_by_customer_by_month",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "billing_month",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": true,
+                            "viewLogic": "{{ config(\n    materialized = \"table\",\n) }}\n\nSELECT\n    date_trunc('month', payment_date) as \"billing_month\",\n    customer_id,\n    sum(amount) as \"amount\"\nFROM\n    {{ ref('payments_base')}}\nGROUP BY\n    billing_month,\n    customer_id",
+                            "formattedViewLogic": "SELECT\n  DATE_TRUNC('MONTH', payment_date) AS \"billing_month\",\n  customer_id,\n  SUM(amount) AS \"amount\"\nFROM \"pagila\".\"dbt_postgres\".\"an-aliased-view-for-payments\"\nGROUP BY\n  billing_month,\n  customer_id",
+                            "viewLanguage": "SQL"
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "model_maturity": "in dev",
+                                "some_other_property": "test 1",
+                                "owner": "ML User(alice1@gmail.com)",
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.actor",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "actor",
+                            "description": "description for actor table from dbt",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:ML User%28alice1@gmail.com%29",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.actor",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1581759273000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "actor_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "first_name",
+                                    "nullable": false,
+                                    "description": "dbt comment: Actors column \u2013 from postgres\n\ndbt model description: description for first_name from dbt",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "globalTags": {
+                                        "tags": [
+                                            {
+                                                "tag": "urn:li:tag:dbt:column_tag"
+                                            }
+                                        ]
+                                    },
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_name",
+                                    "nullable": false,
+                                    "description": "description for last_name from dbt",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "description": "description for last_update from dbt",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),actor_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),actor_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),first_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),first_name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),last_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),last_name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.address",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "address",
+                            "description": "a user's address",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.address",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1623751200000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "address",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "address2",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "address_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "city_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "district",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "phone",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "postal_code",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address2)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address2)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),address_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),city_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),city_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),district)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),district)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),phone)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),phone)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD),postal_code)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),postal_code)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.category",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "category",
+                            "description": "a user's category",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.category",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1623319200000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "category_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),category_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),category_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD),name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.city",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "city",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.city",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1581759925000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "city",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "city_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "country_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),city)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),city_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),country_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),country_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "model_maturity": "in prod",
+                                "owner": "bob@gmail.com",
+                                "some_other_property": "test 2",
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.country",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "country",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:bob@gmail.com",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.country",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1624033800000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "country",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "country_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),country)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),country)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),country_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),country_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.customer",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "customer",
+                            "description": "description for customer table from dbt",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.customer",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1624032000000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "active",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "activebool",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.BooleanType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "boolean",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "address_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "create_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.DateType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "date",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "email",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "first_name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "store_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),active)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),active)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),activebool)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),activebool)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),address_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),address_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),create_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),create_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),email)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),first_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD),store_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),store_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_01",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_01",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1580505371996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "an_array_property": "['alpha', 'beta', 'charlie']",
+                                "model_maturity": "in prod",
+                                "owner": "Analytics User(charles@gmail.com)",
+                                "some_other_property": "test 3",
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_02",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:Analytics User%28charles@gmail.com%29",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_02",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1582319845996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_03",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_03",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1584998318996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_04",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_04",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1588287228996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_05",
+                            "description": "a payment",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_05",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1589460269996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_06",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_06",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": -62135596800000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+                    "value": {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+                        "type": "COPY"
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),email)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),email)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
                 }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)",
-                "value": {
-                    "confidenceScore": 1.0
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+                    "value": {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+                        "type": "COPY"
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
                 }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)",
-                "value": {
-                    "confidenceScore": 1.0
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+                    "value": {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+                        "type": "COPY"
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
                 }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)",
-                "value": {
-                    "confidenceScore": 1.0
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.actor",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
             }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.actor",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-15T09:34:33+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-15T09:34:33+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
-            },
-            "assertionUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.address",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "warn",
-                    "max_loaded_at": "2021-06-15T10:00:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "259200.0"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.address",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
-            },
-            "assertionUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.category",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "FAILURE",
-                "nativeResults": {
-                    "status": "error",
-                    "max_loaded_at": "2021-06-10T10:00:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "691200.0"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "warn",
+                        "max_loaded_at": "2021-06-15T10:00:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "259200.0"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
-            },
-            "assertionUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.city",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "error_after_count": "1",
-                "error_after_period": "day"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-15T09:45:25+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.category",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
-            },
-            "assertionUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.country",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "30",
-                "warn_after_period": "minute"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2021-06-18T16:30:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "2335.925443"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "FAILURE",
+                    "nativeResults": {
+                        "status": "error",
+                        "max_loaded_at": "2021-06-10T10:00:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "691200.0"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
-            },
-            "assertionUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.customer",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "1",
-                "warn_after_period": "day",
-                "error_after_count": "2",
-                "error_after_period": "day"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2021-06-18T16:00:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "4085.925443"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.city",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "error_after_count": "1",
+                    "error_after_period": "day"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
-            },
-            "assertionUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "3",
-                "warn_after_period": "day",
-                "error_after_count": "7",
-                "error_after_period": "day"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-01-31T21:16:11.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-15T09:45:25+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
-            },
-            "assertionUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-21T21:17:25.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.country",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "30",
+                    "warn_after_period": "minute"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
-            },
-            "assertionUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-03-23T21:18:38.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2021-06-18T16:30:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "2335.925443"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
-            },
-            "assertionUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-04-30T22:53:48.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.customer",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "1",
+                    "warn_after_period": "day",
+                    "error_after_count": "2",
+                    "error_after_period": "day"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
-            },
-            "assertionUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-05-14T12:44:29.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2021-06-18T16:00:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "4085.925443"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
                 }
-            },
-            "assertionUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "0001-01-01T00:00:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "3",
+                    "warn_after_period": "day",
+                    "error_after_count": "7",
+                    "error_after_period": "day"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
                 }
-            },
-            "assertionUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-01-31T21:16:11.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-21T21:17:25.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-03-23T21:18:38.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-04-30T22:53:48.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:column_tag",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:column_tag"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-05-14T12:44:29.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:test_tag",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:test_tag"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-source-database-pattern",
-        "lastRunId": "no-run-id-provided"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "0001-01-01T00:00:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:column_tag",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:column_tag"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:test_tag",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:test_tag"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-source-database-pattern",
+            "lastRunId": "no-run-id-provided"
+        }
     }
-}
 ]

--- a/metadata-ingestion/tests/integration/dbt/dbt_test_with_target_platform_instance_mces_golden.json
+++ b/metadata-ingestion/tests/integration/dbt/dbt_test_with_target_platform_instance_mces_golden.json
@@ -1,5767 +1,5851 @@
 [
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "owner": "@alice2",
-                            "business_owner": "jdoe.last@gmail.com",
-                            "data_governance.team_owner": "Finance",
-                            "has_pii": "True",
-                            "int_property": "1",
-                            "double_property": "2.5",
-                            "node_type": "model",
-                            "materialization": "ephemeral",
-                            "dbt_file_path": "models/transform/customer_details.sql",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.customer_details",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "customer_details",
-                        "description": "",
-                        "tags": [
-                            "dbt:test_tag"
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:@alice2",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "owner": "@alice2",
+                                "business_owner": "jdoe.last@gmail.com",
+                                "data_governance.team_owner": "Finance",
+                                "has_pii": "True",
+                                "int_property": "1",
+                                "double_property": "2.5",
+                                "node_type": "model",
+                                "materialization": "ephemeral",
+                                "dbt_file_path": "models/transform/customer_details.sql",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.customer_details",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "customer_details",
+                            "description": "",
+                            "tags": [
+                                "dbt:test_tag"
+                            ]
                         }
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.GlobalTags": {
-                        "tags": [
-                            {
-                                "tag": "urn:li:tag:dbt:test_tag"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.customer_details",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "INT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "full_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "VARCHAR",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "email",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "city",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "postal_code",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "phone",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "TEXT",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),full_name)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),email)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),address)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),city)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),postal_code)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),postal_code)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),phone)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),phone)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": false,
-                        "viewLogic": "{{ config(\n    materialized = \"ephemeral\",\n) }}\n\nSELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name as \"full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\nFROM\n    {{ source('pagila', 'customer')}} c\n    left outer join {{ source('pagila', 'address')}} a on c.address_id = a.address_id\n    left outer join {{ source('pagila', 'city') }} m on a.city_id = m.city_id",
-                        "formattedViewLogic": "SELECT\n  c.customer_id,\n  c.first_name || ' ' || c.last_name AS \"full_name\",\n  c.email,\n  a.address,\n  m.city,\n  a.postal_code,\n  a.phone\nFROM \"pagila\".\"public\".\"customer\" AS c\nLEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n  ON c.address_id = a.address_id\nLEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n  ON a.city_id = m.city_id",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "business_owner": "jdoe.last",
-                            "data_governance.team_owner": "Sales",
-                            "has_pii": "False",
-                            "int_property": "2",
-                            "double_property": "3.5",
-                            "node_type": "model",
-                            "materialization": "table",
-                            "dbt_file_path": "models/billing/monthly_billing_with_cust.sql",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.monthly_billing_with_cust",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "an-aliased-view-for-monthly-billing",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.monthly_billing_with_cust",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "billing_month",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "email",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": true,
-                        "viewLogic": "{{ config(\n    materialized = \"table\",\n    alias='an-aliased-view-for-monthly-billing'\n) }}\n\nSELECT \n    pbc.billing_month,\n    pbc.customer_id,\n    pbc.amount,\n    cust.email\nFROM\n    {{ ref('payments_by_customer_by_month')}} pbc\n    left outer join {{ ref('customer_details')}} cust on pbc.customer_id = cust.customer_id\nORDER BY\n    pbc.billing_month",
-                        "formattedViewLogic": "WITH __dbt__CTE__customer_details AS (\n  SELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name AS \"full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\n  FROM \"pagila\".\"public\".\"customer\" AS c\n  LEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n    ON c.address_id = a.address_id\n  LEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n    ON a.city_id = m.city_id\n)\nSELECT\n  pbc.billing_month,\n  pbc.customer_id,\n  pbc.amount,\n  cust.email\nFROM \"pagila\".\"dbt_postgres\".\"payments_by_customer_by_month\" AS pbc\nLEFT OUTER JOIN __dbt__CTE__customer_details AS cust\n  ON pbc.customer_id = cust.customer_id\nORDER BY\n  pbc.billing_month",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "model",
-                            "materialization": "view",
-                            "dbt_file_path": "models/base/payments_base.sql",
-                            "catalog_type": "VIEW",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.payments_base",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "an-aliased-view-for-payments",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.payments_base",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-                                "type": "TRANSFORMED"
-                            },
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),amount)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),customer_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_date)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),rental_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),staff_id)",
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": false,
-                        "viewLogic": "{{ config(\n    materialized=\"view\",\n    alias='an-aliased-view-for-payments'\n) }}\n\nwith payments as (\n\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_01')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_03')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_04')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_05')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_06')}}\n)\n\nselect *\nfrom payments",
-                        "formattedViewLogic": "WITH payments AS (\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_01\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_03\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_04\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_05\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_06\"\n)\nSELECT\n  *\nFROM payments",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "model",
-                            "materialization": "table",
-                            "dbt_file_path": "models/transform/payments_by_customer_by_month.sql",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "model.sample_dbt.payments_by_customer_by_month",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payments_by_customer_by_month",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "model.sample_dbt.payments_by_customer_by_month",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "billing_month",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-                                "type": "TRANSFORMED"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 0.9
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
-                                ],
-                                "confidenceScore": 0.9
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                        "materialized": true,
-                        "viewLogic": "{{ config(\n    materialized = \"table\",\n) }}\n\nSELECT\n    date_trunc('month', payment_date) as \"billing_month\",\n    customer_id,\n    sum(amount) as \"amount\"\nFROM\n    {{ ref('payments_base')}}\nGROUP BY\n    billing_month,\n    customer_id",
-                        "formattedViewLogic": "SELECT\n  DATE_TRUNC('MONTH', payment_date) AS \"billing_month\",\n  customer_id,\n  SUM(amount) AS \"amount\"\nFROM \"pagila\".\"dbt_postgres\".\"an-aliased-view-for-payments\"\nGROUP BY\n  billing_month,\n  customer_id",
-                        "viewLanguage": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "model_maturity": "in dev",
-                            "some_other_property": "test 1",
-                            "owner": "@alice1",
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.actor",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "actor",
-                        "description": "description for actor table from dbt",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:@alice1",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
                         }
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.actor",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1581759273000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:@alice2",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
                             }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "actor_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.GlobalTags": {
+                            "tags": [
+                                {
+                                    "tag": "urn:li:tag:dbt:test_tag"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.customer_details",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
                             },
-                            {
-                                "fieldPath": "first_name",
-                                "nullable": false,
-                                "description": "dbt comment: Actors column \u2013 from postgres\n\ndbt model description: description for first_name from dbt",
-                                "type": {
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "globalTags": {
-                                    "tags": [
-                                        {
-                                            "tag": "urn:li:tag:dbt:column_tag"
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
                                         }
-                                    ]
+                                    },
+                                    "nativeDataType": "INT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_name",
-                                "nullable": false,
-                                "description": "description for last_name from dbt",
-                                "type": {
+                                {
+                                    "fieldPath": "full_name",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "VARCHAR",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "description": "description for last_update from dbt",
-                                "type": {
+                                {
+                                    "fieldPath": "email",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.actor,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.actor,PROD),actor_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),actor_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.actor,PROD),first_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),first_name)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.actor,PROD),last_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),last_name)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.actor,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.address",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "address",
-                        "description": "a user's address",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.address",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1623751200000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "address",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "address",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address2",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "city",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address_id",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "postal_code",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "city_id",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "phone",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "TEXT",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+                                    "type": "TRANSFORMED"
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "district",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+                                    "type": "TRANSFORMED"
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "phone",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),full_name)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "postal_code",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),email)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),address)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD),address)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD),address2)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address2)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD),address_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD),city_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),city_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD),district)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),district)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD),phone)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),phone)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD),postal_code)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),postal_code)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.category",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "category",
-                        "description": "a user's category",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.category",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1623319200000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "category_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),city)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),postal_code)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),postal_code)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.category,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.category,PROD),category_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),category_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.category,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.category,PROD),name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),name)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.city",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "city",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.city",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1581759925000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "city",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "city_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "country_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.city,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.city,PROD),city)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.city,PROD),city_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.city,PROD),country_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),country_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.city,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "model_maturity": "in prod",
-                            "owner": "@bob",
-                            "some_other_property": "test 2",
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.country",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "country",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:@bob",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),phone)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),phone)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": false,
+                            "viewLogic": "{{ config(\n    materialized = \"ephemeral\",\n) }}\n\nSELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name as \"full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\nFROM\n    {{ source('pagila', 'customer')}} c\n    left outer join {{ source('pagila', 'address')}} a on c.address_id = a.address_id\n    left outer join {{ source('pagila', 'city') }} m on a.city_id = m.city_id",
+                            "formattedViewLogic": "SELECT\n  c.customer_id,\n  c.first_name || ' ' || c.last_name AS \"full_name\",\n  c.email,\n  a.address,\n  m.city,\n  a.postal_code,\n  a.phone\nFROM \"pagila\".\"public\".\"customer\" AS c\nLEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n  ON c.address_id = a.address_id\nLEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n  ON a.city_id = m.city_id",
+                            "viewLanguage": "SQL"
                         }
                     }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.country",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1624033800000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "country",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "country_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.country,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.country,PROD),country)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),country)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.country,PROD),country_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),country_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.country,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.customer",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "customer",
-                        "description": "description for customer table from dbt",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.customer",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1624032000000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "active",
-                                "nullable": false,
-                                "type": {
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "business_owner": "jdoe.last",
+                                "data_governance.team_owner": "Sales",
+                                "has_pii": "False",
+                                "int_property": "2",
+                                "double_property": "3.5",
+                                "node_type": "model",
+                                "materialization": "table",
+                                "dbt_file_path": "models/billing/monthly_billing_with_cust.sql",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.monthly_billing_with_cust",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "an-aliased-view-for-monthly-billing",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.monthly_billing_with_cust",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "activebool",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "billing_month",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.BooleanType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "boolean",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "address_id",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "create_date",
-                                "nullable": false,
-                                "type": {
+                                {
+                                    "fieldPath": "email",
+                                    "nullable": false,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.DateType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+                                    "type": "TRANSFORMED"
                                 },
-                                "nativeDataType": "date",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "email",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
                                 },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "first_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_name",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "text",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "last_update",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "store_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),active)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),active)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),activebool)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),activebool)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),address_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),address_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),create_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),create_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),email)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),first_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),last_name)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),last_update)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_update)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),store_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),store_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_01",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_01",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1580505371996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_01,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_01,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_01,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_01,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_01,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_01,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_01,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "an_array_property": "['alpha', 'beta', 'charlie']",
-                            "model_maturity": "in prod",
-                            "owner": "@charles",
-                            "some_other_property": "test 3",
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_02",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:@charles",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": true,
+                            "viewLogic": "{{ config(\n    materialized = \"table\",\n    alias='an-aliased-view-for-monthly-billing'\n) }}\n\nSELECT \n    pbc.billing_month,\n    pbc.customer_id,\n    pbc.amount,\n    cust.email\nFROM\n    {{ ref('payments_by_customer_by_month')}} pbc\n    left outer join {{ ref('customer_details')}} cust on pbc.customer_id = cust.customer_id\nORDER BY\n    pbc.billing_month",
+                            "formattedViewLogic": "WITH __dbt__CTE__customer_details AS (\n  SELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name AS \"full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\n  FROM \"pagila\".\"public\".\"customer\" AS c\n  LEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n    ON c.address_id = a.address_id\n  LEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n    ON a.city_id = m.city_id\n)\nSELECT\n  pbc.billing_month,\n  pbc.customer_id,\n  pbc.amount,\n  cust.email\nFROM \"pagila\".\"dbt_postgres\".\"payments_by_customer_by_month\" AS pbc\nLEFT OUTER JOIN __dbt__CTE__customer_details AS cust\n  ON pbc.customer_id = cust.customer_id\nORDER BY\n  pbc.billing_month",
+                            "viewLanguage": "SQL"
                         }
                     }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_02",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1582319845996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_02,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_02,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_02,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_02,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_02,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_02,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_02,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_03",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_03",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1584998318996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "model",
+                                "materialization": "view",
+                                "dbt_file_path": "models/base/payments_base.sql",
+                                "catalog_type": "VIEW",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.payments_base",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
                             },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_03,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_03,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_03,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_03,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_03,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_03,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_03,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_04",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_04",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1588287228996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_04,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_04,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_04,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_04,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_04,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_04,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_04,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_05",
-                        "description": "a payment",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_05",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 1589460269996,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_05,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_05,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_05,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_05,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_05,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_05,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_05,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Source"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "node_type": "source",
-                            "dbt_file_path": "models/base.yml",
-                            "catalog_type": "BASE TABLE",
-                            "language": "sql",
-                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
-                            "dbt_package_name": "sample_dbt",
-                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                            "manifest_version": "0.19.1",
-                            "manifest_adapter": "postgres",
-                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                            "catalog_version": "0.19.1"
-                        },
-                        "name": "payment_p2020_06",
-                        "description": "",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "source.sample_dbt.pagila.payment_p2020_06",
-                        "platform": "urn:li:dataPlatform:dbt",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": -62135596800000,
-                            "actor": "urn:li:corpuser:dbt_executor"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "amount",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "numeric(5,2)",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "customer_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_date",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                    }
-                                },
-                                "nativeDataType": "timestamp with time zone",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "payment_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "rental_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            },
-                            {
-                                "fieldPath": "staff_id",
-                                "nullable": false,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "integer",
-                                "recursive": false,
-                                "isPartOfKey": false
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                        "upstreams": [
-                            {
-                                "auditStamp": {
-                                    "time": 1643871600000,
-                                    "actor": "urn:li:corpuser:unknown"
-                                },
-                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_06,PROD)",
-                                "type": "COPY"
-                            }
-                        ],
-                        "fineGrainedLineages": [
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_06,PROD),amount)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),amount)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_06,PROD),customer_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),customer_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_06,PROD),payment_date)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_date)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_06,PROD),payment_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_06,PROD),rental_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),rental_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            },
-                            {
-                                "upstreamType": "FIELD_SET",
-                                "upstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_06,PROD),staff_id)"
-                                ],
-                                "downstreamType": "FIELD",
-                                "downstreams": [
-                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),staff_id)"
-                                ],
-                                "confidenceScore": 1.0
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-                "value": {
-                    "auditStamp": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
+                            "name": "an-aliased-view-for-payments",
+                            "description": "",
+                            "tags": []
+                        }
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-                    "type": "COPY"
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),email)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),email)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-                "value": {
-                    "auditStamp": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-                    "type": "COPY"
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-                "value": {
-                    "auditStamp": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:unknown"
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.payments_base",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-                    "type": "COPY"
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
-            },
-            {
-                "op": "add",
-                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)",
-                "value": {
-                    "confidenceScore": 1.0
-                }
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+                                    "type": "TRANSFORMED"
+                                },
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),customer_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_date)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),rental_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),staff_id)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": false,
+                            "viewLogic": "{{ config(\n    materialized=\"view\",\n    alias='an-aliased-view-for-payments'\n) }}\n\nwith payments as (\n\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_01')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_03')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_04')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_05')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_06')}}\n)\n\nselect *\nfrom payments",
+                            "formattedViewLogic": "WITH payments AS (\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_01\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_03\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_04\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_05\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_06\"\n)\nSELECT\n  *\nFROM payments",
+                            "viewLanguage": "SQL"
+                        }
+                    }
+                ]
             }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.actor",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Model"
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-15T09:34:33+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.address",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)"
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "model",
+                                "materialization": "table",
+                                "dbt_file_path": "models/transform/payments_by_customer_by_month.sql",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "model.sample_dbt.payments_by_customer_by_month",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payments_by_customer_by_month",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "model.sample_dbt.payments_by_customer_by_month",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "billing_month",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+                                    "type": "TRANSFORMED"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                            "materialized": true,
+                            "viewLogic": "{{ config(\n    materialized = \"table\",\n) }}\n\nSELECT\n    date_trunc('month', payment_date) as \"billing_month\",\n    customer_id,\n    sum(amount) as \"amount\"\nFROM\n    {{ ref('payments_base')}}\nGROUP BY\n    billing_month,\n    customer_id",
+                            "formattedViewLogic": "SELECT\n  DATE_TRUNC('MONTH', payment_date) AS \"billing_month\",\n  customer_id,\n  SUM(amount) AS \"amount\"\nFROM \"pagila\".\"dbt_postgres\".\"an-aliased-view-for-payments\"\nGROUP BY\n  billing_month,\n  customer_id",
+                            "viewLanguage": "SQL"
+                        }
+                    }
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "warn",
-                    "max_loaded_at": "2021-06-15T10:00:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "259200.0"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.category",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "FAILURE",
-                "nativeResults": {
-                    "status": "error",
-                    "max_loaded_at": "2021-06-10T10:00:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "691200.0"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "model_maturity": "in dev",
+                                "some_other_property": "test 1",
+                                "owner": "@alice1",
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.actor",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "actor",
+                            "description": "description for actor table from dbt",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:@alice1",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.actor",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1581759273000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "actor_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "first_name",
+                                    "nullable": false,
+                                    "description": "dbt comment: Actors column \u2013 from postgres\n\ndbt model description: description for first_name from dbt",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "globalTags": {
+                                        "tags": [
+                                            {
+                                                "tag": "urn:li:tag:dbt:column_tag"
+                                            }
+                                        ]
+                                    },
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_name",
+                                    "nullable": false,
+                                    "description": "description for last_name from dbt",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "description": "description for last_update from dbt",
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.actor,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.actor,PROD),actor_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),actor_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.actor,PROD),first_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),first_name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.actor,PROD),last_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),last_name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.actor,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.city",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "error_after_count": "1",
-                "error_after_period": "day"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-15T09:45:25+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.country",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "30",
-                "warn_after_period": "minute"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)"
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.address",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "address",
+                            "description": "a user's address",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.address",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1623751200000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "address",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "address2",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "address_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "city_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "district",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "phone",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "postal_code",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD),address)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD),address2)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address2)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD),address_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD),city_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),city_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD),district)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),district)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD),phone)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),phone)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD),postal_code)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),postal_code)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2021-06-18T16:30:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "2335.925443"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.customer",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "1",
-                "warn_after_period": "day",
-                "error_after_count": "2",
-                "error_after_period": "day"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2021-06-18T16:00:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "4085.925443"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.category",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "category",
+                            "description": "a user's category",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.category",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1623319200000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "category_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.category,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.category,PROD),category_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),category_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.category,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.category,PROD),name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "3",
-                "warn_after_period": "day",
-                "error_after_count": "7",
-                "error_after_period": "day"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-01-31T21:16:11.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)"
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.city",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "city",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.city",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1581759925000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "city",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "city_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "country_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.city,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.city,PROD),city)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.city,PROD),city_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.city,PROD),country_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),country_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.city,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-02-21T21:17:25.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-03-23T21:18:38.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "model_maturity": "in prod",
+                                "owner": "@bob",
+                                "some_other_property": "test 2",
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.country",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "country",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:@bob",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.country",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1624033800000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "country",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "country_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.country,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.country,PROD),country)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),country)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.country,PROD),country_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),country_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.country,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-04-30T22:53:48.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)"
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.customer",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "customer",
+                            "description": "description for customer table from dbt",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.customer",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1624032000000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "active",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "activebool",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.BooleanType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "boolean",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "address_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "create_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.DateType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "date",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "email",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "first_name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_name",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "text",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "last_update",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "store_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),active)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),active)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),activebool)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),activebool)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),address_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),address_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),create_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),create_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),email)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),first_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),last_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),last_update)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_update)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),store_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),store_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "2020-05-14T12:44:29.996577+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                "manifest_version": "0.19.1",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "0.19.1",
-                "dbt_freshness_test": "true",
-                "warn_after_count": "12",
-                "warn_after_period": "hour",
-                "error_after_count": "24",
-                "error_after_period": "hour"
-            },
-            "type": "CUSTOM",
-            "customAssertion": {
-                "type": "dbt Freshness",
-                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1624036135925,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {
-                    "status": "pass",
-                    "max_loaded_at": "0001-01-01T00:00:00+00:00",
-                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                    "max_loaded_at_time_ago_in_s": "42276862.910052"
-                }
-            },
-            "assertionUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_01",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_01",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1580505371996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_01,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_01,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_01,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_01,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_01,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_01,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_01,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
-    "changeType": "UPSERT",
-    "aspectName": "dashboardInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "exposure.sample_dbt.customer_dashboard",
-                "exposure_type": "dashboard",
-                "maturity": "high",
-                "dbt_package_name": "sample_dbt",
-                "dbt_file_path": "models/exposures.yml",
-                "team": "analytics"
-            },
-            "externalUrl": "https://bi.example.com/dashboards/customer",
-            "title": "customer_dashboard",
-            "description": "Dashboard showing customer details and billing",
-            "charts": [],
-            "datasets": [
-                "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-                "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)"
-            ],
-            "dashboards": [],
-            "lastModified": {
-                "created": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:dbt_ingestion"
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "an_array_property": "['alpha', 'beta', 'charlie']",
+                                "model_maturity": "in prod",
+                                "owner": "@charles",
+                                "some_other_property": "test 3",
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_02",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:@charles",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_02",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1582319845996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_02,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_02,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_02,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_02,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_02,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_02,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_02,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_03",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_03",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1584998318996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_03,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_03,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_03,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_03,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_03,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_03,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_03,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_04",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_04",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1588287228996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_04,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_04,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_04,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_04,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_04,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_04,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_04,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_05",
+                            "description": "a payment",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_05",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1589460269996,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_05,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_05,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_05,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_05,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_05,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_05,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_05,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Source"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "node_type": "source",
+                                "dbt_file_path": "models/base.yml",
+                                "catalog_type": "BASE TABLE",
+                                "language": "sql",
+                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
+                                "dbt_package_name": "sample_dbt",
+                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                                "manifest_version": "0.19.1",
+                                "manifest_adapter": "postgres",
+                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                                "catalog_version": "0.19.1"
+                            },
+                            "name": "payment_p2020_06",
+                            "description": "",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "source.sample_dbt.pagila.payment_p2020_06",
+                            "platform": "urn:li:dataPlatform:dbt",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": -62135596800000,
+                                "actor": "urn:li:corpuser:dbt_executor"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "amount",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "numeric(5,2)",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "customer_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_date",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "timestamp with time zone",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "payment_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "rental_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                },
+                                {
+                                    "fieldPath": "staff_id",
+                                    "nullable": false,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "integer",
+                                    "recursive": false,
+                                    "isPartOfKey": false
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                            "upstreams": [
+                                {
+                                    "auditStamp": {
+                                        "time": 1643871600000,
+                                        "actor": "urn:li:corpuser:unknown"
+                                    },
+                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_06,PROD)",
+                                    "type": "COPY"
+                                }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_06,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_06,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_06,PROD),payment_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_date)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_06,PROD),payment_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_06,PROD),rental_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),rental_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_06,PROD),staff_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),staff_id)"
+                                    ],
+                                    "confidenceScore": 1.0
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+                    "value": {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+                        "type": "COPY"
+                    }
                 },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),email)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),email)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+                    "value": {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+                        "type": "COPY"
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+        "changeType": "PATCH",
+        "aspectName": "upstreamLineage",
+        "aspect": {
+            "json": [
+                {
+                    "op": "add",
+                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+                    "value": {
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+                        "type": "COPY"
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)",
+                    "value": {
+                        "confidenceScore": 1.0
+                    }
+                }
+            ]
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.actor",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-15T09:34:33+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.address",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "warn",
+                        "max_loaded_at": "2021-06-15T10:00:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "259200.0"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.category",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "FAILURE",
+                    "nativeResults": {
+                        "status": "error",
+                        "max_loaded_at": "2021-06-10T10:00:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "691200.0"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.city",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "error_after_count": "1",
+                    "error_after_period": "day"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-15T09:45:25+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.country",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "30",
+                    "warn_after_period": "minute"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2021-06-18T16:30:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "2335.925443"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.customer",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "1",
+                    "warn_after_period": "day",
+                    "error_after_count": "2",
+                    "error_after_period": "day"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2021-06-18T16:00:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "4085.925443"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "3",
+                    "warn_after_period": "day",
+                    "error_after_count": "7",
+                    "error_after_period": "day"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-01-31T21:16:11.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-02-21T21:17:25.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-03-23T21:18:38.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-04-30T22:53:48.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "2020-05-14T12:44:29.996577+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+        "changeType": "UPSERT",
+        "aspectName": "assertionInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
+                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                    "manifest_version": "0.19.1",
+                    "manifest_adapter": "postgres",
+                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                    "catalog_version": "0.19.1",
+                    "dbt_freshness_test": "true",
+                    "warn_after_count": "12",
+                    "warn_after_period": "hour",
+                    "error_after_count": "24",
+                    "error_after_period": "hour"
+                },
+                "type": "CUSTOM",
+                "customAssertion": {
+                    "type": "dbt Freshness",
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)"
+                },
+                "source": {
+                    "type": "EXTERNAL",
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:__datahub_system"
+                    }
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+        "changeType": "UPSERT",
+        "aspectName": "assertionRunEvent",
+        "aspect": {
+            "json": {
+                "timestampMillis": 1624036135925,
+                "runId": "just-some-random-id",
+                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
+                "status": "COMPLETE",
+                "result": {
+                    "type": "SUCCESS",
+                    "nativeResults": {
+                        "status": "pass",
+                        "max_loaded_at": "0001-01-01T00:00:00+00:00",
+                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                        "max_loaded_at_time_ago_in_s": "42276862.910052"
+                    }
+                },
+                "assertionUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+                "partitionSpec": {
+                    "partition": "FULL_TABLE_SNAPSHOT",
+                    "type": "FULL_TABLE"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
+        "changeType": "UPSERT",
+        "aspectName": "dashboardInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "exposure.sample_dbt.customer_dashboard",
+                    "exposure_type": "dashboard",
+                    "maturity": "high",
+                    "dbt_package_name": "sample_dbt",
+                    "dbt_file_path": "models/exposures.yml",
+                    "team": "analytics"
+                },
+                "externalUrl": "https://bi.example.com/dashboards/customer",
+                "title": "customer_dashboard",
+                "description": "Dashboard showing customer details and billing",
+                "charts": [],
+                "datasets": [
+                    "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+                    "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)"
+                ],
+                "dashboards": [],
                 "lastModified": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:dbt_ingestion"
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:dbt_ingestion"
+                    },
+                    "lastModified": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:dbt_ingestion"
+                    }
                 }
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Dashboard"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
-    "changeType": "UPSERT",
-    "aspectName": "ownership",
-    "aspect": {
-        "json": {
-            "owners": [
-                {
-                    "owner": "urn:li:corpuser:analytics@example.com",
-                    "type": "DATAOWNER"
-                }
-            ],
-            "ownerTypes": {},
-            "lastModified": {
-                "time": 0,
-                "actor": "urn:li:corpuser:unknown"
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
-    "changeType": "UPSERT",
-    "aspectName": "globalTags",
-    "aspect": {
-        "json": {
-            "tags": [
-                {
-                    "tag": "urn:li:tag:dbt:executive"
-                },
-                {
-                    "tag": "urn:li:tag:dbt:customer"
-                }
-            ]
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Dashboard"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:dbt"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
-    "changeType": "UPSERT",
-    "aspectName": "dashboardInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dbt_unique_id": "exposure.sample_dbt.payments_ml_model",
-                "exposure_type": "ml",
-                "maturity": "medium",
-                "dbt_package_name": "sample_dbt",
-                "dbt_file_path": "models/exposures.yml"
-            },
-            "externalUrl": "https://mlflow.example.com/models/payments",
-            "title": "payments_ml_model",
-            "description": "ML model for payment predictions",
-            "charts": [],
-            "datasets": [
-                "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)"
-            ],
-            "dashboards": [],
-            "lastModified": {
-                "created": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:dbt_ingestion"
-                },
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
+        "changeType": "UPSERT",
+        "aspectName": "ownership",
+        "aspect": {
+            "json": {
+                "owners": [
+                    {
+                        "owner": "urn:li:corpuser:analytics@example.com",
+                        "type": "DATAOWNER"
+                    }
+                ],
+                "ownerTypes": {},
                 "lastModified": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:dbt_ingestion"
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
                 }
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "ML Model"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
-    "changeType": "UPSERT",
-    "aspectName": "ownership",
-    "aspect": {
-        "json": {
-            "owners": [
-                {
-                    "owner": "urn:li:corpuser:ds@example.com",
-                    "type": "DATAOWNER"
-                }
-            ],
-            "ownerTypes": {},
-            "lastModified": {
-                "time": 0,
-                "actor": "urn:li:corpuser:unknown"
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
+        "changeType": "UPSERT",
+        "aspectName": "globalTags",
+        "aspect": {
+            "json": {
+                "tags": [
+                    {
+                        "tag": "urn:li:tag:dbt:executive"
+                    },
+                    {
+                        "tag": "urn:li:tag:dbt:customer"
+                    }
+                ]
             }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
-    "changeType": "UPSERT",
-    "aspectName": "globalTags",
-    "aspect": {
-        "json": {
-            "tags": [
-                {
-                    "tag": "urn:li:tag:dbt:ml"
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:dbt"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
+        "changeType": "UPSERT",
+        "aspectName": "dashboardInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dbt_unique_id": "exposure.sample_dbt.payments_ml_model",
+                    "exposure_type": "ml",
+                    "maturity": "medium",
+                    "dbt_package_name": "sample_dbt",
+                    "dbt_file_path": "models/exposures.yml"
                 },
-                {
-                    "tag": "urn:li:tag:dbt:payments"
+                "externalUrl": "https://mlflow.example.com/models/payments",
+                "title": "payments_ml_model",
+                "description": "ML model for payment predictions",
+                "charts": [],
+                "datasets": [
+                    "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)"
+                ],
+                "dashboards": [],
+                "lastModified": {
+                    "created": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:dbt_ingestion"
+                    },
+                    "lastModified": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:dbt_ingestion"
+                    }
                 }
-            ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "ML Model"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
+        "changeType": "UPSERT",
+        "aspectName": "ownership",
+        "aspect": {
+            "json": {
+                "owners": [
+                    {
+                        "owner": "urn:li:corpuser:ds@example.com",
+                        "type": "DATAOWNER"
+                    }
+                ],
+                "ownerTypes": {},
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "dashboard",
+        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
+        "changeType": "UPSERT",
+        "aspectName": "globalTags",
+        "aspect": {
+            "json": {
+                "tags": [
+                    {
+                        "tag": "urn:li:tag:dbt:ml"
+                    },
+                    {
+                        "tag": "urn:li:tag:dbt:payments"
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:column_tag",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:column_tag"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:customer",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:customer"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:executive",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:executive"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:ml",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:ml"
+    {
+        "entityType": "assertion",
+        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:payments",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:payments"
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:column_tag",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:column_tag"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:dbt:test_tag",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "dbt:test_tag"
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:customer",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:customer"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
         }
     },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-with-target-platform-instance",
-        "lastRunId": "no-run-id-provided"
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:executive",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:executive"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:ml",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:ml"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:payments",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:payments"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:dbt:test_tag",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "dbt:test_tag"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "dbt-test-with-target-platform-instance",
+            "lastRunId": "no-run-id-provided"
+        }
     }
-}
 ]

--- a/metadata-ingestion/tests/unit/api/entities/datacontract/test_data_quality_assertion.py
+++ b/metadata-ingestion/tests/unit/api/entities/datacontract/test_data_quality_assertion.py
@@ -1,9 +1,10 @@
 from datahub.api.entities.datacontract.data_quality_assertion import (
     DataQualityAssertion,
 )
-from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.emitter.mce_builder import SYSTEM_ACTOR
 from datahub.metadata.schema_classes import (
     AssertionInfoClass,
+    AssertionSourceTypeClass,
     AssertionStdOperatorClass,
     AssertionStdParameterClass,
     AssertionStdParametersClass,
@@ -26,30 +27,34 @@ def test_parse_sql_assertion():
         "operator": {"type": "between", "min": 5, "max": 10},
     }
 
-    assert DataQualityAssertion.model_validate(d).generate_mcp(
+    mcps = DataQualityAssertion.model_validate(d).generate_mcp(
         assertion_urn, entity_urn
-    ) == [
-        MetadataChangeProposalWrapper(
-            entityUrn=assertion_urn,
-            aspect=AssertionInfoClass(
-                type=AssertionTypeClass.SQL,
-                sqlAssertion=SqlAssertionInfoClass(
-                    type=SqlAssertionTypeClass.METRIC,
-                    changeType=AssertionValueChangeTypeClass.ABSOLUTE,
-                    entity=entity_urn,
-                    statement="SELECT COUNT(*) FROM my_table WHERE value IS NOT NULL",
-                    operator=AssertionStdOperatorClass.BETWEEN,
-                    parameters=AssertionStdParametersClass(
-                        minValue=AssertionStdParameterClass(
-                            value="5",
-                            type=AssertionStdParameterTypeClass.NUMBER,
-                        ),
-                        maxValue=AssertionStdParameterClass(
-                            value="10",
-                            type=AssertionStdParameterTypeClass.NUMBER,
-                        ),
-                    ),
-                ),
+    )
+    assert len(mcps) == 1
+    mcp = mcps[0]
+    assert mcp.entityUrn == assertion_urn
+
+    aspect = mcp.aspect
+    assert isinstance(aspect, AssertionInfoClass)
+    assert aspect.type == AssertionTypeClass.SQL
+    assert aspect.sqlAssertion == SqlAssertionInfoClass(
+        type=SqlAssertionTypeClass.METRIC,
+        changeType=AssertionValueChangeTypeClass.ABSOLUTE,
+        entity=entity_urn,
+        statement="SELECT COUNT(*) FROM my_table WHERE value IS NOT NULL",
+        operator=AssertionStdOperatorClass.BETWEEN,
+        parameters=AssertionStdParametersClass(
+            minValue=AssertionStdParameterClass(
+                value="5",
+                type=AssertionStdParameterTypeClass.NUMBER,
             ),
-        )
-    ]
+            maxValue=AssertionStdParameterClass(
+                value="10",
+                type=AssertionStdParameterTypeClass.NUMBER,
+            ),
+        ),
+    )
+    assert aspect.source is not None
+    assert aspect.source.type == AssertionSourceTypeClass.EXTERNAL
+    assert aspect.source.created is not None
+    assert aspect.source.created.actor == SYSTEM_ACTOR

--- a/metadata-ingestion/tests/unit/dbt/test_dbt_source.py
+++ b/metadata-ingestion/tests/unit/dbt/test_dbt_source.py
@@ -6,6 +6,7 @@ import pytest
 from pydantic import ValidationError
 
 from datahub.emitter import mce_builder
+from datahub.emitter.mce_builder import SYSTEM_ACTOR
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.source.common.subtypes import DatasetSubTypes
@@ -1884,6 +1885,9 @@ def test_make_assertion_from_freshness() -> None:
     assert isinstance(mcp.aspect.customAssertion, CustomAssertionInfoClass)
     assert mcp.aspect.customAssertion.type == "dbt Freshness"
     assert mcp.aspect.customAssertion.entity == "urn:li:dataset:test"
+    assert mcp.aspect.source is not None
+    assert mcp.aspect.source.created is not None
+    assert mcp.aspect.source.created.actor == SYSTEM_ACTOR
     assert mcp.aspect.customProperties is not None
     assert mcp.aspect.customProperties.get("error_after_count") == "24"
     assert mcp.aspect.customProperties.get("warn_after_count") == "12"
@@ -2003,7 +2007,9 @@ def test_make_assertion_from_freshness_warn_only() -> None:
     assert mcp.aspect.customProperties.get("warn_after_period") == "day"
     assert "error_after_count" not in mcp.aspect.customProperties
     assert "error_after_period" not in mcp.aspect.customProperties
-    # Validate that the aspect can be serialized without errors
+    assert mcp.aspect.source is not None
+    assert mcp.aspect.source.created is not None
+    assert mcp.aspect.source.created.actor == SYSTEM_ACTOR
     mcp.aspect.to_obj()
 
 

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_assertion.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_assertion.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from datahub.emitter.mce_builder import SYSTEM_ACTOR
 from datahub.ingestion.source.snowflake.snowflake_assertion import (
     DataQualityMonitoringResult,
     SnowflakeAssertionsHandler,
@@ -189,7 +190,7 @@ class TestAssertionInfoCreation:
         return SnowflakeAssertionsHandler(config, report, connection, identifiers)
 
     def test_assertion_info_has_correct_type_and_source(self, handler):
-        """External DMFs should use CUSTOM type and EXTERNAL source."""
+        """External DMFs should use CUSTOM type and EXTERNAL source with created timestamp."""
         wu = handler._create_assertion_info_workunit(
             assertion_urn="urn:li:assertion:test123",
             dataset_urn="urn:li:dataset:(urn:li:dataPlatform:snowflake,my_db.public.orders,PROD)",
@@ -200,6 +201,8 @@ class TestAssertionInfoCreation:
         assertion_info = wu.metadata.aspect
         assert assertion_info.type == AssertionTypeClass.CUSTOM
         assert assertion_info.source.type == AssertionSourceTypeClass.EXTERNAL
+        assert assertion_info.source.created is not None
+        assert assertion_info.source.created.actor == SYSTEM_ACTOR
         assert assertion_info.customProperties["snowflake_dmf_name"] == "null_check"
         assert assertion_info.customProperties["snowflake_reference_id"] == "ref_abc123"
 


### PR DESCRIPTION
## Summary

Adds a `Source` to every assertion created outside of the UI through areas we control (SDK, ingestion, etc.) The `create` time is generally useful metadata for auditing, and is necessary for properly configuring backfill. The `external` type is nice to have as a distinguishing characteristic for these assertions