### PR TITLE
fix(ci): fix selective CI narrowing for connectors without integration tests

### DIFF
--- a/metadata-ingestion/scripts/selective_ci_checks.py
+++ b/metadata-ingestion/scripts/selective_ci_checks.py
@@ -105,17 +105,41 @@ class ConnectorEntry:
 
 
 @dataclass(frozen=True)
-class EntryPointMapping:
-    """Result of resolving setup.py entry points to test directories."""
+class EntryPointInfo:
+    """Info about a single entry-point module from setup.py."""
 
-    # source_dir -> set of test dirs derived from entry points
-    source_to_tests: dict[str, set[str]] = field(default_factory=dict)
-    # ep module -> test dir (or None for known connectors without integration tests).
-    # Keys include ALL entry-point modules from setup.py. A module mapping to None
-    # means it's a known connector that just has no integration test directory —
-    # distinct from a shared utility (not in this dict at all). This distinction
-    # prevents narrowing failures from cascading through the import graph.
-    ep_module_to_test: dict[str, str | None] = field(default_factory=dict)
+    source_dir: str
+    test_path: str | None = None
+
+
+@dataclass(frozen=True)
+class EntryPointMapping:
+    """Result of resolving setup.py entry points to test directories.
+
+    All data is stored in ep_modules: a dict mapping every entry-point module
+    to its EntryPointInfo. Derived views (source_to_tests, ep_source_dirs) are
+    computed from this single source of truth.
+    """
+
+    # ep module -> info (source_dir + optional test_path).
+    # Keys include ALL entry-point modules from setup.py. A module with
+    # test_path=None is a known connector without integration tests —
+    # distinct from a shared utility (not in this dict at all).
+    ep_modules: dict[str, EntryPointInfo] = field(default_factory=dict)
+
+    @property
+    def source_to_tests(self) -> dict[str, set[str]]:
+        """source_dir -> set of test dirs derived from entry points."""
+        result: dict[str, set[str]] = {}
+        for info in self.ep_modules.values():
+            if info.test_path is not None:
+                result.setdefault(info.source_dir, set()).add(info.test_path)
+        return result
+
+    @property
+    def ep_source_dirs(self) -> set[str]:
+        """Source dirs that contain at least one entry-point module."""
+        return {info.source_dir for info in self.ep_modules.values()}
 
 
 @dataclass(frozen=True)
