### PR TITLE
feat(ingest): configurable report sample sizes for progress and final reports

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -517,6 +517,9 @@ The environment variables listed below take precedence over the DataHub CLI conf
 - `INGESTION_ARTIFACT_DIR` - Directory to save recordings when S3 upload is disabled. If not set, recordings are saved to a temp directory.
 - `DATAHUB_REPORT_FAILURE_SAMPLE_SIZE` (default `10`) - Maximum number of failure entries to include in the ingestion report. Increase to capture more failure samples when debugging.
 - `DATAHUB_REPORT_WARNING_SAMPLE_SIZE` (default `10`) - Maximum number of warning entries to include in the ingestion report. Increase to capture more warning samples when debugging.
+- `DATAHUB_PROGRESS_REPORT_MAX_FAILURES` (default `10`) - Maximum failure entries shown in intermediate progress reports (printed every 60 s). The final report always shows the full sample size.
+- `DATAHUB_PROGRESS_REPORT_MAX_WARNINGS` (default `10`) - Maximum warning entries shown in intermediate progress reports.
+- `DATAHUB_PROGRESS_REPORT_MAX_INFOS` (default `10`) - Maximum info entries shown in intermediate progress reports.
 - `DATAHUB_CALLER` (default: auto-detected) - Override the caller label sent in the User-Agent header to GMS. The CLI auto-detects common callers (e.g. coding agents, CI systems), but you can set this explicitly for custom tools or to distinguish environments (e.g. `airflow-prod-etl`).
 
 ```shell

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -515,8 +515,9 @@ The environment variables listed below take precedence over the DataHub CLI conf
 - `DATAHUB_ACTIONS_IMAGE` (default `acryldata/datahub-actions`) - Set to `-slim` to run a slimmer actions container without pyspark/deequ features.
 - `DATAHUB_RECORDING_PASSWORD` - Password for encrypting/decrypting recording archives. Used by `--record` and `--replay` commands.
 - `INGESTION_ARTIFACT_DIR` - Directory to save recordings when S3 upload is disabled. If not set, recordings are saved to a temp directory.
-- `DATAHUB_REPORT_FAILURE_SAMPLE_SIZE` (default `10`) - Maximum number of failure entries to include in the ingestion report. Increase to capture more failure samples when debugging.
-- `DATAHUB_REPORT_WARNING_SAMPLE_SIZE` (default `10`) - Maximum number of warning entries to include in the ingestion report. Increase to capture more warning samples when debugging.
+- `DATAHUB_REPORT_FAILURE_SAMPLE_SIZE` (default `10`) - Maximum number of failure entries stored and shown in ingestion reports. Applies to both intermediate progress reports and the final report unless `DATAHUB_PROGRESS_REPORT_MAX_FAILURES` is set separately. Also settable via the `report_failure_sample_size` recipe flag under `flags:`.
+- `DATAHUB_REPORT_WARNING_SAMPLE_SIZE` (default `10`) - Maximum number of warning entries stored and shown in ingestion reports. Applies to both intermediate progress reports and the final report unless `DATAHUB_PROGRESS_REPORT_MAX_WARNINGS` is set separately. Also settable via the `report_warning_sample_size` recipe flag under `flags:`.
+- `DATAHUB_REPORT_INFO_SAMPLE_SIZE` (default `10`) - Maximum number of info entries stored and shown in ingestion reports. Applies to both intermediate progress reports and the final report unless `DATAHUB_PROGRESS_REPORT_MAX_INFOS` is set separately. Also settable via the `report_info_sample_size` recipe flag under `flags:`.
 - `DATAHUB_PROGRESS_REPORT_MAX_FAILURES` (default `10`) - Maximum failure entries shown in intermediate progress reports (printed every 60 s). The final report always shows the full sample size.
 - `DATAHUB_PROGRESS_REPORT_MAX_WARNINGS` (default `10`) - Maximum warning entries shown in intermediate progress reports.
 - `DATAHUB_PROGRESS_REPORT_MAX_INFOS` (default `10`) - Maximum info entries shown in intermediate progress reports.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -515,12 +515,8 @@ The environment variables listed below take precedence over the DataHub CLI conf
 - `DATAHUB_ACTIONS_IMAGE` (default `acryldata/datahub-actions`) - Set to `-slim` to run a slimmer actions container without pyspark/deequ features.
 - `DATAHUB_RECORDING_PASSWORD` - Password for encrypting/decrypting recording archives. Used by `--record` and `--replay` commands.
 - `INGESTION_ARTIFACT_DIR` - Directory to save recordings when S3 upload is disabled. If not set, recordings are saved to a temp directory.
-- `DATAHUB_REPORT_FAILURE_SAMPLE_SIZE` (default `10`) - Maximum number of failure entries stored and shown in ingestion reports. Applies to both intermediate progress reports and the final report unless `DATAHUB_PROGRESS_REPORT_MAX_FAILURES` is set separately. Also settable via the `report_failure_sample_size` recipe flag under `flags:`.
-- `DATAHUB_REPORT_WARNING_SAMPLE_SIZE` (default `10`) - Maximum number of warning entries stored and shown in ingestion reports. Applies to both intermediate progress reports and the final report unless `DATAHUB_PROGRESS_REPORT_MAX_WARNINGS` is set separately. Also settable via the `report_warning_sample_size` recipe flag under `flags:`.
-- `DATAHUB_REPORT_INFO_SAMPLE_SIZE` (default `10`) - Maximum number of info entries stored and shown in ingestion reports. Applies to both intermediate progress reports and the final report unless `DATAHUB_PROGRESS_REPORT_MAX_INFOS` is set separately. Also settable via the `report_info_sample_size` recipe flag under `flags:`.
-- `DATAHUB_PROGRESS_REPORT_MAX_FAILURES` (default `10`) - Maximum failure entries shown in intermediate progress reports (printed every 60 s). The final report always shows the full sample size.
-- `DATAHUB_PROGRESS_REPORT_MAX_WARNINGS` (default `10`) - Maximum warning entries shown in intermediate progress reports.
-- `DATAHUB_PROGRESS_REPORT_MAX_INFOS` (default `10`) - Maximum info entries shown in intermediate progress reports.
+- `DATAHUB_REPORT_FAILURE_SAMPLE_SIZE` / `DATAHUB_REPORT_WARNING_SAMPLE_SIZE` / `DATAHUB_REPORT_INFO_SAMPLE_SIZE` (default `10`) - How many failure/warning/info entries to retain and show in the **final** report. Recipe flags: `report_failure_sample_size`, `report_warning_sample_size`, `report_info_sample_size`.
+- `DATAHUB_PROGRESS_REPORT_MAX_FAILURES` / `DATAHUB_PROGRESS_REPORT_MAX_WARNINGS` / `DATAHUB_PROGRESS_REPORT_MAX_INFOS` (default `10`) - How many entries to display in the **interim** 60-second progress reports. The final report is unaffected. Recipe flags: `progress_report_max_failures`, `progress_report_max_warnings`, `progress_report_max_infos`.
 - `DATAHUB_CALLER` (default: auto-detected) - Override the caller label sent in the User-Agent header to GMS. The CLI auto-detects common callers (e.g. coding agents, CI systems), but you can set this explicitly for custom tools or to distinguish environments (e.g. `airflow-prod-etl`).
 
 ```shell

--- a/metadata-ingestion/src/datahub/configuration/env_vars.py
+++ b/metadata-ingestion/src/datahub/configuration/env_vars.py
@@ -159,6 +159,21 @@ def get_report_warning_sample_size() -> int:
     return int(os.getenv("DATAHUB_REPORT_WARNING_SAMPLE_SIZE", "10"))
 
 
+def get_progress_report_max_failures() -> int:
+    """Maximum number of failure entries in intermediate progress reports."""
+    return int(os.getenv("DATAHUB_PROGRESS_REPORT_MAX_FAILURES", "10"))
+
+
+def get_progress_report_max_warnings() -> int:
+    """Maximum number of warning entries in intermediate progress reports."""
+    return int(os.getenv("DATAHUB_PROGRESS_REPORT_MAX_WARNINGS", "10"))
+
+
+def get_progress_report_max_infos() -> int:
+    """Maximum number of info entries in intermediate progress reports."""
+    return int(os.getenv("DATAHUB_PROGRESS_REPORT_MAX_INFOS", "10"))
+
+
 # ============================================================================
 # Logging & Debug Configuration
 # ============================================================================

--- a/metadata-ingestion/src/datahub/configuration/env_vars.py
+++ b/metadata-ingestion/src/datahub/configuration/env_vars.py
@@ -159,6 +159,11 @@ def get_report_warning_sample_size() -> int:
     return int(os.getenv("DATAHUB_REPORT_WARNING_SAMPLE_SIZE", "10"))
 
 
+def get_report_info_sample_size() -> int:
+    """Maximum number of info entries to include in the report."""
+    return int(os.getenv("DATAHUB_REPORT_INFO_SAMPLE_SIZE", "10"))
+
+
 def get_progress_report_max_failures() -> int:
     """Maximum number of failure entries in intermediate progress reports."""
     return int(os.getenv("DATAHUB_PROGRESS_REPORT_MAX_FAILURES", "10"))

--- a/metadata-ingestion/src/datahub/ingestion/api/report.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/report.py
@@ -106,8 +106,12 @@ class Report(SupportsAsObj):
             if value is not None and not str(key).startswith("_")
         }
 
-    def as_string(self) -> str:
+    def as_string(
+        self, progress_sample_caps: Optional[Dict[str, int]] = None
+    ) -> str:
         self_obj = self.as_obj()
+        if progress_sample_caps is not None:
+            self_obj = _cap_report_samples(self_obj, progress_sample_caps)
         _aspects_by_subtypes = self_obj.pop("aspects_by_subtypes", None)
 
         # Format the main report data
@@ -529,3 +533,17 @@ class EntityFilterReport(ReportAttribute):
         return dataclasses.field(
             default_factory=lambda: EntityFilterReport(type=type, severity=severity)
         )
+
+
+def _cap_report_samples(obj: dict, caps: Dict[str, int]) -> dict:
+    """Cap the failures/warnings/infos lists in an as_obj() output."""
+    result = {}
+    for k, v in obj.items():
+        cap = caps.get(k)
+        if cap is not None and isinstance(v, list) and len(v) > cap:
+            result[k] = v[:cap] + [
+                f"... showing {cap} of {len(v)} (interim report)"
+            ]
+        else:
+            result[k] = v
+    return result

--- a/metadata-ingestion/src/datahub/ingestion/api/report.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/report.py
@@ -106,10 +106,16 @@ class Report(SupportsAsObj):
             if value is not None and not str(key).startswith("_")
         }
 
-    def as_string(self, progress_sample_caps: Optional[Dict[str, int]] = None) -> str:
+    def as_string(
+        self,
+        progress_sample_caps: Optional[Dict[str, int]] = None,
+        cap_label: str = "interim report",
+    ) -> str:
         self_obj = self.as_obj()
         if progress_sample_caps is not None:
-            self_obj = _cap_report_samples(self_obj, progress_sample_caps)
+            self_obj = _cap_report_samples(
+                self_obj, progress_sample_caps, label=cap_label
+            )
         _aspects_by_subtypes = self_obj.pop("aspects_by_subtypes", None)
 
         # Format the main report data
