### PR TITLE
feat(dataplex): add Cloud Spanner table schema and Cloud Spanner Graph support

### DIFF
--- a/metadata-ingestion/docs/sources/dataplex/README.md
+++ b/metadata-ingestion/docs/sources/dataplex/README.md
@@ -21,6 +21,7 @@ Dataplex ingestion is entry-type driven: each Universal Catalog `entry_type` map
 | `cloud-spanner-instance`       | `spanner`        | Container (`Instance`)         | Parent is project container            |
 | `cloud-spanner-database`       | `spanner`        | Container (`Database`)         | Parent is Spanner instance container   |
 | `cloud-spanner-table`          | `spanner`        | Dataset (`Table`)              | Parent is Spanner database container   |
+| `cloud-spanner-graph`          | `spanner`        | Dataset (`Graph`)              | Parent is Spanner database container   |
 | `cloud-bigtable-instance`      | `bigtable`       | Container (`Instance`)         | Parent is project container            |
 | `cloud-bigtable-table`         | `bigtable`       | Dataset (`Table`)              | Parent is Bigtable instance container  |
 | `pubsub-topic`                 | `pubsub`         | Dataset (`Topic`)              | Parent is project container            |

--- a/metadata-ingestion/src/datahub/ingestion/source/common/subtypes.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/common/subtypes.py
@@ -12,6 +12,7 @@ class DatasetSubTypes(StrEnum):
     VIEW = "View"
     TOPIC = "Topic"
     SCHEMA = "Schema"
+    GRAPH = "Graph"
     # System-Specific SubTypes
     LOOKER_EXPLORE = "Explore"
     ELASTIC_INDEX_TEMPLATE = "Index Template"
@@ -28,8 +29,6 @@ class DatasetSubTypes(StrEnum):
     SAC_MODEL = "Model"
     SAC_IMPORT_DATA_MODEL = "Import Data Model"
     SAC_LIVE_DATA_MODEL = "Live Data Model"
-    # Graph databases (first use: Spanner Graph)
-    GRAPH = "Graph"
     NEO4J_NODE = "Neo4j Node"
     NEO4J_RELATIONSHIP = "Neo4j Relationship"
     SNOWFLAKE_STREAM = "Snowflake Stream"

--- a/metadata-ingestion/src/datahub/ingestion/source/common/subtypes.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/common/subtypes.py
@@ -28,6 +28,8 @@ class DatasetSubTypes(StrEnum):
     SAC_MODEL = "Model"
     SAC_IMPORT_DATA_MODEL = "Import Data Model"
     SAC_LIVE_DATA_MODEL = "Live Data Model"
+    # Graph databases (first use: Spanner Graph)
+    GRAPH = "Graph"
     NEO4J_NODE = "Neo4j Node"
     NEO4J_RELATIONSHIP = "Neo4j Relationship"
     SNOWFLAKE_STREAM = "Snowflake Stream"

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_entries.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_entries.py
@@ -520,7 +520,7 @@ class DataplexEntriesProcessor:
             if self.config.include_schema:
                 schema_metadata = extract_schema_from_entry_aspects(
                     entry, entry_name, mapping.datahub_platform
-                ) or extract_graph_schema_from_entry_aspects(
+                ) or extract_graph_schema_from_entry_aspects(  # cloud-spanner-graph entries store schema in a graph-schema aspect rather than the standard schema aspect
                     entry, entry_name, mapping.datahub_platform
                 )
 

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_entries.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_entries.py
@@ -21,7 +21,10 @@ from datahub.emitter.mce_builder import make_dataset_urn_with_platform_instance
 from datahub.emitter.mcp_builder import ContainerKey
 from datahub.ingestion.api.report import Report
 from datahub.ingestion.api.source import SourceReport
