### PR TITLE
fix(): Improve defensive handling of missing document fields in datahub-documents source

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
@@ -346,9 +346,9 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
             )
             return
 
-        # Extract text from documentInfo
-        contents = aspect_dict.get("contents", {})
-        text = contents.get("text", "")
+        # Extract text from documentInfo (contents may be null for partial entities)
+        contents = aspect_dict.get("contents") or {}
+        text = contents.get("text") or ""
 
         if not text:
             logger.debug(f"No text content in document {entity_urn}")
@@ -496,8 +496,8 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
         self, aspect_dict: dict[str, Any]
     ) -> Optional[str]:
         """Extract platform name from documentInfo aspect."""
-        # Try to get from dataPlatformInstance
-        platform_instance = aspect_dict.get("dataPlatformInstance", {})
+        # Try to get from dataPlatformInstance (may be null for partial entities)
+        platform_instance = aspect_dict.get("dataPlatformInstance") or {}
         platform_urn = platform_instance.get("platform")
         if platform_urn and isinstance(platform_urn, str):
             # Extract platform name from URN (e.g., "urn:li:dataPlatform:notion" → "notion")
@@ -567,9 +567,9 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
             }
             """
             response = self.graph.execute_graphql(query, {"urn": entity_urn})
-            entity = response.get("entity", {})
-            platform_instance = entity.get("dataPlatformInstance", {})
-            platform = platform_instance.get("platform", {})
+            entity = response.get("entity") or {}
+            platform_instance = entity.get("dataPlatformInstance") or {}
+            platform = platform_instance.get("platform") or {}
             platform_urn = platform.get("urn")
 
             if platform_urn and isinstance(platform_urn, str):
@@ -665,8 +665,8 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
         ):
             return True
 
-        # Extract source type from info
-        source = info.get("source", {})
+        # Extract source type from info (source may be null for partial entities)
+        source = info.get("source") or {}
         source_type = source.get("sourceType")
         # Default to NATIVE if sourceType is not set (backward compatibility with old documents)
         if source_type is None:
@@ -712,9 +712,9 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
 
     def _extract_platform_from_entity(self, entity: dict[str, Any]) -> Optional[str]:
         """Extract platform name from GraphQL entity response."""
-        # Try to get from dataPlatformInstance
-        platform_instance = entity.get("dataPlatformInstance", {})
-        platform = platform_instance.get("platform", {})
+        # Try to get from dataPlatformInstance (fields may be null for partial entities)
+        platform_instance = entity.get("dataPlatformInstance") or {}
+        platform = platform_instance.get("platform") or {}
         platform_urn = platform.get("urn")
         if platform_urn and isinstance(platform_urn, str):
             # Extract platform name from URN (e.g., "urn:li:dataPlatform:notion" → "notion")
@@ -789,11 +789,12 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
 
         try:
             response = self.graph.execute_graphql(query, variables)
-            search_results = response.get("search", {}).get("searchResults", [])
+            search_data = response.get("search") or {}
+            search_results = search_data.get("searchResults") or []
 
             documents = []
             for result in search_results:
-                entity = result.get("entity", {})
+                entity = result.get("entity") or {}
                 urn = entity.get("urn")
 
                 if not urn:
@@ -803,10 +804,10 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
                 if self.config.document_urns and urn not in self.config.document_urns:
                     continue
 
-                # Extract text content
-                info = entity.get("info", {})
-                contents = info.get("contents", {})
-                text = contents.get("text", "")
+                # Extract text content (GraphQL returns null for missing aspects)
+                info = entity.get("info") or {}
+                contents = info.get("contents") or {}
+                text = contents.get("text") or ""
 
                 # Filter by source type (NATIVE vs EXTERNAL) for batch mode
                 should_process = self._should_process_by_source_type(entity, info)

--- a/metadata-ingestion/tests/unit/test_datahub_documents_source.py
+++ b/metadata-ingestion/tests/unit/test_datahub_documents_source.py
@@ -1660,6 +1660,242 @@ class TestConfigFingerprintInHash:
                 assert documents[0]["urn"] == "urn:li:document:notion1"
 
 
+class TestPartialEntityHandling:
+    """Test defensive handling of partial entities with null info/contents fields.
+
+    GraphQL returns null (Python None) for missing aspects, not absent keys.
+    dict.get("key", {}) returns None when key exists with value None, so we
+    must use `or {}` to handle both missing and null cases.
+    """
+
+    @pytest.fixture
+    def config(self):
+        """Create test configuration."""
+        return DataHubDocumentsSourceConfig(
+            platform_filter=None,
+            datahub={"server": "http://test-server:8080"},
+            embedding={
+                "provider": "bedrock",
+                "model": "cohere.embed-english-v3",
+                "aws_region": "us-west-2",
+                "allow_local_embedding_config": True,
+            },
+            min_text_length=10,
+            stateful_ingestion={"enabled": False},
+        )
+
+    @pytest.fixture
+    def ctx(self):
+        """Create test context."""
+        return PipelineContext(run_id="test-run", pipeline_name="test-pipeline")
+
+    @pytest.fixture
+    def mock_graph(self):
+        """Create mock DataHubGraph."""
+        return patch(
+            "datahub.ingestion.source.datahub_documents.datahub_documents_source.DataHubGraph"
+        )
+
+    def test_fetch_documents_skips_entity_with_null_info(self, ctx, config, mock_graph):
+        """Test that entities with info: null are gracefully skipped."""
+        with mock_graph:
+            source = DataHubDocumentsSource(ctx, config)
+
+            mock_response = {
+                "search": {
+                    "searchResults": [
+                        {
+                            "entity": {
+                                "urn": "urn:li:document:partial1",
+                                "info": None,
+                            }
+                        },
+                        {
+                            "entity": {
+                                "urn": "urn:li:document:complete1",
+                                "info": {
+                                    "source": {"sourceType": "NATIVE"},
+                                    "contents": {
+                                        "text": "This is a complete document with enough content."
+                                    },
+                                },
+                            }
+                        },
+                    ]
+                }
+            }
+
+            with patch.object(
+                source.graph, "execute_graphql", return_value=mock_response
+            ):
+                documents = source._fetch_documents_graphql()
+
+                assert len(documents) == 1
+                assert documents[0]["urn"] == "urn:li:document:complete1"
+
+    def test_fetch_documents_skips_entity_with_null_contents(
+        self, ctx, config, mock_graph
+    ):
+        """Test that entities with contents: null inside info are gracefully skipped."""
+        with mock_graph:
+            source = DataHubDocumentsSource(ctx, config)
+
+            mock_response = {
+                "search": {
+                    "searchResults": [
+                        {
+                            "entity": {
+                                "urn": "urn:li:document:no_contents",
+                                "info": {
+                                    "source": {"sourceType": "NATIVE"},
+                                    "contents": None,
+                                },
+                            }
+                        },
+                    ]
+                }
+            }
+
+            with patch.object(
+                source.graph, "execute_graphql", return_value=mock_response
+            ):
+                documents = source._fetch_documents_graphql()
+
+                assert len(documents) == 0
+
+    def test_fetch_documents_skips_entity_with_null_search(
+        self, ctx, config, mock_graph
+    ):
+        """Test that a null search response is handled gracefully."""
+        with mock_graph:
+            source = DataHubDocumentsSource(ctx, config)
+
+            mock_response: dict[str, Any] = {"search": None}
+
+            with patch.object(
+                source.graph, "execute_graphql", return_value=mock_response
+            ):
+                documents = source._fetch_documents_graphql()
+
+                assert len(documents) == 0
+
+    def test_should_process_by_source_type_with_null_source(
+        self, ctx, config, mock_graph
+    ):
+        """Test _should_process_by_source_type when source field is null."""
+        with mock_graph:
+            source = DataHubDocumentsSource(ctx, config)
+
+            entity: dict[str, Any] = {"urn": "urn:li:document:test"}
+            info: dict[str, Any] = {"source": None, "contents": {"text": "some text"}}
+
+            should_process = source._should_process_by_source_type(entity, info)
+            # source=None → sourceType defaults to NATIVE → should process
+            assert should_process is True
+
+    def test_extract_platform_from_entity_with_null_platform_instance(
+        self, ctx, config, mock_graph
+    ):
+        """Test _extract_platform_from_entity when dataPlatformInstance is null."""
+        with mock_graph:
+            source = DataHubDocumentsSource(ctx, config)
+
+            entity: dict[str, Any] = {"dataPlatformInstance": None}
+            platform = source._extract_platform_from_entity(entity)
+            assert platform is None
+
+    def test_extract_platform_from_entity_with_null_platform(
+        self, ctx, config, mock_graph
+    ):
+        """Test _extract_platform_from_entity when platform inside dataPlatformInstance is null."""
+        with mock_graph:
+            source = DataHubDocumentsSource(ctx, config)
+
+            entity: dict[str, Any] = {"dataPlatformInstance": {"platform": None}}
+            platform = source._extract_platform_from_entity(entity)
+            assert platform is None
+
+    def test_extract_platform_from_aspect_with_null_platform_instance(
+        self, ctx, config, mock_graph
+    ):
+        """Test _extract_platform_from_aspect when dataPlatformInstance is null."""
+        with mock_graph:
+            source = DataHubDocumentsSource(ctx, config)
+
+            aspect_dict: dict[str, Any] = {"dataPlatformInstance": None}
+            platform = source._extract_platform_from_aspect(aspect_dict)
+            assert platform is None
+
+    def test_process_single_event_with_null_contents(self, ctx, config, mock_graph):
+        """Test _process_single_event when MCL aspect has contents: null."""
+        with mock_graph:
+            source = DataHubDocumentsSource(ctx, config)
+
+            event: dict[str, Any] = {
+                "entityUrn": "urn:li:document:partial1",
+                "aspectName": "documentInfo",
+                "aspect": json.dumps({"contents": None}),
+            }
+
+            workunits = list(source._process_single_event(event))
+            assert len(workunits) == 0
+
+    def test_fetch_documents_mixed_null_and_valid(self, ctx, config, mock_graph):
+        """Test batch mode with a mix of null-info, null-contents, and valid entities."""
+        with mock_graph:
+            source = DataHubDocumentsSource(ctx, config)
+
+            mock_response = {
+                "search": {
+                    "searchResults": [
+                        {
+                            "entity": {
+                                "urn": "urn:li:document:null_info",
+                                "info": None,
+                            }
+                        },
+                        {
+                            "entity": {
+                                "urn": "urn:li:document:null_contents",
+                                "info": {
+                                    "source": {"sourceType": "NATIVE"},
+                                    "contents": None,
+                                },
+                            }
+                        },
+                        {
+                            "entity": {
+                                "urn": "urn:li:document:empty_text",
+                                "info": {
+                                    "source": {"sourceType": "NATIVE"},
+                                    "contents": {"text": ""},
+                                },
+                            }
+                        },
+                        {
+                            "entity": {
+                                "urn": "urn:li:document:valid",
+                                "info": {
+                                    "source": {"sourceType": "NATIVE"},
+                                    "contents": {
+                                        "text": "This document has valid content that is long enough."
+                                    },
+                                },
+                            }
+                        },
+                    ]
+                }
+            }
+
+            with patch.object(
+                source.graph, "execute_graphql", return_value=mock_response
+            ):
+                documents = source._fetch_documents_graphql()
+
+                assert len(documents) == 1
+                assert documents[0]["urn"] == "urn:li:document:valid"
+
+
 class TestMaxDocumentsLimit:
     """Test max_documents limit behavior."""
 


### PR DESCRIPTION
When GraphQL explicitly returns None value for any fields, the source would hit an unrecoverable error and fail. This prevents this from happening, gracefully skipping documents in such cases. 

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
