### PR TITLE
fix(kafka): add bounded auth exception retry to consumer factories for MSK IAM resilience

### DIFF
--- a/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
@@ -277,6 +277,8 @@ public class PropertiesCollectorConfigurationTest extends AbstractTestNGSpringCo
           "kafka.consumer.metrics.slo",
           "kafka.consumer.pe.autoOffsetReset",
           "kafka.consumer.stopOnDeserializationError",
+          "kafka.consumer.authExceptionRetryIntervalSeconds",
+          "kafka.consumer.maxAuthExceptionRetries",
           "kafka.consumerPool.initialSize",
           "kafka.consumerPool.maxSize",
           "kafka.consumerPool.validationTimeoutSeconds",

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/kafka/ConsumerConfiguration.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/kafka/ConsumerConfiguration.java
@@ -9,6 +9,8 @@ public class ConsumerConfiguration {
   private int maxPartitionFetchBytes;
   private boolean stopOnDeserializationError;
   private boolean healthCheckEnabled;
+  private int authExceptionRetryIntervalSeconds;
+  private int maxAuthExceptionRetries;
 
   private ConsumerOptions mcp;
   private ConsumerOptions mcl;

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -734,6 +734,8 @@ kafka:
     maxPartitionFetchBytes: ${KAFKA_CONSUMER_MAX_PARTITION_FETCH_BYTES:5242880} # the max bytes consumed per partition
     stopOnDeserializationError: ${KAFKA_CONSUMER_STOP_ON_DESERIALIZATION_ERROR:true} # Stops kafka listener container on deserialization error, allows user to fix problems before moving past problematic offset. If false will log and move forward past the offset
     healthCheckEnabled: ${KAFKA_CONSUMER_HEALTH_CHECK_ENABLED:true} # Sets the health indicator to down when a message listener container has stopped due to a deserialization failure, will force consumer apps to restart through k8s and docker-compose health mechanisms
+    authExceptionRetryIntervalSeconds: ${KAFKA_CONSUMER_AUTH_EXCEPTION_RETRY_INTERVAL_SECONDS:10} # Seconds to wait before retrying after an authentication/authorization exception (e.g. MSK IAM credential rotation). Set to 0 to disable (fatal on first auth exception).
+    maxAuthExceptionRetries: ${KAFKA_CONSUMER_MAX_AUTH_EXCEPTION_RETRIES:3} # Max consecutive auth exception retries before stopping the container. Prevents silent infinite retry on permanent auth failure.
     mcp:
       autoOffsetReset: ${KAFKA_CONSUMER_MCP_AUTO_OFFSET_RESET:earliest}
     mcl:

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/CDCConsumerFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/CDCConsumerFactory.java
@@ -76,6 +76,12 @@ public class CDCConsumerFactory {
     factory.setContainerCustomizer(new ThreadPoolContainerCustomizer());
     factory.setConsumerFactory(new DefaultKafkaConsumerFactory<>(customizedProperties));
     factory.setAutoStartup(false);
+    int authRetrySeconds = kafkaConfiguration.getConsumer().getAuthExceptionRetryIntervalSeconds();
+    if (authRetrySeconds > 0) {
+      factory
+          .getContainerProperties()
+          .setAuthExceptionRetryInterval(Duration.ofSeconds(authRetrySeconds));
+    }
 
     log.info("CDC KafkaListenerContainerFactory built successfully for JSON CDC messages");
 

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/KafkaConsumerAuthExceptionGuard.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/KafkaConsumerAuthExceptionGuard.java
@@ -1,0 +1,90 @@
+package com.linkedin.gms.factory.kafka;
+
+import com.linkedin.gms.factory.config.ConfigurationProvider;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.event.EventListener;
+import org.springframework.kafka.event.ConsumerRetryAuthEvent;
+import org.springframework.kafka.event.ConsumerRetryAuthSuccessfulEvent;
+import org.springframework.kafka.listener.MessageListenerContainer;
+import org.springframework.stereotype.Component;
+
+/**
+ * Bounds the number of consecutive authentication/authorization retries for Kafka consumers.
+ *
+ * <p>Without this guard, {@code authExceptionRetryInterval} causes consumers to retry indefinitely
+ * on auth failures — the container stays "running" and the health check never detects the problem.
+ *
+ * <p>This mirrors how the GMS producer bounds retries via {@code delivery.timeout.ms} and {@code
+ * retries}: after a fixed number of consecutive failures the operation fails loudly instead of
+ * retrying forever. On the consumer side, "failing loudly" means stopping the container so that
+ * {@link io.datahubproject.metadata.jobs.common.health.kafka.KafkaHealthIndicator} reports DOWN and
+ * Kubernetes liveness probes can act on it.
+ *
+ * <p>Transient failures (e.g., MSK IAM credential rotation) typically recover on the first retry.
+ * Reaching the max retry threshold signals a permanent auth failure that requires operator
+ * intervention.
+ *
+ * <p>Configurable via {@code kafka.consumer.maxAuthExceptionRetries} / {@code
+ * KAFKA_CONSUMER_MAX_AUTH_EXCEPTION_RETRIES}. Set to 0 to disable (unbounded retries).
+ */
+@Component
+@Slf4j
+public class KafkaConsumerAuthExceptionGuard {
+
+  private final int maxConsecutiveAuthRetries;
+
+  private final ConcurrentHashMap<Object, AtomicInteger> consecutiveFailures =
+      new ConcurrentHashMap<>();
+
+  public KafkaConsumerAuthExceptionGuard(
+      @Qualifier("configurationProvider") ConfigurationProvider configurationProvider) {
+    this.maxConsecutiveAuthRetries =
+        configurationProvider.getKafka().getConsumer().getMaxAuthExceptionRetries();
+  }
+
+  @EventListener
+  void onAuthRetry(ConsumerRetryAuthEvent event) {
+    if (maxConsecutiveAuthRetries <= 0) {
+      return;
+    }
+
+    MessageListenerContainer container = event.getContainer(MessageListenerContainer.class);
+    int failures =
+        consecutiveFailures.computeIfAbsent(container, k -> new AtomicInteger(0)).incrementAndGet();
+
+    log.warn(
+        "Kafka consumer auth retry {}/{} for container [{}] (reason: {})",
+        failures,
+        maxConsecutiveAuthRetries,
+        container.getListenerId(),
+        event.getReason());
+
+    if (failures >= maxConsecutiveAuthRetries) {
+      log.error(
+          "Kafka consumer [{}] exhausted auth retries ({}/{}), stopping container."
+              + " This indicates a permanent authentication/authorization failure"
+              + " — not a transient credential rotation.",
+          container.getListenerId(),
+          failures,
+          maxConsecutiveAuthRetries);
+      consecutiveFailures.remove(container);
+      // Stop asynchronously: the event fires on the consumer thread, and a synchronous
+      // stop() would deadlock (the thread cannot join itself).
+      CompletableFuture.runAsync(() -> container.stop());
+    }
+  }
+
+  @EventListener
+  void onAuthRetrySuccess(ConsumerRetryAuthSuccessfulEvent event) {
+    MessageListenerContainer container = event.getContainer(MessageListenerContainer.class);
+    if (consecutiveFailures.remove(container) != null) {
+      log.info(
+          "Kafka consumer [{}] recovered from auth failure — credential rotation succeeded",
+          container.getListenerId());
+    }
+  }
+}

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/KafkaEventConsumerFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/KafkaEventConsumerFactory.java
@@ -34,6 +34,7 @@ import org.springframework.kafka.support.serializer.DeserializationException;
 @Configuration
 public class KafkaEventConsumerFactory {
   private int kafkaEventConsumerConcurrency;
+  private int authExceptionRetryIntervalSeconds;
 
   @Bean(name = "kafkaConsumerFactory")
   protected DefaultKafkaConsumerFactory<String, GenericRecord> createConsumerFactory(
@@ -42,6 +43,8 @@ public class KafkaEventConsumerFactory {
       @Qualifier("schemaRegistryConfig")
           KafkaConfiguration.SerDeKeyValueConfig schemaRegistryConfig) {
     kafkaEventConsumerConcurrency = provider.getKafka().getListener().getConcurrency();
+    authExceptionRetryIntervalSeconds =
+        provider.getKafka().getConsumer().getAuthExceptionRetryIntervalSeconds();
 
     KafkaConfiguration kafkaConfiguration = provider.getKafka();
     Map<String, Object> customizedProperties =
@@ -58,6 +61,8 @@ public class KafkaEventConsumerFactory {
       @Qualifier("schemaRegistryConfig")
           KafkaConfiguration.SerDeKeyValueConfig schemaRegistryConfig) {
     kafkaEventConsumerConcurrency = provider.getKafka().getListener().getConcurrency();
+    authExceptionRetryIntervalSeconds =
+        provider.getKafka().getConsumer().getAuthExceptionRetryIntervalSeconds();
 
     KafkaConfiguration kafkaConfiguration = provider.getKafka();
     Map<String, Object> customizedProperties =
@@ -242,6 +247,16 @@ public class KafkaEventConsumerFactory {
     factory.setConcurrency(kafkaEventConsumerConcurrency);
     factory.setAutoStartup(false);
 
+    // Allow consumer containers to survive transient authentication failures (e.g.,
+    // MSK IAM credential rotation with EKS Pod Identity) instead of stopping fatally.
+    // The Kafka client's NetworkClient automatically reconnects with fresh credentials
+    // on the next poll — the same self-healing that the producer side already has.
+    if (authExceptionRetryIntervalSeconds > 0) {
+      factory
+          .getContainerProperties()
+          .setAuthExceptionRetryInterval(Duration.ofSeconds(authExceptionRetryIntervalSeconds));
+    }
+
     /*
      * Sets up a delegating error handler for Deserialization errors, if disabled
      * will
@@ -276,6 +291,11 @@ public class KafkaEventConsumerFactory {
     factory.setContainerCustomizer(new ThreadPoolContainerCustomizer());
     factory.setConcurrency(1);
     factory.setAutoStartup(false);
+    if (authExceptionRetryIntervalSeconds > 0) {
+      factory
+          .getContainerProperties()
+          .setAuthExceptionRetryInterval(Duration.ofSeconds(authExceptionRetryIntervalSeconds));
+    }
 
     log.info(
         "Event-based DUHE KafkaListenerContainerFactory built successfully. Consumer concurrency = 1");

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/SimpleKafkaConsumerFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/SimpleKafkaConsumerFactory.java
@@ -65,6 +65,12 @@ public class SimpleKafkaConsumerFactory {
     factory.setContainerCustomizer(new ThreadPoolContainerCustomizer());
     factory.setConsumerFactory(new DefaultKafkaConsumerFactory<>(customizedProperties));
     factory.setAutoStartup(false);
+    int authRetrySeconds = kafkaConfiguration.getConsumer().getAuthExceptionRetryIntervalSeconds();
+    if (authRetrySeconds > 0) {
+      factory
+          .getContainerProperties()
+          .setAuthExceptionRetryInterval(Duration.ofSeconds(authRetrySeconds));
+    }
 
     log.info("Simple KafkaListenerContainerFactory built successfully");
 

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/kafka/KafkaConsumerAuthExceptionGuardTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/kafka/KafkaConsumerAuthExceptionGuardTest.java
@@ -1,0 +1,72 @@
+package com.linkedin.gms.factory.kafka;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.linkedin.gms.factory.config.ConfigurationProvider;
+import com.linkedin.metadata.config.kafka.ConsumerConfiguration;
+import com.linkedin.metadata.config.kafka.KafkaConfiguration;
+import org.springframework.kafka.event.ConsumerRetryAuthEvent;
+import org.springframework.kafka.event.ConsumerRetryAuthSuccessfulEvent;
+import org.springframework.kafka.listener.MessageListenerContainer;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class KafkaConsumerAuthExceptionGuardTest {
+
+  private KafkaConsumerAuthExceptionGuard guard;
+  private MessageListenerContainer container;
+
+  @BeforeMethod
+  public void setup() {
+    ConfigurationProvider configProvider = mock(ConfigurationProvider.class);
+    KafkaConfiguration kafkaConfig = new KafkaConfiguration();
+    ConsumerConfiguration consumerConfig = new ConsumerConfiguration();
+    consumerConfig.setMaxAuthExceptionRetries(3);
+    kafkaConfig.setConsumer(consumerConfig);
+    when(configProvider.getKafka()).thenReturn(kafkaConfig);
+
+    guard = new KafkaConsumerAuthExceptionGuard(configProvider);
+    container = mock(MessageListenerContainer.class);
+    when(container.getListenerId()).thenReturn("test-consumer");
+  }
+
+  @Test
+  void testStopsContainerAfterMaxConsecutiveRetries() {
+    for (int i = 0; i < 2; i++) {
+      guard.onAuthRetry(authRetryEvent());
+    }
+    verify(container, never()).stop();
+
+    // The 3rd retry triggers the stop
+    guard.onAuthRetry(authRetryEvent());
+    verify(container, timeout(1000)).stop();
+  }
+
+  @Test
+  void testSuccessResetsRetryCount() {
+    // Accumulate failures just below the threshold
+    guard.onAuthRetry(authRetryEvent());
+    guard.onAuthRetry(authRetryEvent());
+
+    // Transient recovery resets the counter
+    guard.onAuthRetrySuccess(authSuccessEvent());
+
+    // Another full round of retries below threshold: container must not stop
+    guard.onAuthRetry(authRetryEvent());
+    guard.onAuthRetry(authRetryEvent());
+    verify(container, never()).stop();
+  }
+
+  private ConsumerRetryAuthEvent authRetryEvent() {
+    return new ConsumerRetryAuthEvent(
+        container, container, ConsumerRetryAuthEvent.Reason.AUTHENTICATION);
+  }
+
+  private ConsumerRetryAuthSuccessfulEvent authSuccessEvent() {
+    return new ConsumerRetryAuthSuccessfulEvent(container, container);
+  }
+}

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/kafka/KafkaEventConsumerFactoryTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/kafka/KafkaEventConsumerFactoryTest.java
@@ -1,0 +1,90 @@
+package com.linkedin.gms.factory.kafka;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import com.linkedin.gms.factory.config.ConfigurationProvider;
+import com.linkedin.metadata.config.kafka.ConsumerConfiguration;
+import com.linkedin.metadata.config.kafka.KafkaConfiguration;
+import com.linkedin.metadata.config.kafka.ListenerConfiguration;
+import java.lang.reflect.Field;
+import java.time.Duration;
+import java.util.Map;
+import org.apache.avro.generic.GenericRecord;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class KafkaEventConsumerFactoryTest {
+
+  private KafkaEventConsumerFactory factory;
+  private ConfigurationProvider configProvider;
+  private DefaultKafkaConsumerFactory<String, GenericRecord> kafkaConsumerFactory;
+
+  @BeforeMethod
+  public void setup() {
+    factory = new KafkaEventConsumerFactory();
+    configProvider = mock(ConfigurationProvider.class);
+
+    KafkaConfiguration kafkaConfig = new KafkaConfiguration();
+    kafkaConfig.setBootstrapServers("localhost:9092");
+
+    ConsumerConfiguration consumerConfig = new ConsumerConfiguration();
+    consumerConfig.setAuthExceptionRetryIntervalSeconds(10);
+    consumerConfig.setMaxAuthExceptionRetries(3);
+    consumerConfig.setPe(new ConsumerConfiguration.ConsumerOptions());
+    consumerConfig.setMcp(new ConsumerConfiguration.ConsumerOptions());
+    consumerConfig.setMcl(new ConsumerConfiguration.ConsumerOptions());
+    kafkaConfig.setConsumer(consumerConfig);
+
+    ListenerConfiguration listenerConfig = new ListenerConfiguration();
+    listenerConfig.setConcurrency(1);
+    kafkaConfig.setListener(listenerConfig);
+
+    when(configProvider.getKafka()).thenReturn(kafkaConfig);
+
+    // Create a consumer factory directly — we only need it as input to the listener
+    // factory beans, not to test consumer properties themselves.
+    kafkaConsumerFactory =
+        new DefaultKafkaConsumerFactory<>(Map.of("bootstrap.servers", "localhost:9092"));
+
+    // Initialize the config-driven instance fields that are normally set by createConsumerFactory.
+    // We skip createConsumerFactory because it requires full serde setup.
+    try {
+      Field field =
+          KafkaEventConsumerFactory.class.getDeclaredField("authExceptionRetryIntervalSeconds");
+      field.setAccessible(true);
+      field.setInt(factory, consumerConfig.getAuthExceptionRetryIntervalSeconds());
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  void testAuthExceptionRetryIntervalOnEventConsumers() {
+    // The DEFAULT bean exercises buildDefaultKafkaListenerContainerFactory, which is shared
+    // by all event consumers (PE, MCP, MCL, DEFAULT).
+    var listenerFactory =
+        (ConcurrentKafkaListenerContainerFactory<?, ?>)
+            factory.kafkaEventConsumer(kafkaConsumerFactory, configProvider);
+
+    assertEquals(
+        listenerFactory.getContainerProperties().getAuthExceptionRetryInterval(),
+        Duration.ofSeconds(10),
+        "Event consumers should retry on auth exceptions to survive MSK IAM credential rotation");
+  }
+
+  @Test
+  void testAuthExceptionRetryIntervalOnDuheConsumer() {
+    var listenerFactory =
+        (ConcurrentKafkaListenerContainerFactory<?, ?>)
+            factory.duheKafkaEventConsumer(kafkaConsumerFactory);
+
+    assertEquals(
+        listenerFactory.getContainerProperties().getAuthExceptionRetryInterval(),
+        Duration.ofSeconds(10),
+        "DUHE consumer should retry on auth exceptions to survive MSK IAM credential rotation");
+  }
+}


### PR DESCRIPTION
## Summary

- Adds configurable `authExceptionRetryInterval` to all Kafka consumer container factories (`KafkaEventConsumerFactory`, `SimpleKafkaConsumerFactory`, `CDCConsumerFactory`)
- Adds `KafkaConsumerAuthExceptionGuard` to bound retries: after max consecutive auth failures, the consumer container is stopped so `KafkaHealthIndicator` reports DOWN and Kubernetes can act
- Both settings are configuration-driven via `application.yaml` / env vars, matching the pattern used by `kafka.producer` (retryCount, deliveryTimeout, etc.)
- Prevents MAE/MCE/PE consumer pods from crashing on `SaslAuthenticationException` during MSK IAM credential rotation
- Gives consumers the same self-healing behavior that the GMS producer already has, with equivalent bounding

## Configuration

| Property | Env var | Default | Description |
|---|---|---|---|
| `kafka.consumer.authExceptionRetryIntervalSeconds` | `KAFKA_CONSUMER_AUTH_EXCEPTION_RETRY_INTERVAL_SECONDS` | `10` | Seconds between retries after auth exception. Set to `0` to disable (fatal on first auth exception). |
| `kafka.consumer.maxAuthExceptionRetries` | `KAFKA_CONSUMER_MAX_AUTH_EXCEPTION_RETRIES` | `3` | Max consecutive auth retries before stopping the container. Set to `0` to disable bounding (unbounded retries). |

## Problem

On MSK IAM deployments using EKS Pod Identity, credential rotation (~1h cycle) changes the STS session name. When MSK triggers re-authentication on an existing connection, it rejects the new principal: `Cannot change principals during re-authentication`.

Spring Kafka's default behavior treats `SaslAuthenticationException` as fatal and stops the consumer container immediately. This causes pod restarts on MAE, MCE, and PE consumers.

GMS (producer) already survives this because the Kafka client's `NetworkClient` automatically reconnects with fresh credentials on the next `send()` call. Consumer containers use the same `NetworkClient`, but Spring Kafka kills the container before reconnection can happen.

## Fix

### Auth exception retry interval

`authExceptionRetryInterval` tells Spring Kafka to sleep and retry `poll()` instead of stopping the container. The retry forces a new connection with fresh authentication (not re-authentication), recovering the same way the producer already does.

This is the mechanism Spring Kafka explicitly designed for temporary auth failures. Zero infrastructure changes required.

### Bounded retries (aligned with GMS producer)

Spring Kafka's `authExceptionRetryInterval` retries indefinitely — the container stays "running" and the health check never detects a permanent auth failure. This is unlike the GMS producer, which bounds retries via `delivery.timeout.ms` and `retries`.

`KafkaConsumerAuthExceptionGuard` mirrors the producer's bounding behavior:
- Listens for `ConsumerRetryAuthEvent` and counts consecutive failures per container
- After exceeding the configured max retries, stops the container — `KafkaHealthIndicator` reports DOWN, K8s liveness probes restart the pod
- Resets the counter on `ConsumerRetryAuthSuccessfulEvent` (transient credential rotation recovered)

Transient MSK IAM rotation recovers on the first retry. Reaching the max retry threshold signals a permanent failure requiring operator intervention.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (specifically the [PR title format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [x] Tests added/updated
- [ ] Docs added/updated