### PR TITLE
feat(ingestion/snowplow): add environment filtering, event spec status filtering, and UI source registration

### DIFF
--- a/datahub-web-react/src/app/ingest/source/builder/constants.ts
+++ b/datahub-web-react/src/app/ingest/source/builder/constants.ts
@@ -48,6 +48,7 @@ import sacLogo from '@images/saclogo.svg';
 import sigmaLogo from '@images/sigmalogo.png';
 import snaplogicLogo from '@images/snaplogic.svg';
 import snowflakeLogo from '@images/snowflakelogo.png';
+import snowplowLogo from '@images/snowplowlogo.png';
 import starrocksLogo from '@images/starrockslogo.svg';
 import streamlitLogo from '@images/streamlitlogo.png';
 import supersetLogo from '@images/supersetlogo.png';
@@ -177,6 +178,8 @@ export const SNAPLOGIC = 'snaplogic';
 export const SNAPLOGIC_URN = `urn:li:dataPlatform:${SNAPLOGIC}`;
 export const GOOGLE_SHEETS = 'google_sheets';
 export const GOOGLE_SHEETS_URN = `urn:li:dataPlatform:${GOOGLE_SHEETS}`;
+export const SNOWPLOW = 'snowplow';
+export const SNOWPLOW_URN = `urn:li:dataPlatform:${SNOWPLOW}`;
 export const FABRIC = 'fabric';
 export const FABRIC_URN = `urn:li:dataPlatform:${FABRIC}`;
 export const FABRIC_DATA_FACTORY = 'fabric-data-factory';
@@ -224,6 +227,7 @@ export const PLATFORM_URN_TO_LOGO = {
     [PRESET_URN]: presetLogo,
     [REDSHIFT_URN]: redshiftLogo,
     [SNOWFLAKE_URN]: snowflakeLogo,
+    [SNOWPLOW_URN]: snowplowLogo,
     [STARROCKS_URN]: starrocksLogo,
     [TABLEAU_URN]: tableauLogo,
     [TRINO_URN]: trinoLogo,

--- a/datahub-web-react/src/app/ingest/source/builder/sources.json
+++ b/datahub-web-react/src/app/ingest/source/builder/sources.json
@@ -434,5 +434,16 @@
         "description": "Import Charts and Dashboards from Preset",
         "docsUrl": "https://docs.datahub.com/docs/generated/ingestion/sources/preset/",
         "recipe": "source:\n  type: preset\n  config:\n    # Coordinates\n    connect_uri: Preset workspace URL\n    manager_uri: https://api.app.preset.io\n\n    # Credentials\n    api_key: Preset API Key\n    api_secret: Preset API Secret"
+    },
+    {
+        "urn": "urn:li:dataPlatform:snowplow",
+        "name": "snowplow",
+        "displayName": "Snowplow",
+        "description": "Import Schemas, Event Specifications, Tracking Plans, Pipelines, and Enrichments from Snowplow BDP.",
+        "docsUrl": "https://docs.datahub.com/docs/generated/ingestion/sources/snowplow",
+        "recipe": "source:\n  type: snowplow\n  config:\n    # BDP Console API connection\n    bdp_connection:\n      organization_id: \"YOUR_ORG_UUID\"\n      api_key_id: \"${SNOWPLOW_API_KEY_ID}\"\n      api_key: \"${SNOWPLOW_API_KEY}\"\n\n    # Optional: Filter by Snowplow deployment environment (PROD, DEV)\n    # deployment_environment: PROD\n\n    # Optional: Filter event specifications by status\n    # event_spec_statuses:\n    #   - published\n\n    # Optional: Filter schemas by vendor/name pattern\n    # schema_pattern:\n    #   allow:\n    #     - \"com\\\\.mycompany\\\\..*\"\n\n    stateful_ingestion:\n      enabled: true",
+        "category": "Data Collector",
+        "isPopular": false,
+        "isNew": true
     }
 ]

--- a/datahub-web-react/src/app/ingestV2/source/builder/constants.ts
+++ b/datahub-web-react/src/app/ingestV2/source/builder/constants.ts
@@ -52,6 +52,7 @@ import sageMakerLogo from '@images/sagemakerlogo.png';
 import sigmaLogo from '@images/sigmalogo.png';
 import snaplogicLogo from '@images/snaplogic.svg';
 import snowflakeLogo from '@images/snowflakelogo.png';
+import snowplowLogo from '@images/snowplowlogo.png';
 import sparkLogo from '@images/sparklogo.png';
 import streamlitLogo from '@images/streamlitlogo.png';
 import supersetLogo from '@images/supersetlogo.png';
