### PR TITLE
chore(java8): maintain java 8 compatibility

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -129,7 +129,7 @@ jobs:
           docker system df -v
       - name: Gradle compile (jdk8) for legacy Spark
         run: |
-          ./gradlew -PjavaClassVersionDefault=17 :metadata-integration:java:spark-lineage:compileJava
+          ./gradlew -PjavaClassVersionDefault=8 :metadata-integration:java:spark-lineage:compileJava
       - name: Gather coverage files
         run: |
           {

--- a/.github/workflows/publish-datahub-jars.yml
+++ b/.github/workflows/publish-datahub-jars.yml
@@ -222,8 +222,8 @@ jobs:
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
         run: |
           echo "signingKey=$SIGNING_KEY" >> gradle.properties
-          ./gradlew :metadata-integration:java:datahub-client:printVersion -PjavaClassVersionDefault=17 -ParchiveAppendix=java8
-          ./gradlew :metadata-integration:java:datahub-client:publish -PjavaClassVersionDefault=17 -ParchiveAppendix=java8
+          ./gradlew :metadata-integration:java:datahub-client:printVersion -PjavaClassVersionDefault=8 -ParchiveAppendix=java8
+          ./gradlew :metadata-integration:java:datahub-client:publish -PjavaClassVersionDefault=8 -ParchiveAppendix=java8
       - name: release datahub-client jar
         if: ${{ github.event_name == 'release' }}
         env:
@@ -233,5 +233,5 @@ jobs:
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
         run: |
           echo "signingKey=$SIGNING_KEY" >> gradle.properties
-          ./gradlew -PreleaseVersion=${{ needs.setup.outputs.tag }} :metadata-integration:java:datahub-client:publish -PjavaClassVersionDefault=17 -ParchiveAppendix=java8
-          ./gradlew :metadata-integration:java:datahub-client:closeAndReleaseRepository --info -PjavaClassVersionDefault=17 -ParchiveAppendix=java8
+          ./gradlew -PreleaseVersion=${{ needs.setup.outputs.tag }} :metadata-integration:java:datahub-client:publish -PjavaClassVersionDefault=8 -ParchiveAppendix=java8
+          ./gradlew :metadata-integration:java:datahub-client:closeAndReleaseRepository --info -PjavaClassVersionDefault=8 -ParchiveAppendix=java8

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/common/DocumentationTemplate.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/common/DocumentationTemplate.java
@@ -7,7 +7,6 @@ import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.aspect.patch.template.ArrayMergingTemplate;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import javax.annotation.Nonnull;
 
 public class DocumentationTemplate implements ArrayMergingTemplate<Documentation> {
@@ -38,12 +37,18 @@ public class DocumentationTemplate implements ArrayMergingTemplate<Documentation
   @Nonnull
   @Override
   public JsonNode transformFields(JsonNode baseNode) {
-    return arrayFieldToMap(baseNode, DOCUMENTATIONS_FIELD_NAME, Collections.unmodifiableList(Arrays.asList(ATTRIBUTION_SOURCE)));
+    return arrayFieldToMap(
+        baseNode,
+        DOCUMENTATIONS_FIELD_NAME,
+        Collections.unmodifiableList(Arrays.asList(ATTRIBUTION_SOURCE)));
   }
 
   @Nonnull
   @Override
   public JsonNode rebaseFields(JsonNode patched) {
-    return transformedMapToArray(patched, DOCUMENTATIONS_FIELD_NAME, Collections.unmodifiableList(Arrays.asList(ATTRIBUTION_SOURCE)));
+    return transformedMapToArray(
+        patched,
+        DOCUMENTATIONS_FIELD_NAME,
+        Collections.unmodifiableList(Arrays.asList(ATTRIBUTION_SOURCE)));
   }
 }

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/common/DocumentationTemplate.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/common/DocumentationTemplate.java
@@ -5,6 +5,8 @@ import com.linkedin.common.Documentation;
 import com.linkedin.common.DocumentationAssociationArray;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.aspect.patch.template.ArrayMergingTemplate;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
 
@@ -36,12 +38,12 @@ public class DocumentationTemplate implements ArrayMergingTemplate<Documentation
   @Nonnull
   @Override
   public JsonNode transformFields(JsonNode baseNode) {
-    return arrayFieldToMap(baseNode, DOCUMENTATIONS_FIELD_NAME, List.of(ATTRIBUTION_SOURCE));
+    return arrayFieldToMap(baseNode, DOCUMENTATIONS_FIELD_NAME, Collections.unmodifiableList(Arrays.asList(ATTRIBUTION_SOURCE)));
   }
 
   @Nonnull
   @Override
   public JsonNode rebaseFields(JsonNode patched) {
-    return transformedMapToArray(patched, DOCUMENTATIONS_FIELD_NAME, List.of(ATTRIBUTION_SOURCE));
+    return transformedMapToArray(patched, DOCUMENTATIONS_FIELD_NAME, Collections.unmodifiableList(Arrays.asList(ATTRIBUTION_SOURCE)));
   }
 }

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/common/GlobalTagsTemplate.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/common/GlobalTagsTemplate.java
@@ -5,6 +5,8 @@ import com.linkedin.common.GlobalTags;
 import com.linkedin.common.TagAssociationArray;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.aspect.patch.template.ArrayMergingTemplate;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
 
