### PR TITLE
feat(postgres): add corpuser and corpGroup partial indexes on metadata_aspect_v2

### DIFF
--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/PostgresDatabaseOperations.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/PostgresDatabaseOperations.java
@@ -183,6 +183,10 @@ public class PostgresDatabaseOperations implements DatabaseOperations {
     try (java.sql.Statement stmt = connection.createStatement()) {
       stmt.execute(
           "CREATE INDEX CONCURRENTLY IF NOT EXISTS schemaVersionIndex ON metadata_aspect_v2 ((systemmetadata::jsonb ->> 'schemaVersion'));");
+      stmt.execute(
+          "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_corpuser_aspect_v0 ON metadata_aspect_v2 (urn, aspect) WHERE urn LIKE 'urn:li:corpuser:%' AND version = 0;");
+      stmt.execute(
+          "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_corpgroup_aspect_v0 ON metadata_aspect_v2 (urn, aspect) WHERE urn LIKE 'urn:li:corpGroup:%' AND version = 0;");
     } finally {
       connection.setAutoCommit(prevAutoCommit);
     }


### PR DESCRIPTION
## Summary
- Adds two partial indexes on `metadata_aspect_v2` to speed up current-version aspect lookups for user and group URNs:
  - `idx_corpuser_aspect_v0` — `WHERE urn LIKE 'urn:li:corpuser:%' AND version = 0`
  - `idx_corpgroup_aspect_v0` — `WHERE urn LIKE 'urn:li:corpGroup:%' AND version = 0`
- Created via `CREATE INDEX CONCURRENTLY IF NOT EXISTS` inside the existing `postSetup()` block alongside `schemaVersionIndex`.
- Gated by the existing `createSchemaVersionIndex` / `ZDU_STAGE_10` flag — no new env vars or feature flags.

## Why `postSetup()` and not `createTableSqlStatements()`
- `createTableSqlStatements()` is executed via Ebean's `sqlUpdate().execute()` inside a transaction; Postgres forbids `CREATE INDEX CONCURRENTLY` inside a transaction block.
- On an existing populated `metadata_aspect_v2`, a non-`CONCURRENTLY` `CREATE INDEX` takes an `ACCESS EXCLUSIVE` lock on the table for the full scan. `CONCURRENTLY` is required to avoid blocking reads and writes during rollout.
- `postSetup()` already handles this pattern (autoCommit + `CONCURRENTLY`) for `schemaVersionIndex`; the two new partial indexes follow the same precedent.

## Test plan
- [ ] Existing `DatabaseOperationsTest` cases for `schemaVersionIndex` continue to pass.
- [ ] Verify on a populated Postgres: both indexes appear in `pg_indexes` as `VALID`, and `EXPLAIN` on `SELECT ... WHERE urn = 'urn:li:corpGroup:foo' AND version = 0` uses `idx_corpgroup_aspect_v0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)