@@ -533,13 +539,15 @@ class EntityFilterReport(ReportAttribute):
         )
 
 
-def _cap_report_samples(obj: dict, caps: Dict[str, int]) -> dict:
+def _cap_report_samples(
+    obj: dict, caps: Dict[str, int], label: str = "interim report"
+) -> dict:
     """Cap the failures/warnings/infos lists in an as_obj() output."""
     result = {}
     for k, v in obj.items():
         cap = caps.get(k)
         if cap is not None and isinstance(v, list) and len(v) > cap:
-            result[k] = v[:cap] + [f"... showing {cap} of {len(v)} (interim report)"]
+            result[k] = v[:cap] + [f"... showing {cap} of {len(v)} ({label})"]
         else:
             result[k] = v
     return result

--- a/metadata-ingestion/src/datahub/ingestion/api/report.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/report.py
@@ -536,13 +536,22 @@ class EntityFilterReport(ReportAttribute):
         )
 
 
+def _is_report_sentinel(item: object) -> bool:
+    return isinstance(item, str) and item.startswith("...")
+
+
 def _cap_report_samples(obj: dict, caps: Dict[str, int]) -> dict:
     """Cap the failures/warnings/infos lists in an as_obj() output."""
     result = {}
     for k, v in obj.items():
         cap = caps.get(k)
-        if cap is not None and isinstance(v, list) and len(v) > cap:
-            result[k] = v[:cap] + [f"... and {len(v) - cap} more"]
+        if cap is not None and isinstance(v, list):
+            real = [x for x in v if not _is_report_sentinel(x)]
+            sentinels = [x for x in v if _is_report_sentinel(x)]
+            if len(real) > cap:
+                result[k] = real[:cap] + [f"... and {len(real) - cap} more"] + sentinels
+            else:
+                result[k] = v
         else:
             result[k] = v
     return result

--- a/metadata-ingestion/src/datahub/ingestion/api/report.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/report.py
@@ -108,11 +108,11 @@ class Report(SupportsAsObj):
 
     def as_string(
         self,
-        progress_sample_caps: Optional[Dict[str, int]] = None,
+        sample_caps: Optional[Dict[str, int]] = None,
     ) -> str:
         self_obj = self.as_obj()
-        if progress_sample_caps is not None:
-            self_obj = _cap_report_samples(self_obj, progress_sample_caps)
+        if sample_caps is not None:
+            self_obj = _cap_report_samples(self_obj, sample_caps)
         _aspects_by_subtypes = self_obj.pop("aspects_by_subtypes", None)
 
         # Format the main report data

--- a/metadata-ingestion/src/datahub/ingestion/api/report.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/report.py
@@ -106,9 +106,7 @@ class Report(SupportsAsObj):
             if value is not None and not str(key).startswith("_")
         }
 
-    def as_string(
-        self, progress_sample_caps: Optional[Dict[str, int]] = None
-    ) -> str:
+    def as_string(self, progress_sample_caps: Optional[Dict[str, int]] = None) -> str:
         self_obj = self.as_obj()
         if progress_sample_caps is not None:
             self_obj = _cap_report_samples(self_obj, progress_sample_caps)
@@ -541,9 +539,7 @@ def _cap_report_samples(obj: dict, caps: Dict[str, int]) -> dict:
     for k, v in obj.items():
         cap = caps.get(k)
         if cap is not None and isinstance(v, list) and len(v) > cap:
-            result[k] = v[:cap] + [
-                f"... showing {cap} of {len(v)} (interim report)"
-            ]
+            result[k] = v[:cap] + [f"... showing {cap} of {len(v)} (interim report)"]
         else:
             result[k] = v
     return result

--- a/metadata-ingestion/src/datahub/ingestion/api/report.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/report.py
@@ -28,7 +28,7 @@ from datahub.metadata.schema_classes import (
     UpstreamLineageClass,
 )
 from datahub.utilities.file_backed_collections import FileBackedDict
-from datahub.utilities.lossy_collections import LossyList
+from datahub.utilities.lossy_collections import LossyList, LossySentinel
 from datahub.utilities.urns.urn import guess_platform_name
 
 logger = logging.getLogger(__name__)
@@ -536,20 +536,21 @@ class EntityFilterReport(ReportAttribute):
         )
 
 
-def _is_report_sentinel(item: object) -> bool:
-    return isinstance(item, str) and item.startswith("...")
-
-
 def _cap_report_samples(obj: dict, caps: Dict[str, int]) -> dict:
-    """Cap the failures/warnings/infos lists in an as_obj() output."""
+    """Truncate report lists to the configured cap.
+
+    Only counts non-string items as real entries so the LossyList
+    sentinel string (e.g. ``"... sampled of 30 total elements"``)
+    is not miscounted as an entry.
+    """
     result = {}
     for k, v in obj.items():
         cap = caps.get(k)
         if cap is not None and isinstance(v, list):
-            real = [x for x in v if not _is_report_sentinel(x)]
-            sentinels = [x for x in v if _is_report_sentinel(x)]
-            if len(real) > cap:
-                result[k] = real[:cap] + [f"... and {len(real) - cap} more"] + sentinels
+            entries = [x for x in v if not isinstance(x, LossySentinel)]
+            tail = [x for x in v if isinstance(x, LossySentinel)]
+            if len(entries) > cap:
+                result[k] = entries[:cap] + tail
             else:
                 result[k] = v
         else:

--- a/metadata-ingestion/src/datahub/ingestion/api/report.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/report.py
@@ -109,13 +109,10 @@ class Report(SupportsAsObj):
     def as_string(
         self,
         progress_sample_caps: Optional[Dict[str, int]] = None,
-        cap_label: str = "interim report",
     ) -> str:
         self_obj = self.as_obj()
         if progress_sample_caps is not None:
-            self_obj = _cap_report_samples(
-                self_obj, progress_sample_caps, label=cap_label
-            )
+            self_obj = _cap_report_samples(self_obj, progress_sample_caps)
         _aspects_by_subtypes = self_obj.pop("aspects_by_subtypes", None)
 
         # Format the main report data
@@ -539,15 +536,13 @@ class EntityFilterReport(ReportAttribute):
         )
 
 
-def _cap_report_samples(
-    obj: dict, caps: Dict[str, int], label: str = "interim report"
-) -> dict:
+def _cap_report_samples(obj: dict, caps: Dict[str, int]) -> dict:
     """Cap the failures/warnings/infos lists in an as_obj() output."""
     result = {}
     for k, v in obj.items():
         cap = caps.get(k)
         if cap is not None and isinstance(v, list) and len(v) > cap:
-            result[k] = v[:cap] + [f"... showing {cap} of {len(v)} ({label})"]
+            result[k] = v[:cap] + [f"... and {len(v) - cap} more"]
         else:
             result[k] = v
     return result

--- a/metadata-ingestion/src/datahub/ingestion/api/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/source.py
@@ -205,20 +205,16 @@ class StructuredLogs(Report):
     ) -> None:
         """Override the max_elements on the underlying LossyDicts.
 
-        Must be called before any entries are added (i.e. right after source
-        construction) — resizing a non-empty LossyDict is not supported.
+        Should be called early (right after source construction). Sources may
+        log warnings/errors during __init__, so existing entries are pruned
+        if they exceed the new limit.
         """
-        for level, entries in self._entries.items():
-            assert not entries, (
-                f"set_sample_sizes must be called before any entries are added; "
-                f"{level.name} already has {len(entries)} entries"
-            )
         if failure_size is not None:
-            self._entries[StructuredLogLevel.ERROR].max_elements = failure_size
+            self._entries[StructuredLogLevel.ERROR].resize(failure_size)
         if warning_size is not None:
-            self._entries[StructuredLogLevel.WARN].max_elements = warning_size
+            self._entries[StructuredLogLevel.WARN].resize(warning_size)
         if info_size is not None:
-            self._entries[StructuredLogLevel.INFO].max_elements = info_size
+            self._entries[StructuredLogLevel.INFO].resize(info_size)
 
     def _get_of_type(self, level: StructuredLogLevel) -> LossyList[StructuredLogEntry]:
         entries = self._entries[level]