@@ -371,13 +395,14 @@ def build_source_to_test_dirs(
     # Build module-prefix -> source_dir lookup; longest match wins
     sorted_registry = sorted(registry, key=lambda c: len(c.source_dir), reverse=True)
 
-    # Start with all EP modules mapped to None (no tests).
-    # Modules with matching test dirs get updated below.
-    ep_module_to_test: dict[str, str | None] = {
-        module: None for module in set(plugin_to_module.values())
-    }
+    # Start with all EP modules resolved to their source dir (no tests yet).
+    # Modules with matching test dirs get their test_path set below.
+    ep_modules: dict[str, EntryPointInfo] = {}
+    for module in set(plugin_to_module.values()):
+        src_dir = _find_source_dir(module, sorted_registry)
+        if src_dir:
+            ep_modules[module] = EntryPointInfo(source_dir=src_dir)
 
-    source_to_tests: dict[str, set[str]] = {}
     tests_dir = mi / "tests" / "integration"
 
     if not tests_dir.is_dir():
@@ -386,7 +411,7 @@ def build_source_to_test_dirs(
             f"Entry-point-derived test mapping will be empty.",
             file=sys.stderr,
         )
-        return EntryPointMapping(ep_module_to_test=ep_module_to_test)
+        return EntryPointMapping(ep_modules=ep_modules)
 
     for test_dir in sorted(tests_dir.iterdir()):
         if not test_dir.is_dir() or test_dir.name.startswith("_"):
@@ -397,21 +422,17 @@ def build_source_to_test_dirs(
         if not module:
             continue
 
-        ep_module_to_test[module] = test_rel
         src_dir = _find_source_dir(module, sorted_registry)
         if src_dir:
-            source_to_tests.setdefault(src_dir, set()).add(test_rel)
+            ep_modules[module] = EntryPointInfo(source_dir=src_dir, test_path=test_rel)
 
-    return EntryPointMapping(
-        source_to_tests=source_to_tests,
-        ep_module_to_test=ep_module_to_test,
-    )
+    return EntryPointMapping(ep_modules=ep_modules)
 
 
 def _narrow_ep_tests(
     source_dir: str,
     source_files: list[str],
-    ep_module_to_test: dict[str, str | None],
+    ep_modules: dict[str, EntryPointInfo],
 ) -> set[str] | None:
     """For files changed inside a shared-base source dir, return only the entry-point
     test dirs that map to those specific sub-modules.
@@ -420,14 +441,13 @@ def _narrow_ep_tests(
     caller should fall back to the full ep_mapping.source_to_tests set in that case.
     Returns None also if no files in this dir are in source_files (nothing to narrow).
 
-    ep_module_to_test maps ALL known entry-point modules to their test dir (str) or
-    None for connectors without integration tests. A file matching a None-valued EP
-    is a known connector that just lacks tests — safe to skip without cascading.
+    ep_modules maps ALL known entry-point modules to their EntryPointInfo. A file
+    matching an EP with test_path=None is a known connector that just lacks tests —
+    safe to skip without cascading.
 
-    Example: sql/clickhouse.py -> module datahub.ingestion.source.sql.clickhouse
-             -> ep module datahub.ingestion.source.sql.clickhouse -> clickhouse tests only
+    Example: sql/clickhouse.py -> ep has test_path -> clickhouse tests only
              sql/sql_common.py -> no ep match -> returns None -> caller runs all SQL tests
-             aws/glue.py -> matches ep module (value=None) -> narrowed to empty set
+             aws/glue.py -> ep has test_path=None -> narrowed to empty set
     """
     mi_prefix = f"{MI_PREFIX}{source_dir}/"
     files_in_dir = [f for f in source_files if f.startswith(mi_prefix)]
@@ -439,7 +459,7 @@ def _narrow_ep_tests(
         module = _source_path_to_module(f.removeprefix(MI_PREFIX))
         matched: set[str] = set()
         is_known_ep = False
-        for ep_module, test_dir in ep_module_to_test.items():
+        for ep_module, info in ep_modules.items():
             # File is the ep module itself, or a sub-module, or a parent package of it
             if (
                 module == ep_module
@@ -447,8 +467,8 @@ def _narrow_ep_tests(
                 or ep_module.startswith(module + ".")
             ):
                 is_known_ep = True
-                if test_dir is not None:
-                    matched.add(test_dir)
+                if info.test_path is not None:
+                    matched.add(info.test_path)
         if not matched:
             if is_known_ep:
                 continue  # known connector without tests — skip, don't cascade
@@ -537,12 +557,11 @@ def classify(changed_files: list[str], repo_root: Path) -> CIDecisions:
     # Example: sql/sql_common.py -> narrowing fails, source/sql/ stays in
     #   changed_source_dirs, import graph propagates to all sql dependents correctly.
     pre_resolved_tests: set[str] = set()
-    # Any source dir with entry-point-derived tests is a candidate for narrowing.
-    narrowable = set(ep_mapping.source_to_tests.keys())
+    # Any source dir containing entry-point modules is a candidate for narrowing.
+    # This includes dirs like source/aws/ where all EPs lack integration tests.
+    narrowable = ep_mapping.ep_source_dirs
     for source_dir in list(changed_source_dirs & narrowable):
-        narrowed = _narrow_ep_tests(
-            source_dir, source_files, ep_mapping.ep_module_to_test
-        )
+        narrowed = _narrow_ep_tests(source_dir, source_files, ep_mapping.ep_modules)
         if narrowed is not None:
             pre_resolved_tests.update(narrowed)
             changed_source_dirs.discard(source_dir)

--- a/metadata-ingestion/tests/unit/test_selective_ci_checks.py
+++ b/metadata-ingestion/tests/unit/test_selective_ci_checks.py
@@ -18,6 +18,7 @@ import yaml
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "scripts"))
 from selective_ci_checks import (
     CIDecisions,
+    EntryPointInfo,
     _find_source_dir,
     _narrow_ep_tests,
     _register_plugin_variants,
@@ -618,16 +619,22 @@ class TestSQLNarrowing:
 class TestNarrowEpTests:
     """Direct unit tests for _narrow_ep_tests."""
 
-    EP_MODULE_TO_TEST = {
-        "datahub.ingestion.source.sql.clickhouse": "tests/integration/clickhouse/",
-        "datahub.ingestion.source.sql.mysql": "tests/integration/mysql/",
+    EP_MODULES = {
+        "datahub.ingestion.source.sql.clickhouse": EntryPointInfo(
+            source_dir="src/datahub/ingestion/source/sql",
+            test_path="tests/integration/clickhouse/",
+        ),
+        "datahub.ingestion.source.sql.mysql": EntryPointInfo(
+            source_dir="src/datahub/ingestion/source/sql",
+            test_path="tests/integration/mysql/",
+        ),
     }
 
     def test_specific_file_returns_its_test(self):
         result = _narrow_ep_tests(
             "src/datahub/ingestion/source/sql",
             ["metadata-ingestion/src/datahub/ingestion/source/sql/clickhouse.py"],
-            self.EP_MODULE_TO_TEST,
+            self.EP_MODULES,
         )
         assert result == {"tests/integration/clickhouse/"}
 
@@ -635,7 +642,7 @@ class TestNarrowEpTests:
         result = _narrow_ep_tests(
             "src/datahub/ingestion/source/sql",
             ["metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py"],
-            self.EP_MODULE_TO_TEST,
+            self.EP_MODULES,
         )
         assert result is None
 
@@ -643,7 +650,7 @@ class TestNarrowEpTests:
         result = _narrow_ep_tests(
             "src/datahub/ingestion/source/sql",
             ["metadata-ingestion/src/datahub/ingestion/source/powerbi/powerbi.py"],
-            self.EP_MODULE_TO_TEST,
+            self.EP_MODULES,
         )
         assert result is None
 
@@ -654,7 +661,7 @@ class TestNarrowEpTests:
                 "metadata-ingestion/src/datahub/ingestion/source/sql/clickhouse.py",
                 "metadata-ingestion/src/datahub/ingestion/source/sql/mysql.py",
             ],
-            self.EP_MODULE_TO_TEST,
+            self.EP_MODULES,
         )
         assert result == {
             "tests/integration/clickhouse/",
@@ -669,7 +676,7 @@ class TestNarrowEpTests:
                 "metadata-ingestion/src/datahub/ingestion/source/sql/clickhouse.py",
                 "metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py",
             ],
-            self.EP_MODULE_TO_TEST,
+            self.EP_MODULES,
         )
         assert result is None
 
@@ -685,31 +692,19 @@ class TestBuildSourceToTestDirs:
         )
         assert "tests/integration/clickhouse/" in sql_tests
 
