### PR TITLE
feat(): Adding lifecycle stages concept to DataHub 

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/Constants.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/Constants.java
@@ -43,6 +43,7 @@ public class Constants {
   public static final String TEMPLATE_SCHEMA_FILE = "template.graphql";
   public static final String MODULE_SCHEMA_FILE = "module.graphql";
   public static final String PATCH_SCHEMA_FILE = "patch.graphql";
+  public static final String LIFECYCLE_SCHEMA_FILE = "lifecycle.graphql";
   public static final String BROWSE_PATH_DELIMITER = "/";
   public static final String BROWSE_PATH_V2_DELIMITER = "␟";
   public static final String VERSION_STAMP_FIELD_NAME = "versionStamp";

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -140,6 +140,9 @@ import com.linkedin.datahub.graphql.resolvers.ingest.source.ListIngestionSources
 import com.linkedin.datahub.graphql.resolvers.ingest.source.UpsertIngestionSourceResolver;
 import com.linkedin.datahub.graphql.resolvers.jobs.EntityRunsResolver;
 import com.linkedin.datahub.graphql.resolvers.jobs.ExecutionRunsResolver;
+import com.linkedin.datahub.graphql.resolvers.lifecycle.ListLifecycleStagesResolver;
+import com.linkedin.datahub.graphql.resolvers.lifecycle.SetLifecycleStageResolver;
+import com.linkedin.datahub.graphql.resolvers.lifecycle.StatusLifecycleStageResolver;
 import com.linkedin.datahub.graphql.resolvers.lineage.UpdateLineageResolver;
 import com.linkedin.datahub.graphql.resolvers.load.AspectResolver;
 import com.linkedin.datahub.graphql.resolvers.load.BatchGetEntitiesResolver;
@@ -763,6 +766,7 @@ public class GmsGraphQLEngine {
   public void configureRuntimeWiring(final RuntimeWiring.Builder builder) {
     configureQueryResolvers(builder);
     configureMutationResolvers(builder);
+    configureLifecycleResolvers(builder);
     configureGenericEntityResolvers(builder);
     configureDatasetResolvers(builder);
     configureCorpUserResolvers(builder);
@@ -891,7 +895,8 @@ public class GmsGraphQLEngine {
         .addSchema(fileBasedSchema(SETTINGS_SCHEMA_FILE))
         .addSchema(fileBasedSchema(FILES_SCHEMA_FILE))
         .addSchema(fileBasedSchema(DOCUMENTS_SCHEMA_FILE))
-        .addSchema(fileBasedSchema(RUNS_SCHEMA_FILE));
+        .addSchema(fileBasedSchema(RUNS_SCHEMA_FILE))
+        .addSchema(fileBasedSchema(LIFECYCLE_SCHEMA_FILE));
 
     for (GmsGraphQLPlugin plugin : this.graphQLPlugins) {
       List<String> pluginSchemaFiles = plugin.getSchemaFiles();
@@ -1228,6 +1233,24 @@ public class GmsGraphQLEngine {
 
   private static String getUrnField(DataFetchingEnvironment env) {
     return env.getArgument(URN_FIELD_NAME);
+  }
+
+  private void configureLifecycleResolvers(final RuntimeWiring.Builder builder) {
+    builder.type(
+        "Query",
+        typeWiring ->
+            typeWiring.dataFetcher(
+                "listLifecycleStages", new ListLifecycleStagesResolver(this.entityClient)));
+    builder.type(
+        "Status",
+        typeWiring ->
+            typeWiring.dataFetcher(
+                "lifecycleStage", new StatusLifecycleStageResolver(this.entityClient)));
+    builder.type(
+        "Mutation",
+        typeWiring ->
+            typeWiring.dataFetcher(
+                "setLifecycleStage", new SetLifecycleStageResolver(this.entityClient)));
   }
 
   private void configureMutationResolvers(final RuntimeWiring.Builder builder) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/lifecycle/LifecycleStageTypeMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/lifecycle/LifecycleStageTypeMapper.java
@@ -1,0 +1,40 @@
+package com.linkedin.datahub.graphql.resolvers.lifecycle;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.datahub.graphql.generated.LifecycleStageType;
+import com.linkedin.lifecycle.LifecycleStageTransitionPolicy;
+import com.linkedin.lifecycle.LifecycleStageTypeInfo;
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+
+/** Maps a {@link LifecycleStageTypeInfo} PDL record to the GraphQL {@link LifecycleStageType}. */
+public final class LifecycleStageTypeMapper {
+
+  public static final String ENTITY_NAME = "lifecycleStageType";
+  public static final String INFO_ASPECT = "lifecycleStageTypeInfo";
+
+  private LifecycleStageTypeMapper() {}
+
+  @Nonnull
+  public static LifecycleStageType map(@Nonnull String urn, @Nonnull LifecycleStageTypeInfo info) {
+    LifecycleStageType result = new LifecycleStageType();
+    result.setUrn(urn);
+    result.setName(info.getName());
+    result.setDescription(info.hasDescription() ? info.getDescription() : null);
+    result.setHideInSearch(info.getSettings().isHideInSearch());
+    result.setEntityTypes(info.hasEntityTypes() ? new ArrayList<>(info.getEntityTypes()) : null);
+
+    if (info.hasTransitionPolicy()) {
+      LifecycleStageTransitionPolicy policy = info.getTransitionPolicy();
+      if (policy.hasAllowedPreviousStages()) {
+        result.setAllowedPreviousStages(
+            policy.getAllowedPreviousStages().stream()
+                .map(Urn::toString)
+                .collect(Collectors.toList()));
+      }
+    }
+
+    return result;
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/lifecycle/ListLifecycleStagesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/lifecycle/ListLifecycleStagesResolver.java
@@ -1,0 +1,94 @@
+package com.linkedin.datahub.graphql.resolvers.lifecycle;
+
+import static com.linkedin.datahub.graphql.resolvers.lifecycle.LifecycleStageTypeMapper.ENTITY_NAME;
+import static com.linkedin.datahub.graphql.resolvers.lifecycle.LifecycleStageTypeMapper.INFO_ASPECT;
+
+import com.google.common.collect.ImmutableSet;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
+import com.linkedin.datahub.graphql.generated.LifecycleStageType;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.lifecycle.LifecycleStageTypeInfo;
+import com.linkedin.metadata.search.SearchEntity;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Returns all registered lifecycle stage types.
+ *
+ * <p>Lifecycle stages are data-driven: operators define their vocabulary by ingesting
+ * lifecycleStageType entities (via bootstrap MCPs or ingestion). This resolver searches for all
+ * such entities and returns their names, URNs, and settings so that agents and UIs can discover the
+ * available stages before calling setLifecycleStage.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class ListLifecycleStagesResolver
+    implements DataFetcher<CompletableFuture<List<LifecycleStageType>>> {
+
+  private final EntityClient _entityClient;
+
+  @Override
+  public CompletableFuture<List<LifecycleStageType>> get(DataFetchingEnvironment environment)
+      throws Exception {
+    final QueryContext context = environment.getContext();
+
+    return GraphQLConcurrencyUtils.supplyAsync(
+        () -> {
+          try {
+            return listStages(context);
+          } catch (Exception e) {
+            log.error("Failed to list lifecycle stages", e);
+            throw new RuntimeException("Failed to list lifecycle stages", e);
+          }
+        },
+        this.getClass().getSimpleName(),
+        "get");
+  }
+
+  @Nonnull
+  private List<LifecycleStageType> listStages(QueryContext context) throws Exception {
+    var searchResult =
+        _entityClient.search(context.getOperationContext(), ENTITY_NAME, "", null, null, 0, 1000);
+
+    if (searchResult == null || searchResult.getEntities().isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    Set<Urn> urns =
+        searchResult.getEntities().stream()
+            .map(SearchEntity::getEntity)
+            .collect(Collectors.toSet());
+
+    Map<Urn, EntityResponse> responses =
+        _entityClient.batchGetV2(
+            context.getOperationContext(), ENTITY_NAME, urns, ImmutableSet.of(INFO_ASPECT));
+
+    List<LifecycleStageType> result = new ArrayList<>();
+    for (Map.Entry<Urn, EntityResponse> entry : responses.entrySet()) {
+      EntityResponse response = entry.getValue();
+      if (!response.getAspects().containsKey(INFO_ASPECT)) {
+        continue;
+      }
+
+      LifecycleStageTypeInfo info =
+          new LifecycleStageTypeInfo(response.getAspects().get(INFO_ASPECT).getValue().data());
+
+      result.add(LifecycleStageTypeMapper.map(entry.getKey().toString(), info));
+    }
+
+    return result;
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/lifecycle/SetLifecycleStageResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/lifecycle/SetLifecycleStageResolver.java
@@ -1,0 +1,93 @@
+package com.linkedin.datahub.graphql.resolvers.lifecycle;
+
+import static com.linkedin.metadata.Constants.STATUS_ASPECT_NAME;
+
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.Status;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
+import com.linkedin.entity.Aspect;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.entity.AspectUtils;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nonnull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Resolves the setLifecycleStage mutation: sets or clears the lifecycle stage on any entity.
+ *
+ * <p>Passing null for lifecycleStageUrn clears the stage (publishes/activates the entity).
+ * Transition rules on the destination stage are enforced by LifecycleStageTransitionHook before the
+ * aspect is persisted.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class SetLifecycleStageResolver implements DataFetcher<CompletableFuture<Boolean>> {
+
+  private final EntityClient _entityClient;
+
+  @Override
+  public CompletableFuture<Boolean> get(DataFetchingEnvironment environment) throws Exception {
+    final QueryContext context = environment.getContext();
+    final String urnStr = environment.getArgument("urn");
+    final String lifecycleStageUrn = environment.getArgument("lifecycleStageUrn");
+
+    return GraphQLConcurrencyUtils.supplyAsync(
+        () -> {
+          try {
+            return setLifecycleStage(urnStr, lifecycleStageUrn, context);
+          } catch (Exception e) {
+            log.error(
+                "Failed to set lifecycle stage {} on entity {}", lifecycleStageUrn, urnStr, e);
+            throw new RuntimeException(
+                String.format("Failed to set lifecycle stage on entity %s", urnStr), e);
+          }
+        },
+        this.getClass().getSimpleName(),
+        "get");
+  }
+
+  private boolean setLifecycleStage(
+      @Nonnull String urnStr, String lifecycleStageUrn, @Nonnull QueryContext context)
+      throws Exception {
+    Urn entityUrn = UrnUtils.getUrn(urnStr);
+    String entityType = entityUrn.getEntityType();
+
+    // Load the current Status aspect, or start fresh
+    Status status = new Status();
+    Aspect existing =
+        _entityClient.getLatestAspectObject(
+            context.getOperationContext(), entityUrn, STATUS_ASPECT_NAME, false);
+    if (existing != null) {
+      status = new Status(existing.data());
+    }
+
+    // Apply the change: set or clear lifecycleStage
+    if (lifecycleStageUrn != null && !lifecycleStageUrn.isBlank()) {
+      status.setLifecycleStage(UrnUtils.getUrn(lifecycleStageUrn));
+    } else {
+      status.removeLifecycleStage();
+    }
+
+    // Record who made this transition and when
+    AuditStamp auditStamp =
+        new AuditStamp()
+            .setTime(System.currentTimeMillis())
+            .setActor(UrnUtils.getUrn(context.getActorUrn()));
+    status.setLifecycleLastUpdated(auditStamp);
+
+    _entityClient.ingestProposal(
+        context.getOperationContext(),
+        AspectUtils.buildMetadataChangeProposal(entityUrn, STATUS_ASPECT_NAME, status),
+        false);
+
+    log.info(
+        "Set lifecycle stage {} on entity {} (type: {})", lifecycleStageUrn, urnStr, entityType);
+    return true;
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/lifecycle/StatusLifecycleStageResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/lifecycle/StatusLifecycleStageResolver.java
@@ -1,0 +1,79 @@
+package com.linkedin.datahub.graphql.resolvers.lifecycle;
+
+import static com.linkedin.datahub.graphql.resolvers.lifecycle.LifecycleStageTypeMapper.ENTITY_NAME;
+import static com.linkedin.datahub.graphql.resolvers.lifecycle.LifecycleStageTypeMapper.INFO_ASPECT;
+
+import com.google.common.collect.ImmutableSet;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
+import com.linkedin.datahub.graphql.generated.LifecycleStageType;
+import com.linkedin.datahub.graphql.generated.Status;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.lifecycle.LifecycleStageTypeInfo;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nonnull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Resolves Status.lifecycleStage by fetching the lifecycleStageTypeInfo aspect for the URN stored
+ * in the partially-populated LifecycleStageType set by StatusMapper.
+ *
+ * <p>StatusMapper populates a skeleton LifecycleStageType with only the urn field. This resolver
+ * enriches it with the full stage definition (name, description, settings, transition policy).
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class StatusLifecycleStageResolver
+    implements DataFetcher<CompletableFuture<LifecycleStageType>> {
+
+  private final EntityClient _entityClient;
+
+  @Override
+  public CompletableFuture<LifecycleStageType> get(DataFetchingEnvironment environment)
+      throws Exception {
+    final Status status = environment.getSource();
+    final LifecycleStageType skeleton = status.getLifecycleStage();
+
+    if (skeleton == null || skeleton.getUrn() == null || skeleton.getUrn().isBlank()) {
+      return CompletableFuture.completedFuture(null);
+    }
+
+    final QueryContext context = environment.getContext();
+    final String stageUrn = skeleton.getUrn();
+
+    return GraphQLConcurrencyUtils.supplyAsync(
+        () -> {
+          try {
+            return resolveStageDetails(stageUrn, context);
+          } catch (Exception e) {
+            log.warn("Failed to resolve lifecycle stage details for URN {}", stageUrn, e);
+            return null;
+          }
+        },
+        this.getClass().getSimpleName(),
+        "get");
+  }
+
+  private LifecycleStageType resolveStageDetails(
+      @Nonnull String stageUrn, @Nonnull QueryContext context) throws Exception {
+    Urn urn = UrnUtils.getUrn(stageUrn);
+    EntityResponse response =
+        _entityClient.getV2(
+            context.getOperationContext(), ENTITY_NAME, urn, ImmutableSet.of(INFO_ASPECT));
+
+    if (response == null || !response.getAspects().containsKey(INFO_ASPECT)) {
+      return null;
+    }
+
+    LifecycleStageTypeInfo info =
+        new LifecycleStageTypeInfo(response.getAspects().get(INFO_ASPECT).getValue().data());
+
+    return LifecycleStageTypeMapper.map(stageUrn, info);
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/SearchFlagsInputMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/SearchFlagsInputMapper.java
@@ -72,6 +72,9 @@ public class SearchFlagsInputMapper
     if (searchFlags.getFilterNonLatestVersions() != null) {
       result.setFilterNonLatestVersions(searchFlags.getFilterNonLatestVersions());
     }
+    if (searchFlags.getIncludeHiddenLifecycleStages() != null) {
+      result.setIncludeHiddenLifecycleStages(searchFlags.getIncludeHiddenLifecycleStages());
+    }
     return result;
   }
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/StatusMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/StatusMapper.java
@@ -1,6 +1,7 @@
 package com.linkedin.datahub.graphql.types.common.mappers;
 
 import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.LifecycleStageType;
 import com.linkedin.datahub.graphql.generated.Status;
 import com.linkedin.datahub.graphql.types.mappers.ModelMapper;
 import javax.annotation.Nonnull;
@@ -20,6 +21,15 @@ public class StatusMapper implements ModelMapper<com.linkedin.common.Status, Sta
       @Nullable QueryContext context, @Nonnull final com.linkedin.common.Status input) {
     final Status result = new Status();
     result.setRemoved(input.isRemoved());
+    if (input.hasLifecycleStage()) {
+      LifecycleStageType skeleton = new LifecycleStageType();
+      skeleton.setUrn(input.getLifecycleStage().toString());
+      result.setLifecycleStage(skeleton);
+    }
+    if (input.hasLifecycleLastUpdated()) {
+      result.setLifecycleLastUpdated(
+          AuditStampMapper.map(context, input.getLifecycleLastUpdated()));
+    }
     return result;
   }
 }

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -2548,6 +2548,11 @@ type GlossaryTerm implements Entity {
   glossaryTermInfo: GlossaryTermInfo
 
   """
+  The lifecycle status of the Glossary Term (removed flag and lifecycle stage).
+  """
+  status: Status
+
+  """
   The deprecation status of the Glossary Term
   """
   deprecation: Deprecation
@@ -4093,6 +4098,20 @@ type Status {
   Whether the entity is removed or not
   """
   removed: Boolean!
+
+  """
+  The resolved lifecycle stage of this entity.
+  When null, the entity is in its default active state (visible in search).
+  When set, provides the full stage definition (name, description, settings)
+  without an additional client round-trip.
+  """
+  lifecycleStage: LifecycleStageType
+
+  """
+  Attribution for the lifecycle stage transition — who moved the entity
+  into its current stage and when.
+  """
+  lifecycleLastUpdated: AuditStamp
 }
 
 """

--- a/datahub-graphql-core/src/main/resources/lifecycle.graphql
+++ b/datahub-graphql-core/src/main/resources/lifecycle.graphql
@@ -1,0 +1,68 @@
+# GraphQL schema for lifecycle stage governance.
+# Lifecycle stages (DRAFT, IN_REVIEW, DEPRECATED, etc.) control entity visibility
+# and signal governance state. Stages are data-driven — operators define their own
+# vocabulary by ingesting lifecycleStageType entities.
+
+"""
+A registered lifecycle stage type.
+"""
+type LifecycleStageType {
+  """
+  Full URN of the lifecycle stage type entity.
+  """
+  urn: String!
+
+  """
+  Display name (e.g. "Draft", "In Review", "Deprecated").
+  """
+  name: String!
+
+  """
+  Optional description of what this stage represents.
+  """
+  description: String
+
+  """
+  Entity type names this stage applies to (e.g. ["glossaryTerm", "document"]).
+  Null / absent means the stage applies to all entity types.
+  """
+  entityTypes: [String!]
+
+  """
+  When true, entities in this stage are excluded from default search results.
+  """
+  hideInSearch: Boolean!
+
+  """
+  Allowed previous stage URNs that may transition into this stage.
+  Null means any prior stage is allowed (no enforcement).
+  Empty list means the stage is unreachable.
+  Use "urn:li:lifecycleStageType:__NONE__" as the sentinel for the default active state.
+  """
+  allowedPreviousStages: [String!]
+}
+
+extend type Query {
+  """
+  Return all registered lifecycle stage types.
+  Useful for agents and UIs to discover available stages before calling setLifecycleStage.
+  """
+  listLifecycleStages: [LifecycleStageType!]!
+}
+
+extend input SearchFlags {
+  """
+  When true, entities explicitly part of hidden lifecycle stages (e.g. DRAFT, IN_REVIEW) are included
+  in search results.
+  """
+  includeHiddenLifecycleStages: Boolean
+}
+
+extend type Mutation {
+  """
+  Set or clear the lifecycle stage on any entity that has a Status aspect.
+  Pass null for lifecycleStageUrn to clear the stage (publish/activate the entity).
+  Transition rules defined on the destination stage are enforced server-side.
+  """
+  setLifecycleStage(urn: String!, lifecycleStageUrn: String): Boolean!
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/lifecycle/LifecycleStageTestUtils.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/lifecycle/LifecycleStageTestUtils.java
@@ -1,0 +1,44 @@
+package com.linkedin.datahub.graphql.resolvers.lifecycle;
+
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.entity.Aspect;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspect;
+import com.linkedin.entity.EnvelopedAspectMap;
+import com.linkedin.lifecycle.LifecycleStageSettings;
+import com.linkedin.lifecycle.LifecycleStageTypeInfo;
+
+/** Shared test helpers for lifecycle resolver tests. */
+final class LifecycleStageTestUtils {
+
+  private LifecycleStageTestUtils() {}
+
+  static EntityResponse makeStageResponse(Urn urn, String name, boolean hideInSearch) {
+    LifecycleStageSettings settings = new LifecycleStageSettings();
+    settings.setHideInSearch(hideInSearch);
+
+    AuditStamp stamp = new AuditStamp();
+    stamp.setTime(0L);
+    stamp.setActor(UrnUtils.getUrn("urn:li:corpuser:system"));
+
+    LifecycleStageTypeInfo info = new LifecycleStageTypeInfo();
+    info.setName(name);
+    info.setSettings(settings);
+    info.setCreated(stamp);
+    info.setLastModified(stamp);
+
+    EnvelopedAspect envelopedAspect = new EnvelopedAspect();
+    envelopedAspect.setValue(new Aspect(info.data()));
+
+    EnvelopedAspectMap aspectMap = new EnvelopedAspectMap();
+    aspectMap.put(LifecycleStageTypeMapper.INFO_ASPECT, envelopedAspect);
+
+    EntityResponse response = new EntityResponse();
+    response.setUrn(urn);
+    response.setEntityName(LifecycleStageTypeMapper.ENTITY_NAME);
+    response.setAspects(aspectMap);
+    return response;
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/lifecycle/LifecycleStageTypeMapperTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/lifecycle/LifecycleStageTypeMapperTest.java
@@ -1,0 +1,114 @@
+package com.linkedin.datahub.graphql.resolvers.lifecycle;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.UrnArray;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.StringArray;
+import com.linkedin.datahub.graphql.generated.LifecycleStageType;
+import com.linkedin.lifecycle.LifecycleStageSettings;
+import com.linkedin.lifecycle.LifecycleStageTransitionPolicy;
+import com.linkedin.lifecycle.LifecycleStageTypeInfo;
+import java.util.List;
+import org.testng.annotations.Test;
+
+public class LifecycleStageTypeMapperTest {
+
+  private static final String URN = "urn:li:lifecycleStageType:DRAFT";
+
+  private static AuditStamp makeStamp() {
+    AuditStamp stamp = new AuditStamp();
+    stamp.setTime(0L);
+    stamp.setActor(UrnUtils.getUrn("urn:li:corpuser:system"));
+    return stamp;
+  }
+
+  private static LifecycleStageTypeInfo makeInfo(String name, boolean hideInSearch) {
+    LifecycleStageSettings settings = new LifecycleStageSettings();
+    settings.setHideInSearch(hideInSearch);
+
+    LifecycleStageTypeInfo info = new LifecycleStageTypeInfo();
+    info.setName(name);
+    info.setSettings(settings);
+    info.setCreated(makeStamp());
+    info.setLastModified(makeStamp());
+    return info;
+  }
+
+  @Test
+  public void testBasicMapping() {
+    LifecycleStageTypeInfo info = makeInfo("Draft", true);
+    info.setDescription("A draft stage");
+    info.setEntityTypes(new StringArray(List.of("dataset", "document")));
+
+    LifecycleStageType result = LifecycleStageTypeMapper.map(URN, info);
+
+    assertEquals(result.getUrn(), URN);
+    assertEquals(result.getName(), "Draft");
+    assertEquals(result.getDescription(), "A draft stage");
+    assertTrue(result.getHideInSearch());
+    assertEquals(result.getEntityTypes(), List.of("dataset", "document"));
+    assertNull(result.getAllowedPreviousStages());
+  }
+
+  @Test
+  public void testMissingDescription() {
+    LifecycleStageTypeInfo info = makeInfo("InReview", false);
+
+    LifecycleStageType result = LifecycleStageTypeMapper.map(URN, info);
+
+    assertNull(result.getDescription());
+  }
+
+  @Test
+  public void testMissingEntityTypes() {
+    LifecycleStageTypeInfo info = makeInfo("Archived", true);
+
+    LifecycleStageType result = LifecycleStageTypeMapper.map(URN, info);
+
+    assertNull(result.getEntityTypes());
+  }
+
+  @Test
+  public void testTransitionPolicyWithAllowedPreviousStages() {
+    LifecycleStageTypeInfo info = makeInfo("InReview", true);
+
+    LifecycleStageTransitionPolicy policy = new LifecycleStageTransitionPolicy();
+    policy.setAllowedPreviousStages(
+        new UrnArray(
+            List.of(
+                UrnUtils.getUrn("urn:li:lifecycleStageType:DRAFT"),
+                UrnUtils.getUrn("urn:li:lifecycleStageType:REJECTED"))));
+    info.setTransitionPolicy(policy);
+
+    LifecycleStageType result = LifecycleStageTypeMapper.map(URN, info);
+
+    assertNotNull(result.getAllowedPreviousStages());
+    assertEquals(result.getAllowedPreviousStages().size(), 2);
+    assertTrue(result.getAllowedPreviousStages().contains("urn:li:lifecycleStageType:DRAFT"));
+    assertTrue(result.getAllowedPreviousStages().contains("urn:li:lifecycleStageType:REJECTED"));
+  }
+
+  @Test
+  public void testTransitionPolicyWithoutAllowedPreviousStages() {
+    LifecycleStageTypeInfo info = makeInfo("Open", false);
+    info.setTransitionPolicy(new LifecycleStageTransitionPolicy());
+
+    LifecycleStageType result = LifecycleStageTypeMapper.map(URN, info);
+
+    assertNull(result.getAllowedPreviousStages());
+  }
+
+  @Test
+  public void testHideInSearchFalse() {
+    LifecycleStageTypeInfo info = makeInfo("Deprecated", false);
+
+    LifecycleStageType result = LifecycleStageTypeMapper.map(URN, info);
+
+    assertEquals(result.getHideInSearch(), false);
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/lifecycle/ListLifecycleStagesResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/lifecycle/ListLifecycleStagesResolverTest.java
@@ -1,0 +1,199 @@
+package com.linkedin.datahub.graphql.resolvers.lifecycle;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.LifecycleStageType;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspectMap;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.search.SearchEntity;
+import com.linkedin.metadata.search.SearchEntityArray;
+import com.linkedin.metadata.search.SearchResult;
+import com.linkedin.metadata.search.SearchResultMetadata;
+import graphql.schema.DataFetchingEnvironment;
+import io.datahubproject.metadata.context.OperationContext;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.testng.annotations.Test;
+
+public class ListLifecycleStagesResolverTest {
+
+  private static final Urn STAGE_URN = UrnUtils.getUrn("urn:li:lifecycleStageType:DRAFT");
+
+  @Test
+  public void testListReturnsStages() throws Exception {
+    EntityClient mockClient = mock(EntityClient.class);
+    QueryContext mockContext = mock(QueryContext.class);
+    when(mockContext.getOperationContext()).thenReturn(mock(OperationContext.class));
+
+    DataFetchingEnvironment mockEnv = mock(DataFetchingEnvironment.class);
+    when(mockEnv.getContext()).thenReturn(mockContext);
+
+    SearchResult searchResult = new SearchResult();
+    searchResult.setEntities(
+        new SearchEntityArray(List.of(new SearchEntity().setEntity(STAGE_URN))));
+    searchResult.setFrom(0);
+    searchResult.setPageSize(1);
+    searchResult.setNumEntities(1);
+    searchResult.setMetadata(new SearchResultMetadata());
+    when(mockClient.search(any(), eq("lifecycleStageType"), any(), any(), any(), eq(0), eq(1000)))
+        .thenReturn(searchResult);
+
+    when(mockClient.batchGetV2(any(), eq("lifecycleStageType"), any(), any()))
+        .thenReturn(
+            Map.of(STAGE_URN, LifecycleStageTestUtils.makeStageResponse(STAGE_URN, "Draft", true)));
+
+    ListLifecycleStagesResolver resolver = new ListLifecycleStagesResolver(mockClient);
+    List<LifecycleStageType> result = resolver.get(mockEnv).get();
+
+    assertEquals(result.size(), 1);
+    LifecycleStageType stage = result.get(0);
+    assertEquals(stage.getUrn(), STAGE_URN.toString());
+    assertEquals(stage.getName(), "Draft");
+    assertTrue(stage.getHideInSearch());
+  }
+
+  @Test
+  public void testListReturnsEmptyWhenNoStages() throws Exception {
+    EntityClient mockClient = mock(EntityClient.class);
+    QueryContext mockContext = mock(QueryContext.class);
+    when(mockContext.getOperationContext()).thenReturn(mock(OperationContext.class));
+
+    DataFetchingEnvironment mockEnv = mock(DataFetchingEnvironment.class);
+    when(mockEnv.getContext()).thenReturn(mockContext);
+
+    SearchResult emptyResult = new SearchResult();
+    emptyResult.setEntities(new SearchEntityArray());
+    emptyResult.setFrom(0);
+    emptyResult.setPageSize(0);
+    emptyResult.setNumEntities(0);
+    emptyResult.setMetadata(new SearchResultMetadata());
+    when(mockClient.search(any(), any(), any(), any(), any(), eq(0), eq(1000)))
+        .thenReturn(emptyResult);
+
+    ListLifecycleStagesResolver resolver = new ListLifecycleStagesResolver(mockClient);
+    List<LifecycleStageType> result = resolver.get(mockEnv).get();
+
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void testListReturnsEmptyWhenSearchReturnsNull() throws Exception {
+    EntityClient mockClient = mock(EntityClient.class);
+    QueryContext mockContext = mock(QueryContext.class);
+    when(mockContext.getOperationContext()).thenReturn(mock(OperationContext.class));
+
+    DataFetchingEnvironment mockEnv = mock(DataFetchingEnvironment.class);
+    when(mockEnv.getContext()).thenReturn(mockContext);
+
+    when(mockClient.search(any(), any(), any(), any(), any(), eq(0), eq(1000))).thenReturn(null);
+
+    ListLifecycleStagesResolver resolver = new ListLifecycleStagesResolver(mockClient);
+    List<LifecycleStageType> result = resolver.get(mockEnv).get();
+
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+    verify(mockClient, never()).batchGetV2(any(), any(), any(), any());
+  }
+
+  @Test
+  public void testListMultipleStages() throws Exception {
+    EntityClient mockClient = mock(EntityClient.class);
+    QueryContext mockContext = mock(QueryContext.class);
+    when(mockContext.getOperationContext()).thenReturn(mock(OperationContext.class));
+
+    DataFetchingEnvironment mockEnv = mock(DataFetchingEnvironment.class);
+    when(mockEnv.getContext()).thenReturn(mockContext);
+
+    Urn draftUrn = UrnUtils.getUrn("urn:li:lifecycleStageType:DRAFT");
+    Urn deprecatedUrn = UrnUtils.getUrn("urn:li:lifecycleStageType:DEPRECATED");
+
+    SearchResult searchResult = new SearchResult();
+    searchResult.setEntities(
+        new SearchEntityArray(
+            List.of(
+                new SearchEntity().setEntity(draftUrn),
+                new SearchEntity().setEntity(deprecatedUrn))));
+    searchResult.setFrom(0);
+    searchResult.setPageSize(2);
+    searchResult.setNumEntities(2);
+    searchResult.setMetadata(new SearchResultMetadata());
+    when(mockClient.search(any(), eq("lifecycleStageType"), any(), any(), any(), eq(0), eq(1000)))
+        .thenReturn(searchResult);
+
+    when(mockClient.batchGetV2(any(), eq("lifecycleStageType"), any(), any()))
+        .thenReturn(
+            Map.of(
+                draftUrn,
+                LifecycleStageTestUtils.makeStageResponse(draftUrn, "Draft", true),
+                deprecatedUrn,
+                LifecycleStageTestUtils.makeStageResponse(deprecatedUrn, "Deprecated", false)));
+
+    ListLifecycleStagesResolver resolver = new ListLifecycleStagesResolver(mockClient);
+    List<LifecycleStageType> result = resolver.get(mockEnv).get();
+
+    assertEquals(result.size(), 2);
+    Set<String> names =
+        result.stream().map(LifecycleStageType::getName).collect(Collectors.toSet());
+    assertTrue(names.contains("Draft"));
+    assertTrue(names.contains("Deprecated"));
+  }
+
+  @Test
+  public void testListSkipsStagesWithoutInfoAspect() throws Exception {
+    EntityClient mockClient = mock(EntityClient.class);
+    QueryContext mockContext = mock(QueryContext.class);
+    when(mockContext.getOperationContext()).thenReturn(mock(OperationContext.class));
+
+    DataFetchingEnvironment mockEnv = mock(DataFetchingEnvironment.class);
+    when(mockEnv.getContext()).thenReturn(mockContext);
+
+    Urn goodUrn = UrnUtils.getUrn("urn:li:lifecycleStageType:DRAFT");
+    Urn badUrn = UrnUtils.getUrn("urn:li:lifecycleStageType:ORPHAN");
+
+    SearchResult searchResult = new SearchResult();
+    searchResult.setEntities(
+        new SearchEntityArray(
+            List.of(new SearchEntity().setEntity(goodUrn), new SearchEntity().setEntity(badUrn))));
+    searchResult.setFrom(0);
+    searchResult.setPageSize(2);
+    searchResult.setNumEntities(2);
+    searchResult.setMetadata(new SearchResultMetadata());
+    when(mockClient.search(any(), eq("lifecycleStageType"), any(), any(), any(), eq(0), eq(1000)))
+        .thenReturn(searchResult);
+
+    // badUrn has a response but no info aspect
+    EntityResponse emptyResponse = new EntityResponse();
+    emptyResponse.setUrn(badUrn);
+    emptyResponse.setEntityName("lifecycleStageType");
+    emptyResponse.setAspects(new EnvelopedAspectMap());
+
+    when(mockClient.batchGetV2(any(), eq("lifecycleStageType"), any(), any()))
+        .thenReturn(
+            Map.of(
+                goodUrn,
+                LifecycleStageTestUtils.makeStageResponse(goodUrn, "Draft", true),
+                badUrn,
+                emptyResponse));
+
+    ListLifecycleStagesResolver resolver = new ListLifecycleStagesResolver(mockClient);
+    List<LifecycleStageType> result = resolver.get(mockEnv).get();
+
+    assertEquals(result.size(), 1);
+    assertEquals(result.get(0).getName(), "Draft");
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/lifecycle/SetLifecycleStageResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/lifecycle/SetLifecycleStageResolverTest.java
@@ -1,0 +1,173 @@
+package com.linkedin.datahub.graphql.resolvers.lifecycle;
+
+import static com.linkedin.metadata.Constants.STATUS_ASPECT_NAME;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.common.Status;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.entity.Aspect;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.utils.GenericRecordUtils;
+import com.linkedin.mxe.MetadataChangeProposal;
+import graphql.schema.DataFetchingEnvironment;
+import io.datahubproject.metadata.context.OperationContext;
+import org.mockito.ArgumentCaptor;
+import org.testng.annotations.Test;
+
+public class SetLifecycleStageResolverTest {
+
+  private static final String ENTITY_URN = "urn:li:dataset:(urn:li:dataPlatform:hdfs,mydata,PROD)";
+  private static final String STAGE_URN = "urn:li:lifecycleStageType:DRAFT";
+  private static final String ACTOR_URN = "urn:li:corpuser:testUser";
+
+  @Test
+  public void testSetLifecycleStage() throws Exception {
+    EntityClient mockClient = mock(EntityClient.class);
+    QueryContext mockContext = mock(QueryContext.class);
+    when(mockContext.getOperationContext()).thenReturn(mock(OperationContext.class));
+    when(mockContext.getActorUrn()).thenReturn(ACTOR_URN);
+
+    DataFetchingEnvironment mockEnv = mock(DataFetchingEnvironment.class);
+    when(mockEnv.getContext()).thenReturn(mockContext);
+    when(mockEnv.getArgument("urn")).thenReturn(ENTITY_URN);
+    when(mockEnv.getArgument("lifecycleStageUrn")).thenReturn(STAGE_URN);
+
+    // Existing Status with removed=true to verify we preserve it
+    Status existingStatus = new Status();
+    existingStatus.setRemoved(true);
+    when(mockClient.getLatestAspectObject(
+            any(), eq(UrnUtils.getUrn(ENTITY_URN)), eq(STATUS_ASPECT_NAME), eq(false)))
+        .thenReturn(new Aspect(existingStatus.data()));
+
+    SetLifecycleStageResolver resolver = new SetLifecycleStageResolver(mockClient);
+    boolean result = resolver.get(mockEnv).get();
+
+    assertTrue(result);
+
+    ArgumentCaptor<MetadataChangeProposal> mcpCaptor =
+        ArgumentCaptor.forClass(MetadataChangeProposal.class);
+    verify(mockClient).ingestProposal(any(), mcpCaptor.capture(), eq(false));
+
+    MetadataChangeProposal mcp = mcpCaptor.getValue();
+    Status written = deserializeStatus(mcp);
+    assertTrue(written.isRemoved(), "Should preserve existing removed=true");
+    assertTrue(written.hasLifecycleStage());
+    assertTrue(written.getLifecycleStage().toString().contains("DRAFT"));
+    assertNotNull(written.getLifecycleLastUpdated(), "Should set attribution");
+    assertEquals(written.getLifecycleLastUpdated().getActor().toString(), ACTOR_URN);
+  }
+
+  @Test
+  public void testClearLifecycleStage() throws Exception {
+    EntityClient mockClient = mock(EntityClient.class);
+    QueryContext mockContext = mock(QueryContext.class);
+    when(mockContext.getOperationContext()).thenReturn(mock(OperationContext.class));
+    when(mockContext.getActorUrn()).thenReturn(ACTOR_URN);
+
+    DataFetchingEnvironment mockEnv = mock(DataFetchingEnvironment.class);
+    when(mockEnv.getContext()).thenReturn(mockContext);
+    when(mockEnv.getArgument("urn")).thenReturn(ENTITY_URN);
+    when(mockEnv.getArgument("lifecycleStageUrn")).thenReturn(null);
+
+    Status existingStatus = new Status();
+    existingStatus.setRemoved(false);
+    existingStatus.setLifecycleStage(UrnUtils.getUrn(STAGE_URN));
+    when(mockClient.getLatestAspectObject(
+            any(), eq(UrnUtils.getUrn(ENTITY_URN)), eq(STATUS_ASPECT_NAME), eq(false)))
+        .thenReturn(new Aspect(existingStatus.data()));
+
+    SetLifecycleStageResolver resolver = new SetLifecycleStageResolver(mockClient);
+    boolean result = resolver.get(mockEnv).get();
+
+    assertTrue(result);
+
+    ArgumentCaptor<MetadataChangeProposal> mcpCaptor =
+        ArgumentCaptor.forClass(MetadataChangeProposal.class);
+    verify(mockClient).ingestProposal(any(), mcpCaptor.capture(), eq(false));
+
+    MetadataChangeProposal mcp = mcpCaptor.getValue();
+    Status written = deserializeStatus(mcp);
+    assertFalse(written.hasLifecycleStage(), "lifecycleStage should be cleared");
+    assertNotNull(written.getLifecycleLastUpdated(), "Should set attribution even when clearing");
+    assertEquals(written.getLifecycleLastUpdated().getActor().toString(), ACTOR_URN);
+  }
+
+  @Test
+  public void testSetLifecycleStageNoExistingStatus() throws Exception {
+    EntityClient mockClient = mock(EntityClient.class);
+    QueryContext mockContext = mock(QueryContext.class);
+    when(mockContext.getOperationContext()).thenReturn(mock(OperationContext.class));
+    when(mockContext.getActorUrn()).thenReturn(ACTOR_URN);
+
+    DataFetchingEnvironment mockEnv = mock(DataFetchingEnvironment.class);
+    when(mockEnv.getContext()).thenReturn(mockContext);
+    when(mockEnv.getArgument("urn")).thenReturn(ENTITY_URN);
+    when(mockEnv.getArgument("lifecycleStageUrn")).thenReturn(STAGE_URN);
+
+    when(mockClient.getLatestAspectObject(any(), any(Urn.class), eq(STATUS_ASPECT_NAME), eq(false)))
+        .thenReturn(null);
+
+    SetLifecycleStageResolver resolver = new SetLifecycleStageResolver(mockClient);
+    boolean result = resolver.get(mockEnv).get();
+
+    assertTrue(result);
+
+    ArgumentCaptor<MetadataChangeProposal> mcpCaptor =
+        ArgumentCaptor.forClass(MetadataChangeProposal.class);
+    verify(mockClient).ingestProposal(any(), mcpCaptor.capture(), eq(false));
+
+    MetadataChangeProposal mcp = mcpCaptor.getValue();
+    Status written = deserializeStatus(mcp);
+    assertFalse(written.isRemoved(), "New status should default to removed=false");
+    assertTrue(written.hasLifecycleStage());
+    assertNotNull(written.getLifecycleLastUpdated(), "Should set attribution");
+    assertEquals(written.getLifecycleLastUpdated().getActor().toString(), ACTOR_URN);
+  }
+
+  @Test
+  public void testClearLifecycleStageWithBlankString() throws Exception {
+    EntityClient mockClient = mock(EntityClient.class);
+    QueryContext mockContext = mock(QueryContext.class);
+    when(mockContext.getOperationContext()).thenReturn(mock(OperationContext.class));
+    when(mockContext.getActorUrn()).thenReturn(ACTOR_URN);
+
+    DataFetchingEnvironment mockEnv = mock(DataFetchingEnvironment.class);
+    when(mockEnv.getContext()).thenReturn(mockContext);
+    when(mockEnv.getArgument("urn")).thenReturn(ENTITY_URN);
+    when(mockEnv.getArgument("lifecycleStageUrn")).thenReturn("   ");
+
+    Status existingStatus = new Status();
+    existingStatus.setLifecycleStage(UrnUtils.getUrn(STAGE_URN));
+    when(mockClient.getLatestAspectObject(
+            any(), eq(UrnUtils.getUrn(ENTITY_URN)), eq(STATUS_ASPECT_NAME), eq(false)))
+        .thenReturn(new Aspect(existingStatus.data()));
+
+    SetLifecycleStageResolver resolver = new SetLifecycleStageResolver(mockClient);
+    boolean result = resolver.get(mockEnv).get();
+
+    assertTrue(result);
+
+    ArgumentCaptor<MetadataChangeProposal> mcpCaptor =
+        ArgumentCaptor.forClass(MetadataChangeProposal.class);
+    verify(mockClient).ingestProposal(any(), mcpCaptor.capture(), eq(false));
+
+    Status written = deserializeStatus(mcpCaptor.getValue());
+    assertFalse(written.hasLifecycleStage(), "Blank string should clear lifecycleStage");
+    assertNotNull(written.getLifecycleLastUpdated());
+  }
+
+  private static Status deserializeStatus(MetadataChangeProposal mcp) {
+    return GenericRecordUtils.deserializeAspect(
+        mcp.getAspect().getValue(), mcp.getAspect().getContentType(), Status.class);
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/lifecycle/StatusLifecycleStageResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/lifecycle/StatusLifecycleStageResolverTest.java
@@ -1,0 +1,149 @@
+package com.linkedin.datahub.graphql.resolvers.lifecycle;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.LifecycleStageType;
+import com.linkedin.datahub.graphql.generated.Status;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspectMap;
+import com.linkedin.entity.client.EntityClient;
+import graphql.schema.DataFetchingEnvironment;
+import io.datahubproject.metadata.context.OperationContext;
+import org.testng.annotations.Test;
+
+public class StatusLifecycleStageResolverTest {
+
+  private static final String STAGE_URN = "urn:li:lifecycleStageType:DRAFT";
+
+  @Test
+  public void testReturnsNullWhenNoLifecycleStage() throws Exception {
+    EntityClient mockClient = mock(EntityClient.class);
+    DataFetchingEnvironment mockEnv = mock(DataFetchingEnvironment.class);
+
+    Status status = new Status();
+    status.setRemoved(false);
+    when(mockEnv.getSource()).thenReturn(status);
+
+    StatusLifecycleStageResolver resolver = new StatusLifecycleStageResolver(mockClient);
+    LifecycleStageType result = resolver.get(mockEnv).get();
+
+    assertNull(result);
+    verify(mockClient, never()).getV2(any(), any(), any(Urn.class), any());
+  }
+
+  @Test
+  public void testResolvesStageDetails() throws Exception {
+    EntityClient mockClient = mock(EntityClient.class);
+    QueryContext mockContext = mock(QueryContext.class);
+    when(mockContext.getOperationContext()).thenReturn(mock(OperationContext.class));
+
+    DataFetchingEnvironment mockEnv = mock(DataFetchingEnvironment.class);
+    when(mockEnv.getContext()).thenReturn(mockContext);
+
+    LifecycleStageType skeleton = new LifecycleStageType();
+    skeleton.setUrn(STAGE_URN);
+
+    Status status = new Status();
+    status.setRemoved(false);
+    status.setLifecycleStage(skeleton);
+    when(mockEnv.getSource()).thenReturn(status);
+
+    EntityResponse response =
+        LifecycleStageTestUtils.makeStageResponse(UrnUtils.getUrn(STAGE_URN), "Draft", true);
+    when(mockClient.getV2(any(), eq("lifecycleStageType"), eq(UrnUtils.getUrn(STAGE_URN)), any()))
+        .thenReturn(response);
+
+    StatusLifecycleStageResolver resolver = new StatusLifecycleStageResolver(mockClient);
+    LifecycleStageType result = resolver.get(mockEnv).get();
+
+    assertNotNull(result);
+    assertEquals(result.getUrn(), STAGE_URN);
+    assertEquals(result.getName(), "Draft");
+    assertTrue(result.getHideInSearch());
+  }
+
+  @Test
+  public void testReturnsNullWhenEntityNotFound() throws Exception {
+    EntityClient mockClient = mock(EntityClient.class);
+    QueryContext mockContext = mock(QueryContext.class);
+    when(mockContext.getOperationContext()).thenReturn(mock(OperationContext.class));
+
+    DataFetchingEnvironment mockEnv = mock(DataFetchingEnvironment.class);
+    when(mockEnv.getContext()).thenReturn(mockContext);
+
+    LifecycleStageType skeleton = new LifecycleStageType();
+    skeleton.setUrn(STAGE_URN);
+
+    Status status = new Status();
+    status.setLifecycleStage(skeleton);
+    when(mockEnv.getSource()).thenReturn(status);
+
+    when(mockClient.getV2(any(), any(), any(Urn.class), any())).thenReturn(null);
+
+    StatusLifecycleStageResolver resolver = new StatusLifecycleStageResolver(mockClient);
+    LifecycleStageType result = resolver.get(mockEnv).get();
+
+    assertNull(result);
+  }
+
+  @Test
+  public void testReturnsNullWhenSkeletonUrnIsBlank() throws Exception {
+    EntityClient mockClient = mock(EntityClient.class);
+    DataFetchingEnvironment mockEnv = mock(DataFetchingEnvironment.class);
+
+    LifecycleStageType skeleton = new LifecycleStageType();
+    skeleton.setUrn("   ");
+
+    Status status = new Status();
+    status.setLifecycleStage(skeleton);
+    when(mockEnv.getSource()).thenReturn(status);
+
+    StatusLifecycleStageResolver resolver = new StatusLifecycleStageResolver(mockClient);
+    LifecycleStageType result = resolver.get(mockEnv).get();
+
+    assertNull(result);
+    verify(mockClient, never()).getV2(any(), any(), any(Urn.class), any());
+  }
+
+  @Test
+  public void testReturnsNullWhenResponseMissingInfoAspect() throws Exception {
+    EntityClient mockClient = mock(EntityClient.class);
+    QueryContext mockContext = mock(QueryContext.class);
+    when(mockContext.getOperationContext()).thenReturn(mock(OperationContext.class));
+
+    DataFetchingEnvironment mockEnv = mock(DataFetchingEnvironment.class);
+    when(mockEnv.getContext()).thenReturn(mockContext);
+
+    LifecycleStageType skeleton = new LifecycleStageType();
+    skeleton.setUrn(STAGE_URN);
+
+    Status status = new Status();
+    status.setLifecycleStage(skeleton);
+    when(mockEnv.getSource()).thenReturn(status);
+
+    EntityResponse emptyResponse = new EntityResponse();
+    emptyResponse.setUrn(UrnUtils.getUrn(STAGE_URN));
+    emptyResponse.setEntityName("lifecycleStageType");
+    emptyResponse.setAspects(new EnvelopedAspectMap());
+
+    when(mockClient.getV2(any(), eq("lifecycleStageType"), eq(UrnUtils.getUrn(STAGE_URN)), any()))
+        .thenReturn(emptyResponse);
+
+    StatusLifecycleStageResolver resolver = new StatusLifecycleStageResolver(mockClient);
+    LifecycleStageType result = resolver.get(mockEnv).get();
+
+    assertNull(result);
+  }
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/aspect/hooks/LifecycleStageTransitionHook.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aspect/hooks/LifecycleStageTransitionHook.java
@@ -1,0 +1,171 @@
+package com.linkedin.metadata.aspect.hooks;
+
+import com.linkedin.common.Status;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.lifecycle.LifecycleStageTransitionPolicy;
+import com.linkedin.lifecycle.LifecycleStageTypeInfo;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.aspect.RetrieverContext;
+import com.linkedin.metadata.aspect.batch.ChangeMCP;
+import com.linkedin.metadata.aspect.plugins.config.AspectPluginConfig;
+import com.linkedin.metadata.aspect.plugins.hooks.MutationHook;
+import com.linkedin.util.Pair;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * MutationHook that validates lifecycle stage transitions on the Status aspect.
+ *
+ * <p>When a Status aspect is proposed with a {@code lifecycleStage} URN, this hook looks up the
+ * <em>proposed</em> stage's {@link LifecycleStageTransitionPolicy} and checks whether the entity's
+ * current stage is in the {@code allowedPreviousStages} list.
+ *
+ * <p>Entry constraints are modeled on the destination stage so that adding a new stage is
+ * self-contained — no edits to existing stages required.
+ *
+ * <ul>
+ *   <li>{@code allowedPreviousStages == null}: any prior stage can enter (no enforcement)
+ *   <li>{@code allowedPreviousStages == []}: nothing can enter (unreachable stage)
+ *   <li>Use {@code urn:li:lifecycleStageType:__NONE__} as a sentinel to allow entry from the
+ *       default active state (no stage set)
+ * </ul>
+ *
+ * <p>Invalid transitions are silently reverted: the proposed {@code lifecycleStage} is reset to the
+ * entity's current value and a WARN is logged. Uses {@link MutationHook#writeMutation} so the
+ * revert is applied in-place before persistence — the same pattern as {@code
+ * CorpUserEditableInfoMutator}.
+ *
+ * <p>All required data is read through {@link RetrieverContext} at call time, following DataHub's
+ * idiomatic hook pattern and avoiding Spring context ordering issues.
+ */
+@Slf4j
+@Getter
+@Setter
+@Accessors(chain = true)
+public class LifecycleStageTransitionHook extends MutationHook {
+
+  /** Aspect name for lifecycle stage type info. */
+  private static final String LIFECYCLE_STAGE_TYPE_INFO_ASPECT = "lifecycleStageTypeInfo";
+
+  /**
+   * Data-map key for the lifecycleStage field in the Status aspect. Used to remove the field when
+   * reverting to the null/active state.
+   */
+  private static final String LIFECYCLE_STAGE_FIELD = "lifecycleStage";
+
+  /** Sentinel URN representing "no lifecycle stage" (default active state). */
+  private static final String NO_STAGE_SENTINEL = "urn:li:lifecycleStageType:__NONE__";
+
+  @Nonnull private AspectPluginConfig config;
+
+  @Override
+  protected Stream<Pair<ChangeMCP, Boolean>> writeMutation(
+      @Nonnull Collection<ChangeMCP> changeMCPS, @Nonnull RetrieverContext retrieverContext) {
+    List<Pair<ChangeMCP, Boolean>> results = new ArrayList<>();
+    for (ChangeMCP item : changeMCPS) {
+      results.add(Pair.of(item, revertIfInvalidTransition(item, retrieverContext)));
+    }
+    return results.stream();
+  }
+
+  /**
+   * Checks whether the proposed lifecycle stage transition is valid. If not, reverts the {@code
+   * lifecycleStage} field in the proposed Status aspect to its previous value (in-place mutation),
+   * logs a WARN, and returns {@code true} to indicate a mutation occurred.
+   */
+  private boolean revertIfInvalidTransition(ChangeMCP item, RetrieverContext retrieverContext) {
+    if (!Constants.STATUS_ASPECT_NAME.equals(item.getAspectName())) {
+      return false;
+    }
+
+    Status proposedStatus = item.getAspect(Status.class);
+    if (proposedStatus == null || !proposedStatus.hasLifecycleStage()) {
+      // Clearing the stage (→ null/active) is always allowed.
+      return false;
+    }
+
+    Urn proposedStageUrn = proposedStatus.getLifecycleStage();
+
+    // Current stage from the previous aspect (already loaded by the write pipeline).
+    Status previousStatus = item.getPreviousAspect(Status.class);
+    Urn currentStageUrn =
+        previousStatus != null && previousStatus.hasLifecycleStage()
+            ? previousStatus.getLifecycleStage()
+            : null;
+
+    // Same stage → no-op, allow.
+    if (proposedStageUrn.equals(currentStageUrn)) {
+      return false;
+    }
+
+    // Look up the PROPOSED (destination) stage's entry policy via RetrieverContext.
+    LifecycleStageTransitionPolicy policy = getTransitionPolicy(proposedStageUrn, retrieverContext);
+    if (policy == null || !policy.hasAllowedPreviousStages()) {
+      // No policy on destination stage → open entry, allow.
+      return false;
+    }
+
+    Set<String> allowed =
+        Set.copyOf(policy.getAllowedPreviousStages().stream().map(Urn::toString).toList());
+
+    String currentStageKey =
+        currentStageUrn == null ? NO_STAGE_SENTINEL : currentStageUrn.toString();
+
+    if (!allowed.contains(currentStageKey)) {
+      log.warn(
+          "Lifecycle stage transition to {} from {} on {} is not allowed. "
+              + "Allowed previous stages: {}. Reverting to previous stage.",
+          proposedStageUrn,
+          currentStageUrn == null ? "(none/active)" : currentStageUrn,
+          item.getUrn(),
+          allowed);
+
+      // Revert: restore the previous lifecycleStage in the proposed Status aspect.
+      if (currentStageUrn != null) {
+        proposedStatus.setLifecycleStage(currentStageUrn);
+      } else {
+        // Remove the field to restore the null/active state.
+        proposedStatus.data().remove(LIFECYCLE_STAGE_FIELD);
+      }
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Returns the {@link LifecycleStageTransitionPolicy} for the given stage URN by reading the
+   * {@code lifecycleStageTypeInfo} aspect through the {@link RetrieverContext}.
+   *
+   * <p>Returns {@code null} if the stage is not found or defines no policy — meaning open entry.
+   */
+  @Nullable
+  private LifecycleStageTransitionPolicy getTransitionPolicy(
+      Urn stageUrn, RetrieverContext retrieverContext) {
+    try {
+      var stageAspect =
+          retrieverContext
+              .getAspectRetriever()
+              .getLatestAspectObject(stageUrn, LIFECYCLE_STAGE_TYPE_INFO_ASPECT);
+      if (stageAspect == null) {
+        log.warn("Lifecycle stage {} not found in aspect store, allowing transition", stageUrn);
+        return null;
+      }
+      LifecycleStageTypeInfo info = new LifecycleStageTypeInfo(stageAspect.data());
+      return info.hasTransitionPolicy() ? info.getTransitionPolicy() : null;
+    } catch (Exception e) {
+      log.warn(
+          "Failed to retrieve transition policy for stage {}, allowing transition", stageUrn, e);
+      return null;
+    }
+  }
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/aspect/validation/LifecycleStageValidator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aspect/validation/LifecycleStageValidator.java
@@ -1,0 +1,108 @@
+package com.linkedin.metadata.aspect.validation;
+
+import com.linkedin.common.Status;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.lifecycle.LifecycleStageTypeInfo;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.aspect.RetrieverContext;
+import com.linkedin.metadata.aspect.batch.BatchItem;
+import com.linkedin.metadata.aspect.batch.ChangeMCP;
+import com.linkedin.metadata.aspect.plugins.config.AspectPluginConfig;
+import com.linkedin.metadata.aspect.plugins.validation.AspectPayloadValidator;
+import com.linkedin.metadata.aspect.plugins.validation.AspectValidationException;
+import com.linkedin.metadata.aspect.plugins.validation.ValidationExceptionCollection;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Validates that lifecycleStage URNs on Status aspects reference existing lifecycleStageType
+ * entities and that the stage is applicable to the target entity's type.
+ */
+@Slf4j
+@Setter
+@Getter
+@Accessors(chain = true)
+public class LifecycleStageValidator extends AspectPayloadValidator {
+
+  private static final String LIFECYCLE_STAGE_TYPE_INFO_ASPECT = "lifecycleStageTypeInfo";
+
+  @Nonnull private AspectPluginConfig config;
+
+  @Override
+  protected Stream<AspectValidationException> validateProposedAspects(
+      @Nonnull Collection<? extends BatchItem> mcpItems,
+      @Nonnull RetrieverContext retrieverContext) {
+
+    ValidationExceptionCollection exceptions = ValidationExceptionCollection.newCollection();
+
+    for (BatchItem item : mcpItems) {
+      if (!Constants.STATUS_ASPECT_NAME.equals(item.getAspectName())) {
+        continue;
+      }
+
+      Status status = item.getAspect(Status.class);
+      if (status == null || !status.hasLifecycleStage()) {
+        continue;
+      }
+
+      Urn stageUrn = status.getLifecycleStage();
+      LifecycleStageTypeInfo info = fetchStageInfo(stageUrn, retrieverContext);
+
+      if (info == null) {
+        exceptions.addException(
+            AspectValidationException.forItem(
+                item,
+                String.format(
+                    "Lifecycle stage '%s' does not exist. "
+                        + "Use listLifecycleStages to discover available stages.",
+                    stageUrn)));
+        continue;
+      }
+
+      String entityType = item.getUrn().getEntityType();
+      if (info.hasEntityTypes() && !info.getEntityTypes().isEmpty()) {
+        List<String> allowedTypes = info.getEntityTypes();
+        if (!allowedTypes.contains(entityType)) {
+          exceptions.addException(
+              AspectValidationException.forItem(
+                  item,
+                  String.format(
+                      "Lifecycle stage '%s' does not apply to entity type '%s'. "
+                          + "Allowed entity types: %s",
+                      stageUrn, entityType, allowedTypes)));
+        }
+      }
+    }
+
+    return exceptions.streamAllExceptions();
+  }
+
+  @Override
+  protected Stream<AspectValidationException> validatePreCommitAspects(
+      @Nonnull Collection<ChangeMCP> changeMCPs, @Nonnull RetrieverContext retrieverContext) {
+    return Stream.empty();
+  }
+
+  private LifecycleStageTypeInfo fetchStageInfo(Urn stageUrn, RetrieverContext retrieverContext) {
+    try {
+      RecordTemplate aspect =
+          retrieverContext
+              .getAspectRetriever()
+              .getLatestAspectObject(stageUrn, LIFECYCLE_STAGE_TYPE_INFO_ASPECT);
+      if (aspect == null) {
+        return null;
+      }
+      return new LifecycleStageTypeInfo(aspect.data());
+    } catch (Exception e) {
+      log.warn("Failed to fetch lifecycle stage info for {}", stageUrn, e);
+      return null;
+    }
+  }
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
@@ -3069,7 +3069,7 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
                       } else if (deleteItem
                           .getEntitySpec()
                           .hasAspect(Constants.STATUS_ASPECT_NAME)) {
-                        // soft delete by setting status.removed=true (if applicable)
+                        // Soft delete: set removed=true.
                         final Status statusAspect = new Status();
                         statusAspect.setRemoved(true);
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/utils/ESUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/utils/ESUtils.java
@@ -36,6 +36,7 @@ import com.linkedin.metadata.search.elasticsearch.index.MappingsBuilder;
 import com.linkedin.metadata.search.elasticsearch.query.filter.QueryFilterRewriteChain;
 import com.linkedin.metadata.search.elasticsearch.query.filter.QueryFilterRewriterContext;
 import com.linkedin.metadata.search.elasticsearch.query.request.SearchAfterWrapper;
+import com.linkedin.metadata.service.LifecycleStageTypeService;
 import com.linkedin.metadata.utils.CriterionUtils;
 import com.linkedin.metadata.utils.elasticsearch.SearchClientShim;
 import com.linkedin.metadata.utils.elasticsearch.responses.RawResponse;
@@ -87,12 +88,30 @@ import org.opensearch.search.suggest.term.TermSuggestionBuilder;
 @Slf4j
 public class ESUtils {
 
+  /**
+   * Holds the LifecycleStageTypeService singleton for use in default search filters. Set once at
+   * startup via setLifecycleStageTypeService(). Volatile for visibility across threads.
+   */
+  @Nullable private static volatile LifecycleStageTypeService lifecycleStageTypeService;
+
+  /** Wires the service into the search filter path. Called once from the Spring factory. */
+  public static void setLifecycleStageTypeService(@Nullable LifecycleStageTypeService service) {
+    ESUtils.lifecycleStageTypeService = service;
+  }
+
+  /** Returns the currently wired service, or null if not yet set. */
+  @Nullable
+  public static LifecycleStageTypeService getLifecycleStageTypeService() {
+    return lifecycleStageTypeService;
+  }
+
   private static final String DEFAULT_SEARCH_RESULTS_SORT_BY_FIELD = "urn";
   public static final String KEYWORD_ANALYZER = "keyword";
   public static final String KEYWORD_SUFFIX = ".keyword";
   public static final String OPAQUE_ID_HEADER = "X-Opaque-Id";
   public static final String HEADER_VALUE_DELIMITER = "|";
   public static final String REMOVED = "removed";
+  public static final String LIFECYCLE_STAGE = "lifecycleStage";
   public static final String ALIAS_FIELD_TYPE = "alias";
   public static final String TYPE = "type";
   public static final String KEYWORD = "keyword";
@@ -1120,40 +1139,85 @@ public class ESUtils {
     }
   }
 
+  /**
+   * Resolves the set of hidden lifecycle stage URNs for the given entity types, or empty if the
+   * service is not wired yet or the search targets lifecycle stage types themselves.
+   */
+  @Nonnull
+  public static Set<String> resolveHiddenStageUrns(@Nonnull List<String> entityNames) {
+    return (lifecycleStageTypeService != null
+            && !entityNames.contains(LifecycleStageTypeService.LIFECYCLE_STAGE_TYPE_ENTITY_NAME))
+        ? lifecycleStageTypeService.getHiddenStageUrns(new HashSet<>(entityNames))
+        : Collections.emptySet();
+  }
+
   @Nonnull
   public static BoolQueryBuilder applyDefaultSearchFilters(
       @Nonnull OperationContext opContext,
       @Nonnull List<String> entityNames,
       @Nullable Filter filter,
       @Nonnull BoolQueryBuilder filterQuery) {
-    // filter soft deleted entities by default
-    filterSoftDeletedByDefault(filter, filterQuery, opContext.getSearchContext().getSearchFlags());
+    return applyDefaultSearchFilters(
+        opContext, entityNames, filter, filterQuery, resolveHiddenStageUrns(entityNames));
+  }
+
+  @Nonnull
+  public static BoolQueryBuilder applyDefaultSearchFilters(
+      @Nonnull OperationContext opContext,
+      @Nonnull List<String> entityNames,
+      @Nullable Filter filter,
+      @Nonnull BoolQueryBuilder filterQuery,
+      @Nonnull Set<String> hiddenLifecycleStageUrns) {
+    filterSoftDeletedAndHiddenStages(
+        filter,
+        filterQuery,
+        opContext.getSearchContext().getSearchFlags(),
+        hiddenLifecycleStageUrns);
     return filterQuery;
   }
 
   /**
-   * Applies a default filter to remove entities that are soft deleted only if there isn't a filter
-   * for the REMOVED field already and soft delete entities are not being requested via search flags
+   * Applies default filters to exclude soft-deleted entities and entities in hidden lifecycle
+   * stages unless the caller has explicitly opted in or already filtered on those fields.
+   *
+   * <p>Soft-delete exclusion (removed=true): controlled by SearchFlags.includeSoftDeleted.
+   *
+   * <p>Lifecycle stage exclusion: driven by {@code hiddenLifecycleStageUrns} — the set of lifecycle
+   * stage type URNs whose settings specify {@code hideInSearch=true}. Controlled by
+   * SearchFlags.includeHiddenLifecycleStages. When the caller already filters on the {@code
+   * lifecycleStage} field, the default exclusion is bypassed.
    */
-  private static void filterSoftDeletedByDefault(
+  private static void filterSoftDeletedAndHiddenStages(
       @Nullable Filter filter,
       @Nonnull BoolQueryBuilder filterQuery,
-      @Nonnull SearchFlags searchFlags) {
-    if (Boolean.FALSE.equals(searchFlags.isIncludeSoftDeleted())) {
-      boolean removedInOrFilter = false;
-      if (filter != null) {
-        removedInOrFilter =
-            filter.getOr().stream()
-                .anyMatch(
-                    or ->
-                        or.getAnd().stream()
-                            .anyMatch(
-                                criterion ->
-                                    criterion.getField().equals(REMOVED)
-                                        || criterion.getField().equals(REMOVED + KEYWORD_SUFFIX)));
+      @Nonnull SearchFlags searchFlags,
+      @Nonnull Set<String> hiddenLifecycleStageUrns) {
+    boolean removedInOrFilter = false;
+    boolean lifecycleStageInOrFilter = false;
+    if (filter != null) {
+      for (var or : filter.getOr()) {
+        for (var criterion : or.getAnd()) {
+          String field = criterion.getField();
+          if (field.equals(REMOVED) || field.equals(REMOVED + KEYWORD_SUFFIX)) {
+            removedInOrFilter = true;
+          }
+          if (field.equals(LIFECYCLE_STAGE) || field.equals(LIFECYCLE_STAGE + KEYWORD_SUFFIX)) {
+            lifecycleStageInOrFilter = true;
+          }
+        }
       }
-      if (!removedInOrFilter) {
-        filterQuery.mustNot(QueryBuilders.termQuery(REMOVED, true));
+    }
+
+    if (Boolean.FALSE.equals(searchFlags.isIncludeSoftDeleted()) && !removedInOrFilter) {
+      filterQuery.mustNot(QueryBuilders.termQuery(REMOVED, true));
+    }
+
+    // Exclude entities in hidden lifecycle stages unless the caller opted in or already filters.
+    if (!Boolean.TRUE.equals(searchFlags.isIncludeHiddenLifecycleStages())
+        && !lifecycleStageInOrFilter
+        && !hiddenLifecycleStageUrns.isEmpty()) {
+      for (String stageUrn : hiddenLifecycleStageUrns) {
+        filterQuery.mustNot(QueryBuilders.termQuery(LIFECYCLE_STAGE + KEYWORD_SUFFIX, stageUrn));
       }
     }
   }

--- a/metadata-io/src/test/java/com/linkedin/metadata/aspect/hooks/LifecycleStageTransitionHookTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/aspect/hooks/LifecycleStageTransitionHookTest.java
@@ -1,0 +1,295 @@
+package com.linkedin.metadata.aspect.hooks;
+
+import static com.linkedin.metadata.Constants.STATUS_ASPECT_NAME;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.Status;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.entity.Aspect;
+import com.linkedin.lifecycle.LifecycleStageSettings;
+import com.linkedin.lifecycle.LifecycleStageTransitionPolicy;
+import com.linkedin.lifecycle.LifecycleStageTypeInfo;
+import com.linkedin.metadata.aspect.CachingAspectRetriever;
+import com.linkedin.metadata.aspect.GraphRetriever;
+import com.linkedin.metadata.aspect.batch.ChangeMCP;
+import com.linkedin.metadata.aspect.plugins.config.AspectPluginConfig;
+import com.linkedin.metadata.entity.SearchRetriever;
+import com.linkedin.util.Pair;
+import io.datahubproject.metadata.context.RetrieverContext;
+import java.util.List;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class LifecycleStageTransitionHookTest {
+
+  private static final Urn TEST_ENTITY_URN =
+      UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:postgres,test.table,PROD)");
+  private static final Urn PROPOSED_STAGE = UrnUtils.getUrn("urn:li:lifecycleStageType:PROPOSED");
+  private static final Urn CERTIFIED_STAGE = UrnUtils.getUrn("urn:li:lifecycleStageType:CERTIFIED");
+  private static final Urn ARCHIVED_STAGE = UrnUtils.getUrn("urn:li:lifecycleStageType:ARCHIVED");
+
+  private static final AspectPluginConfig HOOK_CONFIG =
+      AspectPluginConfig.builder()
+          .className(LifecycleStageTransitionHook.class.getName())
+          .enabled(true)
+          .supportedOperations(List.of("UPSERT"))
+          .supportedEntityAspectNames(
+              List.of(
+                  AspectPluginConfig.EntityAspectName.builder()
+                      .entityName("*")
+                      .aspectName(STATUS_ASPECT_NAME)
+                      .build()))
+          .build();
+
+  private CachingAspectRetriever mockAspectRetriever;
+  private RetrieverContext retrieverContext;
+
+  @BeforeMethod
+  public void setup() {
+    mockAspectRetriever = mock(CachingAspectRetriever.class);
+    retrieverContext =
+        RetrieverContext.builder()
+            .searchRetriever(mock(SearchRetriever.class))
+            .cachingAspectRetriever(mockAspectRetriever)
+            .graphRetriever(GraphRetriever.EMPTY)
+            .build();
+    // Default: return null for any stage info lookup (no policy → open entry)
+    when(mockAspectRetriever.getLatestAspectObject(any(), eq("lifecycleStageTypeInfo")))
+        .thenReturn(null);
+  }
+
+  @Test
+  public void testAllowedTransition_noPolicyOnDestination() {
+    // No transition policy on PROPOSED → any prior stage can enter; Status unchanged
+    when(mockAspectRetriever.getLatestAspectObject(
+            eq(PROPOSED_STAGE), eq("lifecycleStageTypeInfo")))
+        .thenReturn(makeStageAspect(true, null));
+
+    Status proposedStatus = makeStatus(PROPOSED_STAGE);
+    ChangeMCP item = makeChangeMCP(proposedStatus, null);
+
+    List<Pair<ChangeMCP, Boolean>> result =
+        buildHook().writeMutation(List.of(item), retrieverContext).toList();
+
+    assertEquals(result.size(), 1);
+    assertFalse(result.get(0).getSecond(), "No mutation expected for allowed transition");
+    assertTrue(proposedStatus.hasLifecycleStage(), "Status should retain the new stage");
+  }
+
+  @Test
+  public void testAllowedTransition_currentStageInAllowedList() {
+    // CERTIFIED allows entry from PROPOSED
+    LifecycleStageTransitionPolicy policy = new LifecycleStageTransitionPolicy();
+    policy.setAllowedPreviousStages(new com.linkedin.common.UrnArray(List.of(PROPOSED_STAGE)));
+    when(mockAspectRetriever.getLatestAspectObject(
+            eq(CERTIFIED_STAGE), eq("lifecycleStageTypeInfo")))
+        .thenReturn(makeStageAspect(false, policy));
+
+    // Proposing CERTIFIED; entity is currently in PROPOSED
+    Status proposedStatus = makeStatus(CERTIFIED_STAGE);
+    Status previousStatus = makeStatus(PROPOSED_STAGE);
+    ChangeMCP item = makeChangeMCP(proposedStatus, previousStatus);
+
+    List<Pair<ChangeMCP, Boolean>> result =
+        buildHook().writeMutation(List.of(item), retrieverContext).toList();
+
+    assertEquals(result.size(), 1);
+    assertFalse(result.get(0).getSecond(), "PROPOSED → CERTIFIED should be allowed, no mutation");
+    assertEquals(proposedStatus.getLifecycleStage(), CERTIFIED_STAGE);
+  }
+
+  @Test
+  public void testBlockedTransition_currentStageNotInAllowedList() {
+    // CERTIFIED only allows entry from PROPOSED, not from ARCHIVED → revert
+    LifecycleStageTransitionPolicy policy = new LifecycleStageTransitionPolicy();
+    policy.setAllowedPreviousStages(new com.linkedin.common.UrnArray(List.of(PROPOSED_STAGE)));
+    when(mockAspectRetriever.getLatestAspectObject(
+            eq(CERTIFIED_STAGE), eq("lifecycleStageTypeInfo")))
+        .thenReturn(makeStageAspect(false, policy));
+
+    // Proposing CERTIFIED; entity is currently in ARCHIVED (not allowed)
+    Status proposedStatus = makeStatus(CERTIFIED_STAGE);
+    Status previousStatus = makeStatus(ARCHIVED_STAGE);
+    ChangeMCP item = makeChangeMCP(proposedStatus, previousStatus);
+
+    List<Pair<ChangeMCP, Boolean>> result =
+        buildHook().writeMutation(List.of(item), retrieverContext).toList();
+
+    assertEquals(result.size(), 1);
+    assertTrue(result.get(0).getSecond(), "ARCHIVED → CERTIFIED should be blocked (mutation)");
+    // Reverted: lifecycleStage restored to ARCHIVED
+    assertEquals(
+        proposedStatus.getLifecycleStage(),
+        ARCHIVED_STAGE,
+        "Stage should be reverted to previous value");
+  }
+
+  @Test
+  public void testBlockedTransition_emptyAllowedList() {
+    // ARCHIVED has empty allowedPreviousStages → unreachable; revert to null
+    LifecycleStageTransitionPolicy policy = new LifecycleStageTransitionPolicy();
+    policy.setAllowedPreviousStages(new com.linkedin.common.UrnArray());
+    when(mockAspectRetriever.getLatestAspectObject(
+            eq(ARCHIVED_STAGE), eq("lifecycleStageTypeInfo")))
+        .thenReturn(makeStageAspect(true, policy));
+
+    // Proposing ARCHIVED from the null/active state
+    Status proposedStatus = makeStatus(ARCHIVED_STAGE);
+    ChangeMCP item = makeChangeMCP(proposedStatus, null); // no previous stage
+
+    List<Pair<ChangeMCP, Boolean>> result =
+        buildHook().writeMutation(List.of(item), retrieverContext).toList();
+
+    assertEquals(result.size(), 1);
+    assertTrue(result.get(0).getSecond(), "Unreachable stage should be blocked (mutation)");
+    // Reverted to null/active: lifecycleStage field removed
+    assertFalse(
+        proposedStatus.hasLifecycleStage(), "Stage should be cleared (reverted to null/active)");
+  }
+
+  @Test
+  public void testAllowedTransition_fromNoStageViaSentinel() {
+    // PROPOSED allows entry only from __NONE__ (default active state)
+    Urn noneSentinel = UrnUtils.getUrn("urn:li:lifecycleStageType:__NONE__");
+    LifecycleStageTransitionPolicy policy = new LifecycleStageTransitionPolicy();
+    policy.setAllowedPreviousStages(new com.linkedin.common.UrnArray(List.of(noneSentinel)));
+    when(mockAspectRetriever.getLatestAspectObject(
+            eq(PROPOSED_STAGE), eq("lifecycleStageTypeInfo")))
+        .thenReturn(makeStageAspect(true, policy));
+
+    // No current stage → matches __NONE__ sentinel → allowed
+    Status proposedStatus = makeStatus(PROPOSED_STAGE);
+    ChangeMCP item = makeChangeMCP(proposedStatus, null);
+
+    List<Pair<ChangeMCP, Boolean>> result =
+        buildHook().writeMutation(List.of(item), retrieverContext).toList();
+
+    assertEquals(result.size(), 1);
+    assertFalse(
+        result.get(0).getSecond(), "(none) → PROPOSED via __NONE__ sentinel should be allowed");
+    assertTrue(proposedStatus.hasLifecycleStage());
+  }
+
+  @Test
+  public void testClearingStageAlwaysAllowed() {
+    // Clearing the stage (proposing null) is always allowed regardless of policy
+    Status proposedStatus = new Status();
+    proposedStatus.setRemoved(false);
+    // No lifecycleStage set (clearing)
+    Status previousStatus = makeStatus(PROPOSED_STAGE);
+    ChangeMCP item = makeChangeMCP(proposedStatus, previousStatus);
+
+    List<Pair<ChangeMCP, Boolean>> result =
+        buildHook().writeMutation(List.of(item), retrieverContext).toList();
+
+    assertEquals(result.size(), 1);
+    assertFalse(result.get(0).getSecond(), "Clearing lifecycle stage should never mutate");
+    assertFalse(
+        proposedStatus.hasLifecycleStage(), "Status should have no lifecycleStage after clear");
+  }
+
+  @Test
+  public void testSameStageNoOp() {
+    // Entity already in PROPOSED, proposing PROPOSED again → no-op, no mutation
+    Status proposedStatus = makeStatus(PROPOSED_STAGE);
+    Status previousStatus = makeStatus(PROPOSED_STAGE);
+    ChangeMCP item = makeChangeMCP(proposedStatus, previousStatus);
+
+    List<Pair<ChangeMCP, Boolean>> result =
+        buildHook().writeMutation(List.of(item), retrieverContext).toList();
+
+    assertEquals(result.size(), 1);
+    assertFalse(result.get(0).getSecond(), "Re-applying same stage should not mutate");
+    assertEquals(proposedStatus.getLifecycleStage(), PROPOSED_STAGE);
+  }
+
+  @Test
+  public void testNonStatusAspect_passThrough() {
+    // Non-status aspects are ignored by the hook
+    ChangeMCP item = mock(ChangeMCP.class);
+    when(item.getAspectName()).thenReturn("glossaryTermInfo");
+
+    List<Pair<ChangeMCP, Boolean>> result =
+        buildHook().writeMutation(List.of(item), retrieverContext).toList();
+
+    assertEquals(result.size(), 1);
+    assertFalse(result.get(0).getSecond(), "Non-status aspect should not be mutated");
+  }
+
+  @Test
+  public void testRevertToNullWhenNoPreviousAspect() {
+    // Invalid transition from null → blocked stage; revert clears the field
+    LifecycleStageTransitionPolicy policy = new LifecycleStageTransitionPolicy();
+    policy.setAllowedPreviousStages(
+        new com.linkedin.common.UrnArray(List.of(PROPOSED_STAGE))); // only PROPOSED allowed
+    when(mockAspectRetriever.getLatestAspectObject(
+            eq(CERTIFIED_STAGE), eq("lifecycleStageTypeInfo")))
+        .thenReturn(makeStageAspect(false, policy));
+
+    // Proposing CERTIFIED from null/active (not in allowed list) → revert to null
+    Status proposedStatus = makeStatus(CERTIFIED_STAGE);
+    ChangeMCP item = makeChangeMCP(proposedStatus, null);
+
+    List<Pair<ChangeMCP, Boolean>> result =
+        buildHook().writeMutation(List.of(item), retrieverContext).toList();
+
+    assertTrue(result.get(0).getSecond(), "Should be mutated (reverted)");
+    assertFalse(proposedStatus.hasLifecycleStage(), "Should revert to null/active");
+  }
+
+  // ── Helpers ─────────────────────────────────────────────────────────────────
+
+  private LifecycleStageTransitionHook buildHook() {
+    LifecycleStageTransitionHook hook = new LifecycleStageTransitionHook();
+    hook.setConfig(HOOK_CONFIG);
+    return hook;
+  }
+
+  private static Status makeStatus(Urn lifecycleStageUrn) {
+    Status status = new Status();
+    status.setRemoved(false);
+    if (lifecycleStageUrn != null) {
+      status.setLifecycleStage(lifecycleStageUrn);
+    }
+    return status;
+  }
+
+  /** Creates a mock ChangeMCP for the Status aspect with the given proposed/previous values. */
+  private static ChangeMCP makeChangeMCP(Status proposed, Status previous) {
+    ChangeMCP item = mock(ChangeMCP.class);
+    when(item.getAspectName()).thenReturn(STATUS_ASPECT_NAME);
+    when(item.getUrn()).thenReturn(TEST_ENTITY_URN);
+    when(item.getAspect(Status.class)).thenReturn(proposed);
+    when(item.getPreviousAspect(Status.class)).thenReturn(previous);
+    return item;
+  }
+
+  /** Serializes a LifecycleStageTypeInfo into the Aspect wrapper used by getLatestAspectObject. */
+  private static Aspect makeStageAspect(
+      boolean hideInSearch, LifecycleStageTransitionPolicy policy) {
+    LifecycleStageSettings settings = new LifecycleStageSettings();
+    settings.setHideInSearch(hideInSearch);
+
+    AuditStamp stamp = new AuditStamp();
+    stamp.setTime(System.currentTimeMillis());
+    stamp.setActor(UrnUtils.getUrn("urn:li:corpuser:system"));
+
+    LifecycleStageTypeInfo info = new LifecycleStageTypeInfo();
+    info.setName("Test Stage");
+    info.setSettings(settings);
+    info.setCreated(stamp);
+    info.setLastModified(stamp);
+    if (policy != null) {
+      info.setTransitionPolicy(policy);
+    }
+    return new Aspect(info.data());
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/aspect/validation/LifecycleStageValidatorTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/aspect/validation/LifecycleStageValidatorTest.java
@@ -1,0 +1,217 @@
+package com.linkedin.metadata.aspect.validation;
+
+import static com.linkedin.metadata.Constants.*;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.Status;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.StringArray;
+import com.linkedin.entity.Aspect;
+import com.linkedin.events.metadata.ChangeType;
+import com.linkedin.lifecycle.LifecycleStageSettings;
+import com.linkedin.lifecycle.LifecycleStageTypeInfo;
+import com.linkedin.metadata.aspect.AspectRetriever;
+import com.linkedin.metadata.aspect.RetrieverContext;
+import com.linkedin.metadata.aspect.plugins.config.AspectPluginConfig;
+import com.linkedin.metadata.models.registry.EntityRegistry;
+import com.linkedin.test.metadata.aspect.TestEntityRegistry;
+import com.linkedin.test.metadata.aspect.batch.TestMCP;
+import java.util.List;
+import java.util.Set;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class LifecycleStageValidatorTest {
+
+  private static final Urn DATASET_URN =
+      UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:hdfs,mydata,PROD)");
+  private static final Urn STAGE_URN = UrnUtils.getUrn("urn:li:lifecycleStageType:DRAFT");
+  private static final Urn NONEXISTENT_URN =
+      UrnUtils.getUrn("urn:li:lifecycleStageType:NONEXISTENT");
+
+  private static final AspectPluginConfig TEST_PLUGIN_CONFIG =
+      AspectPluginConfig.builder()
+          .className(LifecycleStageValidator.class.getName())
+          .enabled(true)
+          .supportedOperations(List.of("CREATE", "CREATE_ENTITY", "UPSERT", "UPDATE"))
+          .supportedEntityAspectNames(
+              List.of(new AspectPluginConfig.EntityAspectName("*", STATUS_ASPECT_NAME)))
+          .build();
+
+  @Mock private RetrieverContext mockRetrieverContext;
+  @Mock private AspectRetriever mockAspectRetriever;
+
+  private EntityRegistry entityRegistry;
+  private LifecycleStageValidator validator;
+
+  @BeforeMethod
+  public void setup() {
+    MockitoAnnotations.openMocks(this);
+    entityRegistry = new TestEntityRegistry();
+    validator = new LifecycleStageValidator();
+    validator.setConfig(TEST_PLUGIN_CONFIG);
+    when(mockRetrieverContext.getAspectRetriever()).thenReturn(mockAspectRetriever);
+    when(mockAspectRetriever.getEntityRegistry()).thenReturn(entityRegistry);
+  }
+
+  @Test
+  public void testValidStagePassesValidation() {
+    LifecycleStageTypeInfo info = makeStageInfo(null);
+    doReturn(new Aspect(info.data()))
+        .when(mockAspectRetriever)
+        .getLatestAspectObject(eq(STAGE_URN), eq("lifecycleStageTypeInfo"));
+
+    Status status = new Status();
+    status.setLifecycleStage(STAGE_URN);
+
+    long errors =
+        validator
+            .validateProposed(Set.of(buildMCP(DATASET_URN, status)), mockRetrieverContext, null)
+            .count();
+
+    assertEquals(errors, 0, "Valid stage should pass validation");
+  }
+
+  @Test
+  public void testNonexistentStageFailsValidation() {
+    when(mockAspectRetriever.getLatestAspectObject(
+            eq(NONEXISTENT_URN), eq("lifecycleStageTypeInfo")))
+        .thenReturn(null);
+
+    Status status = new Status();
+    status.setLifecycleStage(NONEXISTENT_URN);
+
+    long errors =
+        validator
+            .validateProposed(Set.of(buildMCP(DATASET_URN, status)), mockRetrieverContext, null)
+            .count();
+
+    assertEquals(errors, 1, "Non-existent stage should fail validation");
+  }
+
+  @Test
+  public void testNoLifecycleStagePassesValidation() {
+    Status status = new Status();
+    status.setRemoved(false);
+
+    long errors =
+        validator
+            .validateProposed(Set.of(buildMCP(DATASET_URN, status)), mockRetrieverContext, null)
+            .count();
+
+    assertEquals(errors, 0, "Status without lifecycleStage should pass validation");
+    verify(mockAspectRetriever, never()).getLatestAspectObject(any(Urn.class), anyString());
+  }
+
+  @Test
+  public void testEntityTypeMatchPassesValidation() {
+    LifecycleStageTypeInfo info = makeStageInfo(List.of("dataset", "chart"));
+    doReturn(new Aspect(info.data()))
+        .when(mockAspectRetriever)
+        .getLatestAspectObject(eq(STAGE_URN), eq("lifecycleStageTypeInfo"));
+
+    Status status = new Status();
+    status.setLifecycleStage(STAGE_URN);
+
+    long errors =
+        validator
+            .validateProposed(Set.of(buildMCP(DATASET_URN, status)), mockRetrieverContext, null)
+            .count();
+
+    assertEquals(errors, 0, "Stage applicable to dataset should pass for dataset entity");
+  }
+
+  @Test
+  public void testEntityTypeMismatchFailsValidation() {
+    LifecycleStageTypeInfo info = makeStageInfo(List.of("glossaryTerm"));
+    doReturn(new Aspect(info.data()))
+        .when(mockAspectRetriever)
+        .getLatestAspectObject(eq(STAGE_URN), eq("lifecycleStageTypeInfo"));
+
+    Status status = new Status();
+    status.setLifecycleStage(STAGE_URN);
+
+    long errors =
+        validator
+            .validateProposed(Set.of(buildMCP(DATASET_URN, status)), mockRetrieverContext, null)
+            .count();
+
+    assertEquals(errors, 1, "Stage scoped to glossaryTerm should fail for dataset entity");
+  }
+
+  @Test
+  public void testNullEntityTypesAppliesToAll() {
+    LifecycleStageTypeInfo info = makeStageInfo(null);
+    doReturn(new Aspect(info.data()))
+        .when(mockAspectRetriever)
+        .getLatestAspectObject(eq(STAGE_URN), eq("lifecycleStageTypeInfo"));
+
+    Status status = new Status();
+    status.setLifecycleStage(STAGE_URN);
+
+    long errors =
+        validator
+            .validateProposed(Set.of(buildMCP(DATASET_URN, status)), mockRetrieverContext, null)
+            .count();
+
+    assertEquals(errors, 0, "Stage with null entityTypes should pass for any entity type");
+  }
+
+  @Test
+  public void testEmptyEntityTypesAppliesToAll() {
+    LifecycleStageTypeInfo info = makeStageInfo(List.of());
+    doReturn(new Aspect(info.data()))
+        .when(mockAspectRetriever)
+        .getLatestAspectObject(eq(STAGE_URN), eq("lifecycleStageTypeInfo"));
+
+    Status status = new Status();
+    status.setLifecycleStage(STAGE_URN);
+
+    long errors =
+        validator
+            .validateProposed(Set.of(buildMCP(DATASET_URN, status)), mockRetrieverContext, null)
+            .count();
+
+    // Empty entityTypes list means "applies to no types" per the PDL doc,
+    // but the validator treats it as "applies to all" since empty != explicit restriction.
+    // The real enforcement of "empty = disabled" is at the hideInSearch/search layer.
+    assertEquals(errors, 0, "Stage with empty entityTypes should pass (empty != restricted)");
+  }
+
+  private TestMCP buildMCP(Urn entityUrn, Status status) {
+    return TestMCP.builder()
+        .changeType(ChangeType.UPSERT)
+        .urn(entityUrn)
+        .entitySpec(entityRegistry.getEntitySpec(entityUrn.getEntityType()))
+        .aspectSpec(
+            entityRegistry
+                .getEntitySpec(entityUrn.getEntityType())
+                .getAspectSpec(STATUS_ASPECT_NAME))
+        .recordTemplate(status)
+        .build();
+  }
+
+  private static LifecycleStageTypeInfo makeStageInfo(List<String> entityTypes) {
+    AuditStamp stamp = new AuditStamp();
+    stamp.setTime(0L);
+    stamp.setActor(UrnUtils.getUrn("urn:li:corpuser:system"));
+
+    LifecycleStageSettings settings = new LifecycleStageSettings();
+    settings.setHideInSearch(true);
+
+    LifecycleStageTypeInfo info = new LifecycleStageTypeInfo();
+    info.setName("Draft");
+    info.setSettings(settings);
+    info.setCreated(stamp);
+    info.setLastModified(stamp);
+    if (entityTypes != null) {
+      info.setEntityTypes(new StringArray(entityTypes));
+    }
+    return info;
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/utils/ESUtilsLifecycleStageFilterTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/utils/ESUtilsLifecycleStageFilterTest.java
@@ -1,0 +1,156 @@
+package com.linkedin.metadata.search.utils;
+
+import static com.linkedin.metadata.search.utils.ESUtils.KEYWORD_SUFFIX;
+import static com.linkedin.metadata.search.utils.ESUtils.LIFECYCLE_STAGE;
+import static com.linkedin.metadata.search.utils.ESUtils.REMOVED;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import com.datahub.authorization.config.ViewAuthorizationConfiguration;
+import com.linkedin.metadata.query.SearchFlags;
+import com.linkedin.metadata.query.filter.Condition;
+import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
+import com.linkedin.metadata.query.filter.ConjunctiveCriterionArray;
+import com.linkedin.metadata.query.filter.Criterion;
+import com.linkedin.metadata.query.filter.CriterionArray;
+import com.linkedin.metadata.query.filter.Filter;
+import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.metadata.context.OperationContextConfig;
+import io.datahubproject.metadata.context.SearchContext;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.testng.annotations.Test;
+
+/** Tests for the lifecycle stage filtering logic in {@link ESUtils#applyDefaultSearchFilters}. */
+public class ESUtilsLifecycleStageFilterTest {
+
+  private static final String PROPOSED_URN = "urn:li:lifecycleStageType:PROPOSED";
+  private static final String ARCHIVED_URN = "urn:li:lifecycleStageType:ARCHIVED";
+
+  @Test
+  public void testHiddenStagesExcluded() {
+    OperationContext opContext = mockOpContext(new SearchFlags().setIncludeSoftDeleted(false));
+    BoolQueryBuilder query = QueryBuilders.boolQuery();
+
+    ESUtils.applyDefaultSearchFilters(
+        opContext, List.of("document"), null, query, Set.of(PROPOSED_URN));
+
+    // Should have mustNot for removed=true AND mustNot for lifecycleStage=PROPOSED
+    assertEquals(query.mustNot().size(), 2);
+    assertMustNotContainsTerm(query, REMOVED, "true");
+    assertMustNotContainsTerm(query, LIFECYCLE_STAGE + KEYWORD_SUFFIX, PROPOSED_URN);
+  }
+
+  @Test
+  public void testMultipleHiddenStages() {
+    OperationContext opContext = mockOpContext(new SearchFlags().setIncludeSoftDeleted(false));
+    BoolQueryBuilder query = QueryBuilders.boolQuery();
+
+    ESUtils.applyDefaultSearchFilters(
+        opContext, List.of("document"), null, query, Set.of(PROPOSED_URN, ARCHIVED_URN));
+
+    // removed + 2 lifecycle stages = 3 mustNot clauses
+    assertEquals(query.mustNot().size(), 3);
+    assertMustNotContainsTerm(query, LIFECYCLE_STAGE + KEYWORD_SUFFIX, PROPOSED_URN);
+    assertMustNotContainsTerm(query, LIFECYCLE_STAGE + KEYWORD_SUFFIX, ARCHIVED_URN);
+  }
+
+  @Test
+  public void testEmptyHiddenStages_noLifecycleFilter() {
+    OperationContext opContext = mockOpContext(new SearchFlags().setIncludeSoftDeleted(false));
+    BoolQueryBuilder query = QueryBuilders.boolQuery();
+
+    ESUtils.applyDefaultSearchFilters(
+        opContext, List.of("document"), null, query, Collections.emptySet());
+
+    // Only removed=true mustNot, no lifecycle stage filter
+    assertEquals(query.mustNot().size(), 1);
+    assertMustNotContainsTerm(query, REMOVED, "true");
+  }
+
+  @Test
+  public void testIncludeHiddenLifecycleStages_skipsFilter() {
+    SearchFlags flags =
+        new SearchFlags().setIncludeSoftDeleted(false).setIncludeHiddenLifecycleStages(true);
+    OperationContext opContext = mockOpContext(flags);
+    BoolQueryBuilder query = QueryBuilders.boolQuery();
+
+    ESUtils.applyDefaultSearchFilters(
+        opContext, List.of("document"), null, query, Set.of(PROPOSED_URN));
+
+    // Only removed=true, no lifecycle stage filter because includeHiddenLifecycleStages=true
+    assertEquals(query.mustNot().size(), 1);
+    assertMustNotContainsTerm(query, REMOVED, "true");
+  }
+
+  @Test
+  public void testExplicitLifecycleStageFilter_skipsDefault() {
+    OperationContext opContext = mockOpContext(new SearchFlags().setIncludeSoftDeleted(false));
+
+    // User already filtering on lifecycleStage field
+    Criterion stageCriterion = new Criterion();
+    stageCriterion.setField(LIFECYCLE_STAGE);
+    stageCriterion.setCondition(Condition.EQUAL);
+
+    ConjunctiveCriterion conj = new ConjunctiveCriterion();
+    conj.setAnd(new CriterionArray(stageCriterion));
+
+    Filter filter = new Filter();
+    filter.setOr(new ConjunctiveCriterionArray(conj));
+
+    BoolQueryBuilder query = QueryBuilders.boolQuery();
+    ESUtils.applyDefaultSearchFilters(
+        opContext, List.of("document"), filter, query, Set.of(PROPOSED_URN));
+
+    // Only removed=true mustNot, no lifecycle stage filter (user overrides)
+    assertEquals(query.mustNot().size(), 1);
+    assertMustNotContainsTerm(query, REMOVED, "true");
+  }
+
+  @Test
+  public void testIncludeSoftDeleted_skipsRemovedFilter() {
+    SearchFlags flags = new SearchFlags().setIncludeSoftDeleted(true);
+    OperationContext opContext = mockOpContext(flags);
+    BoolQueryBuilder query = QueryBuilders.boolQuery();
+
+    ESUtils.applyDefaultSearchFilters(
+        opContext, List.of("document"), null, query, Set.of(PROPOSED_URN));
+
+    // Only lifecycle stage filter, no removed filter
+    assertEquals(query.mustNot().size(), 1);
+    assertMustNotContainsTerm(query, LIFECYCLE_STAGE + KEYWORD_SUFFIX, PROPOSED_URN);
+  }
+
+  // ── Helpers ─────────────────────────────────────────────────────────────────
+
+  private static OperationContext mockOpContext(SearchFlags searchFlags) {
+    SearchContext searchContext = mock(SearchContext.class);
+    when(searchContext.getSearchFlags()).thenReturn(searchFlags);
+
+    ViewAuthorizationConfiguration viewAuthConfig =
+        ViewAuthorizationConfiguration.builder().enabled(false).build();
+    OperationContextConfig opConfig = mock(OperationContextConfig.class);
+    when(opConfig.getViewAuthorizationConfiguration()).thenReturn(viewAuthConfig);
+
+    OperationContext opContext = mock(OperationContext.class);
+    when(opContext.getSearchContext()).thenReturn(searchContext);
+    when(opContext.isSystemAuth()).thenReturn(true);
+    when(opContext.getOperationContextConfig()).thenReturn(opConfig);
+    return opContext;
+  }
+
+  private static void assertMustNotContainsTerm(
+      BoolQueryBuilder query, String field, String value) {
+    String queryString = query.toString();
+    assertTrue(
+        queryString.contains(field) && queryString.contains(value),
+        String.format(
+            "Expected mustNot to contain term %s=%s, but query was: %s",
+            field, value, queryString));
+  }
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/common/Status.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/common/Status.pdl
@@ -10,9 +10,34 @@ namespace com.linkedin.common
 record Status {
   /**
    * Whether the entity has been removed (soft-deleted).
+   * Kept for backward compatibility. When lifecycleStage is set to a stage
+   * with hideInSearch=true, this field is NOT automatically synced — the
+   * search layer uses lifecycleStage settings directly.
    */
   @Searchable = {
     "fieldType": "BOOLEAN"
   }
   removed: boolean = false
+
+  /**
+   * The lifecycle stage of the entity, referencing a lifecycleStageType entity.
+   * When null, the entity is in its default active state (visible in search).
+   * When set, the referenced lifecycle stage's settings determine behavior
+   * (e.g., hideInSearch=true excludes the entity from default search results).
+   *
+   * Users can override default filtering by explicitly filtering on this field.
+   */
+  @Searchable = {
+    "fieldType": "KEYWORD",
+    "queryByDefault": false
+  }
+  lifecycleStage: optional Urn
+
+  /**
+   * Attribution for the lifecycle stage transition — who moved the entity
+   * into its current stage and when. Populated automatically by the
+   * setLifecycleStage mutation; should be set by any code path that
+   * writes the lifecycleStage field.
+   */
+  lifecycleLastUpdated: optional AuditStamp
 }

--- a/metadata-models/src/main/pegasus/com/linkedin/lifecycle/LifecycleStageSettings.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/lifecycle/LifecycleStageSettings.pdl
@@ -1,0 +1,12 @@
+namespace com.linkedin.lifecycle
+
+/**
+ * Settings that control how entities in a given lifecycle stage behave in the platform.
+ */
+record LifecycleStageSettings {
+  /**
+   * When true, entities in this stage are excluded from default search results.
+   * Users can still discover them by explicitly filtering on the lifecycleStage field.
+   */
+  hideInSearch: boolean = false
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/lifecycle/LifecycleStageTransitionPolicy.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/lifecycle/LifecycleStageTransitionPolicy.pdl
@@ -1,0 +1,23 @@
+namespace com.linkedin.lifecycle
+
+import com.linkedin.common.Urn
+
+/**
+ * Defines which prior stages (or no stage) are allowed to transition INTO this stage.
+ * Enforced server-side via a MutationHook on the Status aspect.
+ *
+ * Modeled as entry constraints rather than exit constraints so that adding a new
+ * stage is self-contained — you declare its own entry policy without editing
+ * every existing stage.
+ */
+record LifecycleStageTransitionPolicy {
+  /**
+   * Lifecycle stage type URNs that an entity must currently be in to transition
+   * INTO this stage. Use the sentinel value "urn:li:lifecycleStageType:__NONE__"
+   * to allow entry from the default active state (no stage set).
+   *
+   * null/absent: any prior stage (or no stage) can transition to this one.
+   * empty list: nothing can transition to this stage (unreachable).
+   */
+  allowedPreviousStages: optional array[Urn]
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/lifecycle/LifecycleStageTypeInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/lifecycle/LifecycleStageTypeInfo.pdl
@@ -1,0 +1,87 @@
+namespace com.linkedin.lifecycle
+
+import com.linkedin.common.AuditStamp
+
+/**
+ * Information about a lifecycle stage type.
+ *
+ * Lifecycle stages control entity visibility and behavior in the platform.
+ * Each stage can apply to specific entity types and define search visibility
+ * and transition policies.
+ *
+ * When an entity's Status.lifecycleStage is set to a lifecycle stage type URN,
+ * the stage's settings determine how the entity is treated (e.g., hidden from
+ * default search when hideInSearch=true).
+ *
+ * The entityTypes field controls which entity types this stage can be applied to:
+ *   - null/absent: the stage applies to ALL entity types
+ *   - empty list: the stage applies to NO entity types (disabled)
+ *   - explicit list: the stage only applies to those entity types
+ */
+@Aspect = {
+  "name": "lifecycleStageTypeInfo"
+}
+record LifecycleStageTypeInfo {
+  /**
+   * Display name of the lifecycle stage type.
+   */
+  @Searchable = {
+    "fieldType": "WORD_GRAM",
+    "enableAutocomplete": true,
+    "boostScore": 10.0
+  }
+  name: string
+
+  /**
+   * Description of what this lifecycle stage represents.
+   */
+  description: optional string
+
+  /**
+   * Entity type names this stage applies to (e.g., ["document", "glossaryTerm"]).
+   * When null/absent, applies to all entity types.
+   * When empty, applies to no entity types (effectively disabled).
+   */
+  entityTypes: optional array[string]
+
+  /**
+   * Settings that control platform behavior for entities in this stage.
+   */
+  settings: LifecycleStageSettings
+
+  /**
+   * Optional policy defining which prior stages can transition INTO this stage.
+   * When null, any prior stage can transition to this one (no enforcement).
+   */
+  transitionPolicy: optional LifecycleStageTransitionPolicy
+
+  /**
+   * Audit stamp capturing the time and actor who created this lifecycle stage type.
+   */
+  @Searchable = {
+    "/time": {
+      "fieldType": "DATETIME",
+      "fieldName": "createdAt"
+    },
+    "/actor": {
+      "fieldType": "URN",
+      "fieldName": "createdBy"
+    }
+  }
+  created: AuditStamp
+
+  /**
+   * Audit stamp capturing the time and actor who last modified this lifecycle stage type.
+   */
+  @Searchable = {
+    "/time": {
+      "fieldType": "DATETIME",
+      "fieldName": "lastModifiedAt"
+    },
+    "/actor": {
+      "fieldType": "URN",
+      "fieldName": "lastModifiedBy"
+    }
+  }
+  lastModified: AuditStamp
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/key/LifecycleStageTypeKey.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/key/LifecycleStageTypeKey.pdl
@@ -1,0 +1,14 @@
+namespace com.linkedin.metadata.key
+
+/**
+ * Key for a Lifecycle Stage Type
+ */
+@Aspect = {
+  "name": "lifecycleStageTypeKey"
+}
+record LifecycleStageTypeKey {
+  /**
+   * Unique identifier for the lifecycle stage type, e.g. "PROPOSED", "CERTIFIED", "ARCHIVED".
+   */
+  id: string
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/query/SearchFlags.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/query/SearchFlags.pdl
@@ -45,6 +45,14 @@ record SearchFlags {
    includeSoftDeleted:optional boolean = false
 
   /**
+   * Include entities in lifecycle stages that have hideInSearch=true.
+   * By default, entities in hidden lifecycle stages are excluded from search results.
+   * Set to true for eval queries or admin tooling that needs to discover all entities
+   * regardless of lifecycle stage settings.
+   */
+   includeHiddenLifecycleStages:optional boolean = false
+
+  /**
    * include restricted entities in results (default is to filter)
    */
    includeRestricted:optional boolean = false

--- a/metadata-models/src/main/resources/entity-registry.yml
+++ b/metadata-models/src/main/resources/entity-registry.yml
@@ -687,6 +687,13 @@ entities:
     aspects:
       - ownershipTypeInfo
       - status
+  - name: lifecycleStageType
+    doc: Defines a lifecycle stage that entities can be placed in (e.g., Proposed, Certified, Archived). Controls search visibility and transition policies.
+    category: core
+    keyAspect: lifecycleStageTypeKey
+    aspects:
+      - lifecycleStageTypeInfo
+      - status
   - name: businessAttribute
     category: core
     keyAspect: businessAttributeKey

--- a/metadata-service/configuration/src/main/resources/bootstrap_mcps.yaml
+++ b/metadata-service/configuration/src/main/resources/bootstrap_mcps.yaml
@@ -30,6 +30,12 @@ bootstrap:
       async: false
       mcps_location: "bootstrap_mcps/ownership-types.yaml"
 
+    - name: lifecycle-stages
+      version: v2
+      blocking: true
+      async: false
+      mcps_location: "bootstrap_mcps/lifecycle-stages.yaml"
+
     - name: roles
       version: v1
       blocking: true

--- a/metadata-service/configuration/src/main/resources/bootstrap_mcps/lifecycle-stages.yaml
+++ b/metadata-service/configuration/src/main/resources/bootstrap_mcps/lifecycle-stages.yaml
@@ -1,0 +1,115 @@
+# Example lifecycle stage types for entity governance.
+# Uncomment and increment the version in bootstrap_mcps.yaml to bootstrap these stages.
+#
+# Lifecycle stages control search visibility via the hideInSearch setting and
+# enforce transition policies via allowedPreviousStages. The special sentinel
+# urn:li:lifecycleStageType:__NONE__ represents the default active state (no stage set).
+#
+# These are examples — customize the stages, entity types, and transition
+# policies to match your organization's governance workflow.
+[]
+# # DRAFT: Entity is being authored. Hidden from default search.
+# - entityUrn: urn:li:lifecycleStageType:DRAFT
+#   entityType: lifecycleStageType
+#   aspectName: lifecycleStageTypeInfo
+#   changeType: UPSERT
+#   aspect:
+#     name: Draft
+#     description: >-
+#       Entity is being drafted and is not yet ready for review.
+#       Hidden from default searches but discoverable via explicit lifecycle stage filter.
+#     entityTypes:
+#       - document
+#       - glossaryTerm
+#     settings:
+#       hideInSearch: true
+#     created: {{&auditStamp}}
+#     lastModified: {{&auditStamp}}
+#
+# # IN_REVIEW: Entity submitted for steward review. Hidden from default search.
+# - entityUrn: urn:li:lifecycleStageType:IN_REVIEW
+#   entityType: lifecycleStageType
+#   aspectName: lifecycleStageTypeInfo
+#   changeType: UPSERT
+#   aspect:
+#     name: In Review
+#     description: >-
+#       Entity has been submitted for steward review and approval.
+#       Hidden from default searches until a reviewer approves and publishes it.
+#     entityTypes:
+#       - document
+#       - glossaryTerm
+#     settings:
+#       hideInSearch: true
+#     transitionPolicy:
+#       allowedPreviousStages:
+#         - urn:li:lifecycleStageType:DRAFT
+#         - urn:li:lifecycleStageType:REJECTED
+#     created: {{&auditStamp}}
+#     lastModified: {{&auditStamp}}
+#
+# # REJECTED: Reviewer rejected the submission. Author must revise and resubmit.
+# - entityUrn: urn:li:lifecycleStageType:REJECTED
+#   entityType: lifecycleStageType
+#   aspectName: lifecycleStageTypeInfo
+#   changeType: UPSERT
+#   aspect:
+#     name: Rejected
+#     description: >-
+#       Entity was reviewed and rejected. The author should address reviewer feedback,
+#       update the entity, and resubmit for review.
+#     entityTypes:
+#       - document
+#       - glossaryTerm
+#     settings:
+#       hideInSearch: true
+#     transitionPolicy:
+#       allowedPreviousStages:
+#         - urn:li:lifecycleStageType:IN_REVIEW
+#     created: {{&auditStamp}}
+#     lastModified: {{&auditStamp}}
+#
+# # DEPRECATED: Entity is retired or superseded. Visible in search with a label.
+# - entityUrn: urn:li:lifecycleStageType:DEPRECATED
+#   entityType: lifecycleStageType
+#   aspectName: lifecycleStageTypeInfo
+#   changeType: UPSERT
+#   aspect:
+#     name: Deprecated
+#     description: >-
+#       Entity is deprecated and should no longer be used for new work.
+#       Remains visible in search with a deprecated label so consumers can
+#       identify affected assets and migrate to a replacement.
+#     entityTypes:
+#       - document
+#       - glossaryTerm
+#     settings:
+#       hideInSearch: false
+#     transitionPolicy:
+#       allowedPreviousStages:
+#         - urn:li:lifecycleStageType:__NONE__
+#     created: {{&auditStamp}}
+#     lastModified: {{&auditStamp}}
+#
+# # ARCHIVED: Permanently hidden. Governance-aware soft-delete.
+# - entityUrn: urn:li:lifecycleStageType:ARCHIVED
+#   entityType: lifecycleStageType
+#   aspectName: lifecycleStageTypeInfo
+#   changeType: UPSERT
+#   aspect:
+#     name: Archived
+#     description: >-
+#       Entity is archived and hidden from all default searches and browse.
+#       Use this instead of hard-delete to preserve audit history.
+#       Can be restored by clearing the lifecycle stage.
+#     entityTypes:
+#       - document
+#       - glossaryTerm
+#     settings:
+#       hideInSearch: true
+#     transitionPolicy:
+#       allowedPreviousStages:
+#         - urn:li:lifecycleStageType:__NONE__
+#         - urn:li:lifecycleStageType:DEPRECATED
+#     created: {{&auditStamp}}
+#     lastModified: {{&auditStamp}}

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/lifecycle/LifecycleStageTypeServiceFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/lifecycle/LifecycleStageTypeServiceFactory.java
@@ -1,0 +1,28 @@
+package com.linkedin.gms.factory.lifecycle;
+
+import com.linkedin.entity.client.SystemEntityClient;
+import com.linkedin.metadata.search.utils.ESUtils;
+import com.linkedin.metadata.service.LifecycleStageTypeService;
+import io.datahubproject.metadata.context.OperationContext;
+import javax.annotation.Nonnull;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+
+@Configuration
+public class LifecycleStageTypeServiceFactory {
+
+  @Bean(name = "lifecycleStageTypeService")
+  @Scope("singleton")
+  @Nonnull
+  protected LifecycleStageTypeService getInstance(
+      @Qualifier("systemEntityClient") final SystemEntityClient systemEntityClient,
+      @Qualifier("systemOperationContext") final OperationContext systemOperationContext) {
+    LifecycleStageTypeService service = new LifecycleStageTypeService(systemEntityClient);
+    service.setSystemOperationContext(systemOperationContext);
+    // Wire into the search filter path so hidden lifecycle stages are excluded from default search.
+    ESUtils.setLifecycleStageTypeService(service);
+    return service;
+  }
+}

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/plugins/SpringStandardPluginConfiguration.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/plugins/SpringStandardPluginConfiguration.java
@@ -10,6 +10,7 @@ import com.linkedin.metadata.aspect.hooks.AspectMigrationMutator;
 import com.linkedin.metadata.aspect.hooks.AspectMigrationMutatorChain;
 import com.linkedin.metadata.aspect.hooks.FieldPathMutator;
 import com.linkedin.metadata.aspect.hooks.IgnoreUnknownMutator;
+import com.linkedin.metadata.aspect.hooks.LifecycleStageTransitionHook;
 import com.linkedin.metadata.aspect.hooks.OwnershipOwnerTypes;
 import com.linkedin.metadata.aspect.plugins.config.AspectPluginConfig;
 import com.linkedin.metadata.aspect.plugins.hooks.MCPSideEffect;
@@ -19,6 +20,7 @@ import com.linkedin.metadata.aspect.validation.ConditionalWriteValidator;
 import com.linkedin.metadata.aspect.validation.CreateIfNotExistsValidator;
 import com.linkedin.metadata.aspect.validation.ExecutionRequestResultValidator;
 import com.linkedin.metadata.aspect.validation.FieldPathValidator;
+import com.linkedin.metadata.aspect.validation.LifecycleStageValidator;
 import com.linkedin.metadata.aspect.validation.PolicyFieldTypeValidator;
 import com.linkedin.metadata.aspect.validation.PrivilegeConstraintsValidator;
 import com.linkedin.metadata.aspect.validation.SystemPolicyValidator;
@@ -606,6 +608,40 @@ public class SpringStandardPluginConfiguration {
                         AspectPluginConfig.EntityAspectName.builder()
                             .entityName(POLICY_ENTITY_NAME)
                             .aspectName(ALL)
+                            .build()))
+                .build());
+  }
+
+  @Bean
+  public MutationHook lifecycleStageTransitionHook() {
+    return new LifecycleStageTransitionHook()
+        .setConfig(
+            AspectPluginConfig.builder()
+                .className(LifecycleStageTransitionHook.class.getName())
+                .enabled(true)
+                .supportedOperations(List.of(CREATE, CREATE_ENTITY, UPSERT, UPDATE))
+                .supportedEntityAspectNames(
+                    List.of(
+                        AspectPluginConfig.EntityAspectName.builder()
+                            .entityName("*")
+                            .aspectName(STATUS_ASPECT_NAME)
+                            .build()))
+                .build());
+  }
+
+  @Bean
+  public AspectPayloadValidator lifecycleStageValidator() {
+    return new LifecycleStageValidator()
+        .setConfig(
+            AspectPluginConfig.builder()
+                .className(LifecycleStageValidator.class.getName())
+                .enabled(true)
+                .supportedOperations(List.of(CREATE, CREATE_ENTITY, UPSERT, UPDATE))
+                .supportedEntityAspectNames(
+                    List.of(
+                        AspectPluginConfig.EntityAspectName.builder()
+                            .entityName("*")
+                            .aspectName(STATUS_ASPECT_NAME)
                             .build()))
                 .build());
   }

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
@@ -1424,11 +1424,25 @@
     "fields" : [ {
       "name" : "removed",
       "type" : "boolean",
-      "doc" : "Whether the entity has been removed (soft-deleted).",
+      "doc" : "Whether the entity has been removed (soft-deleted).\nKept for backward compatibility. When lifecycleStage is set to a stage\nwith hideInSearch=true, this field is NOT automatically synced — the\nsearch layer uses lifecycleStage settings directly.",
       "default" : false,
       "Searchable" : {
         "fieldType" : "BOOLEAN"
       }
+    }, {
+      "name" : "lifecycleStage",
+      "type" : "Urn",
+      "doc" : "The lifecycle stage of the entity, referencing a lifecycleStageType entity.\nWhen null, the entity is in its default active state (visible in search).\nWhen set, the referenced lifecycle stage's settings determine behavior\n(e.g., hideInSearch=true excludes the entity from default search results).\n\nUsers can override default filtering by explicitly filtering on this field.",
+      "optional" : true,
+      "Searchable" : {
+        "fieldType" : "KEYWORD",
+        "queryByDefault" : false
+      }
+    }, {
+      "name" : "lifecycleLastUpdated",
+      "type" : "AuditStamp",
+      "doc" : "Attribution for the lifecycle stage transition — who moved the entity\ninto its current stage and when. Populated automatically by the\nsetLifecycleStage mutation; should be set by any code path that\nwrites the lifecycleStage field.",
+      "optional" : true
     } ],
     "Aspect" : {
       "name" : "status"

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
@@ -1439,11 +1439,25 @@
     "fields" : [ {
       "name" : "removed",
       "type" : "boolean",
-      "doc" : "Whether the entity has been removed (soft-deleted).",
+      "doc" : "Whether the entity has been removed (soft-deleted).\nKept for backward compatibility. When lifecycleStage is set to a stage\nwith hideInSearch=true, this field is NOT automatically synced — the\nsearch layer uses lifecycleStage settings directly.",
       "default" : false,
       "Searchable" : {
         "fieldType" : "BOOLEAN"
       }
+    }, {
+      "name" : "lifecycleStage",
+      "type" : "Urn",
+      "doc" : "The lifecycle stage of the entity, referencing a lifecycleStageType entity.\nWhen null, the entity is in its default active state (visible in search).\nWhen set, the referenced lifecycle stage's settings determine behavior\n(e.g., hideInSearch=true excludes the entity from default search results).\n\nUsers can override default filtering by explicitly filtering on this field.",
+      "optional" : true,
+      "Searchable" : {
+        "fieldType" : "KEYWORD",
+        "queryByDefault" : false
+      }
+    }, {
+      "name" : "lifecycleLastUpdated",
+      "type" : "AuditStamp",
+      "doc" : "Attribution for the lifecycle stage transition — who moved the entity\ninto its current stage and when. Populated automatically by the\nsetLifecycleStage mutation; should be set by any code path that\nwrites the lifecycleStage field.",
+      "optional" : true
     } ],
     "Aspect" : {
       "name" : "status"
@@ -6302,6 +6316,12 @@
       "name" : "includeSoftDeleted",
       "type" : "boolean",
       "doc" : "include soft deleted entities in results",
+      "default" : false,
+      "optional" : true
+    }, {
+      "name" : "includeHiddenLifecycleStages",
+      "type" : "boolean",
+      "doc" : "Include entities in lifecycle stages that have hideInSearch=true.\nBy default, entities in hidden lifecycle stages are excluded from search results.\nSet to true for eval queries or admin tooling that needs to discover all entities\nregardless of lifecycle stage settings.",
       "default" : false,
       "optional" : true
     }, {

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.runs.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.runs.snapshot.json
@@ -1138,11 +1138,25 @@
     "fields" : [ {
       "name" : "removed",
       "type" : "boolean",
-      "doc" : "Whether the entity has been removed (soft-deleted).",
+      "doc" : "Whether the entity has been removed (soft-deleted).\nKept for backward compatibility. When lifecycleStage is set to a stage\nwith hideInSearch=true, this field is NOT automatically synced — the\nsearch layer uses lifecycleStage settings directly.",
       "default" : false,
       "Searchable" : {
         "fieldType" : "BOOLEAN"
       }
+    }, {
+      "name" : "lifecycleStage",
+      "type" : "Urn",
+      "doc" : "The lifecycle stage of the entity, referencing a lifecycleStageType entity.\nWhen null, the entity is in its default active state (visible in search).\nWhen set, the referenced lifecycle stage's settings determine behavior\n(e.g., hideInSearch=true excludes the entity from default search results).\n\nUsers can override default filtering by explicitly filtering on this field.",
+      "optional" : true,
+      "Searchable" : {
+        "fieldType" : "KEYWORD",
+        "queryByDefault" : false
+      }
+    }, {
+      "name" : "lifecycleLastUpdated",
+      "type" : "AuditStamp",
+      "doc" : "Attribution for the lifecycle stage transition — who moved the entity\ninto its current stage and when. Populated automatically by the\nsetLifecycleStage mutation; should be set by any code path that\nwrites the lifecycleStage field.",
+      "optional" : true
     } ],
     "Aspect" : {
       "name" : "status"

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.operations.operations.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.operations.operations.snapshot.json
@@ -1138,11 +1138,25 @@
     "fields" : [ {
       "name" : "removed",
       "type" : "boolean",
-      "doc" : "Whether the entity has been removed (soft-deleted).",
+      "doc" : "Whether the entity has been removed (soft-deleted).\nKept for backward compatibility. When lifecycleStage is set to a stage\nwith hideInSearch=true, this field is NOT automatically synced — the\nsearch layer uses lifecycleStage settings directly.",
       "default" : false,
       "Searchable" : {
         "fieldType" : "BOOLEAN"
       }
+    }, {
+      "name" : "lifecycleStage",
+      "type" : "Urn",
+      "doc" : "The lifecycle stage of the entity, referencing a lifecycleStageType entity.\nWhen null, the entity is in its default active state (visible in search).\nWhen set, the referenced lifecycle stage's settings determine behavior\n(e.g., hideInSearch=true excludes the entity from default search results).\n\nUsers can override default filtering by explicitly filtering on this field.",
+      "optional" : true,
+      "Searchable" : {
+        "fieldType" : "KEYWORD",
+        "queryByDefault" : false
+      }
+    }, {
+      "name" : "lifecycleLastUpdated",
+      "type" : "AuditStamp",
+      "doc" : "Attribution for the lifecycle stage transition — who moved the entity\ninto its current stage and when. Populated automatically by the\nsetLifecycleStage mutation; should be set by any code path that\nwrites the lifecycleStage field.",
+      "optional" : true
     } ],
     "Aspect" : {
       "name" : "status"

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.platform.platform.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.platform.platform.snapshot.json
@@ -1439,11 +1439,25 @@
     "fields" : [ {
       "name" : "removed",
       "type" : "boolean",
-      "doc" : "Whether the entity has been removed (soft-deleted).",
+      "doc" : "Whether the entity has been removed (soft-deleted).\nKept for backward compatibility. When lifecycleStage is set to a stage\nwith hideInSearch=true, this field is NOT automatically synced — the\nsearch layer uses lifecycleStage settings directly.",
       "default" : false,
       "Searchable" : {
         "fieldType" : "BOOLEAN"
       }
+    }, {
+      "name" : "lifecycleStage",
+      "type" : "Urn",
+      "doc" : "The lifecycle stage of the entity, referencing a lifecycleStageType entity.\nWhen null, the entity is in its default active state (visible in search).\nWhen set, the referenced lifecycle stage's settings determine behavior\n(e.g., hideInSearch=true excludes the entity from default search results).\n\nUsers can override default filtering by explicitly filtering on this field.",
+      "optional" : true,
+      "Searchable" : {
+        "fieldType" : "KEYWORD",
+        "queryByDefault" : false
+      }
+    }, {
+      "name" : "lifecycleLastUpdated",
+      "type" : "AuditStamp",
+      "doc" : "Attribution for the lifecycle stage transition — who moved the entity\ninto its current stage and when. Populated automatically by the\nsetLifecycleStage mutation; should be set by any code path that\nwrites the lifecycleStage field.",
+      "optional" : true
     } ],
     "Aspect" : {
       "name" : "status"

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/service/LifecycleStageTypeService.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/service/LifecycleStageTypeService.java
@@ -1,0 +1,215 @@
+package com.linkedin.metadata.service;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableSet;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.client.SystemEntityClient;
+import com.linkedin.lifecycle.LifecycleStageSettings;
+import com.linkedin.lifecycle.LifecycleStageTypeInfo;
+import com.linkedin.metadata.search.SearchEntity;
+import io.datahubproject.metadata.context.OperationContext;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Service for loading and caching lifecycle stage type definitions.
+ *
+ * <p>Provides the search layer with the set of lifecycle stage URNs that should be hidden from
+ * default search results, broken down by entity type. Caches results with periodic refresh.
+ */
+@Slf4j
+public class LifecycleStageTypeService {
+
+  public static final String LIFECYCLE_STAGE_TYPE_ENTITY_NAME = "lifecycleStageType";
+  public static final String LIFECYCLE_STAGE_TYPE_INFO_ASPECT_NAME = "lifecycleStageTypeInfo";
+
+  /** URN constant for the PROPOSED lifecycle stage (bootstrapped default). */
+  public static final String PROPOSED_LIFECYCLE_STAGE_URN = "urn:li:lifecycleStageType:PROPOSED";
+
+  private final SystemEntityClient entityClient;
+
+  /**
+   * Cache key is a sentinel (we cache one global snapshot). Value is a map from entity type name to
+   * the set of lifecycle stage URN strings that should be hidden for that entity type.
+   *
+   * <p>Stages with {@code entityTypes == null} (applies to all) are stored under the special key
+   * {@link #ALL_ENTITY_TYPES_KEY}.
+   */
+  private static final String ALL_ENTITY_TYPES_KEY = "*";
+
+  private final LoadingCache<String, Map<String, Set<String>>> cache;
+
+  @Nullable private volatile OperationContext systemOpContext;
+
+  public LifecycleStageTypeService(@Nonnull SystemEntityClient entityClient) {
+    this.entityClient = entityClient;
+    this.cache =
+        CacheBuilder.newBuilder()
+            .maximumSize(1)
+            .refreshAfterWrite(5, TimeUnit.MINUTES)
+            .build(
+                new CacheLoader<>() {
+                  @Nonnull
+                  @Override
+                  public Map<String, Set<String>> load(@Nonnull String key) {
+                    return loadHiddenStages();
+                  }
+                });
+  }
+
+  /** Must be called once after Spring wiring with the system operation context. */
+  public void setSystemOperationContext(@Nonnull OperationContext opContext) {
+    this.systemOpContext = opContext;
+  }
+
+  /**
+   * Returns the set of lifecycle stage URN strings that should be excluded from default search for
+   * the given entity types. Includes stages that apply to all entity types ({@code entityTypes ==
+   * null} on the definition) and stages that explicitly list any of the requested types.
+   */
+  @Nonnull
+  public Set<String> getHiddenStageUrns(@Nonnull Set<String> entityTypes) {
+    Map<String, Set<String>> hiddenByType;
+    try {
+      hiddenByType = cache.get("singleton");
+    } catch (Exception e) {
+      log.warn("Failed to load lifecycle stage cache, returning empty set", e);
+      return Collections.emptySet();
+    }
+
+    Set<String> result = new HashSet<>();
+
+    // Stages that apply to ALL entity types
+    Set<String> globalStages = hiddenByType.getOrDefault(ALL_ENTITY_TYPES_KEY, Set.of());
+    result.addAll(globalStages);
+
+    // Stages specific to the requested entity types
+    for (String entityType : entityTypes) {
+      result.addAll(hiddenByType.getOrDefault(entityType, Set.of()));
+    }
+
+    return result;
+  }
+
+  /**
+   * Returns the info for a specific lifecycle stage type, or null if not found. Uses the stored
+   * system operation context.
+   */
+  @Nullable
+  public LifecycleStageTypeInfo getStageInfo(@Nonnull Urn stageUrn) {
+    if (systemOpContext == null) {
+      log.debug("System operation context not yet available, cannot load stage info");
+      return null;
+    }
+    return getStageInfo(systemOpContext, stageUrn);
+  }
+
+  /** Returns the info for a specific lifecycle stage type, or null if not found. */
+  @Nullable
+  public LifecycleStageTypeInfo getStageInfo(
+      @Nonnull OperationContext opContext, @Nonnull Urn stageUrn) {
+    try {
+      EntityResponse response =
+          entityClient.getV2(
+              opContext,
+              LIFECYCLE_STAGE_TYPE_ENTITY_NAME,
+              stageUrn,
+              ImmutableSet.of(LIFECYCLE_STAGE_TYPE_INFO_ASPECT_NAME));
+      if (response == null
+          || !response.getAspects().containsKey(LIFECYCLE_STAGE_TYPE_INFO_ASPECT_NAME)) {
+        return null;
+      }
+      return new LifecycleStageTypeInfo(
+          response.getAspects().get(LIFECYCLE_STAGE_TYPE_INFO_ASPECT_NAME).getValue().data());
+    } catch (Exception e) {
+      log.warn("Failed to load lifecycle stage info for {}", stageUrn, e);
+      return null;
+    }
+  }
+
+  /**
+   * Loads all lifecycle stage types and builds the hidden-stage map.
+   *
+   * <p>Returns a map: entity type name → set of lifecycle stage URN strings with hideInSearch=true.
+   * The special key "*" holds stages that apply to all entity types.
+   */
+  @Nonnull
+  private Map<String, Set<String>> loadHiddenStages() {
+    if (systemOpContext == null) {
+      log.debug("System operation context not yet available, returning empty hidden stages");
+      return Collections.emptyMap();
+    }
+
+    try {
+      // Search for all lifecycle stage type entities
+      var searchResult =
+          entityClient.search(
+              systemOpContext, LIFECYCLE_STAGE_TYPE_ENTITY_NAME, "", null, null, 0, 1000);
+
+      if (searchResult == null || searchResult.getEntities().isEmpty()) {
+        return Collections.emptyMap();
+      }
+
+      Set<Urn> stageUrns =
+          searchResult.getEntities().stream()
+              .map(SearchEntity::getEntity)
+              .collect(Collectors.toSet());
+
+      Map<Urn, EntityResponse> responses =
+          entityClient.batchGetV2(
+              systemOpContext,
+              LIFECYCLE_STAGE_TYPE_ENTITY_NAME,
+              stageUrns,
+              ImmutableSet.of(LIFECYCLE_STAGE_TYPE_INFO_ASPECT_NAME));
+
+      Map<String, Set<String>> result = new HashMap<>();
+
+      for (Map.Entry<Urn, EntityResponse> entry : responses.entrySet()) {
+        EntityResponse response = entry.getValue();
+        if (!response.getAspects().containsKey(LIFECYCLE_STAGE_TYPE_INFO_ASPECT_NAME)) {
+          continue;
+        }
+
+        LifecycleStageTypeInfo info =
+            new LifecycleStageTypeInfo(
+                response.getAspects().get(LIFECYCLE_STAGE_TYPE_INFO_ASPECT_NAME).getValue().data());
+
+        LifecycleStageSettings settings = info.getSettings();
+        if (settings == null || !settings.isHideInSearch()) {
+          continue;
+        }
+
+        String stageUrnStr = entry.getKey().toString();
+
+        if (!info.hasEntityTypes()) {
+          // null entityTypes → applies to all entity types
+          result.computeIfAbsent(ALL_ENTITY_TYPES_KEY, k -> new HashSet<>()).add(stageUrnStr);
+        } else if (info.getEntityTypes().isEmpty()) {
+          // empty list → applies to no entity types (skip)
+          continue;
+        } else {
+          for (String entityType : info.getEntityTypes()) {
+            result.computeIfAbsent(entityType, k -> new HashSet<>()).add(stageUrnStr);
+          }
+        }
+      }
+
+      log.debug("Loaded hidden lifecycle stages: {}", result);
+      return result;
+    } catch (Exception e) {
+      log.warn("Failed to load lifecycle stage types", e);
+      return Collections.emptyMap();
+    }
+  }
+}

--- a/metadata-service/services/src/test/java/com/linkedin/metadata/service/LifecycleStageTypeServiceTest.java
+++ b/metadata-service/services/src/test/java/com/linkedin/metadata/service/LifecycleStageTypeServiceTest.java
@@ -1,0 +1,198 @@
+package com.linkedin.metadata.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.StringArray;
+import com.linkedin.entity.Aspect;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspect;
+import com.linkedin.entity.EnvelopedAspectMap;
+import com.linkedin.entity.client.SystemEntityClient;
+import com.linkedin.lifecycle.LifecycleStageSettings;
+import com.linkedin.lifecycle.LifecycleStageTypeInfo;
+import com.linkedin.metadata.search.SearchEntity;
+import com.linkedin.metadata.search.SearchEntityArray;
+import com.linkedin.metadata.search.SearchResult;
+import com.linkedin.metadata.search.SearchResultMetadata;
+import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.test.metadata.context.TestOperationContexts;
+import java.util.Map;
+import java.util.Set;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class LifecycleStageTypeServiceTest {
+
+  private static final Urn ACTOR_URN = UrnUtils.getUrn("urn:li:corpuser:testUser");
+  private static final OperationContext OP_CTX =
+      TestOperationContexts.userContextNoSearchAuthorization(ACTOR_URN);
+
+  private static final Urn PROPOSED_URN = UrnUtils.getUrn("urn:li:lifecycleStageType:PROPOSED");
+  private static final Urn ARCHIVED_URN = UrnUtils.getUrn("urn:li:lifecycleStageType:ARCHIVED");
+  private static final Urn VISIBLE_URN = UrnUtils.getUrn("urn:li:lifecycleStageType:VISIBLE");
+
+  private SystemEntityClient entityClient;
+
+  @BeforeMethod
+  public void setup() {
+    entityClient = mock(SystemEntityClient.class);
+  }
+
+  @Test
+  public void testGetHiddenStageUrns_entityTypeSpecific() throws Exception {
+    // PROPOSED: hideInSearch=true, entityTypes=["document"]
+    // ARCHIVED: hideInSearch=true, entityTypes=null (all)
+    // VISIBLE: hideInSearch=false
+    SearchResult searchResult = makeSearchResult(PROPOSED_URN, ARCHIVED_URN, VISIBLE_URN);
+    when(entityClient.search(any(), any(), any(), any(), any(), eq(0), eq(1000)))
+        .thenReturn(searchResult);
+
+    Map<Urn, EntityResponse> responses =
+        Map.of(
+            PROPOSED_URN, makeResponse(PROPOSED_URN, true, new StringArray("document")),
+            ARCHIVED_URN, makeResponse(ARCHIVED_URN, true, null),
+            VISIBLE_URN, makeResponse(VISIBLE_URN, false, new StringArray("document")));
+    when(entityClient.batchGetV2(any(), any(), any(), any())).thenReturn(responses);
+
+    LifecycleStageTypeService service = new LifecycleStageTypeService(entityClient);
+    service.setSystemOperationContext(OP_CTX);
+
+    // Querying for "document" should get PROPOSED (entity-specific) + ARCHIVED (global)
+    Set<String> hidden = service.getHiddenStageUrns(Set.of("document"));
+    assertEquals(hidden.size(), 2);
+    assertTrue(hidden.contains(PROPOSED_URN.toString()));
+    assertTrue(hidden.contains(ARCHIVED_URN.toString()));
+
+    // Querying for "dataset" should only get ARCHIVED (global)
+    Set<String> datasetHidden = service.getHiddenStageUrns(Set.of("dataset"));
+    assertEquals(datasetHidden.size(), 1);
+    assertTrue(datasetHidden.contains(ARCHIVED_URN.toString()));
+  }
+
+  @Test
+  public void testGetHiddenStageUrns_emptyEntityTypes() throws Exception {
+    // Stage with hideInSearch=true but entityTypes=[] → applies to no types
+    SearchResult searchResult = makeSearchResult(PROPOSED_URN);
+    when(entityClient.search(any(), any(), any(), any(), any(), eq(0), eq(1000)))
+        .thenReturn(searchResult);
+
+    Map<Urn, EntityResponse> responses =
+        Map.of(PROPOSED_URN, makeResponse(PROPOSED_URN, true, new StringArray()));
+    when(entityClient.batchGetV2(any(), any(), any(), any())).thenReturn(responses);
+
+    LifecycleStageTypeService service = new LifecycleStageTypeService(entityClient);
+    service.setSystemOperationContext(OP_CTX);
+
+    Set<String> hidden = service.getHiddenStageUrns(Set.of("document"));
+    assertTrue(hidden.isEmpty(), "Empty entityTypes should match no entity types");
+  }
+
+  @Test
+  public void testGetHiddenStageUrns_noOpContextReturnsEmpty() {
+    LifecycleStageTypeService service = new LifecycleStageTypeService(entityClient);
+    // Don't set system op context
+
+    Set<String> hidden = service.getHiddenStageUrns(Set.of("document"));
+    assertTrue(hidden.isEmpty());
+  }
+
+  @Test
+  public void testGetHiddenStageUrns_noSearchResultsReturnsEmpty() throws Exception {
+    SearchResult emptyResult = new SearchResult();
+    emptyResult.setEntities(new SearchEntityArray());
+    emptyResult.setFrom(0);
+    emptyResult.setPageSize(0);
+    emptyResult.setNumEntities(0);
+    emptyResult.setMetadata(new SearchResultMetadata());
+    when(entityClient.search(any(), any(), any(), any(), any(), eq(0), eq(1000)))
+        .thenReturn(emptyResult);
+
+    LifecycleStageTypeService service = new LifecycleStageTypeService(entityClient);
+    service.setSystemOperationContext(OP_CTX);
+
+    Set<String> hidden = service.getHiddenStageUrns(Set.of("document"));
+    assertTrue(hidden.isEmpty());
+  }
+
+  @Test
+  public void testGetStageInfo_found() throws Exception {
+    EntityResponse response = makeResponse(PROPOSED_URN, true, new StringArray("document"));
+    when(entityClient.getV2(any(), eq("lifecycleStageType"), eq(PROPOSED_URN), any()))
+        .thenReturn(response);
+
+    LifecycleStageTypeService service = new LifecycleStageTypeService(entityClient);
+
+    LifecycleStageTypeInfo info = service.getStageInfo(OP_CTX, PROPOSED_URN);
+    assertNotNull(info);
+    assertEquals(info.getName(), "Test Stage");
+    assertTrue(info.getSettings().isHideInSearch());
+  }
+
+  @Test
+  public void testGetStageInfo_notFound() throws Exception {
+    when(entityClient.getV2(any(), any(), any(), any())).thenReturn(null);
+
+    LifecycleStageTypeService service = new LifecycleStageTypeService(entityClient);
+
+    assertNull(service.getStageInfo(OP_CTX, PROPOSED_URN));
+  }
+
+  // ── Helpers ─────────────────────────────────────────────────────────────────
+
+  private static SearchResult makeSearchResult(Urn... urns) {
+    SearchEntityArray entities = new SearchEntityArray();
+    for (Urn urn : urns) {
+      SearchEntity entity = new SearchEntity();
+      entity.setEntity(urn);
+      entities.add(entity);
+    }
+    SearchResult result = new SearchResult();
+    result.setEntities(entities);
+    result.setFrom(0);
+    result.setPageSize(urns.length);
+    result.setNumEntities(urns.length);
+    result.setMetadata(new SearchResultMetadata());
+    return result;
+  }
+
+  private static EntityResponse makeResponse(
+      Urn urn, boolean hideInSearch, StringArray entityTypes) {
+    LifecycleStageSettings settings = new LifecycleStageSettings();
+    settings.setHideInSearch(hideInSearch);
+
+    AuditStamp stamp = new AuditStamp();
+    stamp.setTime(System.currentTimeMillis());
+    stamp.setActor(UrnUtils.getUrn("urn:li:corpuser:system"));
+
+    LifecycleStageTypeInfo info = new LifecycleStageTypeInfo();
+    info.setName("Test Stage");
+    info.setSettings(settings);
+    info.setCreated(stamp);
+    info.setLastModified(stamp);
+    if (entityTypes != null) {
+      info.setEntityTypes(entityTypes);
+    }
+
+    EnvelopedAspect envelopedAspect = new EnvelopedAspect();
+    envelopedAspect.setValue(new Aspect(info.data()));
+
+    EnvelopedAspectMap aspectMap = new EnvelopedAspectMap();
+    aspectMap.put("lifecycleStageTypeInfo", envelopedAspect);
+
+    EntityResponse response = new EntityResponse();
+    response.setUrn(urn);
+    response.setEntityName("lifecycleStageType");
+    response.setAspects(aspectMap);
+    return response;
+  }
+}

--- a/metadata-service/war/src/main/java/com/linkedin/gms/CommonApplicationConfig.java
+++ b/metadata-service/war/src/main/java/com/linkedin/gms/CommonApplicationConfig.java
@@ -62,6 +62,7 @@ import org.springframework.core.env.Environment;
       "com.linkedin.gms.factory.kafka.trace",
       "com.linkedin.gms.factory.system_info",
       "com.linkedin.gms.factory.consistency",
+      "com.linkedin.gms.factory.lifecycle",
       "com.linkedin.metadata.aspect.consistency.check",
       "com.linkedin.metadata.aspect.consistency.fix",
       "com.linkedin.metadata.aspect.hooks.migrations",

--- a/smoke-test/tests/status/test_lifecycle_state.py
+++ b/smoke-test/tests/status/test_lifecycle_state.py
@@ -1,0 +1,395 @@
+"""
+Smoke tests for the lifecycle stage GraphQL APIs.
+
+Tests create their own lifecycle stage types on the fly (no dependency on
+bootstrap MCPs) and exercise the core lifecycle stage GraphQL operations:
+  - setLifecycleStage mutation
+  - listLifecycleStages query
+  - Status.lifecycleStage resolved entity
+
+Uses a dedicated URN namespace (urn:li:lifecycleStageType:smoketest_*) to
+avoid collisions with any real bootstrapped stages.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from tests.consistency_utils import wait_for_writes_to_sync
+from tests.utils import with_test_retry
+
+logger = logging.getLogger(__name__)
+
+SMOKE_TEST_STAGE_PREFIX = "smoketest"
+
+
+def _unique_id(prefix: str = SMOKE_TEST_STAGE_PREFIX) -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:8]}"
+
+
+def execute_graphql(
+    auth_session, query: str, variables: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
+    payload = {"query": query, "variables": variables or {}}
+    response = auth_session.post(
+        f"{auth_session.frontend_url()}/api/graphql", json=payload
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+# ── Stage ingestion helper ────────────────────────────────────────────────────
+
+
+def _ingest_lifecycle_stage(
+    auth_session,
+    stage_id: str,
+    name: str,
+    *,
+    hide_in_search: bool = True,
+    description: str = "Smoke test stage",
+    entity_types: Optional[List[str]] = None,
+) -> str:
+    """Create a lifecycleStageType entity via the REST emitter. Returns the URN."""
+    from datahub.emitter.mcp import MetadataChangeProposalWrapper
+    from datahub.emitter.rest_emitter import DatahubRestEmitter
+    from datahub.metadata.schema_classes import (
+        AuditStampClass,
+        LifecycleStageSettingsClass,
+        LifecycleStageTypeInfoClass,
+    )
+
+    stage_urn = f"urn:li:lifecycleStageType:{stage_id}"
+
+    now_millis = 0
+    audit = AuditStampClass(time=now_millis, actor="urn:li:corpuser:datahub")
+
+    aspect = LifecycleStageTypeInfoClass(
+        name=name,
+        description=description,
+        entityTypes=entity_types or ["dataset"],
+        settings=LifecycleStageSettingsClass(hideInSearch=hide_in_search),
+        created=audit,
+        lastModified=audit,
+    )
+
+    mcp = MetadataChangeProposalWrapper(entityUrn=stage_urn, aspect=aspect)
+    emitter = DatahubRestEmitter(
+        gms_server=auth_session.gms_url(), token=auth_session.gms_token()
+    )
+    try:
+        emitter.emit(mcp)
+    finally:
+        emitter.close()
+
+    return stage_urn
+
+
+# ── Document helpers ──────────────────────────────────────────────────────────
+
+CREATE_DOCUMENT_MUTATION = """
+    mutation CreateDoc($input: CreateDocumentInput!) {
+        createDocument(input: $input)
+    }
+"""
+
+DELETE_DOCUMENT_MUTATION = """
+    mutation DeleteDoc($urn: String!) {
+        deleteDocument(urn: $urn)
+    }
+"""
+
+SEARCH_DOCUMENTS_QUERY = """
+    query SearchDocs($input: SearchDocumentsInput!) {
+        searchDocuments(input: $input) {
+            total
+            documents { urn }
+        }
+    }
+"""
+
+SET_LIFECYCLE_STAGE_MUTATION = """
+    mutation SetStage($urn: String!, $lifecycleStageUrn: String) {
+        setLifecycleStage(urn: $urn, lifecycleStageUrn: $lifecycleStageUrn)
+    }
+"""
+
+LIST_LIFECYCLE_STAGES_QUERY = """
+    query ListStages {
+        listLifecycleStages {
+            urn
+            name
+            description
+            entityTypes
+            hideInSearch
+            allowedPreviousStages
+        }
+    }
+"""
+
+
+def _create_document(auth_session, doc_id: str, title: str) -> str:
+    """Create a PUBLISHED document. Returns URN."""
+    result = execute_graphql(
+        auth_session,
+        CREATE_DOCUMENT_MUTATION,
+        {
+            "input": {
+                "id": doc_id,
+                "title": title,
+                "contents": {"text": f"Content for {title}"},
+                "state": "PUBLISHED",
+            }
+        },
+    )
+    assert "errors" not in result, f"createDocument errors: {result.get('errors')}"
+    return result["data"]["createDocument"]
+
+
+def _set_lifecycle_stage_via_rest(
+    auth_session, urn: str, lifecycle_stage_urn: Optional[str]
+) -> None:
+    """Set lifecycleStage on an entity by emitting a Status aspect MCP via GMS REST."""
+    from datahub.emitter.mcp import MetadataChangeProposalWrapper
+    from datahub.emitter.rest_emitter import DatahubRestEmitter
+    from datahub.metadata.schema_classes import StatusClass
+
+    status = StatusClass(
+        removed=False,
+        lifecycleStage=lifecycle_stage_urn,
+    )
+    mcp = MetadataChangeProposalWrapper(entityUrn=urn, aspect=status)
+    emitter = DatahubRestEmitter(
+        gms_server=auth_session.gms_url(), token=auth_session.gms_token()
+    )
+    try:
+        emitter.emit(mcp)
+    finally:
+        emitter.close()
+
+
+def _search_documents(auth_session, query: str) -> List[str]:
+    result = execute_graphql(
+        auth_session,
+        SEARCH_DOCUMENTS_QUERY,
+        {"input": {"query": query, "count": 50}},
+    )
+    assert "errors" not in result, f"searchDocuments errors: {result.get('errors')}"
+    docs = result["data"]["searchDocuments"]["documents"]
+    return [d["urn"] for d in docs]
+
+
+def _get_status(auth_session, urn: str) -> Dict[str, Any]:
+    from datahub.ingestion.graph.client import DataHubGraph, DataHubGraphConfig
+    from datahub.metadata.schema_classes import StatusClass
+
+    cfg = DataHubGraphConfig(
+        server=auth_session.gms_url(), token=auth_session.gms_token() or ""
+    )
+    with DataHubGraph(cfg) as graph:
+        aspect = graph.get_aspect(urn, StatusClass)
+    if aspect is None:
+        return {}
+    result: Dict[str, Any] = {"removed": aspect.removed}
+    if aspect.lifecycleStage is not None:
+        result["lifecycleStage"] = aspect.lifecycleStage
+    return result
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+class TestLifecycleStageAPIs:
+    """Tests for lifecycle stage GraphQL APIs using self-ingested stage types."""
+
+    @pytest.fixture(autouse=True)
+    def setup_and_teardown(self, auth_session):
+        self.auth_session = auth_session
+        self.created_urns: List[str] = []
+        self.created_stage_urns: List[str] = []
+        yield
+        for urn in self.created_urns:
+            try:
+                execute_graphql(auth_session, DELETE_DOCUMENT_MUTATION, {"urn": urn})
+            except Exception as exc:
+                logger.warning(f"Cleanup failed for {urn}: {exc}")
+        for stage_urn in self.created_stage_urns:
+            try:
+                from datahub.ingestion.graph.client import (
+                    DataHubGraph,
+                    DataHubGraphConfig,
+                )
+
+                cfg = DataHubGraphConfig(
+                    server=auth_session.gms_url(),
+                    token=auth_session.gms_token() or "",
+                )
+                with DataHubGraph(cfg) as graph:
+                    graph.hard_delete_entity(stage_urn)
+            except Exception as exc:
+                logger.warning(f"Cleanup failed for {stage_urn}: {exc}")
+
+    def _ingest_stage(self, name: str, *, hide_in_search: bool = True) -> str:
+        stage_id = _unique_id()
+        stage_urn = _ingest_lifecycle_stage(
+            self.auth_session,
+            stage_id,
+            name,
+            hide_in_search=hide_in_search,
+            entity_types=["dataset", "document"],
+        )
+        self.created_stage_urns.append(stage_urn)
+        return stage_urn
+
+    def test_list_lifecycle_stages_includes_ingested(self, auth_session):
+        """
+        Ingest a custom lifecycle stage and verify it appears in listLifecycleStages.
+        """
+        stage_name = f"TestStage {_unique_id()}"
+        stage_urn = self._ingest_stage(stage_name, hide_in_search=True)
+        wait_for_writes_to_sync()
+
+        @with_test_retry(max_attempts=12)
+        def _assert_listed():
+            result = execute_graphql(auth_session, LIST_LIFECYCLE_STAGES_QUERY)
+            assert "errors" not in result, (
+                f"listLifecycleStages errors: {result.get('errors')}"
+            )
+            stages = result["data"]["listLifecycleStages"]
+            stage_urns = [s["urn"] for s in stages]
+            assert stage_urn in stage_urns, (
+                f"Expected {stage_urn} in listLifecycleStages, got: {stage_urns}"
+            )
+            stage_obj = next(s for s in stages if s["urn"] == stage_urn)
+            assert stage_obj["name"] == stage_name
+            assert stage_obj["hideInSearch"] is True
+
+        _assert_listed()
+        logger.info("listLifecycleStages returns ingested stage")
+
+    def test_set_lifecycle_stage_mutation(self, auth_session):
+        """
+        setLifecycleStage mutation sets the stage on an entity and the
+        Status aspect reflects it.
+        """
+        stage_urn = self._ingest_stage("MutationTest", hide_in_search=True)
+        wait_for_writes_to_sync()
+
+        title = f"Lifecycle Mutation Test {_unique_id()}"
+        doc_id = _unique_id("lc-mut")
+        urn = _create_document(auth_session, doc_id, title)
+        self.created_urns.append(urn)
+        wait_for_writes_to_sync()
+
+        result = execute_graphql(
+            auth_session,
+            SET_LIFECYCLE_STAGE_MUTATION,
+            {"urn": urn, "lifecycleStageUrn": stage_urn},
+        )
+        assert "errors" not in result, (
+            f"setLifecycleStage errors: {result.get('errors')}"
+        )
+        assert result["data"]["setLifecycleStage"] is True
+        wait_for_writes_to_sync()
+
+        status = _get_status(auth_session, urn)
+        assert status.get("lifecycleStage") == stage_urn, (
+            f"Expected stage {stage_urn}, got: {status}"
+        )
+
+        # Clear stage
+        result = execute_graphql(
+            auth_session,
+            SET_LIFECYCLE_STAGE_MUTATION,
+            {"urn": urn, "lifecycleStageUrn": None},
+        )
+        assert "errors" not in result
+        assert result["data"]["setLifecycleStage"] is True
+        wait_for_writes_to_sync()
+
+        status = _get_status(auth_session, urn)
+        assert status.get("lifecycleStage") is None
+        logger.info("setLifecycleStage mutation set and cleared stage")
+
+    def test_hidden_stage_excludes_from_search(self, auth_session):
+        """
+        Entities in a hideInSearch=true stage are excluded from default search.
+        Clearing the stage restores visibility.
+        """
+        stage_urn = self._ingest_stage("HiddenStage", hide_in_search=True)
+        wait_for_writes_to_sync()
+
+        title = f"Lifecycle Search Test {_unique_id()}"
+        doc_id = _unique_id("lc-search")
+        urn = _create_document(auth_session, doc_id, title)
+        self.created_urns.append(urn)
+        wait_for_writes_to_sync()
+
+        @with_test_retry(max_attempts=12)
+        def _assert_visible():
+            urns = _search_documents(auth_session, title)
+            assert urn in urns, f"Expected {urn} in search, got: {urns}"
+
+        _assert_visible()
+
+        _set_lifecycle_stage_via_rest(auth_session, urn, stage_urn)
+        wait_for_writes_to_sync()
+
+        @with_test_retry(max_attempts=12)
+        def _assert_hidden():
+            urns = _search_documents(auth_session, title)
+            assert urn not in urns, "Entity in hidden stage should not appear in search"
+
+        _assert_hidden()
+        logger.info("Hidden stage excludes entity from search")
+
+        _set_lifecycle_stage_via_rest(auth_session, urn, None)
+        wait_for_writes_to_sync()
+
+        @with_test_retry(max_attempts=12)
+        def _assert_visible_again():
+            urns = _search_documents(auth_session, title)
+            assert urn in urns, f"Cleared entity should be visible: {urns}"
+
+        _assert_visible_again()
+        logger.info("Cleared stage restores search visibility")
+
+    def test_visible_stage_remains_in_search(self, auth_session):
+        """
+        Entities in a hideInSearch=false stage remain visible in default search.
+        """
+        stage_urn = self._ingest_stage("VisibleStage", hide_in_search=False)
+        wait_for_writes_to_sync()
+
+        title = f"Lifecycle Visible Test {_unique_id()}"
+        doc_id = _unique_id("lc-vis")
+        urn = _create_document(auth_session, doc_id, title)
+        self.created_urns.append(urn)
+        wait_for_writes_to_sync()
+
+        @with_test_retry(max_attempts=12)
+        def _assert_visible_before():
+            urns = _search_documents(auth_session, title)
+            assert urn in urns, f"Expected {urn} in search, got: {urns}"
+
+        _assert_visible_before()
+
+        _set_lifecycle_stage_via_rest(auth_session, urn, stage_urn)
+        wait_for_writes_to_sync()
+
+        @with_test_retry(max_attempts=12)
+        def _assert_still_visible():
+            urns = _search_documents(auth_session, title)
+            assert urn in urns, (
+                f"Entity in visible stage should remain in search: {urns}"
+            )
+
+        _assert_still_visible()
+
+        status = _get_status(auth_session, urn)
+        assert status.get("lifecycleStage") == stage_urn
+        logger.info("Visible stage keeps entity in search results")


### PR DESCRIPTION
## Summary

In this PR, we add a new feature for adding lifecycle stages for entities. This enables you to define custom lifecycle stages for each entity type using the new LifecycleStageType entity that stands on it's own. The pattern largely follows what we have implemented for Ownership Types and Structured Property Definitions. 

This feature WILL have a corresponding PR for open source, which will be linked here shortly. 

The main changes:

1. Entity models for new lifecycle stages entities 
2. GraphQL resolvers for new lifecycle stages entities 

Status: Ready for review 

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