@@ -190,6 +191,8 @@ export const VERTEX_AI = 'vertexai';
 export const VERTEXAI_URN = `urn:li:dataPlatform:${VERTEX_AI}`;
 export const SNAPLOGIC = 'snaplogic';
 export const SNAPLOGIC_URN = `urn:li:dataPlatform:${SNAPLOGIC}`;
+export const SNOWPLOW = 'snowplow';
+export const SNOWPLOW_URN = `urn:li:dataPlatform:${SNOWPLOW}`;
 export const FABRIC = 'fabric';
 export const FABRIC_URN = `urn:li:dataPlatform:${FABRIC}`;
 export const FABRIC_DATA_FACTORY = 'fabric-data-factory';
@@ -240,6 +243,7 @@ export const PLATFORM_URN_TO_LOGO = {
     [S3_URN]: s3Logo,
     [SAGE_MAKER_URN]: sageMakerLogo,
     [SNOWFLAKE_URN]: snowflakeLogo,
+    [SNOWPLOW_URN]: snowplowLogo,
     [STREAMLIT_URN]: streamlitLogo,
     [SPARK_URN]: sparkLogo,
     [TABLEAU_URN]: tableauLogo,

--- a/datahub-web-react/src/app/ingestV2/source/builder/sources.json
+++ b/datahub-web-react/src/app/ingestV2/source/builder/sources.json
@@ -600,5 +600,16 @@
         "description": "Import glossary terms, term groups, and relationships from RDF/OWL ontologies (SKOS, Turtle, RDF/XML).",
         "docsUrl": "https://docs.datahub.com/docs/generated/ingestion/sources/rdf",
         "recipe": "source:\n  type: rdf\n  config:\n    source: path/to/glossary.ttl\n    environment: PROD\n    export_only:\n      - glossary"
+    },
+    {
+        "urn": "urn:li:dataPlatform:snowplow",
+        "name": "snowplow",
+        "displayName": "Snowplow",
+        "description": "Import Schemas, Event Specifications, Tracking Plans, Pipelines, and Enrichments from Snowplow BDP.",
+        "docsUrl": "https://docs.datahub.com/docs/generated/ingestion/sources/snowplow",
+        "recipe": "source:\n  type: snowplow\n  config:\n    # BDP Console API connection\n    bdp_connection:\n      organization_id: \"YOUR_ORG_UUID\"\n      api_key_id: \"${SNOWPLOW_API_KEY_ID}\"\n      api_key: \"${SNOWPLOW_API_KEY}\"\n\n    # Optional: Filter by Snowplow deployment environment (PROD, DEV)\n    # deployment_environment: PROD\n\n    # Optional: Filter event specifications by status\n    # event_spec_statuses:\n    #   - published\n\n    # Optional: Filter schemas by vendor/name pattern\n    # schema_pattern:\n    #   allow:\n    #     - \"com\\\\.mycompany\\\\..*\"\n\n    stateful_ingestion:\n      enabled: true",
+        "category": "Data Collector",
+        "isPopular": false,
+        "isNew": true
     }
 ]

--- a/metadata-ingestion/src/datahub/ingestion/source/snowplow/constants.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowplow/constants.py
@@ -24,6 +24,15 @@ class ConnectionMode(StrEnum):
     BOTH = "both"  # Both BDP and Iglu
 
 
+class EventSpecStatus(StrEnum):
+    """Event specification status values from BDP API."""
+
+    DRAFT = "draft"
+    PUBLISHED = "published"
+    DEPRECATED = "deprecated"
+    ARCHIVED = "archived"
+
+
 class DataClassification(StrEnum):
     """Data classification levels for field tagging."""
 

--- a/metadata-ingestion/src/datahub/ingestion/source/snowplow/processors/event_spec_processor.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowplow/processors/event_spec_processor.py
@@ -99,10 +99,32 @@ class EventSpecProcessor(EntityProcessor):
             )
             return
 
+        # Pre-compute allowed statuses set (already normalized to lowercase by config validator)
+        allowed_statuses: Optional[frozenset] = None
+        if self.config.event_spec_statuses is not None:
+            allowed_statuses = frozenset(self.config.event_spec_statuses)
+
         for event_spec in event_specs:
             self.report.report_event_spec_found()
 
-            # Apply filtering
+            # Apply status filtering
+            if allowed_statuses is not None:
+                if event_spec.status is None:
+                    logger.info(
+                        f"Filtering out event spec '{event_spec.name}' "
+                        f"(no status set, filter requires one of {self.config.event_spec_statuses})"
+                    )
+                    self.report.report_event_spec_filtered(event_spec.name)
+                    continue
+                if event_spec.status.lower() not in allowed_statuses:
+                    logger.info(
+                        f"Filtering out event spec '{event_spec.name}' "
+                        f"(status='{event_spec.status}' not in {self.config.event_spec_statuses})"
+                    )
+                    self.report.report_event_spec_filtered(event_spec.name)
+                    continue
+
+            # Apply name pattern filtering
             if not self.config.event_spec_pattern.allowed(event_spec.name):
                 self.report.report_event_spec_filtered(event_spec.name)
                 continue

