### PR TITLE
feat(ui): make top level MFE menu header configurable (DATAMGT-11505)

### DIFF
--- a/datahub-web-react/src/app/homeV2/layout/navBarRedesign/NavSidebar.tsx
+++ b/datahub-web-react/src/app/homeV2/layout/navBarRedesign/NavSidebar.tsx
@@ -182,7 +182,7 @@ export const NavSidebar = () => {
             mfeSection = [
                 {
                     type: NavBarMenuItemTypes.Dropdown,
-                    title: 'MFE Apps',
+                    title: mfeConfig.topLevelMenuTitle || 'MFE Apps',
                     icon: <AppWindow />,
                     key: 'mfe-dropdown',
                     items: getMfeMenuDropdownItems(mfeConfig),
@@ -193,7 +193,7 @@ export const NavSidebar = () => {
                 {
                     type: NavBarMenuItemTypes.Group,
                     key: 'mfe-group',
-                    title: 'MFE Apps',
+                    title: mfeConfig.topLevelMenuTitle || 'MFE Apps',
                     items: getMfeMenuItems(mfeConfig),
                 } as NavBarMenuGroup,
             ];

--- a/datahub-web-react/src/app/mfeframework/README-MFE.md
+++ b/datahub-web-react/src/app/mfeframework/README-MFE.md
@@ -18,6 +18,7 @@ Most examples include both a "host app" and a "remote app." For DataHub, you onl
 Edit [`mfe.config.local.yaml`](/datahub-frontend/conf/mfe.config.local.yaml) to resemble the following:
 
 ```yaml
+topLevelMenuTitle: My Apps
 subNavigationMode: false
 microFrontends:
     - id: HelloWorld

--- a/datahub-web-react/src/app/mfeframework/_tests_/mfeNavBarMenuUtils.test.tsx
+++ b/datahub-web-react/src/app/mfeframework/_tests_/mfeNavBarMenuUtils.test.tsx
@@ -9,6 +9,7 @@ import { getMfeMenuDropdownItems, getMfeMenuItems } from '@app/mfeframework/mfeN
 describe('getMfeMenuItems and getMfeMenuDropdownItems', () => {
     it('returns only valid menu items where flags.showInNav is true and maps navIcon to correct icon', () => {
         const mfeConfig: MFESchema = {
+            topLevelMenuTitle: 'My Apps',
             subNavigationMode: false,
             microFrontends: [
                 {
@@ -78,6 +79,7 @@ describe('getMfeMenuItems and getMfeMenuDropdownItems', () => {
 
     it('returns items of type DropdownElement when subNavigationMode is true', () => {
         const mfeConfig: MFESchema = {
+            topLevelMenuTitle: 'My Apps',
             subNavigationMode: true,
             microFrontends: [
                 {
@@ -108,13 +110,13 @@ describe('getMfeMenuItems and getMfeMenuDropdownItems', () => {
     });
 
     it('returns empty array if no microFrontends (getMfeMenuItems)', () => {
-        const mfeConfig: MFESchema = { microFrontends: [], subNavigationMode: false };
+        const mfeConfig: MFESchema = { topLevelMenuTitle: 'My Apps', microFrontends: [], subNavigationMode: false };
         const items = getMfeMenuItems(mfeConfig);
         expect(items).toEqual([]);
     });
 
     it('returns empty array if no microFrontends (getMfeMenuDropdownItems)', () => {
-        const mfeConfig: MFESchema = { microFrontends: [], subNavigationMode: true };
+        const mfeConfig: MFESchema = { topLevelMenuTitle: 'My Apps', microFrontends: [], subNavigationMode: true };
         const items = getMfeMenuDropdownItems(mfeConfig);
         expect(items).toEqual([]);
     });

--- a/datahub-web-react/src/app/mfeframework/mfeConfigLoader.tsx
+++ b/datahub-web-react/src/app/mfeframework/mfeConfigLoader.tsx
@@ -25,6 +25,7 @@ export interface MFEConfig {
 
 // MFESchema: The overall config schema.
 export interface MFESchema {
+    topLevelMenuTitle: string;
     subNavigationMode: boolean;
     microFrontends: MFEConfig[];
 }


### PR DESCRIPTION
## Summary

- Makes the top-level MFE menu header configurable

## Test plan

- [ ] Verify MFE menu header renders correctly with custom config
- [ ] Verify existing MFE nav sidebar behavior is unchanged

Authored-by: Nikolov, Philip (CCB, USA) <philip.nikolov@chase.com>