--- a/metadata-ingestion/src/datahub/ingestion/api/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/source.py
@@ -208,6 +208,11 @@ class StructuredLogs(Report):
         Must be called before any entries are added (i.e. right after source
         construction) — resizing a non-empty LossyDict is not supported.
         """
+        for level, entries in self._entries.items():
+            assert not entries, (
+                f"set_sample_sizes must be called before any entries are added; "
+                f"{level.name} already has {len(entries)} entries"
+            )
         if failure_size is not None:
             self._entries[StructuredLogLevel.ERROR].max_elements = failure_size
         if warning_size is not None:
@@ -258,6 +263,18 @@ class SourceReport(ExamplesReport, IngestionStageReport):
     @property
     def infos(self) -> LossyList[StructuredLogEntry]:
         return self._structured_logs.infos
+
+    def set_sample_sizes(
+        self,
+        failure_size: Optional[int] = None,
+        warning_size: Optional[int] = None,
+        info_size: Optional[int] = None,
+    ) -> None:
+        self._structured_logs.set_sample_sizes(
+            failure_size=failure_size,
+            warning_size=warning_size,
+            info_size=info_size,
+        )
 
     def report_workunit(self, wu: WorkUnit) -> None:
         self.events_produced += 1

--- a/metadata-ingestion/src/datahub/ingestion/api/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/source.py
@@ -26,6 +26,7 @@ from typing_extensions import LiteralString, Self
 from datahub.configuration.common import ConfigModel
 from datahub.configuration.env_vars import (
     get_report_failure_sample_size,
+    get_report_info_sample_size,
     get_report_warning_sample_size,
 )
 from datahub.configuration.source_common import PlatformInstanceConfigMixin
@@ -121,7 +122,7 @@ class StructuredLogs(Report):
         default_factory=lambda: {
             StructuredLogLevel.ERROR: LossyDict(get_report_failure_sample_size()),
             StructuredLogLevel.WARN: LossyDict(get_report_warning_sample_size()),
-            StructuredLogLevel.INFO: LossyDict(10),
+            StructuredLogLevel.INFO: LossyDict(get_report_info_sample_size()),
         }
     )
 
@@ -195,6 +196,24 @@ class StructuredLogs(Report):
         else:
             if context is not None:
                 entries[log_key].context.append(context)
+
+    def set_sample_sizes(
+        self,
+        failure_size: Optional[int] = None,
+        warning_size: Optional[int] = None,
+        info_size: Optional[int] = None,
+    ) -> None:
+        """Override the max_elements on the underlying LossyDicts.
+
+        Must be called before any entries are added (i.e. right after source
+        construction) — resizing a non-empty LossyDict is not supported.
+        """
+        if failure_size is not None:
+            self._entries[StructuredLogLevel.ERROR].max_elements = failure_size
+        if warning_size is not None:
+            self._entries[StructuredLogLevel.WARN].max_elements = warning_size
+        if info_size is not None:
+            self._entries[StructuredLogLevel.INFO].max_elements = info_size
 
     def _get_of_type(self, level: StructuredLogLevel) -> LossyList[StructuredLogEntry]:
         entries = self._entries[level]

--- a/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
+++ b/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
@@ -707,13 +707,22 @@ class Pipeline:
             # out the report would just be annoying.
             pass
         else:
+            sample_caps = (
+                {
+                    "failures": self.config.flags.progress_report_max_failures,
+                    "warnings": self.config.flags.progress_report_max_warnings,
+                    "infos": self.config.flags.progress_report_max_infos,
+                }
+                if currently_running
+                else None
+            )
             click.echo()
             click.secho("Cli report:", bold=True)
-            click.echo(self.cli_report.as_string())
+            click.echo(self.cli_report.as_string(sample_caps))
             click.secho(f"Source ({self.source_type}) report:", bold=True)
-            click.echo(self.source.get_report().as_string())
+            click.echo(self.source.get_report().as_string(sample_caps))
             click.secho(f"Sink ({self.sink_type}) report:", bold=True)
-            click.echo(self.sink.get_report().as_string())
+            click.echo(self.sink.get_report().as_string(sample_caps))
             global_warnings = get_global_warnings()
             if len(global_warnings) > 0:
                 click.secho("Global Warnings:", bold=True)

--- a/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
+++ b/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
@@ -224,6 +224,18 @@ class Pipeline:
                     )
             logger.info(f"Sink configured successfully. {self.sink.configured()}")
 
+            # Apply recipe-level sample sizes to the sink report.
+            flags = self.config.flags
+            sink_report = self.sink.get_report()
+            sink_report.failures.max_elements = max(
+                flags.report_failure_sample_size,
+                flags.progress_report_max_failures,
+            )
+            sink_report.warnings.max_elements = max(
+                flags.report_warning_sample_size,
+                flags.progress_report_max_warnings,
+            )
+
             if self.graph is None and isinstance(self.sink, DatahubRestSink):
                 with _add_init_error_context("setup default datahub client"):
                     self.graph = self.sink.emitter.to_graph()

--- a/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
+++ b/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
@@ -253,6 +253,13 @@ class Pipeline:
                     )
                     logger.info("Source configured successfully.")
 
+                    # Apply recipe-level report sample sizes.
+                    self.source.get_report()._structured_logs.set_sample_sizes(
+                        failure_size=self.config.flags.report_failure_sample_size,
+                        warning_size=self.config.flags.report_warning_sample_size,
+                        info_size=self.config.flags.report_info_sample_size,
+                    )
+
                 extractor_type = self.config.source.extractor
                 with _add_init_error_context(
                     f"configure the extractor ({extractor_type})"

--- a/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
+++ b/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
@@ -253,11 +253,22 @@ class Pipeline:
                     )
                     logger.info("Source configured successfully.")
 
-                    # Apply recipe-level report sample sizes.
+                    # Retain enough entries for whichever is larger: the
+                    # final report size or the interim display cap.
+                    flags = self.config.flags
                     self.source.get_report()._structured_logs.set_sample_sizes(
-                        failure_size=self.config.flags.report_failure_sample_size,
-                        warning_size=self.config.flags.report_warning_sample_size,
-                        info_size=self.config.flags.report_info_sample_size,
+                        failure_size=max(
+                            flags.report_failure_sample_size,
+                            flags.progress_report_max_failures,
+                        ),
+                        warning_size=max(
+                            flags.report_warning_sample_size,
+                            flags.progress_report_max_warnings,
+                        ),
+                        info_size=max(
+                            flags.report_info_sample_size,
+                            flags.progress_report_max_infos,
+                        ),
                     )
 
                 extractor_type = self.config.source.extractor

--- a/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
+++ b/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
@@ -731,25 +731,19 @@ class Pipeline:
                     "warnings": self.config.flags.progress_report_max_warnings,
                     "infos": self.config.flags.progress_report_max_infos,
                 }
-                cap_label = "interim report"
             else:
                 sample_caps = {
                     "failures": self.config.flags.report_failure_sample_size,
                     "warnings": self.config.flags.report_warning_sample_size,
                     "infos": self.config.flags.report_info_sample_size,
                 }
-                cap_label = "capped"
             click.echo()
             click.secho("Cli report:", bold=True)
-            click.echo(self.cli_report.as_string(sample_caps, cap_label=cap_label))
+            click.echo(self.cli_report.as_string(sample_caps))
             click.secho(f"Source ({self.source_type}) report:", bold=True)
-            click.echo(
-                self.source.get_report().as_string(sample_caps, cap_label=cap_label)
-            )
+            click.echo(self.source.get_report().as_string(sample_caps))
             click.secho(f"Sink ({self.sink_type}) report:", bold=True)
-            click.echo(
-                self.sink.get_report().as_string(sample_caps, cap_label=cap_label)
-            )
+            click.echo(self.sink.get_report().as_string(sample_caps))
             global_warnings = get_global_warnings()
             if len(global_warnings) > 0:
                 click.secho("Global Warnings:", bold=True)

--- a/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
+++ b/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
@@ -256,7 +256,7 @@ class Pipeline:
                     # Retain enough entries for whichever is larger: the
                     # final report size or the interim display cap.
                     flags = self.config.flags
-                    self.source.get_report()._structured_logs.set_sample_sizes(
+                    self.source.get_report().set_sample_sizes(
                         failure_size=max(
                             flags.report_failure_sample_size,
                             flags.progress_report_max_failures,

--- a/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
+++ b/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
@@ -725,22 +725,31 @@ class Pipeline:
             # out the report would just be annoying.
             pass
         else:
-            sample_caps = (
-                {
+            if currently_running:
+                sample_caps = {
                     "failures": self.config.flags.progress_report_max_failures,
                     "warnings": self.config.flags.progress_report_max_warnings,
                     "infos": self.config.flags.progress_report_max_infos,
                 }
-                if currently_running
-                else None
-            )
+                cap_label = "interim report"
+            else:
+                sample_caps = {
+                    "failures": self.config.flags.report_failure_sample_size,
+                    "warnings": self.config.flags.report_warning_sample_size,
+                    "infos": self.config.flags.report_info_sample_size,
+                }
+                cap_label = "capped"
             click.echo()
             click.secho("Cli report:", bold=True)
-            click.echo(self.cli_report.as_string(sample_caps))
+            click.echo(self.cli_report.as_string(sample_caps, cap_label=cap_label))
             click.secho(f"Source ({self.source_type}) report:", bold=True)
-            click.echo(self.source.get_report().as_string(sample_caps))
+            click.echo(
+                self.source.get_report().as_string(sample_caps, cap_label=cap_label)
+            )
             click.secho(f"Sink ({self.sink_type}) report:", bold=True)
-            click.echo(self.sink.get_report().as_string(sample_caps))
+            click.echo(
+                self.sink.get_report().as_string(sample_caps, cap_label=cap_label)
+            )
             global_warnings = get_global_warnings()
             if len(global_warnings) > 0:
                 click.secho("Global Warnings:", bold=True)

--- a/metadata-ingestion/src/datahub/ingestion/run/pipeline_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/run/pipeline_config.py
@@ -9,6 +9,11 @@ from typing import Dict, List, Optional
 from pydantic import Field, model_validator
 
 from datahub.configuration.common import ConfigModel, DynamicTypedConfig, HiddenFromDocs
+from datahub.configuration.env_vars import (
+    get_progress_report_max_failures,
+    get_progress_report_max_infos,
+    get_progress_report_max_warnings,
+)
 from datahub.ingestion.graph.config import DatahubClientConfig
 from datahub.ingestion.recording.config import RecordingConfig
 from datahub.ingestion.sink.file import FileSinkConfig
@@ -63,6 +68,28 @@ class FlagsConfig(ConfigModel):
         default=None,
         description=(
             "Generate memray memory dumps for ingestion process by providing a path to write the dump file in."
+        ),
+    )
+
+    progress_report_max_failures: int = Field(
+        default_factory=get_progress_report_max_failures,
+        description=(
+            "Maximum failure entries in intermediate progress reports. "
+            "Also settable via DATAHUB_PROGRESS_REPORT_MAX_FAILURES env var."
+        ),
+    )
+    progress_report_max_warnings: int = Field(
+        default_factory=get_progress_report_max_warnings,
+        description=(
+            "Maximum warning entries in intermediate progress reports. "
+            "Also settable via DATAHUB_PROGRESS_REPORT_MAX_WARNINGS env var."
+        ),
+    )
+    progress_report_max_infos: int = Field(
+        default_factory=get_progress_report_max_infos,
+        description=(
+            "Maximum info entries in intermediate progress reports. "
+            "Also settable via DATAHUB_PROGRESS_REPORT_MAX_INFOS env var."
         ),
     )
 

--- a/metadata-ingestion/src/datahub/ingestion/run/pipeline_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/run/pipeline_config.py
@@ -13,6 +13,9 @@ from datahub.configuration.env_vars import (
     get_progress_report_max_failures,
     get_progress_report_max_infos,
     get_progress_report_max_warnings,
+    get_report_failure_sample_size,
+    get_report_info_sample_size,
+    get_report_warning_sample_size,
 )
 from datahub.ingestion.graph.config import DatahubClientConfig
 from datahub.ingestion.recording.config import RecordingConfig
@@ -90,6 +93,28 @@ class FlagsConfig(ConfigModel):
         description=(
             "Maximum info entries in intermediate progress reports. "
             "Also settable via DATAHUB_PROGRESS_REPORT_MAX_INFOS env var."
+        ),
+    )
+
+    report_failure_sample_size: int = Field(
+        default_factory=get_report_failure_sample_size,
+        description=(
+            "Maximum failure entries in the final report. "
+            "Also settable via DATAHUB_REPORT_FAILURE_SAMPLE_SIZE env var."
+        ),
+    )
+    report_warning_sample_size: int = Field(
+        default_factory=get_report_warning_sample_size,
+        description=(
+            "Maximum warning entries in the final report. "
+            "Also settable via DATAHUB_REPORT_WARNING_SAMPLE_SIZE env var."
+        ),
+    )
+    report_info_sample_size: int = Field(
+        default_factory=get_report_info_sample_size,
+        description=(
+            "Maximum info entries in the final report. "
+            "Also settable via DATAHUB_REPORT_INFO_SAMPLE_SIZE env var."
         ),
     )
 

--- a/metadata-ingestion/src/datahub/ingestion/run/pipeline_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/run/pipeline_config.py
@@ -77,21 +77,24 @@ class FlagsConfig(ConfigModel):
     progress_report_max_failures: int = Field(
         default_factory=get_progress_report_max_failures,
         description=(
-            "Maximum failure entries in intermediate progress reports. "
+            "Maximum failure entries shown in interim progress reports (every 60 s). "
+            "Does not affect the final report. "
             "Also settable via DATAHUB_PROGRESS_REPORT_MAX_FAILURES env var."
         ),
     )
     progress_report_max_warnings: int = Field(
         default_factory=get_progress_report_max_warnings,
         description=(
-            "Maximum warning entries in intermediate progress reports. "
+            "Maximum warning entries shown in interim progress reports. "
+            "Does not affect the final report. "
             "Also settable via DATAHUB_PROGRESS_REPORT_MAX_WARNINGS env var."
         ),
     )
     progress_report_max_infos: int = Field(
         default_factory=get_progress_report_max_infos,
         description=(
-            "Maximum info entries in intermediate progress reports. "
+            "Maximum info entries shown in interim progress reports. "
+            "Does not affect the final report. "
             "Also settable via DATAHUB_PROGRESS_REPORT_MAX_INFOS env var."
         ),
     )
@@ -99,21 +102,24 @@ class FlagsConfig(ConfigModel):
     report_failure_sample_size: int = Field(
         default_factory=get_report_failure_sample_size,
         description=(
-            "Maximum failure entries in the final report. "
+            "How many failure entries to retain. Controls the final report size "
+            "and the pool that interim reports draw from. "
             "Also settable via DATAHUB_REPORT_FAILURE_SAMPLE_SIZE env var."
         ),
     )
     report_warning_sample_size: int = Field(
         default_factory=get_report_warning_sample_size,
         description=(
-            "Maximum warning entries in the final report. "
+            "How many warning entries to retain. Controls the final report size "
+            "and the pool that interim reports draw from. "
             "Also settable via DATAHUB_REPORT_WARNING_SAMPLE_SIZE env var."
         ),
     )
     report_info_sample_size: int = Field(
         default_factory=get_report_info_sample_size,
         description=(
-            "Maximum info entries in the final report. "
+            "How many info entries to retain. Controls the final report size "
+            "and the pool that interim reports draw from. "
             "Also settable via DATAHUB_REPORT_INFO_SAMPLE_SIZE env var."
         ),
     )

--- a/metadata-ingestion/src/datahub/ingestion/run/pipeline_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/run/pipeline_config.py
@@ -75,6 +75,7 @@ class FlagsConfig(ConfigModel):
     )
 
     progress_report_max_failures: int = Field(
+        ge=0,
         default_factory=get_progress_report_max_failures,
         description=(
             "Maximum failure entries shown in interim progress reports (every 60 s). "
@@ -83,6 +84,7 @@ class FlagsConfig(ConfigModel):
         ),
     )
     progress_report_max_warnings: int = Field(
+        ge=0,
         default_factory=get_progress_report_max_warnings,
         description=(
             "Maximum warning entries shown in interim progress reports. "
@@ -91,6 +93,7 @@ class FlagsConfig(ConfigModel):
         ),
     )
     progress_report_max_infos: int = Field(
+        ge=0,
         default_factory=get_progress_report_max_infos,
         description=(
             "Maximum info entries shown in interim progress reports. "
@@ -100,6 +103,7 @@ class FlagsConfig(ConfigModel):
     )
 
     report_failure_sample_size: int = Field(
+        ge=0,
         default_factory=get_report_failure_sample_size,
         description=(
             "How many failure entries to retain. Controls the final report size "
@@ -108,6 +112,7 @@ class FlagsConfig(ConfigModel):
         ),
     )
     report_warning_sample_size: int = Field(
+        ge=0,
         default_factory=get_report_warning_sample_size,
         description=(
             "How many warning entries to retain. Controls the final report size "
@@ -116,6 +121,7 @@ class FlagsConfig(ConfigModel):
         ),
     )
     report_info_sample_size: int = Field(
+        ge=0,
         default_factory=get_report_info_sample_size,
         description=(
             "How many info entries to retain. Controls the final report size "

--- a/metadata-ingestion/src/datahub/utilities/lossy_collections.py
+++ b/metadata-ingestion/src/datahub/utilities/lossy_collections.py
@@ -195,6 +195,18 @@ class LossyDict(Dict[_KT, _VT], Generic[_KT, _VT]):
             )
         return base_dict
 
+    def resize(self, max_elements: int) -> None:
+        """Change max_elements, pruning excess entries if needed."""
+        self.max_elements = max_elements
+        excess = super().__len__() - max_elements
+        if excess > 0:
+            keys_to_drop = random.sample(list(super().__iter__()), excess)
+            for k in keys_to_drop:
+                super().pop(k)
+                self._items_removed += 1
+            self._overflow += excess
+            self.sampled = True
+
     def total_key_count(self) -> int:
         """Returns the total number of keys that have been added to this dictionary."""
         return super().__len__() + self._overflow

--- a/metadata-ingestion/src/datahub/utilities/lossy_collections.py
+++ b/metadata-ingestion/src/datahub/utilities/lossy_collections.py
@@ -18,6 +18,16 @@ _KT = TypeVar("_KT")
 _VT = TypeVar("_VT")
 
 
+class LossySentinel(str):
+    """Marks a lossy-collection truncation summary.
+
+    ``str`` subclass so it renders naturally in pprint/JSON but can be
+    distinguished from real entries via ``isinstance``.
+    """
+
+    pass
+
+
 class LossyList(List[T], Generic[T]):
     """A list that performs reservoir sampling of a much larger list"""
 
@@ -91,7 +101,9 @@ class LossyList(List[T], Generic[T]):
             Report.to_pure_python_obj(value) for value in list(self.__iter__())
         ]
         if self.sampled:
-            base_list.append(f"... sampled of {self.total_elements} total elements")
+            base_list.append(
+                LossySentinel(f"... sampled of {self.total_elements} total elements")
+            )
         return base_list
 
     def set_total(self, total: int) -> None:

--- a/metadata-ingestion/tests/unit/api/test_entity_filter_report.py
+++ b/metadata-ingestion/tests/unit/api/test_entity_filter_report.py
@@ -24,3 +24,32 @@ def test_entity_filter_report():
 
     # Verify that the reports don't accidentally share any state.
     assert report2.as_string() == "{'views': {'filtered': [], 'processed': []}}"
+
+
+def test_progress_report_caps_failures_and_warnings():
+    from datahub.ingestion.api.report import _cap_report_samples
+
+    obj = {
+        "events_produced": 500,
+        "failures": ["err1", "err2", "err3", "err4", "err5"],
+        "warnings": ["w1", "w2", "w3"],
+        "infos": ["i1", "i2"],
+        "aspects": {"dataset": {"schemaMetadata": 100}},
+    }
+    caps = {"failures": 2, "warnings": 1, "infos": 5}
+    capped = _cap_report_samples(obj, caps)
+
+    # failures capped to 2 + summary message
+    assert len(capped["failures"]) == 3
+    assert "interim report" in capped["failures"][-1]
+
+    # warnings capped to 1 + summary message
+    assert len(capped["warnings"]) == 2
+    assert "interim report" in capped["warnings"][-1]
+
+    # infos under cap — untouched
+    assert capped["infos"] == ["i1", "i2"]
+
+    # non-sample fields untouched
+    assert capped["events_produced"] == 500
+    assert capped["aspects"] == {"dataset": {"schemaMetadata": 100}}

--- a/metadata-ingestion/tests/unit/api/test_entity_filter_report.py
+++ b/metadata-ingestion/tests/unit/api/test_entity_filter_report.py
@@ -321,6 +321,7 @@ def _run_pipeline_get_reports(flags: dict, num_each: int = 30) -> dict:
         }
         return {
             "source": pipeline.source.get_report().as_obj(),
+            "source_report": pipeline.source.get_report(),
             "sink": pipeline.sink.get_report().as_obj(),
             "retention": retention,
         }
@@ -359,20 +360,25 @@ def test_retention_progress_max_higher():
 
 
 def test_retention_progress_max_higher_final_shows_report_size():
-    """progress_max=25, report_size=5: retain 25, but final shows only 5."""
+    """progress_max=25, report_size=5: retain 25, final displays only 5."""
     result = _run_pipeline_get_reports(
         flags={
             "progress_report_max_failures": 25,
             "report_failure_sample_size": 5,
         }
     )
-    # Retained max(25, 5) = 25
+    # Retained max(25, 5) = 25 so interim can show up to 25
     assert result["retention"]["failure_max_elements"] == 25
-    # But the final report's LossyDict has 25, so as_obj() returns up to 25.
-    # The report_failure_sample_size controls retention, but with the max()
-    # fix the LossyDict is sized to 25. The final report shows all retained.
-    final_failures = _count_real_entries(result["source"], "failures")
-    assert final_failures == 25
+    # as_obj() returns all 25 retained (raw data)
+    raw_failures = _count_real_entries(result["source"], "failures")
+    assert raw_failures == 25
+    # But as_string with the final caps shows only 5
+    final_str = result["source_report"].as_string(
+        progress_sample_caps={"failures": 5, "warnings": 10, "infos": 10},
+        cap_label="capped",
+    )
+    assert "showing 5 of" in final_str
+    assert "(capped)" in final_str
 
 
 def test_retention_both_set_equal():

--- a/metadata-ingestion/tests/unit/api/test_entity_filter_report.py
+++ b/metadata-ingestion/tests/unit/api/test_entity_filter_report.py
@@ -235,13 +235,22 @@ def test_structured_logs_set_sample_sizes_partial():
     assert logs._entries[StructuredLogLevel.WARN].max_elements == 10  # unchanged
 
 
-def test_set_sample_sizes_after_entries_added_raises():
-    import pytest
-
+def test_set_sample_sizes_after_entries_added_prunes():
+    """set_sample_sizes resizes even when entries already exist."""
     logs = StructuredLogs()
-    logs.report_log(StructuredLogLevel.ERROR, "something broke", context="table_x")
-    with pytest.raises(AssertionError, match="must be called before"):
-        logs.set_sample_sizes(failure_size=50)
+    for i in range(5):
+        logs.report_log(StructuredLogLevel.ERROR, f"err_{i}", context=f"ctx_{i}")
+    assert len(logs._entries[StructuredLogLevel.ERROR]) == 5
+
+    # Grow: all entries kept
+    logs.set_sample_sizes(failure_size=50)
+    assert logs._entries[StructuredLogLevel.ERROR].max_elements == 50
+    assert len(logs._entries[StructuredLogLevel.ERROR]) == 5
+
+    # Shrink: excess entries pruned
+    logs.set_sample_sizes(failure_size=2)
+    assert logs._entries[StructuredLogLevel.ERROR].max_elements == 2
+    assert len(logs._entries[StructuredLogLevel.ERROR]) == 2
 
 
 def test_cap_ignores_lossy_list_sentinel():

--- a/metadata-ingestion/tests/unit/api/test_entity_filter_report.py
+++ b/metadata-ingestion/tests/unit/api/test_entity_filter_report.py
@@ -2,7 +2,14 @@ import dataclasses
 import os
 from unittest import mock
 
-from datahub.ingestion.api.report import EntityFilterReport, Report, SupportsAsObj
+from datahub.ingestion.api.report import (
+    EntityFilterReport,
+    Report,
+    SupportsAsObj,
+    _cap_report_samples,
+)
+from datahub.ingestion.api.source import StructuredLogLevel, StructuredLogs
+from datahub.ingestion.run.pipeline_config import FlagsConfig
 
 
 @dataclasses.dataclass
@@ -34,8 +41,6 @@ def test_entity_filter_report():
 
 
 def test_cap_report_samples_basic():
-    from datahub.ingestion.api.report import _cap_report_samples
-
     obj = {
         "events_produced": 500,
         "failures": ["err1", "err2", "err3", "err4", "err5"],
@@ -66,7 +71,6 @@ def test_cap_report_samples_basic():
 
 def test_cap_report_samples_zero_cap():
     """cap=0 should suppress all entries but still show the count."""
-    from datahub.ingestion.api.report import _cap_report_samples
 
     obj = {"failures": ["e1", "e2", "e3"], "warnings": [], "infos": ["i1"]}
     caps = {"failures": 0, "warnings": 0, "infos": 0}
@@ -87,7 +91,6 @@ def test_cap_report_samples_zero_cap():
 
 def test_cap_report_samples_key_not_in_caps():
     """Keys absent from the caps dict are never capped."""
-    from datahub.ingestion.api.report import _cap_report_samples
 
     obj = {"failures": ["e1", "e2"], "other_list": ["a", "b", "c"]}
     caps = {"failures": 1}
@@ -99,7 +102,6 @@ def test_cap_report_samples_key_not_in_caps():
 
 def test_cap_report_samples_empty_caps_dict():
     """Empty caps dict means nothing is capped."""
-    from datahub.ingestion.api.report import _cap_report_samples
 
     obj = {"failures": ["e1", "e2", "e3"]}
     capped = _cap_report_samples(obj, {})
@@ -108,7 +110,6 @@ def test_cap_report_samples_empty_caps_dict():
 
 def test_cap_report_samples_nested_dict_not_capped():
     """Dicts nested inside the report are passed through, not recursed into."""
-    from datahub.ingestion.api.report import _cap_report_samples
 
     inner = {"nested_failures": ["x", "y", "z"]}
     obj = {"failures": ["e1"], "sub_report": inner}
@@ -121,7 +122,6 @@ def test_cap_report_samples_nested_dict_not_capped():
 
 def test_cap_report_samples_exact_cap():
     """List with length == cap should NOT be capped (only > triggers it)."""
-    from datahub.ingestion.api.report import _cap_report_samples
 
     obj = {"failures": ["e1", "e2", "e3"]}
     caps = {"failures": 3}
@@ -172,7 +172,6 @@ def test_as_string_none_caps_shows_all():
 
 def test_flags_config_defaults():
     """FlagsConfig fields default to 10 when env vars are not set."""
-    from datahub.ingestion.run.pipeline_config import FlagsConfig
 
     with mock.patch.dict(os.environ, {}, clear=True):
         flags = FlagsConfig()
@@ -186,7 +185,6 @@ def test_flags_config_defaults():
 
 def test_flags_config_from_env_vars():
     """FlagsConfig fields pick up env vars."""
-    from datahub.ingestion.run.pipeline_config import FlagsConfig
 
     env = {
         "DATAHUB_PROGRESS_REPORT_MAX_FAILURES": "5",
@@ -208,7 +206,6 @@ def test_flags_config_from_env_vars():
 
 def test_flags_config_recipe_overrides_env():
     """Explicit recipe values take precedence over env vars."""
-    from datahub.ingestion.run.pipeline_config import FlagsConfig
 
     env = {
         "DATAHUB_PROGRESS_REPORT_MAX_FAILURES": "5",
@@ -230,7 +227,6 @@ def test_flags_config_recipe_overrides_env():
 
 def test_structured_logs_set_sample_sizes():
     """set_sample_sizes adjusts the underlying LossyDict max_elements."""
-    from datahub.ingestion.api.source import StructuredLogLevel, StructuredLogs
 
     logs = StructuredLogs()
     # defaults
@@ -244,9 +240,188 @@ def test_structured_logs_set_sample_sizes():
 
 def test_structured_logs_set_sample_sizes_partial():
     """set_sample_sizes with None leaves the original value."""
-    from datahub.ingestion.api.source import StructuredLogLevel, StructuredLogs
 
     logs = StructuredLogs()
     logs.set_sample_sizes(failure_size=99)
     assert logs._entries[StructuredLogLevel.ERROR].max_elements == 99
     assert logs._entries[StructuredLogLevel.WARN].max_elements == 10  # unchanged
+
+
+# ---------------------------------------------------------------------------
+# Pipeline retention sizing: max(report_size, progress_max)
+# ---------------------------------------------------------------------------
+
+
+def _run_pipeline_get_reports(flags: dict, num_each: int = 30) -> dict:
+    """Helper: run a fast pipeline and return source report as_obj()."""
+    import contextlib
+    import io
+    from typing import Iterable
+
+    from datahub.configuration.common import ConfigModel
+    from datahub.emitter.mcp import MetadataChangeProposalWrapper
+    from datahub.ingestion.api.common import PipelineContext
+    from datahub.ingestion.api.source import Source, SourceReport
+    from datahub.ingestion.api.workunit import MetadataWorkUnit
+    from datahub.ingestion.run.pipeline import Pipeline
+    from datahub.metadata.schema_classes import DatasetPropertiesClass
+
+    class _Cfg(ConfigModel):
+        n: int = 30
+
+    class _Src(Source):
+        def __init__(self, config: _Cfg, ctx: PipelineContext):
+            super().__init__(ctx)
+            self.config = config
+            self.report = SourceReport()
+
+        @classmethod
+        def create(cls, config_dict, ctx):
+            return cls(_Cfg.model_validate(config_dict), ctx)
+
+        def get_workunits(self) -> Iterable[MetadataWorkUnit]:
+            for i in range(self.config.n):
+                self.report.failure(message=f"F{i}", context=f"ctx-f-{i}")
+                self.report.warning(message=f"W{i}", context=f"ctx-w-{i}")
+                self.report.info(message=f"I{i}", context=f"ctx-i-{i}")
+            mcp = MetadataChangeProposalWrapper(
+                entityUrn="urn:li:dataset:(urn:li:dataPlatform:test,t,PROD)",
+                aspect=DatasetPropertiesClass(name="t"),
+            )
+            yield mcp.as_workunit()
+
+        def get_report(self):
+            return self.report
+
+        def close(self):
+            pass
+
+    # Register the source temporarily
+    from datahub.ingestion.source.source_registry import source_registry
+
+    source_registry.register("_test_combo_src", _Src)
+    try:
+        recipe = {
+            "source": {"type": "_test_combo_src", "config": {"n": num_each}},
+            "sink": {"type": "console"},
+            "flags": flags,
+        }
+        pipeline = Pipeline.create(recipe)
+        with contextlib.redirect_stdout(io.StringIO()):
+            pipeline.run()
+
+        # Get the underlying LossyDict max_elements for verification
+        logs = pipeline.source.get_report()._structured_logs
+        retention = {
+            "failure_max_elements": logs._entries[
+                StructuredLogLevel.ERROR
+            ].max_elements,
+            "warning_max_elements": logs._entries[StructuredLogLevel.WARN].max_elements,
+            "info_max_elements": logs._entries[StructuredLogLevel.INFO].max_elements,
+        }
+        return {
+            "source": pipeline.source.get_report().as_obj(),
+            "sink": pipeline.sink.get_report().as_obj(),
+            "retention": retention,
+        }
+    finally:
+        source_registry._mapping.pop("_test_combo_src", None)
+
+
+def _count_real_entries(report_obj: dict, key: str) -> int:
+    """Count non-sentinel entries in a report list."""
+    items = report_obj.get(key, [])
+    return sum(
+        1
+        for item in items
+        if not (isinstance(item, str) and ("sampled" in item or "showing" in item))
+    )
+
+
+def test_retention_both_defaults():
+    """Both at default 10: retain 10, final shows 10."""
+    result = _run_pipeline_get_reports(flags={})
+    assert result["retention"]["failure_max_elements"] == 10
+    assert _count_real_entries(result["source"], "failures") == 10
+
+
+def test_retention_report_size_higher():
+    """report_size=20 > progress_max=10 (default): retain 20, final shows 20."""
+    result = _run_pipeline_get_reports(flags={"report_failure_sample_size": 20})
+    assert result["retention"]["failure_max_elements"] == 20
+    assert _count_real_entries(result["source"], "failures") == 20
+
+
+def test_retention_progress_max_higher():
+    """progress_max=25 > report_size=10 (default): retain 25 so interim can show 25."""
+    result = _run_pipeline_get_reports(flags={"progress_report_max_failures": 25})
+    assert result["retention"]["failure_max_elements"] == 25
+
+
+def test_retention_progress_max_higher_final_shows_report_size():
+    """progress_max=25, report_size=5: retain 25, but final shows only 5."""
+    result = _run_pipeline_get_reports(
+        flags={
+            "progress_report_max_failures": 25,
+            "report_failure_sample_size": 5,
+        }
+    )
+    # Retained max(25, 5) = 25
+    assert result["retention"]["failure_max_elements"] == 25
+    # But the final report's LossyDict has 25, so as_obj() returns up to 25.
+    # The report_failure_sample_size controls retention, but with the max()
+    # fix the LossyDict is sized to 25. The final report shows all retained.
+    final_failures = _count_real_entries(result["source"], "failures")
+    assert final_failures == 25
+
+
+def test_retention_both_set_equal():
+    """Both set to 15: retain 15, final shows 15."""
+    result = _run_pipeline_get_reports(
+        flags={
+            "report_failure_sample_size": 15,
+            "progress_report_max_failures": 15,
+        }
+    )
+    assert result["retention"]["failure_max_elements"] == 15
+    assert _count_real_entries(result["source"], "failures") == 15
+
+
+def test_retention_independent_per_severity():
+    """Each severity can have different retention sizes."""
+    result = _run_pipeline_get_reports(
+        flags={
+            "report_failure_sample_size": 5,
+            "progress_report_max_failures": 20,
+            "report_warning_sample_size": 25,
+            "progress_report_max_warnings": 3,
+            "report_info_sample_size": 8,
+            "progress_report_max_infos": 8,
+        }
+    )
+    # failures: max(5, 20) = 20
+    assert result["retention"]["failure_max_elements"] == 20
+    # warnings: max(25, 3) = 25
+    assert result["retention"]["warning_max_elements"] == 25
+    # infos: max(8, 8) = 8
+    assert result["retention"]["info_max_elements"] == 8
+
+
+def test_retention_not_set_uses_defaults():
+    """No flags at all: all default to max(10, 10) = 10."""
+    result = _run_pipeline_get_reports(flags={})
+    assert result["retention"]["failure_max_elements"] == 10
+    assert result["retention"]["warning_max_elements"] == 10
+    assert result["retention"]["info_max_elements"] == 10
+
+
+def test_sink_report_present_and_correct():
+    """Sink report has the expected fields and records written count."""
+    result = _run_pipeline_get_reports(flags={})
+    sink = result["sink"]
+    assert sink["total_records_written"] == 1
+    assert "failures" in sink
+    assert "warnings" in sink
+    # Console sink shouldn't produce its own failures/warnings
+    assert len(sink["failures"]) == 0
+    assert len(sink["warnings"]) == 0

--- a/metadata-ingestion/tests/unit/api/test_entity_filter_report.py
+++ b/metadata-ingestion/tests/unit/api/test_entity_filter_report.py
@@ -101,13 +101,6 @@ def test_cap_report_samples_key_not_in_caps():
     assert capped["other_list"] == ["a", "b", "c"]
 
 
-def test_cap_report_samples_empty_caps_dict():
-    """Empty caps dict means nothing is capped."""
-    obj = {"failures": ["e1", "e2", "e3"]}
-    capped = _cap_report_samples(obj, {})
-    assert capped["failures"] == ["e1", "e2", "e3"]
-
-
 def test_cap_report_samples_nested_dict_not_capped():
     """Dicts nested inside the report are passed through, not recursed into."""
     inner = {"nested_failures": ["x", "y", "z"]}
@@ -126,7 +119,7 @@ def test_cap_report_samples_exact_cap():
 
 
 # ---------------------------------------------------------------------------
-# Report.as_string integration with progress_sample_caps
+# Report.as_string integration with sample_caps
 # ---------------------------------------------------------------------------
 
 
@@ -143,7 +136,7 @@ def test_as_string_with_caps_applies_capping():
         warnings=["w1"],
         count=42,
     )
-    result = report.as_string(progress_sample_caps={"failures": 2, "warnings": 5})
+    result = report.as_string(sample_caps={"failures": 2, "warnings": 5})
     assert "e1" in result
     assert "e2" in result
     assert "e3" not in result  # truncated
@@ -155,7 +148,7 @@ def test_as_string_none_caps_shows_all():
         failures=["e1", "e2", "e3"],
         count=10,
     )
-    result = report.as_string(progress_sample_caps=None)
+    result = report.as_string(sample_caps=None)
     assert "e1" in result
     assert "e3" in result
 
@@ -367,11 +360,17 @@ def _run_pipeline_get_reports(flags: dict, num_each: int = 30) -> dict:
             "warning_max_elements": logs._entries[StructuredLogLevel.WARN].max_elements,
             "info_max_elements": logs._entries[StructuredLogLevel.INFO].max_elements,
         }
+        sink_report = pipeline.sink.get_report()
+        sink_retention = {
+            "failure_max_elements": sink_report.failures.max_elements,
+            "warning_max_elements": sink_report.warnings.max_elements,
+        }
         return {
             "source": pipeline.source.get_report().as_obj(),
             "source_report": pipeline.source.get_report(),
-            "sink": pipeline.sink.get_report().as_obj(),
+            "sink": sink_report.as_obj(),
             "retention": retention,
+            "sink_retention": sink_retention,
         }
     finally:
         source_registry._mapping.pop("_test_combo_src", None)
@@ -418,21 +417,9 @@ def test_retention_progress_max_higher_final_shows_report_size():
     assert raw_failures == 25
     # But as_string with the final caps shows only 5
     final_str = result["source_report"].as_string(
-        progress_sample_caps={"failures": 5, "warnings": 10, "infos": 10},
+        sample_caps={"failures": 5, "warnings": 10, "infos": 10},
     )
     assert final_str.count("'message': 'F") == 5
-
-
-def test_retention_both_set_equal():
-    """Both set to 15: retain 15, final shows 15."""
-    result = _run_pipeline_get_reports(
-        flags={
-            "report_failure_sample_size": 15,
-            "progress_report_max_failures": 15,
-        }
-    )
-    assert result["retention"]["failure_max_elements"] == 15
-    assert _count_real_entries(result["source"], "failures") == 15
 
 
 def test_retention_independent_per_severity():
@@ -455,14 +442,6 @@ def test_retention_independent_per_severity():
     assert result["retention"]["info_max_elements"] == 8
 
 
-def test_retention_not_set_uses_defaults():
-    """No flags at all: all default to max(10, 10) = 10."""
-    result = _run_pipeline_get_reports(flags={})
-    assert result["retention"]["failure_max_elements"] == 10
-    assert result["retention"]["warning_max_elements"] == 10
-    assert result["retention"]["info_max_elements"] == 10
-
-
 def test_sink_report_present_and_correct():
     """Sink report has the expected fields and records written count."""
     result = _run_pipeline_get_reports(flags={})
@@ -470,6 +449,21 @@ def test_sink_report_present_and_correct():
     assert sink["total_records_written"] == 1
     assert "failures" in sink
     assert "warnings" in sink
-    # Console sink shouldn't produce its own failures/warnings
     assert len(sink["failures"]) == 0
     assert len(sink["warnings"]) == 0
+
+
+def test_sink_retention_follows_flags():
+    """Sink LossyList sizing should respect recipe flags."""
+    result = _run_pipeline_get_reports(
+        flags={
+            "report_failure_sample_size": 25,
+            "report_warning_sample_size": 30,
+            "progress_report_max_failures": 5,
+            "progress_report_max_warnings": 50,
+        }
+    )
+    # failures: max(25, 5) = 25
+    assert result["sink_retention"]["failure_max_elements"] == 25
+    # warnings: max(30, 50) = 50
+    assert result["sink_retention"]["warning_max_elements"] == 50

--- a/metadata-ingestion/tests/unit/api/test_entity_filter_report.py
+++ b/metadata-ingestion/tests/unit/api/test_entity_filter_report.py
@@ -54,12 +54,11 @@ def test_cap_report_samples_basic():
     # failures capped to 2 + summary message
     assert len(capped["failures"]) == 3
     assert capped["failures"][:2] == ["err1", "err2"]
-    assert "interim report" in capped["failures"][-1]
-    assert "2 of 5" in capped["failures"][-1]
+    assert "and 3 more" in capped["failures"][-1]
 
     # warnings capped to 1 + summary message
     assert len(capped["warnings"]) == 2
-    assert "interim report" in capped["warnings"][-1]
+    assert "and 2 more" in capped["warnings"][-1]
 
     # infos under cap — untouched
     assert capped["infos"] == ["i1", "i2"]
@@ -78,15 +77,14 @@ def test_cap_report_samples_zero_cap():
 
     # failures: all suppressed, one sentinel line
     assert len(capped["failures"]) == 1
-    assert "0 of 3" in capped["failures"][0]
-    assert "interim report" in capped["failures"][0]
+    assert "and 3 more" in capped["failures"][0]
 
     # empty list stays empty (len(0) > 0 is False)
     assert capped["warnings"] == []
 
     # single-element list: still capped since 1 > 0
     assert len(capped["infos"]) == 1
-    assert "0 of 1" in capped["infos"][0]
+    assert "and 1 more" in capped["infos"][0]
 
 
 def test_cap_report_samples_key_not_in_caps():
@@ -148,10 +146,9 @@ def test_as_string_with_caps_applies_capping():
         count=42,
     )
     result = report.as_string(progress_sample_caps={"failures": 2, "warnings": 5})
-    assert "interim report" in result
-    assert "2 of 5" in result
+    assert "and 3 more" in result
     # warnings list (len 1) is under cap 5, so no sentinel
-    assert result.count("interim report") == 1
+    assert result.count("more") == 1
 
 
 def test_as_string_none_caps_shows_all():
@@ -160,7 +157,7 @@ def test_as_string_none_caps_shows_all():
         count=10,
     )
     result = report.as_string(progress_sample_caps=None)
-    assert "interim report" not in result
+    assert "more" not in result
     assert "e1" in result
     assert "e3" in result
 
@@ -372,13 +369,13 @@ def test_retention_progress_max_higher_final_shows_report_size():
     # as_obj() returns all 25 retained (raw data)
     raw_failures = _count_real_entries(result["source"], "failures")
     assert raw_failures == 25
-    # But as_string with the final caps shows only 5
+    # But as_string with the final caps shows only 5 + sentinel
     final_str = result["source_report"].as_string(
         progress_sample_caps={"failures": 5, "warnings": 10, "infos": 10},
-        cap_label="capped",
     )
-    assert "showing 5 of" in final_str
-    assert "(capped)" in final_str
+    assert "more" in final_str
+    # Verify only 5 real failure entries are displayed
+    assert final_str.count("'message': 'F") == 5
 
 
 def test_retention_both_set_equal():

--- a/metadata-ingestion/tests/unit/api/test_entity_filter_report.py
+++ b/metadata-ingestion/tests/unit/api/test_entity_filter_report.py
@@ -179,6 +179,9 @@ def test_flags_config_defaults():
     assert flags.progress_report_max_failures == 10
     assert flags.progress_report_max_warnings == 10
     assert flags.progress_report_max_infos == 10
+    assert flags.report_failure_sample_size == 10
+    assert flags.report_warning_sample_size == 10
+    assert flags.report_info_sample_size == 10
 
 
 def test_flags_config_from_env_vars():
@@ -189,19 +192,61 @@ def test_flags_config_from_env_vars():
         "DATAHUB_PROGRESS_REPORT_MAX_FAILURES": "5",
         "DATAHUB_PROGRESS_REPORT_MAX_WARNINGS": "20",
         "DATAHUB_PROGRESS_REPORT_MAX_INFOS": "0",
+        "DATAHUB_REPORT_FAILURE_SAMPLE_SIZE": "50",
+        "DATAHUB_REPORT_WARNING_SAMPLE_SIZE": "25",
+        "DATAHUB_REPORT_INFO_SAMPLE_SIZE": "15",
     }
     with mock.patch.dict(os.environ, env, clear=True):
         flags = FlagsConfig()
     assert flags.progress_report_max_failures == 5
     assert flags.progress_report_max_warnings == 20
     assert flags.progress_report_max_infos == 0
+    assert flags.report_failure_sample_size == 50
+    assert flags.report_warning_sample_size == 25
+    assert flags.report_info_sample_size == 15
 
 
 def test_flags_config_recipe_overrides_env():
     """Explicit recipe values take precedence over env vars."""
     from datahub.ingestion.run.pipeline_config import FlagsConfig
 
-    env = {"DATAHUB_PROGRESS_REPORT_MAX_FAILURES": "5"}
+    env = {
+        "DATAHUB_PROGRESS_REPORT_MAX_FAILURES": "5",
+        "DATAHUB_REPORT_FAILURE_SAMPLE_SIZE": "50",
+    }
     with mock.patch.dict(os.environ, env, clear=True):
-        flags = FlagsConfig(progress_report_max_failures=99)
+        flags = FlagsConfig(
+            progress_report_max_failures=99,
+            report_failure_sample_size=200,
+        )
     assert flags.progress_report_max_failures == 99
+    assert flags.report_failure_sample_size == 200
+
+
+# ---------------------------------------------------------------------------
+# StructuredLogs.set_sample_sizes
+# ---------------------------------------------------------------------------
+
+
+def test_structured_logs_set_sample_sizes():
+    """set_sample_sizes adjusts the underlying LossyDict max_elements."""
+    from datahub.ingestion.api.source import StructuredLogLevel, StructuredLogs
+
+    logs = StructuredLogs()
+    # defaults
+    assert logs._entries[StructuredLogLevel.ERROR].max_elements == 10
+    assert logs._entries[StructuredLogLevel.WARN].max_elements == 10
+
+    logs.set_sample_sizes(failure_size=50, warning_size=25)
+    assert logs._entries[StructuredLogLevel.ERROR].max_elements == 50
+    assert logs._entries[StructuredLogLevel.WARN].max_elements == 25
+
+
+def test_structured_logs_set_sample_sizes_partial():
+    """set_sample_sizes with None leaves the original value."""
+    from datahub.ingestion.api.source import StructuredLogLevel, StructuredLogs
+
+    logs = StructuredLogs()
+    logs.set_sample_sizes(failure_size=99)
+    assert logs._entries[StructuredLogLevel.ERROR].max_elements == 99
+    assert logs._entries[StructuredLogLevel.WARN].max_elements == 10  # unchanged

--- a/metadata-ingestion/tests/unit/api/test_entity_filter_report.py
+++ b/metadata-ingestion/tests/unit/api/test_entity_filter_report.py
@@ -10,6 +10,7 @@ from datahub.ingestion.api.report import (
 )
 from datahub.ingestion.api.source import StructuredLogLevel, StructuredLogs
 from datahub.ingestion.run.pipeline_config import FlagsConfig
+from datahub.utilities.lossy_collections import LossySentinel
 
 
 @dataclasses.dataclass
@@ -41,24 +42,22 @@ def test_entity_filter_report():
 
 
 def test_cap_report_samples_basic():
+    sentinel = LossySentinel("... sampled of 50 total elements")
     obj = {
         "events_produced": 500,
-        "failures": ["err1", "err2", "err3", "err4", "err5"],
-        "warnings": ["w1", "w2", "w3"],
+        "failures": ["err1", "err2", "err3", "err4", "err5", sentinel],
+        "warnings": ["w1", "w2", "w3", sentinel],
         "infos": ["i1", "i2"],
         "aspects": {"dataset": {"schemaMetadata": 100}},
     }
     caps = {"failures": 2, "warnings": 1, "infos": 5}
     capped = _cap_report_samples(obj, caps)
 
-    # failures capped to 2 + summary message
-    assert len(capped["failures"]) == 3
-    assert capped["failures"][:2] == ["err1", "err2"]
-    assert "and 3 more" in capped["failures"][-1]
+    # failures: 2 entries + sentinel preserved
+    assert capped["failures"] == ["err1", "err2", sentinel]
 
-    # warnings capped to 1 + summary message
-    assert len(capped["warnings"]) == 2
-    assert "and 2 more" in capped["warnings"][-1]
+    # warnings: 1 entry + sentinel preserved
+    assert capped["warnings"] == ["w1", sentinel]
 
     # infos under cap — untouched
     assert capped["infos"] == ["i1", "i2"]
@@ -69,38 +68,41 @@ def test_cap_report_samples_basic():
 
 
 def test_cap_report_samples_zero_cap():
-    """cap=0 should suppress all entries but still show the count."""
-
-    obj = {"failures": ["e1", "e2", "e3"], "warnings": [], "infos": ["i1"]}
+    """cap=0 should remove all entries but keep the sentinel."""
+    sentinel = LossySentinel("... sampled of 30 total elements")
+    obj = {"failures": ["e1", "e2", "e3", sentinel], "warnings": [], "infos": ["i1"]}
     caps = {"failures": 0, "warnings": 0, "infos": 0}
     capped = _cap_report_samples(obj, caps)
 
-    # failures: all suppressed, one sentinel line
-    assert len(capped["failures"]) == 1
-    assert "and 3 more" in capped["failures"][0]
+    # failures: all entries removed, sentinel preserved
+    assert capped["failures"] == [sentinel]
 
-    # empty list stays empty (len(0) > 0 is False)
+    # empty list stays empty
     assert capped["warnings"] == []
 
-    # single-element list: still capped since 1 > 0
-    assert len(capped["infos"]) == 1
-    assert "and 1 more" in capped["infos"][0]
+    # single entry removed, no sentinel to preserve
+    assert capped["infos"] == []
+
+
+def test_cap_report_samples_no_sentinel():
+    """Lists without a LossySentinel are just truncated."""
+    obj = {"failures": ["e1", "e2", "e3"]}
+    capped = _cap_report_samples(obj, {"failures": 1})
+    assert capped["failures"] == ["e1"]
 
 
 def test_cap_report_samples_key_not_in_caps():
     """Keys absent from the caps dict are never capped."""
-
     obj = {"failures": ["e1", "e2"], "other_list": ["a", "b", "c"]}
     caps = {"failures": 1}
     capped = _cap_report_samples(obj, caps)
 
-    assert len(capped["failures"]) == 2  # 1 + sentinel
-    assert capped["other_list"] == ["a", "b", "c"]  # untouched
+    assert capped["failures"] == ["e1"]
+    assert capped["other_list"] == ["a", "b", "c"]
 
 
 def test_cap_report_samples_empty_caps_dict():
     """Empty caps dict means nothing is capped."""
-
     obj = {"failures": ["e1", "e2", "e3"]}
     capped = _cap_report_samples(obj, {})
     assert capped["failures"] == ["e1", "e2", "e3"]
@@ -108,19 +110,15 @@ def test_cap_report_samples_empty_caps_dict():
 
 def test_cap_report_samples_nested_dict_not_capped():
     """Dicts nested inside the report are passed through, not recursed into."""
-
     inner = {"nested_failures": ["x", "y", "z"]}
     obj = {"failures": ["e1"], "sub_report": inner}
     caps = {"failures": 10, "nested_failures": 1}
     capped = _cap_report_samples(obj, caps)
-
-    # The nested dict is untouched — capping is shallow
     assert capped["sub_report"] == inner
 
 
 def test_cap_report_samples_exact_cap():
-    """List with length == cap should NOT be capped (only > triggers it)."""
-
+    """List with length == cap should NOT be capped."""
     obj = {"failures": ["e1", "e2", "e3"]}
     caps = {"failures": 3}
     capped = _cap_report_samples(obj, caps)
@@ -146,9 +144,10 @@ def test_as_string_with_caps_applies_capping():
         count=42,
     )
     result = report.as_string(progress_sample_caps={"failures": 2, "warnings": 5})
-    assert "and 3 more" in result
-    # warnings list (len 1) is under cap 5, so no sentinel
-    assert result.count("more") == 1
+    assert "e1" in result
+    assert "e2" in result
+    assert "e3" not in result  # truncated
+    assert "w1" in result  # under cap, kept
 
 
 def test_as_string_none_caps_shows_all():
@@ -157,7 +156,6 @@ def test_as_string_none_caps_shows_all():
         count=10,
     )
     result = report.as_string(progress_sample_caps=None)
-    assert "more" not in result
     assert "e1" in result
     assert "e3" in result
 
@@ -254,37 +252,37 @@ def test_set_sample_sizes_after_entries_added_raises():
 
 
 def test_cap_ignores_lossy_list_sentinel():
-    """The '... sampled of N' sentinel from LossyList shouldn't count as a real entry."""
+    """LossySentinel shouldn't count as a real entry."""
+    sentinel = LossySentinel("... sampled of 30 total elements")
     obj = {
         "failures": [
-            {"message": "connection timeout", "context": ["db.orders"]},
-            {"message": "permission denied", "context": ["db.users"]},
-            {"message": "schema mismatch", "context": ["db.products"]},
-            "... sampled of 30 total elements",
+            {"message": "connection timeout"},
+            {"message": "permission denied"},
+            {"message": "schema mismatch"},
+            sentinel,
         ],
     }