--- a/metadata-ingestion/src/datahub/ingestion/source/snowplow/processors/pipeline_processor.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowplow/processors/pipeline_processor.py
@@ -120,7 +120,38 @@ class PipelineProcessor(EntityProcessor):
                 )
                 return
 
-            # Use first pipeline (most orgs have one pipeline)
+            # Filter pipelines by label matching deployment_environment (if set)
+            # deployment_environment is already normalized to uppercase by config validator
+            if self.config.deployment_environment:
+                target_env = self.config.deployment_environment
+                matching_pipelines = []
+                for p in physical_pipelines:
+                    if not p.label:
+                        # Pipeline has no environment label — include by default
+                        logger.info(
+                            f"Pipeline '{p.name}' has no label, including it "
+                            f"(cannot determine if it matches deployment_environment='{target_env}')"
+                        )
+                        matching_pipelines.append(p)
+                    elif p.label.upper() != target_env:
+                        logger.info(
+                            f"Filtering out pipeline '{p.name}' "
+                            f"(label='{p.label}' does not match deployment_environment='{target_env}')"
+                        )
+                        self.report.report_pipeline_filtered_by_env(p.name)
+                    else:
+                        matching_pipelines.append(p)
+
+                if not matching_pipelines:
+                    logger.warning(
+                        f"No pipelines match deployment_environment={target_env} "
+                        f"(found {len(physical_pipelines)} pipelines with labels: "
+                        f"{[p.label for p in physical_pipelines]}). "
+                        "Skipping pipeline extraction."
+                    )
+                    return
+                physical_pipelines = matching_pipelines
+
             pipeline = physical_pipelines[0]
             self.state.physical_pipeline = pipeline
 

--- a/metadata-ingestion/src/datahub/ingestion/source/snowplow/processors/schema_processor.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowplow/processors/schema_processor.py
@@ -134,6 +134,7 @@ class SchemaProcessor(EntityProcessor):
                 self._build_field_version_mappings(data_structures)
 
         # Apply filters
+        data_structures = self._filter_by_deployment_env(data_structures)
         data_structures = self._filter_by_deployed_since(data_structures)
         data_structures = self._filter_by_schema_pattern(data_structures)
 
@@ -170,6 +171,48 @@ class SchemaProcessor(EntityProcessor):
                 exc=e,
             )
             return []
+
+    def _filter_by_deployment_env(
+        self, data_structures: List[DataStructure]
+    ) -> List[DataStructure]:
+        """Filter data structures by Snowplow deployment environment.
+
+        Only includes schemas that have at least one deployment matching
+        config.deployment_environment. Schemas with no deployments (e.g., drafts)
+        are still included. Skipped when deployment_environment is not set.
+        """
+        if not self.config.deployment_environment:
+            return data_structures
+
+        # Already normalized to uppercase by config validator
+        target_env = self.config.deployment_environment
+        filtered = []
+        for ds in data_structures:
+            schema_key = f"{ds.vendor}/{ds.name}"
+            if not ds.deployments:
+                # No deployment info — include (could be a draft or Iglu-only schema)
+                filtered.append(ds)
+                continue
+
+            has_matching_env = any(
+                dep.env and dep.env.upper() == target_env for dep in ds.deployments
+            )
+            if has_matching_env:
+                filtered.append(ds)
+            else:
+                deployed_envs = {dep.env for dep in ds.deployments if dep.env}
+                logger.info(
+                    f"Filtering out schema {schema_key}: "
+                    f"no {target_env} deployment (deployed to: {deployed_envs})"
+                )
+                self.report.report_schema_filtered_by_env(schema_key)
+
+        if len(filtered) < len(data_structures):
+            logger.info(
+                f"Filtered schemas by deployment_environment={target_env}: "
+                f"{len(filtered)}/{len(data_structures)} schemas retained"
+            )
+        return filtered
 
     def _filter_by_deployed_since(
         self, data_structures: List[DataStructure]

--- a/metadata-ingestion/src/datahub/ingestion/source/snowplow/snowplow.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowplow/snowplow.py
@@ -447,10 +447,23 @@ class SnowplowSource(StatefulIngestionSourceBase, TestableSource):
             env=self.config.env,
         )
 