-    def test_ep_module_to_test_populated(self, repo_root):
+    def test_ep_modules_populated(self, repo_root):
         registry = load_connector_registry(repo_root)
         ep_mapping = build_source_to_test_dirs(repo_root, registry)
-        assert "datahub.ingestion.source.sql.clickhouse" in ep_mapping.ep_module_to_test
-        assert (
-            ep_mapping.ep_module_to_test["datahub.ingestion.source.sql.clickhouse"]
-            == "tests/integration/clickhouse/"
-        )
-
-    def test_ep_module_to_test_includes_testless_connectors(self, repo_root):
-        """ep_module_to_test includes ALL entry points, with None for testless ones."""
-        registry = load_connector_registry(repo_root)
-        ep_mapping = build_source_to_test_dirs(repo_root, registry)
-        # clickhouse has a test dir → mapped to its test path
-        assert (
-            ep_mapping.ep_module_to_test["datahub.ingestion.source.sql.clickhouse"]
-            == "tests/integration/clickhouse/"
-        )
+        info = ep_mapping.ep_modules["datahub.ingestion.source.sql.clickhouse"]
+        assert info.test_path == "tests/integration/clickhouse/"
+        assert info.source_dir == "src/datahub/ingestion/source/sql"
 
     def test_missing_setup_py_returns_empty(self, repo_root):
         (repo_root / "metadata-ingestion" / "setup.py").unlink()
         registry = load_connector_registry(repo_root)
         ep_mapping = build_source_to_test_dirs(repo_root, registry)
         assert ep_mapping.source_to_tests == {}
-        assert ep_mapping.ep_module_to_test == {}
+        assert ep_mapping.ep_modules == {}
 
 
 class TestSourcePathToModule:
@@ -911,13 +906,16 @@ class TestNarrowEpParentPackage:
 
     def test_init_file_matches_child_ep(self):
         """Changing sql/__init__.py matches the clickhouse EP via parent-package rule."""