-    # 3 real entries at cap of 3 — no truncation needed
     capped = _cap_report_samples(obj, {"failures": 3})
     assert capped["failures"] == obj["failures"]
 
 
 def test_cap_with_sentinel_and_truncation():
-    """When truncating, preserve the existing LossyList sentinel alongside the new one."""
+    """When truncating, the LossySentinel is preserved."""
+    sentinel = LossySentinel("... sampled of 50 total elements")
     obj = {
         "failures": [
-            {"message": "connection timeout", "context": ["db.orders"]},
-            {"message": "permission denied", "context": ["db.users"]},
-            {"message": "schema mismatch", "context": ["db.products"]},
-            {"message": "null column", "context": ["db.events"]},
-            "... sampled of 50 total elements",
+            {"message": "connection timeout"},
+            {"message": "permission denied"},
+            {"message": "schema mismatch"},
+            {"message": "null column"},
+            sentinel,
         ],
     }
     capped = _cap_report_samples(obj, {"failures": 2})
-    assert len(capped["failures"]) == 4  # 2 real + our sentinel + LossyList sentinel
+    assert len(capped["failures"]) == 3  # 2 entries + sentinel
     assert capped["failures"][0]["message"] == "connection timeout"
     assert capped["failures"][1]["message"] == "permission denied"
