### PR TITLE
fix(): Apply correct filtering for show in global context when searching documents

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/DocumentSearchFilterUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/DocumentSearchFilterUtils.java
@@ -8,6 +8,7 @@ import com.linkedin.metadata.query.filter.CriterionArray;
 import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.utils.CriterionUtils;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
 
@@ -22,14 +23,16 @@ public class DocumentSearchFilterUtils {
   }
 
   /**
-   * Builds a combined filter with ownership constraints and showInGlobalContext=true requirement.
+   * Builds a combined filter with ownership constraints that excludes documents explicitly hidden
+   * from global context.
    *
-   * <p>This is the default for global document searches (sidebar, search popovers). Documents with
-   * showInGlobalContext=false are context-only and should not appear in global searches.
+   * <p>This is the default for global document searches (sidebar, search popovers). Only documents
+   * with showInGlobalContext explicitly set to false are excluded; documents without the
+   * documentSettings aspect are shown by default.
    *
    * @param baseCriteria The base user criteria (without state filtering)
    * @param userAndGroupUrns List of URNs for the current user and their groups
-   * @return The combined filter with showInGlobalContext=true requirement
+   * @return The combined filter excluding showInGlobalContext=false documents
    */
   @Nonnull
   public static Filter buildCombinedFilter(
@@ -41,16 +44,20 @@ public class DocumentSearchFilterUtils {
    * Builds a combined filter with ownership constraints and optional showInGlobalContext filter.
    *
    * <p>The filter structure is: - With showInGlobalContext: (user-filters AND PUBLISHED AND
-   * showInGlobalContext=true) OR (user-filters AND UNPUBLISHED AND owned-by-user-or-groups AND
-   * showInGlobalContext=true)
+   * showInGlobalContext!=false) OR (user-filters AND UNPUBLISHED AND owned-by-user-or-groups AND
+   * showInGlobalContext!=false)
    *
    * <p>- Without showInGlobalContext: (user-filters AND PUBLISHED) OR (user-filters AND UNPUBLISHED
    * AND owned-by-user-or-groups)
    *
+   * <p>Uses negated EQUAL (field != "false") instead of positive EQUAL (field == "true") so that
+   * documents without an explicit documentSettings aspect are included by default. Only documents
+   * that explicitly set showInGlobalContext=false are excluded.
+   *
    * @param baseCriteria The base user criteria (without state filtering)
    * @param userAndGroupUrns List of URNs for the current user and their groups
-   * @param applyShowInGlobalContext Whether to require showInGlobalContext=true (set to false for
-   *     related documents queries where context-only docs should be visible)
+   * @param applyShowInGlobalContext Whether to exclude showInGlobalContext=false documents (set to
+   *     false for related documents queries where context-only docs should be visible)
    * @return The combined filter
    */
   @Nonnull
@@ -65,8 +72,7 @@ public class DocumentSearchFilterUtils {
     List<Criterion> publishedCriteria = new ArrayList<>(baseCriteria);
     publishedCriteria.add(CriterionUtils.buildCriterion("state", Condition.EQUAL, "PUBLISHED"));
     if (applyShowInGlobalContext) {
-      publishedCriteria.add(
-          CriterionUtils.buildCriterion("showInGlobalContext", Condition.EQUAL, "true"));
+      publishedCriteria.add(buildNegatedCriterion("showInGlobalContext", "false"));
     }
     orClauses.add(new ConjunctiveCriterion().setAnd(new CriterionArray(publishedCriteria)));
 
@@ -77,11 +83,24 @@ public class DocumentSearchFilterUtils {
     unpublishedOwnedCriteria.add(
         CriterionUtils.buildCriterion("owners", Condition.EQUAL, userAndGroupUrns));
     if (applyShowInGlobalContext) {
-      unpublishedOwnedCriteria.add(
-          CriterionUtils.buildCriterion("showInGlobalContext", Condition.EQUAL, "true"));
+      unpublishedOwnedCriteria.add(buildNegatedCriterion("showInGlobalContext", "false"));
     }
     orClauses.add(new ConjunctiveCriterion().setAnd(new CriterionArray(unpublishedOwnedCriteria)));
 
     return new Filter().setOr(new ConjunctiveCriterionArray(orClauses));
+  }
+
+  /**
+   * Builds a negated Criterion (field != value). Documents where the field is absent will pass
+   * through (not be excluded).
+   */
+  private static Criterion buildNegatedCriterion(String field, String value) {
+    Criterion criterion = new Criterion();
+    criterion.setField(field);
+    criterion.setCondition(Condition.EQUAL);
+    criterion.setValues(
+        new com.linkedin.data.template.StringArray(Collections.singletonList(value)));
+    criterion.setNegated(true);
+    return criterion;
   }
 }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/DocumentSearchFilterUtilsTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/DocumentSearchFilterUtilsTest.java
@@ -28,7 +28,7 @@ public class DocumentSearchFilterUtilsTest {
     assertNotNull(filter.getOr());
     assertEquals(filter.getOr().size(), 2); // PUBLISHED OR UNPUBLISHED owned
 
-    // Check first clause: PUBLISHED AND showInGlobalContext=true
+    // Check first clause: PUBLISHED AND showInGlobalContext!=false
     ConjunctiveCriterion publishedClause = filter.getOr().get(0);
     assertNotNull(publishedClause.getAnd());
     assertEquals(publishedClause.getAnd().size(), 2); // state + showInGlobalContext
@@ -36,13 +36,14 @@ public class DocumentSearchFilterUtilsTest {
     assertEquals(stateCriterion.getField(), "state");
     assertEquals(stateCriterion.getCondition(), Condition.EQUAL);
     assertEquals(stateCriterion.getValues().get(0), "PUBLISHED");
-    // Verify showInGlobalContext filter
+    // Verify showInGlobalContext uses negated filter (exclude false, not require true)
     Criterion showInGlobalContextCriterion = publishedClause.getAnd().get(1);
     assertEquals(showInGlobalContextCriterion.getField(), "showInGlobalContext");
     assertEquals(showInGlobalContextCriterion.getCondition(), Condition.EQUAL);
-    assertEquals(showInGlobalContextCriterion.getValues().get(0), "true");
+    assertEquals(showInGlobalContextCriterion.getValues().get(0), "false");
+    assertTrue(showInGlobalContextCriterion.isNegated());
 
-    // Check second clause: UNPUBLISHED AND owned AND showInGlobalContext=true
+    // Check second clause: UNPUBLISHED AND owned AND showInGlobalContext!=false
     ConjunctiveCriterion unpublishedClause = filter.getOr().get(1);
     assertNotNull(unpublishedClause.getAnd());
     assertEquals(unpublishedClause.getAnd().size(), 3); // State + owners + showInGlobalContext
@@ -55,11 +56,12 @@ public class DocumentSearchFilterUtilsTest {
     assertEquals(ownersCriterion.getCondition(), Condition.EQUAL);
     assertTrue(ownersCriterion.getValues().contains(TEST_USER_URN));
     assertTrue(ownersCriterion.getValues().contains(TEST_GROUP_URN));
-    // Verify showInGlobalContext filter in unpublished clause
+    // Verify showInGlobalContext uses negated filter in unpublished clause
     Criterion unpublishedShowInGlobalContextCriterion = unpublishedClause.getAnd().get(2);
     assertEquals(unpublishedShowInGlobalContextCriterion.getField(), "showInGlobalContext");
     assertEquals(unpublishedShowInGlobalContextCriterion.getCondition(), Condition.EQUAL);
-    assertEquals(unpublishedShowInGlobalContextCriterion.getValues().get(0), "true");
+    assertEquals(unpublishedShowInGlobalContextCriterion.getValues().get(0), "false");
+    assertTrue(unpublishedShowInGlobalContextCriterion.isNegated());
   }
 
   @Test
@@ -79,20 +81,20 @@ public class DocumentSearchFilterUtilsTest {
     assertNotNull(filter.getOr());
     assertEquals(filter.getOr().size(), 2);
 
-    // Check first clause: base criteria AND PUBLISHED AND showInGlobalContext=true
+    // Check first clause: base criteria AND PUBLISHED AND showInGlobalContext!=false
     ConjunctiveCriterion publishedClause = filter.getOr().get(0);
     assertNotNull(publishedClause.getAnd());
     assertEquals(
         publishedClause.getAnd().size(), 4); // types + domains + state + showInGlobalContext
 
-    // Check second clause: base criteria AND UNPUBLISHED AND owned AND showInGlobalContext=true
+    // Check second clause: base criteria AND UNPUBLISHED AND owned AND showInGlobalContext!=false
     ConjunctiveCriterion unpublishedClause = filter.getOr().get(1);
     assertNotNull(unpublishedClause.getAnd());
     assertEquals(
         unpublishedClause.getAnd().size(),
         5); // types + domains + state + owners + showInGlobalContext
 
-    // Verify base criteria are in both clauses
+    // Verify base criteria and showInGlobalContext are in both clauses
     boolean foundTypesInPublished = false;
     boolean foundDomainsInPublished = false;
     boolean foundTypesInUnpublished = false;
@@ -109,6 +111,7 @@ public class DocumentSearchFilterUtilsTest {
       }
       if ("showInGlobalContext".equals(criterion.getField())) {
         foundShowInGlobalContextInPublished = true;
+        assertTrue(criterion.isNegated(), "showInGlobalContext should use negated filter");
       }
     }
 
@@ -121,6 +124,7 @@ public class DocumentSearchFilterUtilsTest {
       }
       if ("showInGlobalContext".equals(criterion.getField())) {
         foundShowInGlobalContextInUnpublished = true;
+        assertTrue(criterion.isNegated(), "showInGlobalContext should use negated filter");
       }
     }
 
@@ -181,8 +185,8 @@ public class DocumentSearchFilterUtilsTest {
 
   @Test
   public void testBuildCombinedFilterStructure() {
-    // Verify the filter structure: (base AND PUBLISHED AND showInGlobalContext=true)
-    // OR (base AND UNPUBLISHED AND owners AND showInGlobalContext=true)
+    // Verify the filter structure: (base AND PUBLISHED AND showInGlobalContext!=false)
+    // OR (base AND UNPUBLISHED AND owners AND showInGlobalContext!=false)
     List<Criterion> baseCriteria = new ArrayList<>();
     baseCriteria.add(
         CriterionUtils.buildCriterion(
@@ -202,7 +206,8 @@ public class DocumentSearchFilterUtilsTest {
     assertEquals(publishedClause.getAnd().get(1).getField(), "state");
     assertEquals(publishedClause.getAnd().get(1).getValues().get(0), "PUBLISHED");
     assertEquals(publishedClause.getAnd().get(2).getField(), "showInGlobalContext");
-    assertEquals(publishedClause.getAnd().get(2).getValues().get(0), "true");
+    assertEquals(publishedClause.getAnd().get(2).getValues().get(0), "false");
+    assertTrue(publishedClause.getAnd().get(2).isNegated());
 
     // Unpublished clause should have: relatedAssets + state + owners + showInGlobalContext
     ConjunctiveCriterion unpublishedClause = filter.getOr().get(1);
@@ -211,12 +216,15 @@ public class DocumentSearchFilterUtilsTest {
     assertEquals(unpublishedClause.getAnd().get(1).getValues().get(0), "UNPUBLISHED");
     assertEquals(unpublishedClause.getAnd().get(2).getField(), "owners");
     assertEquals(unpublishedClause.getAnd().get(3).getField(), "showInGlobalContext");
-    assertEquals(unpublishedClause.getAnd().get(3).getValues().get(0), "true");
+    assertEquals(unpublishedClause.getAnd().get(3).getValues().get(0), "false");
+    assertTrue(unpublishedClause.getAnd().get(3).isNegated());
   }
 
   @Test
-  public void testBuildCombinedFilterRequiresShowInGlobalContext() {
-    // Verify that showInGlobalContext=true is required in both published and unpublished clauses
+  public void testBuildCombinedFilterExcludesExplicitlyHidden() {
+    // Verify that showInGlobalContext!=false is used in both published and unpublished clauses.
+    // This excludes only documents that explicitly set showInGlobalContext=false;
+    // documents without a documentSettings aspect are included by default.
     List<Criterion> baseCriteria = new ArrayList<>();
     List<String> userAndGroupUrns = ImmutableList.of(TEST_USER_URN);
 
@@ -226,16 +234,17 @@ public class DocumentSearchFilterUtilsTest {
     assertNotNull(filter.getOr());
     assertEquals(filter.getOr().size(), 2);
 
-    // Both clauses should have showInGlobalContext=true criterion
-    boolean foundShowInGlobalContextInPublished = false;
-    boolean foundShowInGlobalContextInUnpublished = false;
+    // Both clauses should have negated showInGlobalContext=false criterion
+    boolean foundNegatedInPublished = false;
+    boolean foundNegatedInUnpublished = false;
 
     ConjunctiveCriterion publishedClause = filter.getOr().get(0);
     for (Criterion criterion : publishedClause.getAnd()) {
       if ("showInGlobalContext".equals(criterion.getField())
           && criterion.getCondition() == Condition.EQUAL
-          && criterion.getValues().contains("true")) {
-        foundShowInGlobalContextInPublished = true;
+          && criterion.getValues().contains("false")
+          && criterion.isNegated()) {
+        foundNegatedInPublished = true;
       }
     }
 
@@ -243,16 +252,15 @@ public class DocumentSearchFilterUtilsTest {
     for (Criterion criterion : unpublishedClause.getAnd()) {
       if ("showInGlobalContext".equals(criterion.getField())
           && criterion.getCondition() == Condition.EQUAL
-          && criterion.getValues().contains("true")) {
-        foundShowInGlobalContextInUnpublished = true;
+          && criterion.getValues().contains("false")
+          && criterion.isNegated()) {
+        foundNegatedInUnpublished = true;
       }
     }
 
     assertTrue(
-        foundShowInGlobalContextInPublished,
-        "Published clause should require showInGlobalContext=true");
+        foundNegatedInPublished, "Published clause should exclude showInGlobalContext=false");
     assertTrue(
-        foundShowInGlobalContextInUnpublished,
-        "Unpublished clause should require showInGlobalContext=true");
+        foundNegatedInUnpublished, "Unpublished clause should exclude showInGlobalContext=false");
   }
 }


### PR DESCRIPTION
Currently, in primary search we exclude docs that have explicity set showInGlobalContext = false. When searching documents though, we were doing the opposite, only showing documents where showInGlobalContext = true.

In general, when a document doesn't have the setting specified, we should assume it SHOULD be shown in global context (in the docs sidebar navigator and in search), this fix aligns how we handle searchDocuments vs searchAcrossEntities when it comes to filtering documents.

This issue was caught when testing the demo for AI Agents Platform. I noticed that some docs were being filtered out of the docs sidebar when they should NOT have been.

This change will need to go to OSS as well. See a followup PR.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