@@ -40,13 +42,13 @@ public class GlobalTagsTemplate implements ArrayMergingTemplate<GlobalTags> {
   @Nonnull
   @Override
   public JsonNode transformFields(JsonNode baseNode) {
-    return arrayFieldToMap(baseNode, TAGS_FIELD_NAME, List.of(TAG_FIELD_NAME, ATTRIBUTION_SOURCE));
+    return arrayFieldToMap(baseNode, TAGS_FIELD_NAME, Collections.unmodifiableList(Arrays.asList(TAG_FIELD_NAME, ATTRIBUTION_SOURCE)));
   }
 
   @Nonnull
   @Override
   public JsonNode rebaseFields(JsonNode patched) {
     return transformedMapToArray(
-        patched, TAGS_FIELD_NAME, List.of(TAG_FIELD_NAME, ATTRIBUTION_SOURCE));
+        patched, TAGS_FIELD_NAME, Collections.unmodifiableList(Arrays.asList(TAG_FIELD_NAME, ATTRIBUTION_SOURCE)));
   }
 }

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/common/GlobalTagsTemplate.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/common/GlobalTagsTemplate.java
@@ -7,7 +7,6 @@ import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.aspect.patch.template.ArrayMergingTemplate;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import javax.annotation.Nonnull;
 
 public class GlobalTagsTemplate implements ArrayMergingTemplate<GlobalTags> {
@@ -42,13 +41,18 @@ public class GlobalTagsTemplate implements ArrayMergingTemplate<GlobalTags> {
   @Nonnull
   @Override
   public JsonNode transformFields(JsonNode baseNode) {
-    return arrayFieldToMap(baseNode, TAGS_FIELD_NAME, Collections.unmodifiableList(Arrays.asList(TAG_FIELD_NAME, ATTRIBUTION_SOURCE)));
+    return arrayFieldToMap(
+        baseNode,
+        TAGS_FIELD_NAME,
+        Collections.unmodifiableList(Arrays.asList(TAG_FIELD_NAME, ATTRIBUTION_SOURCE)));
   }
 
   @Nonnull
   @Override
   public JsonNode rebaseFields(JsonNode patched) {
     return transformedMapToArray(
-        patched, TAGS_FIELD_NAME, Collections.unmodifiableList(Arrays.asList(TAG_FIELD_NAME, ATTRIBUTION_SOURCE)));
+        patched,
+        TAGS_FIELD_NAME,
+        Collections.unmodifiableList(Arrays.asList(TAG_FIELD_NAME, ATTRIBUTION_SOURCE)));
   }
 }

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/common/GlossaryTermsTemplate.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/common/GlossaryTermsTemplate.java
@@ -13,7 +13,6 @@ import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.aspect.patch.template.ArrayMergingTemplate;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import javax.annotation.Nonnull;
 
 public class GlossaryTermsTemplate implements ArrayMergingTemplate<GlossaryTerms> {
@@ -62,7 +61,10 @@ public class GlossaryTermsTemplate implements ArrayMergingTemplate<GlossaryTerms
       auditStampNode.put(ACTOR_FIELD, SYSTEM_ACTOR).put(TIME_FIELD, System.currentTimeMillis());
       ((ObjectNode) baseNode).set(AUDIT_STAMP_FIELD, auditStampNode);
     }
-    return arrayFieldToMap(baseNode, TERMS_FIELD_NAME, Collections.unmodifiableList(Arrays.asList(URN_FIELD_NAME, ATTRIBUTION_SOURCE)));
+    return arrayFieldToMap(
+        baseNode,
+        TERMS_FIELD_NAME,
+        Collections.unmodifiableList(Arrays.asList(URN_FIELD_NAME, ATTRIBUTION_SOURCE)));
   }
 
   @Nonnull