+        # Resolve display name: API name > UUID fallback
+        display_label = org_id
+        if self.bdp_client:
+            try:
+                org = self.bdp_client.get_organization()
+                if org and org.name:
+                    display_label = org.name
+            except Exception as e:
+                logger.warning(
+                    f"Failed to resolve organization name for {org_id}, "
+                    f"falling back to organization ID: {e}"
+                )
+
         # Use gen_containers to emit all container aspects properly
         yield from gen_containers(
             container_key=org_key,
-            name=f"Snowplow Organization ({org_id})",
+            name=f"Snowplow Organization ({display_label})",
             sub_types=[DatasetContainerSubTypes.DATABASE],
             description="Snowplow BDP organization containing event and entity schemas",
             extra_properties={

--- a/metadata-ingestion/src/datahub/ingestion/source/snowplow/snowplow_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowplow/snowplow_config.py
@@ -20,6 +20,7 @@ from datahub.configuration.source_common import (
 )
 from datahub.ingestion.source.snowplow.constants import (
     DEFAULT_SCHEMA_TYPES,
+    EventSpecStatus,
     SchemaType,
 )
 from datahub.ingestion.source.state.stale_entity_removal_handler import (
@@ -356,6 +357,22 @@ class SnowplowSourceConfig(
         description="Regex patterns for tracking plans to filter",
     )
 
+    deployment_environment: Optional[str] = Field(
+        default=None,
+        description="Filter schemas by Snowplow deployment environment. "
+        "Only schemas deployed to this environment will be ingested. "
+        "Common values from BDP API: 'PROD', 'DEV'. "
+        "Case-insensitive. When not set, schemas from all environments are included.",
+    )
+
+    event_spec_statuses: Optional[List[str]] = Field(
+        default=None,
+        description="Filter event specifications by status. "
+        "Only event specs with a status in this list will be ingested. "
+        "Valid values: draft, published, deprecated, archived. "
+        "When not set, all statuses are included.",
+    )
+
     # ============================================
     # Feature Flags
     # ============================================
@@ -519,6 +536,38 @@ class SnowplowSourceConfig(
                     "Tracking plans are only available via BDP Console API."
                 )
         return v
+
+    @field_validator("deployment_environment", mode="after")
+    @classmethod
+    def validate_deployment_environment(cls, v: Optional[str]) -> Optional[str]:
+        """Normalize deployment environment: strip whitespace, uppercase, reject empty."""
+        if v is not None:
+            v = v.strip().upper()
+            if not v:
+                return None
+        return v
+
+    @field_validator("event_spec_statuses", mode="after")
+    @classmethod
+    def validate_event_spec_statuses(
+        cls, v: Optional[List[str]]
+    ) -> Optional[List[str]]:
+        """Validate and normalize event spec status values."""
+        if v is None:
+            return v
+        valid = {s.value for s in EventSpecStatus}
+        normalized = []
+        for status in v:
+            s = status.strip().lower()
+            if s not in valid:
+                raise ValueError(
+                    f"Unknown event_spec_statuses value '{status}'. "
+                    f"Valid values: {', '.join(sorted(valid))}"
+                )
+            normalized.append(s)
+        if not normalized:
+            return None
+        return normalized
 
     @field_validator("schema_types_to_extract", mode="after")
     @classmethod

--- a/metadata-ingestion/src/datahub/ingestion/source/snowplow/snowplow_report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowplow/snowplow_report.py
@@ -194,6 +194,12 @@ class SnowplowSourceReport(StaleEntityRemovalSourceReport):
     num_deployment_fetch_failures: int = 0
     failed_deployment_fetches: List[str] = field(default_factory=list)
 
+    # Environment filtering stats
+    num_schemas_filtered_by_env: int = 0
+    filtered_schemas_by_env: List[str] = field(default_factory=list)
+    num_pipelines_filtered_by_env: int = 0
+    filtered_pipelines_by_env: List[str] = field(default_factory=list)
+
     # Hidden schemas
     num_hidden_schemas: int = 0
     num_hidden_schemas_skipped: int = 0
@@ -286,6 +292,16 @@ class SnowplowSourceReport(StaleEntityRemovalSourceReport):
     def report_enrichment_filtered(self, enrichment_name: str) -> None:
         """Record that an enrichment was filtered out."""
         self.num_enrichments_filtered += 1
+
+    def report_schema_filtered_by_env(self, schema_name: str) -> None:
+        """Record that a schema was filtered out by deployment environment."""
+        self.num_schemas_filtered_by_env += 1
+        self.filtered_schemas_by_env.append(schema_name)
+
+    def report_pipeline_filtered_by_env(self, pipeline_name: str) -> None:
+        """Record that a pipeline was filtered out by environment label."""
+        self.num_pipelines_filtered_by_env += 1
+        self.filtered_pipelines_by_env.append(pipeline_name)
 
     def report_warehouse_lineage_extracted(self) -> None:
         """Record that warehouse lineage was extracted."""

--- a/metadata-ingestion/tests/integration/snowplow/golden_files/snowplow_enrichments_golden.json
+++ b/metadata-ingestion/tests/integration/snowplow/golden_files/snowplow_enrichments_golden.json
@@ -19,7 +19,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -43,7 +43,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -67,7 +67,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -117,7 +117,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -161,7 +161,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -178,14 +178,14 @@
                 "organization_id": "test-org-uuid",
                 "connection_mode": "bdp"
             },
-            "name": "Snowplow Organization (test-org-uuid)",
+            "name": "Snowplow Organization (Acrylic Datahub)",
             "description": "Snowplow BDP organization containing event and entity schemas",
             "env": "PROD"
         }
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -201,7 +201,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -217,7 +217,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -235,7 +235,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -251,7 +251,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -935,7 +935,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -960,7 +960,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -976,7 +976,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -994,7 +994,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1010,7 +1010,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1031,7 +1031,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1047,7 +1047,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1070,7 +1070,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1086,7 +1086,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1102,7 +1102,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1120,7 +1120,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1141,7 +1141,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1157,7 +1157,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1180,7 +1180,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1196,7 +1196,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1212,7 +1212,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1230,7 +1230,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1255,7 +1255,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1271,7 +1271,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1291,7 +1291,23 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowplow,com.acme.checkout_started,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:f4525bbaa1b69a02102f287c909fa00b"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1704067200000,
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1420,7 +1436,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1436,7 +1452,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1464,23 +1480,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowplow,com.acme.checkout_started,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:f4525bbaa1b69a02102f287c909fa00b"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1498,7 +1498,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1536,7 +1536,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1565,7 +1565,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1622,7 +1622,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1679,7 +1679,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1736,7 +1736,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1793,7 +1793,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1850,7 +1850,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1907,7 +1907,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1964,7 +1964,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1980,7 +1980,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2000,7 +2000,23 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowplow,com.acme.product_viewed,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:f4525bbaa1b69a02102f287c909fa00b"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1704067200000,
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2086,7 +2102,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2102,7 +2118,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2130,23 +2146,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowplow,com.acme.product_viewed,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:f4525bbaa1b69a02102f287c909fa00b"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2164,7 +2164,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2194,7 +2194,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2223,7 +2223,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2280,7 +2280,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2337,7 +2337,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2394,7 +2394,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2451,7 +2451,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2467,7 +2467,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2487,7 +2487,23 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowplow,com.acme.user_context,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:f4525bbaa1b69a02102f287c909fa00b"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1704067200000,
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2560,7 +2576,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2576,7 +2592,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2603,23 +2619,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowplow,com.acme.user_context,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:f4525bbaa1b69a02102f287c909fa00b"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2637,7 +2637,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2667,7 +2667,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2696,7 +2696,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2753,7 +2753,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2810,7 +2810,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2867,7 +2867,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2893,7 +2893,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2911,7 +2911,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2927,7 +2927,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2943,7 +2943,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3008,7 +3008,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3029,7 +3029,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3055,7 +3055,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3073,7 +3073,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3089,7 +3089,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3105,7 +3105,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3154,7 +3154,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3175,7 +3175,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3980,7 +3980,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4037,7 +4037,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4094,7 +4094,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4151,7 +4151,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4208,7 +4208,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4265,7 +4265,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4322,7 +4322,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4379,7 +4379,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4436,7 +4436,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4493,7 +4493,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4550,7 +4550,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4607,7 +4607,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4664,7 +4664,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4721,7 +4721,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4778,7 +4778,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4835,7 +4835,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4892,7 +4892,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4949,7 +4949,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -5006,7 +5006,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -5810,7 +5810,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -6559,7 +6559,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -6616,7 +6616,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -6673,7 +6673,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -6730,7 +6730,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -6787,7 +6787,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -6844,7 +6844,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -6901,7 +6901,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -6958,7 +6958,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -7015,7 +7015,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -7072,7 +7072,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -7129,7 +7129,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -7186,7 +7186,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -7243,7 +7243,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -7965,7 +7965,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -7991,7 +7991,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8007,7 +8007,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8023,7 +8023,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8044,7 +8044,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8075,7 +8075,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8091,7 +8091,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8111,7 +8111,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8142,7 +8142,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8158,7 +8158,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8178,7 +8178,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8205,7 +8205,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8225,7 +8225,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8241,7 +8241,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8257,7 +8257,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8273,7 +8273,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8289,7 +8289,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8305,7 +8305,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8321,7 +8321,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8337,7 +8337,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8353,7 +8353,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8369,7 +8369,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8385,7 +8385,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8401,7 +8401,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8417,7 +8417,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8433,7 +8433,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8449,7 +8449,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8465,7 +8465,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8481,7 +8481,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8497,7 +8497,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8513,7 +8513,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8529,7 +8529,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8545,7 +8545,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8561,7 +8561,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8577,7 +8577,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8593,7 +8593,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8609,7 +8609,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8625,7 +8625,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8641,7 +8641,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8657,7 +8657,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8673,7 +8673,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8689,7 +8689,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8705,7 +8705,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8721,7 +8721,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8737,7 +8737,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8753,7 +8753,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8769,7 +8769,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8785,7 +8785,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8801,7 +8801,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8817,7 +8817,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8833,7 +8833,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8849,7 +8849,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1704067200000,
-        "runId": "snowplow-2024_01_01-00_00_00-ymeans",
+        "runId": "snowplow-2024_01_01-00_00_00-aefugh",
         "lastRunId": "no-run-id-provided"
     }
 }