-    assert "and 2 more" in capped["failures"][2]
-    assert "sampled of 50" in capped["failures"][3]
+    assert capped["failures"][2] is sentinel
 
 
 def test_negative_sample_size_rejected():
@@ -382,11 +380,7 @@ def _run_pipeline_get_reports(flags: dict, num_each: int = 30) -> dict:
 def _count_real_entries(report_obj: dict, key: str) -> int:
     """Count non-sentinel entries in a report list."""
     items = report_obj.get(key, [])
-    return sum(
-        1
-        for item in items
-        if not (isinstance(item, str) and ("sampled" in item or "showing" in item))
-    )
+    return sum(1 for item in items if not isinstance(item, LossySentinel))
 
 
 def test_retention_both_defaults():
@@ -422,12 +416,10 @@ def test_retention_progress_max_higher_final_shows_report_size():
     # as_obj() returns all 25 retained (raw data)
     raw_failures = _count_real_entries(result["source"], "failures")
     assert raw_failures == 25
-    # But as_string with the final caps shows only 5 + sentinel
+    # But as_string with the final caps shows only 5
     final_str = result["source_report"].as_string(
         progress_sample_caps={"failures": 5, "warnings": 10, "infos": 10},
     )
-    assert "more" in final_str
-    # Verify only 5 real failure entries are displayed
     assert final_str.count("'message': 'F") == 5
 
 

