### PR TITLE
fix(timeout): Handle Report timeout properly In Mode

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/mode.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/mode.py
@@ -1856,21 +1856,30 @@ class ModeSource(StatefulIngestionSourceBase):
             )
         except Exception as e:
             try:
+                is_timeout = isinstance(e, (TimeoutError, requests.exceptions.Timeout))
                 logger.warning(
-                    f"Failed to process report {report_name} ({report_token}) "
-                    f"in space {space_token}",
+                    f"{'Timed out' if is_timeout else 'Failed'} processing report "
+                    f"{report_name} ({report_token}) in space {space_token}",
                     exc_info=True,
                 )
-                self.report.report_failure(
-                    title="Failed to Process Report",
-                    message=f"Unexpected error processing report {report_name} ({report_token}).",
-                    context=f"Space Token: {space_token}, Error: {str(e)}",
-                    exc=e,
-                )
+                if is_timeout:
+                    self.report.report_warning(
+                        title="Report Processing Timeout",
+                        message=f"Timed out processing report {report_name} ({report_token}).",
+                        context=f"Space Token: {space_token}, Error: {str(e)}",
+                        exc=e,
+                    )
+                else:
+                    self.report.report_failure(
+                        title="Failed to Process Report",
+                        message=f"Unexpected error processing report {report_name} ({report_token}).",
+                        context=f"Space Token: {space_token}, Error: {str(e)}",
+                        exc=e,
+                    )
             except Exception:
                 # Guard against the error handler itself raising (e.g., a
-                # serialization issue in report_failure). If this propagated,
-                # ThreadedIteratorExecutor would abort all remaining workers.
+                # serialization issue in report_warning/report_failure). If this
+                # propagated, ThreadedIteratorExecutor would abort all remaining workers.
                 logger.error(
                     f"Failed to record error for report {report_token}",
                     exc_info=True,

--- a/metadata-ingestion/tests/unit/test_mode_source.py
+++ b/metadata-ingestion/tests/unit/test_mode_source.py
@@ -14,6 +14,7 @@ Tests cover:
 from typing import Dict, Iterator, List
 from unittest.mock import MagicMock, patch
 
+import requests
 from requests.models import HTTPError
 
 from datahub.configuration.common import AllowDenyPattern
@@ -494,6 +495,52 @@ class TestProcessReportErrorIsolation:
 
         # Failure should have been recorded
         assert source.report.failures
+
+    def test_timeout_error_uses_report_warning_not_failure(self):
+        """Built-in TimeoutError should call report_warning, not report_failure,
+        so one timed-out report doesn't mark the whole run as FAILURE."""
+        source = _make_source()
+        report = {"token": "tok", "name": "Report"}
+
+        def timeout_inner(space_token: str, report: dict) -> Iterator:
+            raise TimeoutError("timed out")
+            yield
+
+        with patch.object(source, "_process_report_inner", side_effect=timeout_inner):
+            list(source._process_report("space1", report))
+
+        assert not source.report.failures
+        assert source.report.warnings
+
+    def test_requests_timeout_uses_report_warning_not_failure(self):
+        """requests.exceptions.Timeout should also call report_warning."""
+        source = _make_source()
+        report = {"token": "tok", "name": "Report"}
+
+        def timeout_inner(space_token: str, report: dict) -> Iterator:
+            raise requests.exceptions.Timeout("connection timed out")
+            yield
+
+        with patch.object(source, "_process_report_inner", side_effect=timeout_inner):
+            list(source._process_report("space1", report))
+
+        assert not source.report.failures
+        assert source.report.warnings
+
+    def test_non_timeout_error_still_uses_report_failure(self):
+        """Non-timeout exceptions should still call report_failure."""
+        source = _make_source()
+        report = {"token": "tok", "name": "Report"}
+
+        def failing_inner(space_token: str, report: dict) -> Iterator:
+            raise ValueError("unexpected error")
+            yield
+
+        with patch.object(source, "_process_report_inner", side_effect=failing_inner):
+            list(source._process_report("space1", report))
+
+        assert source.report.failures
+        assert not source.report.warnings
 
     def test_error_handler_failure_does_not_propagate(self):
         """If report_failure itself raises (e.g. serialization error),


### PR DESCRIPTION


**Problem:** _process_report caught all exceptions (including TimeoutError / requests.exceptions.Timeout) and called report_failure. This caused has_failures() to return true, marking the entire run as FAILURE and skipping stale entity removal — even if only 1 of 8,675 reports timed out.

**Fix:** Added a timeout detection check before deciding which report method to call:
  - TimeoutError or requests.exceptions.Timeout → report_warning (run continues, stale removal proceeds)
  - All other exceptions → report_failure (unchanged)
  
  Tests are added for same 