### PR TITLE
test(ingest): enable SQL parsing performance tests in CI

### DIFF
--- a/metadata-ingestion/tests/performance/sql_parsing/test_sql_aggregator.py
+++ b/metadata-ingestion/tests/performance/sql_parsing/test_sql_aggregator.py
@@ -150,6 +150,7 @@ def run_configuration(
 
 
 # adding retries to mitigate flakiness in CI env
+@pytest.mark.perf
 @pytest.mark.flaky(reruns=5)
 def test_benchmark(pytestconfig: pytest.Config) -> None:
     """Run benchmark test across a matrix of configurations.

--- a/metadata-ingestion/tests/performance/test_sqlglot_memory_leak.py
+++ b/metadata-ingestion/tests/performance/test_sqlglot_memory_leak.py
@@ -294,28 +294,3 @@ def test_parse_cache_memory_footprint():
         print(
             f"Projected for 1000 cache entries: {result_size * 1000 / 1024 / 1024:.2f} MB"
         )
-
-
-if __name__ == "__main__":
-    # Run tests directly
-    import sqlglot.exp
-
-    print("=" * 80)
-    print("Testing sqlglot[c] memory leak...")
-    print("=" * 80)
-
-    try:
-        test_sqlglot_table_name_memory_leak()
-        print("✅ No memory leak detected in Table.name access")
-    except AssertionError as e:
-        print(f"❌ {e}")
-
-    print("\n" + "=" * 80)
-    print("Testing view lineage extraction memory usage...")
-    print("=" * 80)
-    test_view_lineage_extraction_memory_usage()
-
-    print("\n" + "=" * 80)
-    print("Testing parse cache memory footprint...")
-    print("=" * 80)
-    test_parse_cache_memory_footprint()

--- a/metadata-ingestion/tests/unit/dbt/test_dbt_source.py
+++ b/metadata-ingestion/tests/unit/dbt/test_dbt_source.py
@@ -812,7 +812,7 @@ def test_drop_duplicate_sources() -> None:
     assert source.report.duplicate_sources_references_updated == 1
 
 
-def _make_dbt_node(
+def _make_dbt_node_for_sibling_test(
     materialization: str = "table",
     node_type: str = "model",
     name: str = "test_model",
@@ -853,7 +853,7 @@ def test_dbt_sibling_created_for_semantic_views(dbt_is_primary_sibling: bool) ->
     """Regression test for CUS-7718: semantic views showed as duplicate search
     results because the SiblingAssociationHook only handles the "source" subtype."""
     source = _make_dbt_source(dbt_is_primary_sibling)
-    node = _make_dbt_node(materialization="semantic_view")
+    node = _make_dbt_node_for_sibling_test(materialization="semantic_view")
     assert source._should_create_sibling_relationships(node) is True
 
 
@@ -862,7 +862,7 @@ def test_dbt_sibling_not_created_for_standard_models_when_primary() -> None:
     when dbt is primary. Only semantic views need explicit emission."""
     source = _make_dbt_source(dbt_is_primary_sibling=True)
     for materialization in ("table", "view", "incremental"):
-        node = _make_dbt_node(materialization=materialization)
+        node = _make_dbt_node_for_sibling_test(materialization=materialization)
         assert source._should_create_sibling_relationships(node) is False
 
 
@@ -871,7 +871,7 @@ def test_dbt_sibling_created_for_all_nodes_when_not_primary() -> None:
     the dbt source emits siblings for all nodes."""
     source = _make_dbt_source(dbt_is_primary_sibling=False)
     for materialization in ("table", "view", "incremental", "semantic_view"):
-        node = _make_dbt_node(materialization=materialization)
+        node = _make_dbt_node_for_sibling_test(materialization=materialization)
         assert source._should_create_sibling_relationships(node) is True
 
 
@@ -883,7 +883,9 @@ def test_dbt_sibling_not_created_for_ephemeral_or_test_nodes(
     materialization: str, node_type: str
 ) -> None:
     source = _make_dbt_source()
-    node = _make_dbt_node(materialization=materialization, node_type=node_type)
+    node = _make_dbt_node_for_sibling_test(
+        materialization=materialization, node_type=node_type
+    )
     assert source._should_create_sibling_relationships(node) is False
 
 

--- a/metadata-ingestion/tests/unit/dbt/test_dbt_source.py
+++ b/metadata-ingestion/tests/unit/dbt/test_dbt_source.py
@@ -812,7 +812,7 @@ def test_drop_duplicate_sources() -> None:
     assert source.report.duplicate_sources_references_updated == 1
 
 
-def _make_dbt_node_for_sibling_test(
+def _make_dbt_node(
     materialization: str = "table",
     node_type: str = "model",
     name: str = "test_model",
@@ -853,7 +853,7 @@ def test_dbt_sibling_created_for_semantic_views(dbt_is_primary_sibling: bool) ->
     """Regression test for CUS-7718: semantic views showed as duplicate search
     results because the SiblingAssociationHook only handles the "source" subtype."""
     source = _make_dbt_source(dbt_is_primary_sibling)
-    node = _make_dbt_node_for_sibling_test(materialization="semantic_view")
+    node = _make_dbt_node(materialization="semantic_view")
     assert source._should_create_sibling_relationships(node) is True
 
 
@@ -862,7 +862,7 @@ def test_dbt_sibling_not_created_for_standard_models_when_primary() -> None:
     when dbt is primary. Only semantic views need explicit emission."""
     source = _make_dbt_source(dbt_is_primary_sibling=True)
     for materialization in ("table", "view", "incremental"):
-        node = _make_dbt_node_for_sibling_test(materialization=materialization)
+        node = _make_dbt_node(materialization=materialization)
         assert source._should_create_sibling_relationships(node) is False
 
 
@@ -871,7 +871,7 @@ def test_dbt_sibling_created_for_all_nodes_when_not_primary() -> None:
     the dbt source emits siblings for all nodes."""
     source = _make_dbt_source(dbt_is_primary_sibling=False)
     for materialization in ("table", "view", "incremental", "semantic_view"):
-        node = _make_dbt_node_for_sibling_test(materialization=materialization)
+        node = _make_dbt_node(materialization=materialization)
         assert source._should_create_sibling_relationships(node) is True
 
 
@@ -883,9 +883,7 @@ def test_dbt_sibling_not_created_for_ephemeral_or_test_nodes(
     materialization: str, node_type: str
 ) -> None:
     source = _make_dbt_source()
-    node = _make_dbt_node_for_sibling_test(
-        materialization=materialization, node_type=node_type
-    )
+    node = _make_dbt_node(materialization=materialization, node_type=node_type)
     assert source._should_create_sibling_relationships(node) is False
 
 


### PR DESCRIPTION
## Summary
- Add `@pytest.mark.perf` marker to `test_sql_aggregator.py::test_benchmark` so it runs in CI
- Remove unnecessary `if __name__ == "__main__"` block from `test_sqlglot_memory_leak.py`

Follow-up to #17057 to ensure SQL parsing performance is properly monitored in CI.

## Test plan
- [x] Modified tests now run via `./gradlew :metadata-ingestion:testPerformance`

🤖 Generated with [Claude Code](https://claude.com/claude-code)