### PR TITLE
fix(ui): fix loading state of entity sidebar header (#9068)

### DIFF
--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/SidebarEntityHeader.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/SidebarEntityHeader.tsx
@@ -18,10 +18,13 @@ import { useEntityRegistry } from '@app/useEntityRegistry';
 
 import { DataPlatform, EntityType, Post } from '@types';
 
-const TitleContainer = styled(HorizontalScroller)<{ $hasPlatform: boolean }>`
+const Wrapper = styled.div<{ $hasPlatformIcon?: boolean }>`
+    padding: 0 ${(props) => (props.$hasPlatformIcon ? '16px' : '20px')};
+`;
+
+const TitleContainer = styled(HorizontalScroller)`
     display: flex;
     gap: 8px;
-    padding: 0 ${(props) => (props.$hasPlatform ? '16px' : '20px')};
 `;
 
 const EntityDetailsContainer = styled.div`
@@ -53,47 +56,53 @@ const SidebarEntityHeader = () => {
     const parentEntities = getParentEntities(entityData, entityType);
 
     if (loading) {
-        return <EntityTitleLoadingSection />;
+        return (
+            <Wrapper>
+                <EntityTitleLoadingSection />
+            </Wrapper>
+        );
     }
     return (
-        <TitleContainer scrollButtonSize={18} scrollButtonOffset={15} $hasPlatform={!!platform}>
-            {platform && (
-                <PlatformHeaderIcons
-                    platform={platform as DataPlatform}
-                    platforms={platforms as DataPlatform[]}
-                    size={24}
-                />
-            )}
-            <EntityDetailsContainer>
-                <NameWrapper>
-                    <EntityName isNameEditable={false} />
-                    {!!entityData?.notes?.total && (
-                        <NotesIcon notes={entityData?.notes?.relationships?.map((r) => r.entity as Post) || []} />
-                    )}
-                    {entityData?.deprecation?.deprecated && (
-                        <DeprecationIcon
-                            urn={urn}
-                            deprecation={entityData?.deprecation}
-                            showUndeprecate
-                            refetch={refetch}
-                            showText={false}
-                        />
-                    )}
-                    {entityData?.health && <HealthIcon urn={urn} health={entityData.health} baseUrl={entityUrl} />}
-                    <StructuredPropertyBadge structuredProperties={entityData?.structuredProperties} />
-                    <VersioningBadge
-                        versionProperties={entityData?.versionProperties ?? undefined}
-                        showPopover={false}
+        <Wrapper $hasPlatformIcon={!!platform}>
+            <TitleContainer scrollButtonSize={18} scrollButtonOffset={platform ? 11 : 15}>
+                {platform && (
+                    <PlatformHeaderIcons
+                        platform={platform as DataPlatform}
+                        platforms={platforms as DataPlatform[]}
+                        size={24}
                     />
-                </NameWrapper>
-                <ContextPath
-                    displayedEntityType={displayedEntityType}
-                    entityType={entityType}
-                    browsePaths={entityData?.browsePathV2}
-                    parentEntities={parentEntities}
-                />
-            </EntityDetailsContainer>
-        </TitleContainer>
+                )}
+                <EntityDetailsContainer>
+                    <NameWrapper>
+                        <EntityName isNameEditable={false} />
+                        {!!entityData?.notes?.total && (
+                            <NotesIcon notes={entityData?.notes?.relationships?.map((r) => r.entity as Post) || []} />
+                        )}
+                        {entityData?.deprecation?.deprecated && (
+                            <DeprecationIcon
+                                urn={urn}
+                                deprecation={entityData?.deprecation}
+                                showUndeprecate
+                                refetch={refetch}
+                                showText={false}
+                            />
+                        )}
+                        {entityData?.health && <HealthIcon urn={urn} health={entityData.health} baseUrl={entityUrl} />}
+                        <StructuredPropertyBadge structuredProperties={entityData?.structuredProperties} />
+                        <VersioningBadge
+                            versionProperties={entityData?.versionProperties ?? undefined}
+                            showPopover={false}
+                        />
+                    </NameWrapper>
+                    <ContextPath
+                        displayedEntityType={displayedEntityType}
+                        entityType={entityType}
+                        browsePaths={entityData?.browsePathV2}
+                        parentEntities={parentEntities}
+                    />
+                </EntityDetailsContainer>
+            </TitleContainer>
+        </Wrapper>
     );
 };
 


### PR DESCRIPTION
Linear: https://linear.app/acryl-data/issue/CAT-1763/loading-state-has-gotten-off-center-on-entity-sidebar

This PR fixes loading state of entity sidebar header. Also it fixes position of scroll buttons

Original SaaS PR - https://github.com/acryldata/datahub-fork/pull/9068

<img width="512" height="263" alt="image" src="https://github.com/user-attachments/assets/5ad19f2b-492c-4a1f-9b64-ca4dd6a21229" />

Scroll buttons before:

<img width="512" height="263" alt="image" src="https://github.com/user-attachments/assets/a1acbfa6-51ad-4d74-a340-639b6b96840c" />

Scroll buttons after:

<img width="512" height="263" alt="image" src="https://github.com/user-attachments/assets/92f2268d-afe2-48d7-ad0b-f34239e7eab9" />


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
