### PR TITLE
fix(smoke-test): context-aware GMS health probe URL

### DIFF
--- a/smoke-test/tests/utilities/env_vars.py
+++ b/smoke-test/tests/utilities/env_vars.py
@@ -24,6 +24,19 @@ def get_gms_url() -> Optional[str]:
     return os.getenv("DATAHUB_GMS_URL")
 
 
+def get_direct_gms_url() -> Optional[str]:
+    """Direct GMS base URL only (``DATAHUB_GMS_URL``).
+
+    Does not infer ``{frontend}/gms``. Used for readiness probes against GMS without the gateway.
+    """
+    return os.getenv("DATAHUB_GMS_URL")
+
+
+def get_gms_health_url() -> Optional[str]:
+    """Full URL for GMS readiness GET (``DATAHUB_GMS_HEALTH_URL``), overriding probe inference."""
+    return os.getenv("DATAHUB_GMS_HEALTH_URL")
+
+
 def get_gms_management_url() -> Optional[str]:
     """Override base URL for Spring Actuator / Micrometer (e.g. `http://localhost:4319`).
 

--- a/smoke-test/tests/utils.py
+++ b/smoke-test/tests/utils.py
@@ -179,9 +179,31 @@ def is_k8s_enabled():
     return env_vars.get_k8s_cluster_enabled()
 
 
+def gms_health_probe_url() -> str:
+    """URL for GMS readiness GET in ``wait_for_healthcheck_util``.
+
+    Resolution order:
+
+    1. ``DATAHUB_GMS_HEALTH_URL`` — full URL override.
+    2. ``DATAHUB_GMS_URL`` set — direct GMS (Docker/local): ``{GMS}/health``.
+    3. ``DATAHUB_FRONTEND_URL`` set — gateway-only / SaaS: ``{frontend}/api/gms/health`` (Play proxy).
+    4. Neither env var — local OSS default: ``{get_frontend_url()}/api/gms/health`` (quickstart).
+    """
+    override = env_vars.get_gms_health_url()
+    if override:
+        return override
+    direct = env_vars.get_direct_gms_url()
+    if direct:
+        return f"{direct.rstrip('/')}/health"
+    fe = env_vars.get_frontend_url()
+    if fe:
+        return f"{fe.rstrip('/')}/api/gms/health"
+    return f"{get_frontend_url().rstrip('/')}/api/gms/health"
+
+
 def wait_for_healthcheck_util(auth_session):
     assert not check_endpoint(auth_session, f"{get_frontend_url()}/admin")
-    assert not check_endpoint(auth_session, f"{get_gms_url()}/health")
+    assert not check_endpoint(auth_session, gms_health_probe_url())
 
 
 def check_endpoint(auth_session, url):


### PR DESCRIPTION
wait_for_healthcheck_util used get_gms_url()/health, which does not match gateway-only setups where only DATAHUB_FRONTEND_URL is set.

Resolution: DATAHUB_GMS_HEALTH_URL override, else DATAHUB_GMS_URL + /health (direct GMS), else DATAHUB_FRONTEND_URL + /api/gms/health (Play proxy), else local default via frontend.

Add env_vars.get_direct_gms_url and get_gms_health_url.

Made-with: Cursor

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
