### PR TITLE
feat(mode-reports):  Add report_pattern (AllowDenyPattern) to Mode connector

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/mode.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/mode.py
@@ -228,6 +228,13 @@ class ModeConfig(
         description="Regex patterns for mode spaces to filter in ingestion (Spaces named as 'Personal' are filtered by default.) Specify regex to only match the space name. e.g. to only ingest space named analytics, use the regex 'analytics'",
     )
 
+    report_pattern: AllowDenyPattern = Field(
+        default=AllowDenyPattern.allow_all(),
+        description="Regex patterns for Mode reports to filter in ingestion. "
+        "Matched against the report name. "
+        "e.g. to exclude a report named 'slow_report', use deny=['slow_report'].",
+    )
+
     owner_username_instead_of_email: bool = Field(
         default=True, description="Use username for owner URN instead of Email"
     )
@@ -303,6 +310,7 @@ def _is_http_404(error: Exception) -> bool:
 @dataclass
 class ModeSourceReport(StaleEntityRemovalSourceReport):
     filtered_spaces: LossyList[str] = dataclasses.field(default_factory=LossyList)
+    filtered_reports: LossyList[str] = dataclasses.field(default_factory=LossyList)
     num_sql_parsed: int = 0
     num_sql_parser_failures: int = 0
     num_sql_parser_success: int = 0
@@ -344,6 +352,10 @@ class ModeSourceReport(StaleEntityRemovalSourceReport):
     def report_dropped_space(self, ent_name: str) -> None:
         with self._lock:
             self.filtered_spaces.append(ent_name)
+
+    def report_dropped_report(self, ent_name: str) -> None:
+        with self._lock:
+            self.filtered_reports.append(ent_name)
 
     def report_warning(self, *args: Any, **kwargs: Any) -> None:
         with self._lock:
@@ -2035,6 +2047,10 @@ class ModeSource(StatefulIngestionSourceBase):
         report_args: List[Tuple[str, dict]] = []
         for report_page in self._get_reports(space_token):
             for report in report_page:
+                report_name = report.get("name", "")
+                if not self.config.report_pattern.allowed(report_name):
+                    self.report.report_dropped_report(report_name)
+                    continue
                 report_args.append((space_token, report))
 
         dataset_args: List[Tuple[str, dict]] = []