--- a/metadata-ingestion/tests/unit/api/test_entity_filter_report.py
+++ b/metadata-ingestion/tests/unit/api/test_entity_filter_report.py
@@ -244,6 +244,59 @@ def test_structured_logs_set_sample_sizes_partial():
     assert logs._entries[StructuredLogLevel.WARN].max_elements == 10  # unchanged
 
 
+def test_set_sample_sizes_after_entries_added_raises():
+    import pytest
+
+    logs = StructuredLogs()
+    logs.report_log(StructuredLogLevel.ERROR, "something broke", context="table_x")
+    with pytest.raises(AssertionError, match="must be called before"):
+        logs.set_sample_sizes(failure_size=50)
+
+
+def test_cap_ignores_lossy_list_sentinel():
+    """The '... sampled of N' sentinel from LossyList shouldn't count as a real entry."""
+    obj = {
+        "failures": [
+            {"message": "connection timeout", "context": ["db.orders"]},
+            {"message": "permission denied", "context": ["db.users"]},
+            {"message": "schema mismatch", "context": ["db.products"]},
+            "... sampled of 30 total elements",
+        ],
+    }
+    # 3 real entries at cap of 3 — no truncation needed
+    capped = _cap_report_samples(obj, {"failures": 3})
+    assert capped["failures"] == obj["failures"]
+
+
+def test_cap_with_sentinel_and_truncation():
+    """When truncating, preserve the existing LossyList sentinel alongside the new one."""
+    obj = {
+        "failures": [
+            {"message": "connection timeout", "context": ["db.orders"]},
+            {"message": "permission denied", "context": ["db.users"]},
+            {"message": "schema mismatch", "context": ["db.products"]},
+            {"message": "null column", "context": ["db.events"]},
+            "... sampled of 50 total elements",
+        ],
+    }
+    capped = _cap_report_samples(obj, {"failures": 2})
+    assert len(capped["failures"]) == 4  # 2 real + our sentinel + LossyList sentinel
+    assert capped["failures"][0]["message"] == "connection timeout"
+    assert capped["failures"][1]["message"] == "permission denied"
+    assert "and 2 more" in capped["failures"][2]
+    assert "sampled of 50" in capped["failures"][3]
+
+
+def test_negative_sample_size_rejected():
+    import pytest
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        FlagsConfig(progress_report_max_failures=-1)
+    with pytest.raises(ValidationError):
+        FlagsConfig(report_failure_sample_size=-5)
+
+
 # ---------------------------------------------------------------------------
 # Pipeline retention sizing: max(report_size, progress_max)
 # ---------------------------------------------------------------------------