--- a/metadata-ingestion/tests/integration/snowplow/test_snowplow.py
+++ b/metadata-ingestion/tests/integration/snowplow/test_snowplow.py
@@ -55,6 +55,7 @@ def test_snowplow_ingest(pytestconfig, tmp_path, mock_time):
 
         # Mock test_connection
         mock_client.test_connection.return_value = True
+        mock_client.get_organization.return_value = None
 
         # Mock get_users for ownership resolution
         from datahub.ingestion.source.snowplow.models.snowplow_models import User
@@ -195,6 +196,7 @@ def test_snowplow_event_specs_and_tracking_plans(pytestconfig, tmp_path, mock_ti
 
         # Mock test_connection
         mock_client.test_connection.return_value = True
+        mock_client.get_organization.return_value = None
 
         # Mock get_users for ownership resolution
         mock_users = [
@@ -337,6 +339,7 @@ def test_snowplow_tracking_plans(pytestconfig, tmp_path, mock_time):
 
         # Mock test_connection
         mock_client.test_connection.return_value = True
+        mock_client.get_organization.return_value = None
 
         # Mock get_users for ownership resolution
         mock_users = [
@@ -450,6 +453,7 @@ def test_snowplow_pipelines(pytestconfig, tmp_path, mock_time):
             User(id="user2", email="jane@company.com", name="Jane Doe"),
         ]
         mock_client.get_users.return_value = mock_users
+        mock_client.get_organization.return_value = None
 
         # Run ingestion with pipelines enabled
         pipeline_run = Pipeline.create(
@@ -816,6 +820,7 @@ def test_snowplow_enrichments_without_event_spec_processor(
         ]
         mock_client.get_destinations.return_value = []
         mock_client.test_connection.return_value = True
+        mock_client.get_organization.return_value = None
 
         # Run ingestion with the critical flag combination:
         # extract_event_specifications=FALSE but extract_enrichments=TRUE
@@ -963,6 +968,7 @@ def test_snowplow_all_event_specs_processed(pytestconfig, tmp_path, mock_time):
         ]
         mock_client.get_destinations.return_value = []
         mock_client.test_connection.return_value = True
+        mock_client.get_organization.return_value = None
 
         pipeline_run = Pipeline.create(
             {

--- a/metadata-ingestion/tests/unit/snowplow/test_event_spec_processor.py
+++ b/metadata-ingestion/tests/unit/snowplow/test_event_spec_processor.py
@@ -49,6 +49,8 @@ class TestEventSpecProcessorIsEnabled:
         """Create mock dependencies."""
         deps = Mock()
         deps.config = Mock()
+        deps.config.deployment_environment = None
+        deps.config.event_spec_statuses = None
         deps.config.extract_event_specifications = True
         deps.bdp_client = Mock()
         deps.report = Mock()
@@ -92,6 +94,8 @@ class TestEventSpecProcessorExtract:
         """Create mock dependencies."""
         deps = Mock()
         deps.config = Mock()
+        deps.config.deployment_environment = None
+        deps.config.event_spec_statuses = None
         deps.config.extract_event_specifications = True
         deps.config.bdp_connection = Mock()
         deps.config.bdp_connection.organization_id = "test-org"
@@ -198,6 +202,8 @@ class TestEventSpecProcessorProcessing:
         """Create mock dependencies with full configuration."""
         deps = Mock()
         deps.config = Mock()
+        deps.config.deployment_environment = None
+        deps.config.event_spec_statuses = None
         deps.config.extract_event_specifications = True
         deps.config.bdp_connection = Mock()
         deps.config.bdp_connection.organization_id = "test-org"
@@ -305,6 +311,8 @@ class TestCollectUpstreamUrns:
     def mock_deps(self):
         deps = Mock()
         deps.config = Mock()
+        deps.config.deployment_environment = None
+        deps.config.event_spec_statuses = None
         deps.config.extract_event_specifications = True
         deps.bdp_client = Mock()
         deps.report = Mock()
@@ -429,6 +437,8 @@ class TestEmitEventSpecSchemaMetadata:
     def mock_deps(self):
         deps = Mock()
         deps.config = Mock()
+        deps.config.deployment_environment = None
+        deps.config.event_spec_statuses = None
         deps.config.extract_event_specifications = True
         deps.config.bdp_connection = Mock()
         deps.config.bdp_connection.organization_id = "test-org"

--- a/metadata-ingestion/tests/unit/snowplow/test_feature_flag_combinations.py
+++ b/metadata-ingestion/tests/unit/snowplow/test_feature_flag_combinations.py
@@ -45,6 +45,8 @@ class TestEnrichmentsWithoutEventSpecProcessor:
         """Create mock dependencies for pipeline processor."""
         deps = Mock()
         deps.config = Mock()
+        deps.config.deployment_environment = None
+        deps.config.event_spec_statuses = None
         # Key config: extract_event_specifications is FALSE but extract_enrichments is TRUE
         deps.config.extract_event_specifications = False
         deps.config.extract_pipelines = True
@@ -289,6 +291,8 @@ class TestAllEventSpecsProcessed:
         """Create mock dependencies for event spec processor."""
         deps = Mock()
         deps.config = Mock()
+        deps.config.deployment_environment = None
+        deps.config.event_spec_statuses = None
         deps.config.extract_event_specifications = True
         deps.config.bdp_connection = Mock()
         deps.config.bdp_connection.organization_id = "test-org"
@@ -380,6 +384,8 @@ class TestProcessorCoordination:
         """Create mock dependencies for EventSpecProcessor."""
         deps = Mock()
         deps.config = Mock()
+        deps.config.deployment_environment = None
+        deps.config.event_spec_statuses = None
         deps.config.extract_event_specifications = True
         deps.config.bdp_connection = Mock()
         deps.config.bdp_connection.organization_id = "test-org"
@@ -403,6 +409,8 @@ class TestProcessorCoordination:
         """Create mock dependencies for PipelineProcessor."""
         deps = Mock()
         deps.config = Mock()
+        deps.config.deployment_environment = None
+        deps.config.event_spec_statuses = None
         deps.config.extract_event_specifications = True
         deps.config.extract_pipelines = True
         deps.config.extract_enrichments = True

--- a/metadata-ingestion/tests/unit/snowplow/test_pipeline_processor.py
+++ b/metadata-ingestion/tests/unit/snowplow/test_pipeline_processor.py
@@ -55,6 +55,8 @@ class TestPipelineProcessorIsEnabled:
         """Create mock dependencies."""
         deps = Mock()
         deps.config = Mock()
+        deps.config.deployment_environment = None
+        deps.config.event_spec_statuses = None
         deps.config.extract_pipelines = True
         deps.config.extract_enrichments = False
         deps.bdp_client = Mock()
@@ -105,6 +107,8 @@ class TestPipelineProcessorExtract:
         """Create mock dependencies."""
         deps = Mock()
         deps.config = Mock()
+        deps.config.deployment_environment = None
+        deps.config.event_spec_statuses = None
         deps.config.extract_pipelines = True
         deps.config.extract_enrichments = False
         deps.config.bdp_connection = Mock()
@@ -169,6 +173,8 @@ class TestPipelineProcessorEnrichments:
         """Create mock dependencies."""
         deps = Mock()
         deps.config = Mock()
+        deps.config.deployment_environment = None
+        deps.config.event_spec_statuses = None
         deps.config.extract_pipelines = False
         deps.config.extract_enrichments = True
         deps.config.bdp_connection = Mock()
@@ -216,6 +222,8 @@ class TestPipelineProcessorDataFlowCreation:
         """Create mock dependencies."""
         deps = Mock()
         deps.config = Mock()
+        deps.config.deployment_environment = None
+        deps.config.event_spec_statuses = None
         deps.config.extract_pipelines = True
         deps.config.extract_enrichments = False
         deps.config.env = "PROD"
@@ -380,6 +388,8 @@ class TestExpandFieldUrnsToAllEventSpecs:
         """Create mock dependencies."""
         deps = Mock()
         deps.config = Mock()
+        deps.config.deployment_environment = None
+        deps.config.event_spec_statuses = None
         deps.config.extract_pipelines = True
         deps.config.extract_enrichments = True
         deps.bdp_client = Mock()
@@ -614,6 +624,8 @@ class TestFieldMatches:
         """Create mock dependencies."""
         deps = Mock()
         deps.config = Mock()
+        deps.config.deployment_environment = None
+        deps.config.event_spec_statuses = None
         deps.config.extract_pipelines = True
         deps.config.extract_enrichments = True
         deps.bdp_client = Mock()
@@ -681,6 +693,8 @@ class TestFindEventSpecsWithField:
         """Create mock dependencies."""
         deps = Mock()
         deps.config = Mock()
+        deps.config.deployment_environment = None
+        deps.config.event_spec_statuses = None
         deps.config.extract_pipelines = True
         deps.config.extract_enrichments = True
         deps.bdp_client = Mock()
@@ -799,6 +813,8 @@ class TestExtractFieldNameFromUrn:
         """Create mock dependencies."""
         deps = Mock()
         deps.config = Mock()
+        deps.config.deployment_environment = None
+        deps.config.event_spec_statuses = None
         deps.config.extract_pipelines = True
         deps.config.extract_enrichments = True
         deps.bdp_client = Mock()
@@ -852,6 +868,8 @@ class TestEmitCollectorDataJob:
         """Create mock dependencies."""
         deps = Mock()
         deps.config = Mock()
+        deps.config.deployment_environment = None
+        deps.config.event_spec_statuses = None
         deps.config.extract_pipelines = True
         deps.config.extract_enrichments = True
         deps.bdp_client = Mock()

--- a/metadata-ingestion/tests/unit/snowplow/test_structured_property_propagation.py
+++ b/metadata-ingestion/tests/unit/snowplow/test_structured_property_propagation.py
@@ -169,6 +169,8 @@ class TestEventSpecProcessorStructuredProperties:
         """Create mock dependencies for event spec processor."""
         deps = Mock()
         deps.config = Mock()
+        deps.config.deployment_environment = None
+        deps.config.event_spec_statuses = None
         deps.config.extract_event_specifications = True
         deps.config.bdp_connection = Mock()
         deps.config.bdp_connection.organization_id = "test-org"

--- a/metadata-ingestion/tests/unit/snowplow/test_tracking_plan_processor.py
+++ b/metadata-ingestion/tests/unit/snowplow/test_tracking_plan_processor.py
@@ -23,6 +23,8 @@ class TestTrackingPlanProcessorIsEnabled:
         """Create mock dependencies."""
         deps = Mock()
         deps.config = Mock()
+        deps.config.deployment_environment = None
+        deps.config.event_spec_statuses = None
         deps.config.extract_tracking_plans = True
         deps.bdp_client = Mock()
         deps.report = Mock()
@@ -63,6 +65,8 @@ class TestTrackingPlanProcessorExtract:
         """Create mock dependencies with full configuration."""
         deps = Mock()
         deps.config = Mock()
+        deps.config.deployment_environment = None
+        deps.config.event_spec_statuses = None
         deps.config.extract_tracking_plans = True
         deps.config.bdp_connection = Mock()
         deps.config.bdp_connection.organization_id = "test-org"


### PR DESCRIPTION
## Summary

Addresses customer feedback on Snowplow ingestion:

- **Environment filtering**: New `deployment_environment` config filters schemas by Snowplow deployment env (PROD/DEV) and pipelines by label. Decoupled from DataHub's `env` field to avoid value-space conflicts.
- **Event spec status filtering**: New `event_spec_statuses` config filters event specs by status (draft/published/deprecated/archived). Validated against `EventSpecStatus` enum.
- **Organization display name**: Container now shows the org name from the BDP API instead of the raw UUID. Falls back gracefully on API errors.
- **UI source registration**: Snowplow is now a selectable source in the DataHub ingestion UI with a sample recipe template.

### New config fields

| Field | Type | Default | Description |
|---|---|---|---|
| `deployment_environment` | `Optional[str]` | `None` | Filter by Snowplow deployment env (e.g., `PROD`, `DEV`). Case-insensitive. |
| `event_spec_statuses` | `Optional[List[str]]` | `None` | Filter event specs by status. Valid: `draft`, `published`, `deprecated`, `archived`. |

### Example recipe
```yaml
source:
  type: snowplow
  config:
    bdp_connection:
      organization_id: "YOUR_ORG_UUID"
      api_key_id: "${SNOWPLOW_API_KEY_ID}"
      api_key: "${SNOWPLOW_API_KEY}"
    deployment_environment: PROD
    event_spec_statuses:
      - published
```

## Test plan

- [x] Existing unit tests pass (659 tests, all green)
- [x] Lint passes (ruff + mypy via `lintFix`)
- [x] Tested live against Snowplow BDP API with PROD and DEV environments
- [x] Verified ingestion into local DataHub instance
- [x] Verified pipeline label filtering (prod pipeline label correctly filtered DEV ingestion)
- [x] Verified event spec status filtering (12 draft specs correctly filtered)
- [x] Verified org display name resolved from API ("Acryl Datahub" instead of UUID)