--- a/metadata-ingestion/src/datahub/ingestion/source/mode.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/mode.py
@@ -229,7 +229,7 @@ class ModeConfig(
     )
 
     report_pattern: AllowDenyPattern = Field(
-        default=AllowDenyPattern.allow_all(),
+        default_factory=AllowDenyPattern.allow_all,
         description="Regex patterns for Mode reports to filter in ingestion. "
         "Matched against the report name. "
         "e.g. to exclude a report named 'slow_report', use deny=['slow_report'].",
@@ -2047,9 +2047,10 @@ class ModeSource(StatefulIngestionSourceBase):
         report_args: List[Tuple[str, dict]] = []
         for report_page in self._get_reports(space_token):
             for report in report_page:
-                report_name = report.get("name", "")
+                report_name = report.get("name") or report.get("token", "unknown")
                 if not self.config.report_pattern.allowed(report_name):
                     self.report.report_dropped_report(report_name)
+                    logger.debug(f"Skipping report {report_name} due to report_pattern")
                     continue
                 report_args.append((space_token, report))
 

--- a/metadata-ingestion/src/datahub/ingestion/source/mode.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/mode.py
@@ -229,7 +229,7 @@ class ModeConfig(
     )
 
     report_pattern: AllowDenyPattern = Field(
-        default=AllowDenyPattern.allow_all(),
+        default_factory=AllowDenyPattern.allow_all,
         description="Regex patterns for Mode reports to filter in ingestion. "
         "Matched against the report name. "
         "e.g. to exclude a report named 'slow_report', use deny=['slow_report'].",
@@ -2036,9 +2036,10 @@ class ModeSource(StatefulIngestionSourceBase):
         report_args: List[Tuple[str, dict]] = []
         for report_page in self._get_reports(space_token):
             for report in report_page:
-                report_name = report.get("name", "")
+                report_name = report.get("name") or report.get("token", "unknown")
                 if not self.config.report_pattern.allowed(report_name):
                     self.report.report_dropped_report(report_name)
+                    logger.debug(f"Skipping report {report_name} due to report_pattern")
                     continue
                 report_args.append((space_token, report))
 

--- a/metadata-ingestion/src/datahub/ingestion/source/mode.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/mode.py
@@ -228,6 +228,13 @@ class ModeConfig(
         description="Regex patterns for mode spaces to filter in ingestion (Spaces named as 'Personal' are filtered by default.) Specify regex to only match the space name. e.g. to only ingest space named analytics, use the regex 'analytics'",
     )
 
+    report_pattern: AllowDenyPattern = Field(
+        default=AllowDenyPattern.allow_all(),
+        description="Regex patterns for Mode reports to filter in ingestion. "
+        "Matched against the report name. "
+        "e.g. to exclude a report named 'slow_report', use deny=['slow_report'].",
+    )
+
     owner_username_instead_of_email: bool = Field(
         default=True, description="Use username for owner URN instead of Email"
     )
@@ -303,6 +310,7 @@ def _is_http_404(error: Exception) -> bool:
 @dataclass
 class ModeSourceReport(StaleEntityRemovalSourceReport):
     filtered_spaces: LossyList[str] = dataclasses.field(default_factory=LossyList)
+    filtered_reports: LossyList[str] = dataclasses.field(default_factory=LossyList)
     num_sql_parsed: int = 0
     num_sql_parser_failures: int = 0
     num_sql_parser_success: int = 0
@@ -344,6 +352,10 @@ class ModeSourceReport(StaleEntityRemovalSourceReport):
     def report_dropped_space(self, ent_name: str) -> None:
         with self._lock:
             self.filtered_spaces.append(ent_name)
+
+    def report_dropped_report(self, ent_name: str) -> None:
+        with self._lock:
+            self.filtered_reports.append(ent_name)
 
     def report_warning(self, *args: Any, **kwargs: Any) -> None:
         with self._lock:
@@ -2024,6 +2036,10 @@ class ModeSource(StatefulIngestionSourceBase):
         report_args: List[Tuple[str, dict]] = []
         for report_page in self._get_reports(space_token):
             for report in report_page:
+                report_name = report.get("name", "")
+                if not self.config.report_pattern.allowed(report_name):
+                    self.report.report_dropped_report(report_name)
+                    continue
                 report_args.append((space_token, report))
 
         dataset_args: List[Tuple[str, dict]] = []

--- a/metadata-ingestion/tests/unit/test_mode_source.py
+++ b/metadata-ingestion/tests/unit/test_mode_source.py
@@ -763,6 +763,7 @@ class TestReportPattern:
 
     def test_report_pattern_deny_excludes_report(self):
         """Reports matching the deny pattern should be excluded and tracked."""
+
         source = self._make_source_with_config(
             report_pattern=AllowDenyPattern(deny=["^slow_report$"])
         )
@@ -784,22 +785,3 @@ class TestReportPattern:
         assert len(report_args) == 1
         assert report_args[0][1]["token"] == "tok2"
         assert "slow_report" in list(source.report.filtered_reports)
-
-    def test_report_pattern_allow_all_by_default(self):
-        """Default report_pattern passes all reports through."""
-        source = self._make_source_with_config()
-
-        reports = [
-            {"token": "tok1", "name": "report_a"},
-            {"token": "tok2", "name": "report_b"},
-        ]
-
-        with (
-            patch.object(source, "_get_reports", return_value=iter([reports])),
-            patch.object(source, "_get_datasets", return_value=iter([])),
-            patch.object(source, "construct_space_container", return_value=iter([])),
-        ):
-            report_args, _, _ = source._collect_space_work_items("space1", "MySpace")
-
-        assert len(report_args) == 2
-        assert list(source.report.filtered_reports) == []

--- a/metadata-ingestion/tests/unit/test_mode_source.py
+++ b/metadata-ingestion/tests/unit/test_mode_source.py
@@ -734,3 +734,72 @@ class TestChartFetchGating:
         source = _make_source()
         assert self._drive(source, explorations_count=5, chart_count=0) == 0
         assert source.report.chart_api_calls_skipped == 1
+
+
+# ──────────────────────────────────────────────────────────────────────
+# report_pattern filtering
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestReportPattern:
+    def _make_source_with_config(self, **kwargs: object) -> ModeSource:
+        config = ModeConfig(
+            token="test",
+            password="test",
+            workspace="test_workspace",
+            **kwargs,
+        )
+        with (
+            patch("datahub.ingestion.source.mode.requests.Session"),
+            patch.object(ModeSource, "_get_request_json", return_value={}),
+        ):
+            ctx = MagicMock()
+            ctx.graph = None
+            ctx.pipeline_name = "test"
+            ctx.run_id = "test-run"
+            ctx.pipeline_config = None
+            source = ModeSource(ctx, config)
+        return source
+
+    def test_report_pattern_deny_excludes_report(self):
+        """Reports matching the deny pattern should be excluded and tracked."""
+        source = self._make_source_with_config(
+            report_pattern=AllowDenyPattern(deny=["^slow_report$"])
+        )
+
+        reports = [
+            {"token": "tok1", "name": "slow_report"},
+            {"token": "tok2", "name": "fast_report"},
+        ]
+
+        with (
+            patch.object(
+                source, "_get_reports", return_value=iter([[reports[0]], [reports[1]]])
+            ),
+            patch.object(source, "_get_datasets", return_value=iter([])),
+            patch.object(source, "construct_space_container", return_value=iter([])),
+        ):
+            report_args, _, _ = source._collect_space_work_items("space1", "MySpace")
+
+        assert len(report_args) == 1
+        assert report_args[0][1]["token"] == "tok2"
+        assert "slow_report" in list(source.report.filtered_reports)
+
+    def test_report_pattern_allow_all_by_default(self):
+        """Default report_pattern passes all reports through."""
+        source = self._make_source_with_config()
+
+        reports = [
+            {"token": "tok1", "name": "report_a"},
+            {"token": "tok2", "name": "report_b"},
+        ]
+
+        with (
+            patch.object(source, "_get_reports", return_value=iter([reports])),
+            patch.object(source, "_get_datasets", return_value=iter([])),
+            patch.object(source, "construct_space_container", return_value=iter([])),
+        ):
+            report_args, _, _ = source._collect_space_work_items("space1", "MySpace")
+
+        assert len(report_args) == 2
+        assert list(source.report.filtered_reports) == []

--- a/metadata-ingestion/tests/unit/test_mode_source.py
+++ b/metadata-ingestion/tests/unit/test_mode_source.py
@@ -639,3 +639,74 @@ class TestExcludePersonalCollections:
 
         assert "tok1" in result
         assert "tok2" not in result
+
+
+# ──────────────────────────────────────────────────────────────────────
+# report_pattern filtering
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestReportPattern:
+    def _make_source_with_config(self, **kwargs: object) -> ModeSource:
+        config = ModeConfig(
+            token="test",
+            password="test",
+            workspace="test_workspace",
+            **kwargs,
+        )
+        with (
+            patch("datahub.ingestion.source.mode.requests.Session"),
+            patch.object(ModeSource, "_get_request_json", return_value={}),
+        ):
+            ctx = MagicMock()
+            ctx.graph = None
+            ctx.pipeline_name = "test"
+            ctx.run_id = "test-run"
+            ctx.pipeline_config = None
+            source = ModeSource(ctx, config)
+        return source
+
+    def test_report_pattern_deny_excludes_report(self):
+        """Reports matching the deny pattern should be excluded and tracked."""
+        from datahub.configuration.common import AllowDenyPattern
+
+        source = self._make_source_with_config(
+            report_pattern=AllowDenyPattern(deny=["^slow_report$"])
+        )
+
+        reports = [
+            {"token": "tok1", "name": "slow_report"},
+            {"token": "tok2", "name": "fast_report"},
+        ]
+
+        with (
+            patch.object(
+                source, "_get_reports", return_value=iter([[reports[0]], [reports[1]]])
+            ),
+            patch.object(source, "_get_datasets", return_value=iter([])),
+            patch.object(source, "construct_space_container", return_value=iter([])),
+        ):
+            report_args, _, _ = source._collect_space_work_items("space1", "MySpace")
+
+        assert len(report_args) == 1
+        assert report_args[0][1]["token"] == "tok2"
+        assert "slow_report" in list(source.report.filtered_reports)
+
+    def test_report_pattern_allow_all_by_default(self):
+        """Default report_pattern passes all reports through."""
+        source = self._make_source_with_config()
+
+        reports = [
+            {"token": "tok1", "name": "report_a"},
+            {"token": "tok2", "name": "report_b"},
+        ]
+
+        with (
+            patch.object(source, "_get_reports", return_value=iter([reports])),
+            patch.object(source, "_get_datasets", return_value=iter([])),
+            patch.object(source, "construct_space_container", return_value=iter([])),
+        ):
+            report_args, _, _ = source._collect_space_work_items("space1", "MySpace")
+
+        assert len(report_args) == 2
+        assert list(source.report.filtered_reports) == []

--- a/metadata-ingestion/tests/unit/test_mode_source.py
+++ b/metadata-ingestion/tests/unit/test_mode_source.py
@@ -668,7 +668,6 @@ class TestReportPattern:
 
     def test_report_pattern_deny_excludes_report(self):
         """Reports matching the deny pattern should be excluded and tracked."""
-        from datahub.configuration.common import AllowDenyPattern
 
         source = self._make_source_with_config(
             report_pattern=AllowDenyPattern(deny=["^slow_report$"])
@@ -691,22 +690,3 @@ class TestReportPattern:
         assert len(report_args) == 1
         assert report_args[0][1]["token"] == "tok2"
         assert "slow_report" in list(source.report.filtered_reports)
-
-    def test_report_pattern_allow_all_by_default(self):
-        """Default report_pattern passes all reports through."""
-        source = self._make_source_with_config()
-
-        reports = [
-            {"token": "tok1", "name": "report_a"},
-            {"token": "tok2", "name": "report_b"},
-        ]
-
-        with (
-            patch.object(source, "_get_reports", return_value=iter([reports])),
-            patch.object(source, "_get_datasets", return_value=iter([])),
-            patch.object(source, "construct_space_container", return_value=iter([])),
-        ):
-            report_args, _, _ = source._collect_space_work_items("space1", "MySpace")
-
-        assert len(report_args) == 2
-        assert list(source.report.filtered_reports) == []


### PR DESCRIPTION

mode.py:
  - ModeConfig: added report_pattern: AllowDenyPattern (default: allow all) after space_pattern
  - ModeSourceReport: added filtered_reports: LossyList[str] field and report_dropped_report() method
  - _collect_space_work_items: filters each report against report_pattern before adding to report_args; excluded reports are tracked in filtered_reports

  test_mode_source.py:
  - TestReportPattern: two tests — deny pattern excludes a report and records it, default allows everything through

  A user can now exclude a problematic report (e.g., the one with 200K+ user tokens) via:
  report_pattern:
    deny:
      - "^slow_report_name$"

space_pattern has a non-trivial default (denies Personal spaces), while report_pattern defaults to allow_all().

**mode_recipe.yml changes if we need to deny any report** 

source:
    type: mode
    config:
      token: "..."
      password: "..."
      workspace: "my_workspace"
      report_pattern:
        deny:
          - "^broken_report_name$"
          
Tests are added for same