-from datahub.ingestion.source.common.subtypes import DatasetContainerSubTypes
+from datahub.ingestion.source.common.subtypes import (
+    DatasetContainerSubTypes,
+    DatasetSubTypes,
+)
 from datahub.ingestion.source.dataplex.dataplex_config import DataplexConfig
 from datahub.ingestion.source.dataplex.dataplex_helpers import EntryDataTuple
 from datahub.ingestion.source.dataplex.dataplex_ids import (
@@ -38,6 +41,7 @@ from datahub.ingestion.source.dataplex.dataplex_properties import (
     extract_entry_custom_properties,
 )
 from datahub.ingestion.source.dataplex.dataplex_schema import (
+    extract_graph_schema_from_entry_aspects,
     extract_schema_from_entry_aspects,
 )
 from datahub.sdk.container import Container
@@ -517,11 +521,18 @@ class DataplexEntriesProcessor:
 
             schema_metadata = None
             if self.config.include_schema:
-                schema_metadata = extract_schema_from_entry_aspects(
-                    entry,
-                    entry_name,
-                    mapping.datahub_platform,
-                )
+                if mapping.datahub_subtype == DatasetSubTypes.GRAPH:
+                    schema_metadata = extract_graph_schema_from_entry_aspects(
+                        entry,
+                        entry_name,
+                        mapping.datahub_platform,
+                    )
+                else:
+                    schema_metadata = extract_schema_from_entry_aspects(
+                        entry,
+                        entry_name,
+                        mapping.datahub_platform,
+                    )
 
             parent_container_key: Optional[ContainerKey] = None
             if (

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_entries.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_entries.py
@@ -21,10 +21,7 @@ from datahub.emitter.mce_builder import make_dataset_urn_with_platform_instance
 from datahub.emitter.mcp_builder import ContainerKey
 from datahub.ingestion.api.report import Report
 from datahub.ingestion.api.source import SourceReport
-from datahub.ingestion.source.common.subtypes import (
-    DatasetContainerSubTypes,
-    DatasetSubTypes,
-)
+from datahub.ingestion.source.common.subtypes import DatasetContainerSubTypes
 from datahub.ingestion.source.dataplex.dataplex_config import DataplexConfig
 from datahub.ingestion.source.dataplex.dataplex_helpers import EntryDataTuple
 from datahub.ingestion.source.dataplex.dataplex_ids import (
@@ -521,18 +518,11 @@ class DataplexEntriesProcessor:
 
             schema_metadata = None
             if self.config.include_schema:
-                if mapping.datahub_subtype == DatasetSubTypes.GRAPH:
-                    schema_metadata = extract_graph_schema_from_entry_aspects(
-                        entry,
-                        entry_name,
-                        mapping.datahub_platform,
-                    )
-                else:
-                    schema_metadata = extract_schema_from_entry_aspects(
-                        entry,
-                        entry_name,
-                        mapping.datahub_platform,
-                    )
+                schema_metadata = extract_schema_from_entry_aspects(
+                    entry, entry_name, mapping.datahub_platform
+                ) or extract_graph_schema_from_entry_aspects(
+                    entry, entry_name, mapping.datahub_platform
+                )
 
             parent_container_key: Optional[ContainerKey] = None
             if (

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_entries.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_entries.py
@@ -190,9 +190,9 @@ class DataplexEntriesProcessor:
           project with thousands of entries.
 
         * Phase 1c (sequential): run the Spanner ``search_entries`` workaround
-          for each project × location pair.  Spanner entries come back already
-          fully-fetched from the search API and require no separate
-          ``get_entry`` call, so there is nothing to parallelise here.
+          for each project × location pair.  Search results contain only stub
+          data (no aspects), so a separate ``get_entry(view=ALL)`` call is made
+          per entry to fetch full detail including schema aspects.
         """
         # Phase 1a: accumulate entry stubs across all projects and locations.
         # Wrap each (project, location) pair individually so one failing project
@@ -329,10 +329,9 @@ class DataplexEntriesProcessor:
     ) -> Iterable["Entity"]:
         """Process Spanner entries via ``search_entries`` workaround (Phase 1c).
 
-        Spanner entries are returned already fully-fetched from the search API
-        so no separate ``get_entry`` call is needed.  This phase runs
-        sequentially after the parallel Phase 1b because it uses a different
-        API surface and has nothing to parallelise.
+        ``search_entries`` returns stub entries without aspects, so a separate
+        ``get_entry(view=ALL)`` call is made per entry to fetch full detail
+        including schema aspects.
         """
         logger.info(
             f"SearchEntries spanner for project={project_id} location={location}"
@@ -350,23 +349,31 @@ class DataplexEntriesProcessor:
             self.report.report_catalog_api_call(
                 "search_entries", timer.elapsed_seconds()
             )
-            for result in search_results:
-                logger.info(f"SearchEntries result payload: {result}")
-                dataplex_entry = getattr(result, "dataplex_entry", None)
-                if dataplex_entry is None:
-                    continue
-                if not self._report_and_should_process_entry(dataplex_entry):
-                    logger.debug(
-                        "Skipping filtered spanner entry %s from search_entries",
-                        dataplex_entry.name,
-                    )
-                    continue
-                logger.debug(f"Spanner dataplex entry payload: {dataplex_entry}")
-                yield from self._build_entities_for_entry(dataplex_entry, location)
         except Exception as exc:
             logger.warning(
                 f"Spanner workaround search failed for {project_id}/{location}: {exc}"
             )
+            return
+
+        for result in search_results:
+            logger.info(f"SearchEntries result payload: {result}")
+            dataplex_entry = getattr(result, "dataplex_entry", None)
+            if dataplex_entry is None:
+                continue
+            if not self._report_and_should_process_entry(dataplex_entry):
+                logger.debug(
+                    "Skipping filtered spanner entry %s from search_entries",
+                    dataplex_entry.name,
+                )
+                continue
+            try:
+                detailed_entry = self._fetch_entry_detail(dataplex_entry.name)
+            except Exception as exc:
+                logger.warning(
+                    f"Failed to fetch detail for Spanner entry {dataplex_entry.name}: {exc}"
+                )
+                continue
+            yield from self._build_entities_for_entry(detailed_entry, location)
 
     def _track_entry_for_lineage(
         self, dataplex_location: str, entry: dataplex_v1.Entry

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_entries.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_entries.py
@@ -518,10 +518,13 @@ class DataplexEntriesProcessor:
 
             schema_metadata = None
             if self.config.include_schema:
-                schema_metadata = extract_schema_from_entry_aspects(
-                    entry, entry_name, mapping.datahub_platform
-                ) or extract_graph_schema_from_entry_aspects(  # cloud-spanner-graph entries store schema in a graph-schema aspect rather than the standard schema aspect
-                    entry, entry_name, mapping.datahub_platform
+                schema_metadata = (
+                    extract_schema_from_entry_aspects(
+                        entry, entry_name, mapping.datahub_platform
+                    )
+                    or extract_graph_schema_from_entry_aspects(  # cloud-spanner-graph entries store schema in a graph-schema aspect rather than the standard schema aspect
+                        entry, entry_name, mapping.datahub_platform
+                    )
                 )
 
             parent_container_key: Optional[ContainerKey] = None

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_ids.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_ids.py
@@ -275,6 +275,9 @@ SPANNER_DATABASE_FQN_REGEX = re.compile(
 SPANNER_TABLE_FQN_REGEX = re.compile(
     r"^spanner:(?P<project_id>[^.]+)\.regional-(?P<location>[^.]+)\.(?P<instance_id>[^.]+)\.(?P<database_id>[^.]+)\.(?P<table_id>[^.]+)$"
 )
+SPANNER_GRAPH_FQN_REGEX = re.compile(
+    r"^spanner:graph:(?P<project_id>[^.]+)\.regional-(?P<location>[^.]+)\.(?P<instance_id>[^.]+)\.(?P<database_id>[^.]+)\.(?P<graph_id>[^.]+)$"
+)
 PUBSUB_TOPIC_FQN_REGEX = re.compile(
     r"^pubsub:topic:(?P<project_id>[^.]+)\.(?P<topic_id>[^.]+)$"
 )
@@ -401,6 +404,20 @@ DATAPLEX_ENTRY_TYPE_MAPPINGS: dict[str, DataplexEntryTypeMapping] = {
         parent_container_key_class=DataplexCloudSpannerDatabase,
         datahub_dataset_name_format=(
             "{project_id}.regional-{location}.{instance_id}.{database_id}.{table_id}"
+        ),
+    ),
+    # TODO: Process the "Graph Schema" aspect for cloud-spanner-graph entries to capture
+    # node and edge type definitions exposed by the Dataplex Catalog.
+    "cloud-spanner-graph": DataplexEntryTypeMapping(
+        datahub_platform="spanner",
+        datahub_entity_type="Dataset",
+        datahub_subtype=DatasetSubTypes.GRAPH,
+        fqn_regex=SPANNER_GRAPH_FQN_REGEX,
+        parent_entry_regex=SPANNER_DATABASE_PARENT_ENTRY_REGEX,
+        container_key_class=None,
+        parent_container_key_class=DataplexCloudSpannerDatabase,
+        datahub_dataset_name_format=(
+            "{project_id}.regional-{location}.{instance_id}.{database_id}.{graph_id}"
         ),
     ),
     "pubsub-topic": DataplexEntryTypeMapping(

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_ids.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_ids.py
@@ -406,8 +406,6 @@ DATAPLEX_ENTRY_TYPE_MAPPINGS: dict[str, DataplexEntryTypeMapping] = {
             "{project_id}.regional-{location}.{instance_id}.{database_id}.{table_id}"
         ),
     ),
-    # TODO: Process the "Graph Schema" aspect for cloud-spanner-graph entries to capture
-    # node and edge type definitions exposed by the Dataplex Catalog.
     "cloud-spanner-graph": DataplexEntryTypeMapping(
         datahub_platform="spanner",
         datahub_entity_type="Dataset",

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_schema.py
@@ -53,7 +53,9 @@ def extract_graph_schema_from_entry_aspects(
 
         nodes_data = data_dict.get("nodes")
         if nodes_data and hasattr(nodes_data, "list_value"):
-            for node_value in nodes_data.list_value.values:
+            # Proto Value form
+            node_items_proto = nodes_data.list_value.values
+            for node_value in node_items_proto:
                 node_fields = dict(node_value.struct_value.fields)
                 name_val = node_fields.get("name")
                 node_name = name_val.string_value if name_val else None
@@ -67,9 +69,27 @@ def extract_graph_schema_from_entry_aspects(
                             recursive=False,
                         )
                     )
+        elif nodes_data and hasattr(nodes_data, "__iter__"):
+            # Python-native list form (proto-plus auto-marshaled Struct → dict)
+            for node_item in nodes_data:
+                if isinstance(node_item, dict):
+                    node_name = node_item.get("name")
+                else:
+                    node_name = getattr(node_item, "name", None)
+                if node_name:
+                    fields.append(
+                        SchemaFieldClass(
+                            fieldPath=f"[nodes].{node_name}",
+                            type=SchemaFieldDataTypeClass(type=RecordTypeClass()),
+                            nativeDataType="NODE",
+                            nullable=True,
+                            recursive=False,
+                        )
+                    )
 
         edges_data = data_dict.get("edges")
         if edges_data and hasattr(edges_data, "list_value"):
+            # Proto Value form
             for edge_value in edges_data.list_value.values:
                 edge_fields = dict(edge_value.struct_value.fields)
 
@@ -87,6 +107,38 @@ def extract_graph_schema_from_entry_aspects(
                 if dst_val and hasattr(dst_val, "struct_value"):
                     dst_name_val = dict(dst_val.struct_value.fields).get("name")
                     dst_name = dst_name_val.string_value if dst_name_val else None
+
+                if edge_name:
+                    description = (
+                        f"{src_name} \u2192 {dst_name}"
+                        if src_name and dst_name
+                        else None
+                    )
+                    fields.append(
+                        SchemaFieldClass(
+                            fieldPath=f"[edges].{edge_name}",
+                            type=SchemaFieldDataTypeClass(type=RecordTypeClass()),
+                            nativeDataType="EDGE",
+                            description=description,
+                            nullable=True,
+                            recursive=False,
+                        )
+                    )
+        elif edges_data and hasattr(edges_data, "__iter__"):
+            # Python-native list form (proto-plus auto-marshaled Struct → dict)
+            for edge_item in edges_data:
+                if isinstance(edge_item, dict):
+                    edge_name = edge_item.get("name")
+                    src = edge_item.get("source")
+                    src_name = src.get("name") if isinstance(src, dict) else None
+                    dst = edge_item.get("destination")
+                    dst_name = dst.get("name") if isinstance(dst, dict) else None
+                else:
+                    edge_name = getattr(edge_item, "name", None)
+                    src = getattr(edge_item, "source", None)
+                    src_name = getattr(src, "name", None) if src else None
+                    dst = getattr(edge_item, "destination", None)
+                    dst_name = getattr(dst, "name", None) if dst else None
 
                 if edge_name:
                     description = (

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_schema.py
@@ -23,6 +23,112 @@ from datahub.metadata.urns import DataPlatformUrn
 logger = logging.getLogger(__name__)
 
 
+def extract_graph_schema_from_entry_aspects(
+    entry: dataplex_v1.Entry, entry_id: str, platform: str
+) -> Optional[SchemaMetadataClass]:
+    """Extract schema from a Spanner Graph ``graph-schema`` aspect.
+
+    Nodes are emitted as fields under ``[nodes].<name>`` and edges as fields
+    under ``[edges].<name>``, with source→destination in the edge description.
+    """
+    if not entry.aspects:
+        return None
+
+    graph_aspect = None
+    for aspect_key, aspect_value in entry.aspects.items():
+        if "graph-schema" in aspect_key:
+            graph_aspect = aspect_value
+            break
+
+    if graph_aspect is None:
+        logger.debug(f"No graph-schema aspect found for entry {entry_id}")
+        return None
+    if not hasattr(graph_aspect, "data") or not graph_aspect.data:
+        logger.debug(f"graph-schema aspect for entry {entry_id} has no data")
+        return None
+
+    fields: list[SchemaFieldClass] = []
+    try:
+        data_dict = dict(graph_aspect.data)
+
+        nodes_data = data_dict.get("nodes")
+        if nodes_data and hasattr(nodes_data, "list_value"):
+            for node_value in nodes_data.list_value.values:
+                node_fields = dict(node_value.struct_value.fields)
+                name_val = node_fields.get("name")
+                node_name = name_val.string_value if name_val else None
+                if node_name:
+                    fields.append(
+                        SchemaFieldClass(
+                            fieldPath=f"[nodes].{node_name}",
+                            type=SchemaFieldDataTypeClass(type=RecordTypeClass()),
+                            nativeDataType="NODE",
+                            nullable=True,
+                            recursive=False,
+                        )
+                    )
+
+        edges_data = data_dict.get("edges")
+        if edges_data and hasattr(edges_data, "list_value"):
+            for edge_value in edges_data.list_value.values:
+                edge_fields = dict(edge_value.struct_value.fields)
+
+                name_val = edge_fields.get("name")
+                edge_name = name_val.string_value if name_val else None
+
+                src_val = edge_fields.get("source")
+                src_name = None
+                if src_val and hasattr(src_val, "struct_value"):
+                    src_name_val = dict(src_val.struct_value.fields).get("name")
+                    src_name = src_name_val.string_value if src_name_val else None
+
+                dst_val = edge_fields.get("destination")
+                dst_name = None
+                if dst_val and hasattr(dst_val, "struct_value"):
+                    dst_name_val = dict(dst_val.struct_value.fields).get("name")
+                    dst_name = dst_name_val.string_value if dst_name_val else None
+
+                if edge_name:
+                    description = (
+                        f"{src_name} \u2192 {dst_name}"
+                        if src_name and dst_name
+                        else None
+                    )
+                    fields.append(
+                        SchemaFieldClass(
+                            fieldPath=f"[edges].{edge_name}",
+                            type=SchemaFieldDataTypeClass(type=RecordTypeClass()),
+                            nativeDataType="EDGE",
+                            description=description,
+                            nullable=True,
+                            recursive=False,
+                        )
+                    )
+
+        if not fields:
+            logger.debug(
+                f"No nodes or edges extracted from graph-schema for {entry_id}"
+            )
+            return None
+
+        logger.info(f"Extracted {len(fields)} graph schema fields for entry {entry_id}")
+        return SchemaMetadataClass(
+            schemaName=entry_id,
+            platform=str(DataPlatformUrn(platform)),
+            version=0,
+            hash="",
+            platformSchema=OtherSchemaClass(rawSchema=""),
+            fields=fields,
+        )
+
+    except Exception as e:
+        logger.warning(
+            f"Failed to extract graph schema from entry {entry_id}: {e}",
+            exc_info=True,
+        )
+        return None
+
+
 def extract_field_value(field_data: Any, field_key: str, default: str = "") -> str:
     """Extract a field value from protobuf field data (dict or object).
 

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_schema.py
@@ -23,6 +23,54 @@ from datahub.metadata.urns import DataPlatformUrn
 logger = logging.getLogger(__name__)
 
 
+def _create_node_field(node_name: str) -> SchemaFieldClass:
+    """Create a SchemaFieldClass for a graph node."""
+    return SchemaFieldClass(
+        fieldPath=f"[nodes].{node_name}",
+        type=SchemaFieldDataTypeClass(type=RecordTypeClass()),
+        nativeDataType="NODE",
+        nullable=True,
+        recursive=False,
+    )
+
+
+def _create_edge_field(
+    edge_name: str, src_name: Optional[str], dst_name: Optional[str]
+) -> SchemaFieldClass:
+    """Create a SchemaFieldClass for a graph edge."""
+    description = f"{src_name} → {dst_name}" if src_name and dst_name else None
+    return SchemaFieldClass(
+        fieldPath=f"[edges].{edge_name}",
+        type=SchemaFieldDataTypeClass(type=RecordTypeClass()),
+        nativeDataType="EDGE",
+        description=description,
+        nullable=True,
+        recursive=False,
+    )
+
+
+def _extract_proto_edge_names(
+    edge_fields: dict,
+) -> tuple[Optional[str], Optional[str], Optional[str]]:
+    """Extract edge name and source/destination names from proto Value form."""
+    name_val = edge_fields.get("name")
+    edge_name = name_val.string_value if name_val else None
+
+    src_val = edge_fields.get("source")
+    src_name = None
+    if src_val and hasattr(src_val, "struct_value"):
+        src_name_val = dict(src_val.struct_value.fields).get("name")
+        src_name = src_name_val.string_value if src_name_val else None
+
+    dst_val = edge_fields.get("destination")
+    dst_name = None
+    if dst_val and hasattr(dst_val, "struct_value"):
+        dst_name_val = dict(dst_val.struct_value.fields).get("name")
+        dst_name = dst_name_val.string_value if dst_name_val else None
+
+    return edge_name, src_name, dst_name
+
+
 def extract_graph_schema_from_entry_aspects(
     entry: dataplex_v1.Entry, entry_id: str, platform: str
 ) -> Optional[SchemaMetadataClass]:
@@ -54,108 +102,46 @@ def extract_graph_schema_from_entry_aspects(
         nodes_data = data_dict.get("nodes")
         if nodes_data and hasattr(nodes_data, "list_value"):
             # Proto Value form
-            node_items_proto = nodes_data.list_value.values
-            for node_value in node_items_proto:
+            for node_value in nodes_data.list_value.values:
                 node_fields = dict(node_value.struct_value.fields)
                 name_val = node_fields.get("name")
                 node_name = name_val.string_value if name_val else None
                 if node_name:
-                    fields.append(
-                        SchemaFieldClass(
-                            fieldPath=f"[nodes].{node_name}",
-                            type=SchemaFieldDataTypeClass(type=RecordTypeClass()),
-                            nativeDataType="NODE",
-                            nullable=True,
-                            recursive=False,
-                        )
-                    )
+                    fields.append(_create_node_field(node_name))
         elif nodes_data and hasattr(nodes_data, "__iter__"):
             # Python-native list form (proto-plus auto-marshaled Struct → dict)
             for node_item in nodes_data:
-                if isinstance(node_item, dict):
-                    node_name = node_item.get("name")
-                else:
-                    node_name = getattr(node_item, "name", None)
+                # MapComposite objects from proto-plus need dict conversion
+                node_dict = (
+                    dict(node_item) if not isinstance(node_item, dict) else node_item
+                )
+                node_name = node_dict.get("name")
                 if node_name:
-                    fields.append(
-                        SchemaFieldClass(
-                            fieldPath=f"[nodes].{node_name}",
-                            type=SchemaFieldDataTypeClass(type=RecordTypeClass()),
-                            nativeDataType="NODE",
-                            nullable=True,
-                            recursive=False,
-                        )
-                    )
+                    fields.append(_create_node_field(node_name))
 
         edges_data = data_dict.get("edges")
         if edges_data and hasattr(edges_data, "list_value"):
             # Proto Value form
             for edge_value in edges_data.list_value.values:
                 edge_fields = dict(edge_value.struct_value.fields)
-
-                name_val = edge_fields.get("name")
-                edge_name = name_val.string_value if name_val else None
-
-                src_val = edge_fields.get("source")
-                src_name = None
-                if src_val and hasattr(src_val, "struct_value"):
-                    src_name_val = dict(src_val.struct_value.fields).get("name")
-                    src_name = src_name_val.string_value if src_name_val else None
-
-                dst_val = edge_fields.get("destination")
-                dst_name = None
-                if dst_val and hasattr(dst_val, "struct_value"):
-                    dst_name_val = dict(dst_val.struct_value.fields).get("name")
-                    dst_name = dst_name_val.string_value if dst_name_val else None
-
+                edge_name, src_name, dst_name = _extract_proto_edge_names(edge_fields)
                 if edge_name:
-                    description = (
-                        f"{src_name} \u2192 {dst_name}"
-                        if src_name and dst_name
-                        else None
-                    )
-                    fields.append(
-                        SchemaFieldClass(
-                            fieldPath=f"[edges].{edge_name}",
-                            type=SchemaFieldDataTypeClass(type=RecordTypeClass()),
-                            nativeDataType="EDGE",
-                            description=description,
-                            nullable=True,
-                            recursive=False,
-                        )
-                    )
+                    fields.append(_create_edge_field(edge_name, src_name, dst_name))
         elif edges_data and hasattr(edges_data, "__iter__"):
             # Python-native list form (proto-plus auto-marshaled Struct → dict)
             for edge_item in edges_data:
-                if isinstance(edge_item, dict):
-                    edge_name = edge_item.get("name")
-                    src = edge_item.get("source")
-                    src_name = src.get("name") if isinstance(src, dict) else None
-                    dst = edge_item.get("destination")
-                    dst_name = dst.get("name") if isinstance(dst, dict) else None
-                else:
-                    edge_name = getattr(edge_item, "name", None)
-                    src = getattr(edge_item, "source", None)
-                    src_name = getattr(src, "name", None) if src else None
-                    dst = getattr(edge_item, "destination", None)
-                    dst_name = getattr(dst, "name", None) if dst else None
+                # MapComposite objects from proto-plus need dict conversion
+                edge_dict = (
+                    dict(edge_item) if not isinstance(edge_item, dict) else edge_item
+                )
+                edge_name = edge_dict.get("name")
+                src = edge_dict.get("source")
+                src_name = dict(src).get("name") if src else None
+                dst = edge_dict.get("destination")
+                dst_name = dict(dst).get("name") if dst else None
 
                 if edge_name:
-                    description = (
-                        f"{src_name} \u2192 {dst_name}"
-                        if src_name and dst_name
-                        else None
-                    )
-                    fields.append(
-                        SchemaFieldClass(
-                            fieldPath=f"[edges].{edge_name}",
-                            type=SchemaFieldDataTypeClass(type=RecordTypeClass()),
-                            nativeDataType="EDGE",
-                            description=description,
-                            nullable=True,
-                            recursive=False,
-                        )
-                    )
+                    fields.append(_create_edge_field(edge_name, src_name, dst_name))
 
         if not fields:
             logger.debug(

--- a/metadata-ingestion/tests/unit/dataplex/test_dataplex_entries.py
+++ b/metadata-ingestion/tests/unit/dataplex/test_dataplex_entries.py
@@ -205,7 +205,11 @@ class TestDataplexEntriesProcessorDesign:
             ),
             patch(
                 "datahub.ingestion.source.dataplex.dataplex_entries.extract_schema_from_entry_aspects",
-                return_value=[],
+                return_value=None,
+            ),
+            patch(
+                "datahub.ingestion.source.dataplex.dataplex_entries.extract_graph_schema_from_entry_aspects",
+                return_value=None,
             ),
         ):
             dataset_entity = processor.build_entity_for_entry(dataset_entry)

--- a/metadata-ingestion/tests/unit/dataplex/test_dataplex_ids.py
+++ b/metadata-ingestion/tests/unit/dataplex/test_dataplex_ids.py
@@ -109,6 +109,7 @@ def test_supported_entry_type_mapping_keys() -> None:
         "cloud-spanner-instance",
         "cloud-spanner-database",
         "cloud-spanner-table",
+        "cloud-spanner-graph",
         "cloud-bigtable-instance",
         "cloud-bigtable-table",
         "pubsub-topic",
@@ -275,6 +276,17 @@ def test_dataplex_entry_type_mapping_instances_are_valid(
             },
         ),
         (
+            "cloud-spanner-graph",
+            "spanner:graph:harshal-playground-306419.regional-us-west2.sergio-test.cymbal.ECommerceGraph",
+            {
+                "project_id": "harshal-playground-306419",
+                "location": "us-west2",
+                "instance_id": "sergio-test",
+                "database_id": "cymbal",
+                "graph_id": "ECommerceGraph",
+            },
+        ),
+        (
             "cloudsql-mysql-table",
             "cloudsql_mysql:harshal-playground-306419.us-west2.sergio-test.sergio-db.your_table",
             {
@@ -369,6 +381,17 @@ def test_parse_fully_qualified_name_invalid() -> None:
             },
         ),
         (
+            "cloud-spanner-graph",
+            "projects/harshal-playground-306419/locations/us-west2/entryGroups/@spanner/entries/"
+            "spanner.googleapis.com/projects/harshal-playground-306419/instances/sergio-test/databases/cymbal",
+            {
+                "project_id": "harshal-playground-306419",
+                "location": "us-west2",
+                "instance_id": "sergio-test",
+                "database_id": "cymbal",
+            },
+        ),
+        (
             "cloudsql-mysql-table",
             "projects/harshal-playground-306419/locations/us-west2/entryGroups/@cloudsql/entries/"
             "cloudsql.googleapis.com/projects/harshal-playground-306419/locations/us-west2/instances/sergio-test/"
@@ -443,6 +466,23 @@ def test_build_parent_container_key() -> None:
     )
     assert isinstance(parent_key, DataplexCloudSpannerDatabase)
     assert parent_key.database_id == "cymbal"
+
+
+def test_build_dataset_urn_from_fqn_spanner_graph() -> None:
+    graph_urn = build_dataset_urn_from_fqn(
+        "cloud-spanner-graph",
+        "spanner:graph:harshal-playground-306419.regional-us-west2.sergio-test.cymbal.ECommerceGraph",
+        env="PROD",
+    )
+    assert graph_urn is not None
+    assert "urn:li:dataPlatform:spanner" in graph_urn
+    # Spanner tables and graphs share the same namespace so names never collide;
+    # the URN format mirrors cloud-spanner-table.
+    assert (
+        "harshal-playground-306419.regional-us-west2.sergio-test.cymbal.ECommerceGraph"
+        in graph_urn
+    )
+    assert "graph:" not in graph_urn
 
 
 def test_build_dataset_urn_from_fqn() -> None:
@@ -594,6 +634,7 @@ def test_is_supported_lineage_entry_type_helper() -> None:
     assert is_supported_lineage_entry_type("bigquery-view")
     assert is_supported_lineage_entry_type("cloudsql-mysql-table")
     assert is_supported_lineage_entry_type("cloud-spanner-table")
+    assert is_supported_lineage_entry_type("cloud-spanner-graph")
     assert is_supported_lineage_entry_type("cloud-bigtable-table")
     assert is_supported_lineage_entry_type("pubsub-topic")
     assert is_supported_lineage_entry_type("vertexai-dataset")

--- a/metadata-ingestion/tests/unit/dataplex/test_dataplex_schema.py
+++ b/metadata-ingestion/tests/unit/dataplex/test_dataplex_schema.py
@@ -2,6 +2,15 @@
 
 from unittest.mock import Mock
 
+from google.cloud import dataplex_v1
+
+from datahub.ingestion.source.dataplex.dataplex_schema import (
+    extract_field_value,
+    extract_graph_schema_from_entry_aspects,
+    extract_schema_from_entry_aspects,
+    map_aspect_type_to_datahub,
+    process_schema_field_item,
+)
 from datahub.metadata.schema_classes import (
     ArrayTypeClass,
     BooleanTypeClass,
@@ -12,15 +21,6 @@ from datahub.metadata.schema_classes import (
     SchemaFieldDataTypeClass,
     StringTypeClass,
     TimeTypeClass,
-)
-from google.cloud import dataplex_v1
-
-from datahub.ingestion.source.dataplex.dataplex_schema import (
-    extract_field_value,
-    extract_graph_schema_from_entry_aspects,
-    extract_schema_from_entry_aspects,
-    map_aspect_type_to_datahub,
-    process_schema_field_item,
 )
 
 

--- a/metadata-ingestion/tests/unit/dataplex/test_dataplex_schema.py
+++ b/metadata-ingestion/tests/unit/dataplex/test_dataplex_schema.py
@@ -474,3 +474,45 @@ class TestExtractGraphSchemaFromEntryAspects:
         assert result is not None
         assert result.schemaName == "MyGraph"
         assert "spanner" in result.platform
+
+    def test_nodes_and_edges_native_list_form(self) -> None:
+        """Python-native list form produced by proto-plus auto-marshaling."""
+        aspect = Mock()
+        aspect.data = {
+            "nodes": [
+                {"name": "Users"},
+                {"name": "Orders"},
+            ],
+            "edges": [
+                {
+                    "name": "ShoppingCarts",
+                    "source": {"name": "Users"},
+                    "destination": {"name": "Products"},
+                }
+            ],
+        }
+        entry = Mock(spec=dataplex_v1.Entry)
+        entry.aspects = {"655216118709.global.graph-schema": aspect}
+
+        result = extract_graph_schema_from_entry_aspects(
+            entry, "ECommerceGraph", "spanner"
+        )
+
+        assert result is not None
+        field_paths = [f.fieldPath for f in result.fields]
+        assert "[nodes].Users" in field_paths
+        assert "[nodes].Orders" in field_paths
+        assert "[edges].ShoppingCarts" in field_paths
+
+        edge_field = next(
+            f for f in result.fields if f.fieldPath == "[edges].ShoppingCarts"
+        )
+        assert edge_field.description == "Users \u2192 Products"
+        assert edge_field.nativeDataType == "EDGE"
+
+    def test_empty_nodes_and_edges_returns_none(self) -> None:
+        aspect = Mock()
+        aspect.data = {"nodes": [], "edges": []}
+        entry = Mock(spec=dataplex_v1.Entry)
+        entry.aspects = {"655216118709.global.graph-schema": aspect}
+        assert extract_graph_schema_from_entry_aspects(entry, "g", "spanner") is None

--- a/metadata-ingestion/tests/unit/dataplex/test_dataplex_schema.py
+++ b/metadata-ingestion/tests/unit/dataplex/test_dataplex_schema.py
@@ -8,6 +8,8 @@ from datahub.metadata.schema_classes import (
     BytesTypeClass,
     NumberTypeClass,
     RecordTypeClass,
+    SchemaFieldClass,
+    SchemaFieldDataTypeClass,
     StringTypeClass,
     TimeTypeClass,
 )
@@ -447,19 +449,30 @@ class TestExtractGraphSchemaFromEntryAspects:
         )
 
         assert result is not None
-        field_paths = [f.fieldPath for f in result.fields]
-        assert "[nodes].Users" in field_paths
-        assert "[nodes].Orders" in field_paths
-        assert "[edges].ShoppingCarts" in field_paths
-
-        edge_field = next(
-            f for f in result.fields if f.fieldPath == "[edges].ShoppingCarts"
-        )
-        assert edge_field.description == "Users \u2192 Products"
-        assert edge_field.nativeDataType == "EDGE"
-
-        node_field = next(f for f in result.fields if f.fieldPath == "[nodes].Users")
-        assert node_field.nativeDataType == "NODE"
+        assert result.fields == [
+            SchemaFieldClass(
+                fieldPath="[nodes].Users",
+                type=SchemaFieldDataTypeClass(type=RecordTypeClass()),
+                nativeDataType="NODE",
+                nullable=True,
+                recursive=False,
+            ),
+            SchemaFieldClass(
+                fieldPath="[nodes].Orders",
+                type=SchemaFieldDataTypeClass(type=RecordTypeClass()),
+                nativeDataType="NODE",
+                nullable=True,
+                recursive=False,
+            ),
+            SchemaFieldClass(
+                fieldPath="[edges].ShoppingCarts",
+                type=SchemaFieldDataTypeClass(type=RecordTypeClass()),
+                nativeDataType="EDGE",
+                description="Users \u2192 Products",
+                nullable=True,
+                recursive=False,
+            ),
+        ]
 
     def test_schema_name_and_platform(self) -> None:
         aspect = _make_graph_aspect(
@@ -499,16 +512,30 @@ class TestExtractGraphSchemaFromEntryAspects:
         )
 
         assert result is not None
-        field_paths = [f.fieldPath for f in result.fields]
-        assert "[nodes].Users" in field_paths
-        assert "[nodes].Orders" in field_paths
-        assert "[edges].ShoppingCarts" in field_paths
-
-        edge_field = next(
-            f for f in result.fields if f.fieldPath == "[edges].ShoppingCarts"
-        )
-        assert edge_field.description == "Users \u2192 Products"
-        assert edge_field.nativeDataType == "EDGE"
+        assert result.fields == [
+            SchemaFieldClass(
+                fieldPath="[nodes].Users",
+                type=SchemaFieldDataTypeClass(type=RecordTypeClass()),
+                nativeDataType="NODE",
+                nullable=True,
+                recursive=False,
+            ),
+            SchemaFieldClass(
+                fieldPath="[nodes].Orders",
+                type=SchemaFieldDataTypeClass(type=RecordTypeClass()),
+                nativeDataType="NODE",
+                nullable=True,
+                recursive=False,
+            ),
+            SchemaFieldClass(
+                fieldPath="[edges].ShoppingCarts",
+                type=SchemaFieldDataTypeClass(type=RecordTypeClass()),
+                nativeDataType="EDGE",
+                description="Users \u2192 Products",
+                nullable=True,
+                recursive=False,
+            ),
+        ]
 
     def test_empty_nodes_and_edges_returns_none(self) -> None:
         aspect = Mock()

--- a/metadata-ingestion/tests/unit/dataplex/test_dataplex_schema.py
+++ b/metadata-ingestion/tests/unit/dataplex/test_dataplex_schema.py
@@ -2,14 +2,6 @@
 
 from unittest.mock import Mock
 
-from google.cloud import dataplex_v1
-
-from datahub.ingestion.source.dataplex.dataplex_schema import (
-    extract_field_value,
-    extract_schema_from_entry_aspects,
-    map_aspect_type_to_datahub,
-    process_schema_field_item,
-)
 from datahub.metadata.schema_classes import (
     ArrayTypeClass,
     BooleanTypeClass,
@@ -18,6 +10,15 @@ from datahub.metadata.schema_classes import (
     RecordTypeClass,
     StringTypeClass,
     TimeTypeClass,
+)
+from google.cloud import dataplex_v1
+
+from datahub.ingestion.source.dataplex.dataplex_schema import (
+    extract_field_value,
+    extract_graph_schema_from_entry_aspects,
+    extract_schema_from_entry_aspects,
+    map_aspect_type_to_datahub,
+    process_schema_field_item,
 )
 
 
@@ -357,3 +358,119 @@ class TestExtractSchemaFromEntryAspects:
         result = extract_schema_from_entry_aspects(entry, "test_entry", "bigquery")
 
         assert result is None
+
+
+def _make_node_value(name: str) -> Mock:
+    """Build a mock protobuf Value for a graph node entry."""
+    name_val = Mock()
+    name_val.string_value = name
+
+    struct = Mock()
+    struct.fields = {"name": name_val}
+
+    value = Mock()
+    value.struct_value = struct
+    return value
+
+
+def _make_edge_value(name: str, source: str, destination: str) -> Mock:
+    """Build a mock protobuf Value for a graph edge entry."""
+    name_val = Mock()
+    name_val.string_value = name
+
+    src_name_val = Mock()
+    src_name_val.string_value = source
+    src_struct = Mock()
+    src_struct.fields = {"name": src_name_val}
+    src_val = Mock()
+    src_val.struct_value = src_struct
+
+    dst_name_val = Mock()
+    dst_name_val.string_value = destination
+    dst_struct = Mock()
+    dst_struct.fields = {"name": dst_name_val}
+    dst_val = Mock()
+    dst_val.struct_value = dst_struct
+
+    edge_struct = Mock()
+    edge_struct.fields = {"name": name_val, "source": src_val, "destination": dst_val}
+
+    value = Mock()
+    value.struct_value = edge_struct
+    return value
+
+
+def _make_graph_aspect(nodes: list, edges: list) -> Mock:
+    nodes_list = Mock()
+    nodes_list.values = nodes
+    nodes_val = Mock()
+    nodes_val.list_value = nodes_list
+
+    edges_list = Mock()
+    edges_list.values = edges
+    edges_val = Mock()
+    edges_val.list_value = edges_list
+
+    aspect = Mock()
+    aspect.data = {"nodes": nodes_val, "edges": edges_val}
+    return aspect
+
+
+class TestExtractGraphSchemaFromEntryAspects:
+    def test_no_aspects_returns_none(self) -> None:
+        entry = Mock(spec=dataplex_v1.Entry)
+        entry.aspects = {}
+        assert extract_graph_schema_from_entry_aspects(entry, "g", "spanner") is None
+
+    def test_no_graph_schema_aspect_returns_none(self) -> None:
+        entry = Mock(spec=dataplex_v1.Entry)
+        entry.aspects = {"some-other-aspect": Mock()}
+        assert extract_graph_schema_from_entry_aspects(entry, "g", "spanner") is None
+
+    def test_graph_schema_aspect_no_data_returns_none(self) -> None:
+        aspect = Mock()
+        aspect.data = None
+        entry = Mock(spec=dataplex_v1.Entry)
+        entry.aspects = {"655216118709.global.graph-schema": aspect}
+        assert extract_graph_schema_from_entry_aspects(entry, "g", "spanner") is None
+
+    def test_nodes_and_edges_extracted(self) -> None:
+        aspect = _make_graph_aspect(
+            nodes=[_make_node_value("Users"), _make_node_value("Orders")],
+            edges=[_make_edge_value("ShoppingCarts", "Users", "Products")],
+        )
+        entry = Mock(spec=dataplex_v1.Entry)
+        entry.aspects = {"655216118709.global.graph-schema": aspect}
+
+        result = extract_graph_schema_from_entry_aspects(
+            entry, "ECommerceGraph", "spanner"
+        )
+
+        assert result is not None
+        field_paths = [f.fieldPath for f in result.fields]
+        assert "[nodes].Users" in field_paths
+        assert "[nodes].Orders" in field_paths
+        assert "[edges].ShoppingCarts" in field_paths
+
+        edge_field = next(
+            f for f in result.fields if f.fieldPath == "[edges].ShoppingCarts"
+        )
+        assert edge_field.description == "Users \u2192 Products"
+        assert edge_field.nativeDataType == "EDGE"
+
+        node_field = next(f for f in result.fields if f.fieldPath == "[nodes].Users")
+        assert node_field.nativeDataType == "NODE"
+
+    def test_schema_name_and_platform(self) -> None:
+        aspect = _make_graph_aspect(
+            nodes=[_make_node_value("A")],
+            edges=[],
+        )
+        entry = Mock(spec=dataplex_v1.Entry)
+        entry.aspects = {"655216118709.global.graph-schema": aspect}
+
+        result = extract_graph_schema_from_entry_aspects(entry, "MyGraph", "spanner")
+
+        assert result is not None
+        assert result.schemaName == "MyGraph"
+        assert "spanner" in result.platform


### PR DESCRIPTION
## Summary

- **Cloud Spanner table schemas**: Spanner entries are fetched via `search_entries` (a workaround required because they are not returned by standard `list_entries`), which returns stub entries without aspects. This PR adds a `get_entry(view=ALL)` call per entry after filtering, so schema aspects are now fetched and emitted for Spanner tables.

- **Cloud Spanner Graph**: Adds support for the `cloud-spanner-graph` Dataplex entry type (Cloud Spanner Property Graph). Graph entries are mapped to DataHub Datasets with subtype `Graph`. Schema is extracted from the `graph-schema` aspect, mapping nodes to `[nodes].<name>` fields and edges to `[edges].<name>` fields (with `source → destination` in the edge description). Handles both proto Value form and Python-native list form produced by proto-plus auto-marshaling.

## Changes

- `subtypes.py`: Add `DatasetSubTypes.GRAPH = "Graph"` (first use: Spanner Graph)
- `dataplex_ids.py`: Add `cloud-spanner-graph` entry type mapping with FQN regex and dataset name format
- `dataplex_entries.py`: Call `get_entry` detail for each Spanner entry from `search_entries`; use standard schema aspect with graph-schema aspect as fallback
- `dataplex_schema.py`: Add `extract_graph_schema_from_entry_aspects` supporting both proto Value and Python-native list forms
- `README.md`: Add `cloud-spanner-graph` row to concept mapping table
- Tests: New unit tests for graph schema extraction (proto form, native list form, edge cases)

## Test plan

- [ ] Unit tests: `tests/unit/dataplex/test_dataplex_schema.py` — graph schema extraction (proto + native list form)
- [ ] Unit tests: `tests/unit/dataplex/test_dataplex_ids.py` — FQN parsing, parent entry parsing, URN building for `cloud-spanner-graph`
- [ ] End-to-end: Spanner tables now appear with schema metadata in DataHub UI
- [ ] End-to-end: Spanner Graph entities appear under their parent database container with `Graph` subtype and node/edge fields in schema

https://claude.ai/code/session_01NGKSZESMRCs2ubMFWJu5dd