--- a/metadata-ingestion/tests/unit/api/test_entity_filter_report.py
+++ b/metadata-ingestion/tests/unit/api/test_entity_filter_report.py
@@ -1,4 +1,6 @@
 import dataclasses
+import os
+from unittest import mock
 
 from datahub.ingestion.api.report import EntityFilterReport, Report, SupportsAsObj
 
@@ -26,7 +28,12 @@ def test_entity_filter_report():
     assert report2.as_string() == "{'views': {'filtered': [], 'processed': []}}"
 
 
-def test_progress_report_caps_failures_and_warnings():
+# ---------------------------------------------------------------------------
+# _cap_report_samples tests
+# ---------------------------------------------------------------------------
+
+
+def test_cap_report_samples_basic():
     from datahub.ingestion.api.report import _cap_report_samples
 
     obj = {
@@ -41,7 +48,9 @@ def test_progress_report_caps_failures_and_warnings():
 
     # failures capped to 2 + summary message
     assert len(capped["failures"]) == 3
+    assert capped["failures"][:2] == ["err1", "err2"]
     assert "interim report" in capped["failures"][-1]
+    assert "2 of 5" in capped["failures"][-1]
 
     # warnings capped to 1 + summary message
     assert len(capped["warnings"]) == 2
@@ -50,6 +59,149 @@ def test_progress_report_caps_failures_and_warnings():
     # infos under cap — untouched
     assert capped["infos"] == ["i1", "i2"]
 
-    # non-sample fields untouched
+    # non-list fields untouched
     assert capped["events_produced"] == 500
     assert capped["aspects"] == {"dataset": {"schemaMetadata": 100}}
+
+
+def test_cap_report_samples_zero_cap():
+    """cap=0 should suppress all entries but still show the count."""
+    from datahub.ingestion.api.report import _cap_report_samples
+
+    obj = {"failures": ["e1", "e2", "e3"], "warnings": [], "infos": ["i1"]}
+    caps = {"failures": 0, "warnings": 0, "infos": 0}
+    capped = _cap_report_samples(obj, caps)
+
+    # failures: all suppressed, one sentinel line
+    assert len(capped["failures"]) == 1
+    assert "0 of 3" in capped["failures"][0]
+    assert "interim report" in capped["failures"][0]
+
+    # empty list stays empty (len(0) > 0 is False)
+    assert capped["warnings"] == []
+
+    # single-element list: still capped since 1 > 0
+    assert len(capped["infos"]) == 1
+    assert "0 of 1" in capped["infos"][0]
+
+
+def test_cap_report_samples_key_not_in_caps():
+    """Keys absent from the caps dict are never capped."""
+    from datahub.ingestion.api.report import _cap_report_samples
+
+    obj = {"failures": ["e1", "e2"], "other_list": ["a", "b", "c"]}
+    caps = {"failures": 1}
+    capped = _cap_report_samples(obj, caps)
+
+    assert len(capped["failures"]) == 2  # 1 + sentinel
+    assert capped["other_list"] == ["a", "b", "c"]  # untouched
+
+
+def test_cap_report_samples_empty_caps_dict():
+    """Empty caps dict means nothing is capped."""
+    from datahub.ingestion.api.report import _cap_report_samples
+
+    obj = {"failures": ["e1", "e2", "e3"]}
+    capped = _cap_report_samples(obj, {})
+    assert capped["failures"] == ["e1", "e2", "e3"]
+
+
+def test_cap_report_samples_nested_dict_not_capped():
+    """Dicts nested inside the report are passed through, not recursed into."""
+    from datahub.ingestion.api.report import _cap_report_samples
+
+    inner = {"nested_failures": ["x", "y", "z"]}
+    obj = {"failures": ["e1"], "sub_report": inner}
+    caps = {"failures": 10, "nested_failures": 1}
+    capped = _cap_report_samples(obj, caps)
+
+    # The nested dict is untouched — capping is shallow
+    assert capped["sub_report"] == inner
+
+
+def test_cap_report_samples_exact_cap():
+    """List with length == cap should NOT be capped (only > triggers it)."""
+    from datahub.ingestion.api.report import _cap_report_samples
+
+    obj = {"failures": ["e1", "e2", "e3"]}
+    caps = {"failures": 3}
+    capped = _cap_report_samples(obj, caps)
+    assert capped["failures"] == ["e1", "e2", "e3"]
+
+
+# ---------------------------------------------------------------------------
+# Report.as_string integration with progress_sample_caps
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class SimpleReport(Report):
+    failures: list = dataclasses.field(default_factory=list)
+    warnings: list = dataclasses.field(default_factory=list)
+    count: int = 0
+
+
+def test_as_string_with_caps_applies_capping():
+    report = SimpleReport(
+        failures=["e1", "e2", "e3", "e4", "e5"],
+        warnings=["w1"],
+        count=42,
+    )
+    result = report.as_string(progress_sample_caps={"failures": 2, "warnings": 5})
+    assert "interim report" in result
+    assert "2 of 5" in result
+    # warnings list (len 1) is under cap 5, so no sentinel
+    assert result.count("interim report") == 1
+
+
+def test_as_string_none_caps_shows_all():
+    report = SimpleReport(
+        failures=["e1", "e2", "e3"],
+        count=10,
+    )
+    result = report.as_string(progress_sample_caps=None)
+    assert "interim report" not in result
+    assert "e1" in result
+    assert "e3" in result
+
+
+# ---------------------------------------------------------------------------
+# FlagsConfig env var integration
+# ---------------------------------------------------------------------------
+
+
+def test_flags_config_defaults():
+    """FlagsConfig fields default to 10 when env vars are not set."""
+    from datahub.ingestion.run.pipeline_config import FlagsConfig
+
+    with mock.patch.dict(os.environ, {}, clear=True):
+        flags = FlagsConfig()
+    assert flags.progress_report_max_failures == 10
+    assert flags.progress_report_max_warnings == 10
+    assert flags.progress_report_max_infos == 10
+
+
+def test_flags_config_from_env_vars():
+    """FlagsConfig fields pick up env vars."""
+    from datahub.ingestion.run.pipeline_config import FlagsConfig
+
+    env = {
+        "DATAHUB_PROGRESS_REPORT_MAX_FAILURES": "5",
+        "DATAHUB_PROGRESS_REPORT_MAX_WARNINGS": "20",
+        "DATAHUB_PROGRESS_REPORT_MAX_INFOS": "0",
+    }
+    with mock.patch.dict(os.environ, env, clear=True):
+        flags = FlagsConfig()
+    assert flags.progress_report_max_failures == 5
+    assert flags.progress_report_max_warnings == 20
+    assert flags.progress_report_max_infos == 0
+
+
+def test_flags_config_recipe_overrides_env():
+    """Explicit recipe values take precedence over env vars."""
+    from datahub.ingestion.run.pipeline_config import FlagsConfig
+
+    env = {"DATAHUB_PROGRESS_REPORT_MAX_FAILURES": "5"}
+    with mock.patch.dict(os.environ, env, clear=True):
+        flags = FlagsConfig(progress_report_max_failures=99)
+    assert flags.progress_report_max_failures == 99

--- a/metadata-ingestion/tests/unit/utilities/test_lossy_collections.py
+++ b/metadata-ingestion/tests/unit/utilities/test_lossy_collections.py
@@ -86,6 +86,57 @@ def test_lossydict_sampling(length, sampling, sub_length):
         assert len(v) == element_length_map[k]
 
 
+def test_lossydict_resize_grow():
+    """resize to a larger limit keeps all entries."""
+    d: LossyDict[str, int] = LossyDict(max_elements=3)
+    d["a"] = 1
+    d["b"] = 2
+    d.resize(10)
+    assert d.max_elements == 10
+    assert dict(d) == {"a": 1, "b": 2}
+    assert not d.sampled
+
+
+def test_lossydict_resize_shrink():
+    """resize to a smaller limit prunes excess entries."""
+    d: LossyDict[str, int] = LossyDict(max_elements=10)
+    for i in range(8):
+        d[f"k{i}"] = i
+    assert len(d) == 8
+
+    d.resize(3)
+    assert d.max_elements == 3
+    assert len(d) == 3
+    assert d.sampled
+    # surviving keys are a subset of the originals
+    assert set(d.keys()).issubset({f"k{i}" for i in range(8)})
+
+
+def test_lossydict_resize_to_same_size():
+    """resize to the current size is a no-op."""
+    d: LossyDict[str, int] = LossyDict(max_elements=5)
+    for i in range(5):
+        d[f"k{i}"] = i
+    d.resize(5)
+    assert len(d) == 5
+    assert not d.sampled
+
+
+def test_lossydict_resize_respects_new_limit_on_insert():
+    """After resize, new inserts respect the new max_elements."""
+    d: LossyDict[str, int] = LossyDict(max_elements=100)
+    d["a"] = 1
+    d["b"] = 2
+    d.resize(3)
+    # insert up to new limit
+    d["c"] = 3
+    assert len(d) == 3
+    # one more triggers sampling
+    d["d"] = 4
+    assert len(d) <= 3
+    assert d.sampled
+
+
 def test_lossylist_getitem_direct_indexing():
     """Test that direct indexing returns unwrapped items, not tuples.
 


### PR DESCRIPTION
## Summary

Add configurable caps for ingestion report sizes, separately for interim (60-second progress) and final reports. Both source and sink reports are affected.

### Configuration

All settings default to 10. Recipe flags take precedence over env vars.

**Interim progress report display caps:**
```yaml
flags:
  progress_report_max_failures: 10
  progress_report_max_warnings: 10
  progress_report_max_infos: 10
```

**Final report sample sizes:**
```yaml
flags:
  report_failure_sample_size: 10
  report_warning_sample_size: 10
  report_info_sample_size: 10
```

Equivalent env vars: `DATAHUB_PROGRESS_REPORT_MAX_FAILURES`, `DATAHUB_PROGRESS_REPORT_MAX_WARNINGS`, `DATAHUB_PROGRESS_REPORT_MAX_INFOS`, `DATAHUB_REPORT_FAILURE_SAMPLE_SIZE`, `DATAHUB_REPORT_WARNING_SAMPLE_SIZE`, `DATAHUB_REPORT_INFO_SAMPLE_SIZE`.

The underlying `LossyDict` retains `max(report_size, progress_max)` entries so both reports can draw from a sufficient pool. Each report then displays up to its own configured cap.

Info sample size (`DATAHUB_REPORT_INFO_SAMPLE_SIZE`) is now configurable via env var and recipe flag, matching the existing behavior of failures and warnings.

## Test plan

- [x] 24 unit tests covering capping logic, sentinel handling, FlagsConfig defaults/env/recipe precedence, retention combos, and sink sizing
- [x] End-to-end: interim + final reports with various flag combinations (suppress interim, cap interim, override per severity, size > generated count)

🤖 Generated with [Claude Code](https://claude.com/claude-code)