@@ -75,6 +77,8 @@ public class GlossaryTermsTemplate implements ArrayMergingTemplate<GlossaryTerms
       ((ObjectNode) patched).set(AUDIT_STAMP_FIELD, auditStampNode);
     }
     return transformedMapToArray(
-        patched, TERMS_FIELD_NAME, Collections.unmodifiableList(Arrays.asList(URN_FIELD_NAME, ATTRIBUTION_SOURCE)));
+        patched,
+        TERMS_FIELD_NAME,
+        Collections.unmodifiableList(Arrays.asList(URN_FIELD_NAME, ATTRIBUTION_SOURCE)));
   }
 }

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/common/GlossaryTermsTemplate.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/common/GlossaryTermsTemplate.java
@@ -11,6 +11,8 @@ import com.linkedin.common.GlossaryTerms;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.aspect.patch.template.ArrayMergingTemplate;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
 
@@ -60,7 +62,7 @@ public class GlossaryTermsTemplate implements ArrayMergingTemplate<GlossaryTerms
       auditStampNode.put(ACTOR_FIELD, SYSTEM_ACTOR).put(TIME_FIELD, System.currentTimeMillis());
       ((ObjectNode) baseNode).set(AUDIT_STAMP_FIELD, auditStampNode);
     }
-    return arrayFieldToMap(baseNode, TERMS_FIELD_NAME, List.of(URN_FIELD_NAME, ATTRIBUTION_SOURCE));
+    return arrayFieldToMap(baseNode, TERMS_FIELD_NAME, Collections.unmodifiableList(Arrays.asList(URN_FIELD_NAME, ATTRIBUTION_SOURCE)));
   }
 
   @Nonnull
@@ -73,6 +75,6 @@ public class GlossaryTermsTemplate implements ArrayMergingTemplate<GlossaryTerms
       ((ObjectNode) patched).set(AUDIT_STAMP_FIELD, auditStampNode);
     }
     return transformedMapToArray(
-        patched, TERMS_FIELD_NAME, List.of(URN_FIELD_NAME, ATTRIBUTION_SOURCE));
+        patched, TERMS_FIELD_NAME, Collections.unmodifiableList(Arrays.asList(URN_FIELD_NAME, ATTRIBUTION_SOURCE)));
   }
 }

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/common/OwnershipTemplate.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/common/OwnershipTemplate.java
@@ -11,7 +11,6 @@ import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.aspect.patch.template.ArrayMergingTemplate;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import javax.annotation.Nonnull;
 
 public class OwnershipTemplate implements ArrayMergingTemplate<Ownership> {
@@ -55,7 +54,9 @@ public class OwnershipTemplate implements ArrayMergingTemplate<Ownership> {
     return arrayFieldToMap(
         baseNode,
         OWNERS_FIELD_NAME,
-        Collections.unmodifiableList(Arrays.asList(OWNER_FIELD_NAME, TYPE_FIELD_NAME, TYPE_URN_FIELD_NAME, ATTRIBUTION_SOURCE)));
+        Collections.unmodifiableList(
+            Arrays.asList(
+                OWNER_FIELD_NAME, TYPE_FIELD_NAME, TYPE_URN_FIELD_NAME, ATTRIBUTION_SOURCE)));
   }
 
   @Nonnull
@@ -64,6 +65,8 @@ public class OwnershipTemplate implements ArrayMergingTemplate<Ownership> {
     return transformedMapToArray(
         patched,
         OWNERS_FIELD_NAME,
-        Collections.unmodifiableList(Arrays.asList(OWNER_FIELD_NAME, TYPE_FIELD_NAME, TYPE_URN_FIELD_NAME, ATTRIBUTION_SOURCE)));
+        Collections.unmodifiableList(
+            Arrays.asList(
+                OWNER_FIELD_NAME, TYPE_FIELD_NAME, TYPE_URN_FIELD_NAME, ATTRIBUTION_SOURCE)));
   }
 }

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/common/OwnershipTemplate.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/common/OwnershipTemplate.java
@@ -9,6 +9,8 @@ import com.linkedin.common.Ownership;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.aspect.patch.template.ArrayMergingTemplate;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
 
@@ -53,7 +55,7 @@ public class OwnershipTemplate implements ArrayMergingTemplate<Ownership> {
     return arrayFieldToMap(
         baseNode,
         OWNERS_FIELD_NAME,
-        List.of(OWNER_FIELD_NAME, TYPE_FIELD_NAME, TYPE_URN_FIELD_NAME, ATTRIBUTION_SOURCE));
+        Collections.unmodifiableList(Arrays.asList(OWNER_FIELD_NAME, TYPE_FIELD_NAME, TYPE_URN_FIELD_NAME, ATTRIBUTION_SOURCE)));
   }
 
   @Nonnull