-        ep_module_to_test = {
-            "datahub.ingestion.source.sql.clickhouse": "tests/integration/clickhouse/",
+        ep_modules = {
+            "datahub.ingestion.source.sql.clickhouse": EntryPointInfo(
+                source_dir="src/datahub/ingestion/source/sql",
+                test_path="tests/integration/clickhouse/",
+            ),
         }
         result = _narrow_ep_tests(
             "src/datahub/ingestion/source/sql",
             ["metadata-ingestion/src/datahub/ingestion/source/sql/__init__.py"],
-            ep_module_to_test,
+            ep_modules,
         )
         # __init__.py module is datahub.ingestion.source.sql.__init__
         # This does NOT match clickhouse EP via parent-package rule because
@@ -1027,29 +1025,37 @@ class TestKnownConnectorWithoutTests:
 
     def test_narrow_ep_tests_with_known_ep_no_tests(self):
         """Direct test: _narrow_ep_tests returns empty set for known EP without tests."""
-        ep_module_to_test: dict[str, str | None] = {
-            "datahub.ingestion.source.aws.s3_util": "tests/integration/s3/",
-            "datahub.ingestion.source.aws.glue": None,
-            "datahub.ingestion.source.aws.sagemaker": None,
+        aws_dir = "src/datahub/ingestion/source/aws"
+        ep_modules = {
+            "datahub.ingestion.source.aws.s3_util": EntryPointInfo(
+                source_dir=aws_dir, test_path="tests/integration/s3/"
+            ),
+            "datahub.ingestion.source.aws.glue": EntryPointInfo(source_dir=aws_dir),
+            "datahub.ingestion.source.aws.sagemaker": EntryPointInfo(
+                source_dir=aws_dir
+            ),
         }
         result = _narrow_ep_tests(
-            "src/datahub/ingestion/source/aws",
+            aws_dir,
             ["metadata-ingestion/src/datahub/ingestion/source/aws/glue.py"],
-            ep_module_to_test,
+            ep_modules,
         )
-        # glue is a known EP (value=None) — narrowing succeeds with empty set
+        # glue is a known EP (test_path=None) — narrowing succeeds with empty set
         assert result == set()
 
     def test_narrow_ep_tests_shared_utility_returns_none(self):
         """Direct test: _narrow_ep_tests returns None for shared utility."""
-        ep_module_to_test: dict[str, str | None] = {
-            "datahub.ingestion.source.aws.s3_util": "tests/integration/s3/",
-            "datahub.ingestion.source.aws.glue": None,
+        aws_dir = "src/datahub/ingestion/source/aws"
+        ep_modules = {
+            "datahub.ingestion.source.aws.s3_util": EntryPointInfo(
+                source_dir=aws_dir, test_path="tests/integration/s3/"
+            ),
+            "datahub.ingestion.source.aws.glue": EntryPointInfo(source_dir=aws_dir),
         }
         result = _narrow_ep_tests(
-            "src/datahub/ingestion/source/aws",
+            aws_dir,
             ["metadata-ingestion/src/datahub/ingestion/source/aws/aws_common.py"],
-            ep_module_to_test,
+            ep_modules,
         )
-        # aws_common is NOT a key in ep_module_to_test — narrowing fails
+        # aws_common is NOT a key in ep_modules — narrowing fails
         assert result is None


### PR DESCRIPTION
## Summary

Follow-up to #17036 which introduced the `EntryPointMapping` dataclass but had a bug: source dirs like `source/aws/` where **all** entry-point connectors (glue, sagemaker) lack integration test directories were never entered into the narrowing path because `narrowable` was gated on `source_to_tests.keys()`.

- Introduces `EntryPointInfo` dataclass storing both `source_dir` and `test_path` per EP module
- `EntryPointMapping` now derives `source_to_tests` and `ep_source_dirs` from a single `ep_modules` dict
- Uses `ep_source_dirs` (all dirs with any EP) as the narrowable set instead of `source_to_tests.keys()`

**Verified locally against the real repo:**

| Change | Before | After |
|--------|--------|-------|
| `aws/glue.py` only | 25 integration tests | **0 tests** |
| `aws/glue.py` + unit test | 25 integration tests | **0 tests** |
| `aws/aws_common.py` (shared utility) | 25 tests | **25 tests** (correct) |
| `glue.py` + `aws_common.py` | 25 tests | **25 tests** (correct) |
| `sql/clickhouse.py` | 1 test | **1 test** (unchanged) |

## Test plan

- [x] All 77 unit tests pass (`test_selective_ci_checks.py`)
- [x] Verified with `classify()` against the real repo for all scenarios above
- [ ] Verify on a real PR that changes only `glue.py` to confirm reduced test matrix