### PR TITLE
fix(snowflake): add connection pool health checks to prevent stale JWT failures

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_connection.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_connection.py
@@ -314,6 +314,10 @@ class SnowflakeConnectionConfig(ConfigModel):
         options_connect_args: Dict = self.get_connect_args()
         options_connect_args.update(self.options.get("connect_args", {}))
         self.options["connect_args"] = options_connect_args
+        # Validate connections before reuse and recycle them periodically to
+        # prevent stale JWT/session failures during long-running ingestion.
+        self.options.setdefault("pool_pre_ping", True)
+        self.options.setdefault("pool_recycle", 1800)
         return self.options
 
     def get_oauth_connection(self) -> NativeSnowflakeConnection:


### PR DESCRIPTION
## Summary
- Add `pool_pre_ping=True` and `pool_recycle=1800` to Snowflake's SQLAlchemy engine options via `get_options()`
- Prevents stale connection reuse that causes sporadic "JWT token is invalid" (`250001`) errors during long-running ingestion
- Matches the pattern already used by Teradata (`pool_recycle=1800`) and Fabric/OneLake (`pool_recycle=3600`) connectors

## Context
Reported by a customer whose Snowflake ingestion fails ~20 minutes in with:
```
(snowflake.connector.errors.DatabaseError) 250001 (08001): Failed to connect to DB: ...JWT token is invalid
```

Root cause: SQLAlchemy's connection pool reuses connections without validating them. When a Snowflake session/JWT becomes stale, the pool hands back a dead connection → immediate auth failure.

`pool_pre_ping` tests each connection before use. `pool_recycle` forces fresh connections every 30 minutes, well before typical JWT expiry. Uses `setdefault` so users can override via the existing `options` config field.

## Test plan
- [ ] Verify lint passes (ruff check + format confirmed clean)
- [ ] Existing Snowflake unit tests pass (no behavioral change for healthy connections)
- [ ] Manual validation with long-running Snowflake ingestion that previously hit JWT expiry

🤖 Generated with [Claude Code](https://claude.com/claude-code)