@@ -62,6 +64,6 @@ public class OwnershipTemplate implements ArrayMergingTemplate<Ownership> {
     return transformedMapToArray(
         patched,
         OWNERS_FIELD_NAME,
-        List.of(OWNER_FIELD_NAME, TYPE_FIELD_NAME, TYPE_URN_FIELD_NAME, ATTRIBUTION_SOURCE));
+        Collections.unmodifiableList(Arrays.asList(OWNER_FIELD_NAME, TYPE_FIELD_NAME, TYPE_URN_FIELD_NAME, ATTRIBUTION_SOURCE)));
   }
 }

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/common/StructuredPropertiesTemplate.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/common/StructuredPropertiesTemplate.java
@@ -7,7 +7,6 @@ import com.linkedin.structured.StructuredProperties;
 import com.linkedin.structured.StructuredPropertyValueAssignmentArray;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import javax.annotation.Nonnull;
 
 public class StructuredPropertiesTemplate implements ArrayMergingTemplate<StructuredProperties> {
@@ -42,13 +41,17 @@ public class StructuredPropertiesTemplate implements ArrayMergingTemplate<Struct
   @Override
   public JsonNode transformFields(JsonNode baseNode) {
     return arrayFieldToMap(
-        baseNode, PROPERTIES_FIELD_NAME, Collections.unmodifiableList(Arrays.asList(URN_FIELD_NAME, ATTRIBUTION_SOURCE)));
+        baseNode,
+        PROPERTIES_FIELD_NAME,
+        Collections.unmodifiableList(Arrays.asList(URN_FIELD_NAME, ATTRIBUTION_SOURCE)));
   }
 
   @Nonnull
   @Override
   public JsonNode rebaseFields(JsonNode patched) {
     return transformedMapToArray(
-        patched, PROPERTIES_FIELD_NAME, Collections.unmodifiableList(Arrays.asList(URN_FIELD_NAME, ATTRIBUTION_SOURCE)));
+        patched,
+        PROPERTIES_FIELD_NAME,
+        Collections.unmodifiableList(Arrays.asList(URN_FIELD_NAME, ATTRIBUTION_SOURCE)));
   }
 }

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/common/StructuredPropertiesTemplate.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/common/StructuredPropertiesTemplate.java
@@ -5,6 +5,8 @@ import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.aspect.patch.template.ArrayMergingTemplate;
 import com.linkedin.structured.StructuredProperties;
 import com.linkedin.structured.StructuredPropertyValueAssignmentArray;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
 
@@ -40,13 +42,13 @@ public class StructuredPropertiesTemplate implements ArrayMergingTemplate<Struct
   @Override
   public JsonNode transformFields(JsonNode baseNode) {
     return arrayFieldToMap(
-        baseNode, PROPERTIES_FIELD_NAME, List.of(URN_FIELD_NAME, ATTRIBUTION_SOURCE));
+        baseNode, PROPERTIES_FIELD_NAME, Collections.unmodifiableList(Arrays.asList(URN_FIELD_NAME, ATTRIBUTION_SOURCE)));
   }
 
   @Nonnull
   @Override
   public JsonNode rebaseFields(JsonNode patched) {
     return transformedMapToArray(
-        patched, PROPERTIES_FIELD_NAME, List.of(URN_FIELD_NAME, ATTRIBUTION_SOURCE));
+        patched, PROPERTIES_FIELD_NAME, Collections.unmodifiableList(Arrays.asList(URN_FIELD_NAME, ATTRIBUTION_SOURCE)));
   }
 }


### PR DESCRIPTION
## Problem

Two CI workflows were passing `-PjavaClassVersionDefault=17` where Java 8
bytecode is required:

1. `build-and-test.yml`: The "Gradle compile (jdk8) for legacy Spark" step
   was compiling `spark-lineage` with `--release 17`, making the compat
   check meaningless.

2. `publish-datahub-jars.yml`: The `publish-java8` job was publishing
   `datahub-client-*-java8.jar` compiled with `--release 17` — incorrectly
   labeled as Java 8 compatible.

## Fix

- Changed `-PjavaClassVersionDefault=17` → `-PjavaClassVersionDefault=8`
  in both affected workflows.
- Replaced `List.of(...)` (Java 9+) with
  `Collections.unmodifiableList(Arrays.asList(...))` in 5 entity-registry
  template files compiled as part of the java8 artifact.

## Affected Files

- `.github/workflows/build-and-test.yml`
- `.github/workflows/publish-datahub-jars.yml`
- `entity-registry/.../template/common/{Documentation,GlobalTags,
  GlossaryTerms,Ownership,StructuredProperties}Template.java`

## Testing

Ran 
```
./gradlew -PjavaClassVersionDefault=8 :metadata-integration:java:spark-lineage:test 
./gradlew -PjavaClassVersionDefault=8 :metadata-integration:java:spark-lineage-legacy:test 
```
to make sure everything compiles 