### PR TITLE
fix(systemUpdate): apply reindex optimization flag to full scope of changes to avoid permissions issues in nonblocking job

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ESIndexBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ESIndexBuilder.java
@@ -1283,18 +1283,27 @@ public class ESIndexBuilder {
     }
     setIndexSetting(tempIndexName, "0", INDEX_NUMBER_OF_REPLICAS);
     setIndexSetting(tempIndexName, "-1", INDEX_REFRESH_INTERVAL);
-    // these depend on jvm max heap...
     // flush_threshold_size: 512MB by def. Increasing to 1gb, if heap at least 16gb (this is more
     // conservative than %25 mentioned
     // https://docs.opensearch.org/docs/2.11/tuning-your-cluster/performance/
     //    "index.translog.flush_threshold_size": "512mb",
-    double jvmheapgb = jvminfo.getAverageDataNodeMaxHeapSizeGB();
-    String setting = INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE;
-    String optimValue = "1024mb";
-    String curval = getIndexSetting(tempIndexName, setting);
-    if (SizeUtils.isGreaterSize(optimValue, curval) && jvmheapgb >= MINJVMHEAP) {
-      setIndexSetting(tempIndexName, optimValue, setting);
-      res.put(ORIGINALPREFIX + setting, curval);
+    // The heap query hits the cluster-level /_nodes/stats endpoint which may fail in
+    // reduced-permission deployments. Guard the whole flush_threshold optimization so a
+    // failure here only skips this tuning rather than aborting the reindex.
+    try {
+      double jvmheapgb = jvminfo.getAverageDataNodeMaxHeapSizeGB();
+      String setting = INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE;
+      String optimValue = "1024mb";
+      String curval = getIndexSetting(tempIndexName, setting);
+      if (SizeUtils.isGreaterSize(optimValue, curval) && jvmheapgb >= MINJVMHEAP) {
+        setIndexSetting(tempIndexName, optimValue, setting);
+        res.put(ORIGINALPREFIX + setting, curval);
+      }
+    } catch (Exception e) {
+      log.warn(
+          "Failed to optimize translog.flush_threshold_size for {}, keeping current value: {}",
+          tempIndexName,
+          e.getMessage());
     }
     // this is a cluster setting "index_buffer_size": "10%",
     // GET _cluster/settings?include_defaults&filter_path=defaults.indices.memory

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ESIndexBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ESIndexBuilder.java
@@ -1274,9 +1274,14 @@ public class ESIndexBuilder {
   private Map<String, Object> setReindexOptimalSettings(String tempIndexName, int targetShards)
       throws IOException {
     Map<String, Object> res = new HashMap<>();
-    if (config.getBuildIndices().isReindexOptimizationEnabled()) {
-      setIndexSetting(tempIndexName, "0", INDEX_NUMBER_OF_REPLICAS);
+    // When reindex optimization is disabled, skip all settings writes and the cluster-level
+    // /_nodes/stats heap query. The latter fails in reduced-permission deployments (e.g.
+    // non-blocking system upgrades) and would otherwise abort the reindex.
+    if (!config.getBuildIndices().isReindexOptimizationEnabled()) {
+      res.put("optimalSlices", calculateOptimalSlices(targetShards));
+      return res;
     }
+    setIndexSetting(tempIndexName, "0", INDEX_NUMBER_OF_REPLICAS);
     setIndexSetting(tempIndexName, "-1", INDEX_REFRESH_INTERVAL);
     // these depend on jvm max heap...
     // flush_threshold_size: 512MB by def. Increasing to 1gb, if heap at least 16gb (this is more
@@ -1312,10 +1317,13 @@ public class ESIndexBuilder {
       String refreshinterval,
       Map<String, Object> reinfo)
       throws IOException {
-    // set the original values
-    if (config.getBuildIndices().isReindexOptimizationEnabled()) {
-      setIndexSetting(tempIndexName, targetReplicas, INDEX_NUMBER_OF_REPLICAS);
+    // Symmetric with setReindexOptimalSettings: if optimization was disabled, nothing was
+    // changed, so there is nothing to restore.
+    if (!config.getBuildIndices().isReindexOptimizationEnabled()) {
+      return;
     }
+    // set the original values
+    setIndexSetting(tempIndexName, targetReplicas, INDEX_NUMBER_OF_REPLICAS);
     setIndexSetting(tempIndexName, refreshinterval, INDEX_REFRESH_INTERVAL);
     // Restore translog settings if they were saved (may be empty if not originally set)
     String setting = INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE;

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/indexbuilder/ESIndexBuilderTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/indexbuilder/ESIndexBuilderTest.java
@@ -1016,6 +1016,119 @@ public class ESIndexBuilderTest {
             any(RequestOptions.class));
   }
 
+  /**
+   * Exercises the non-zero-docs path (unlike the 0-docs test above which short-circuits before
+   * submitReindex). When reindexOptimizationEnabled=false, setReindexOptimalSettings must skip all
+   * settings writes AND the cluster-level /_nodes/stats heap query. The latter is the call that
+   * fails in reduced-permission deployments (e.g. non-blocking system upgrades) and would otherwise
+   * abort the reindex with an uncaught IOException.
+   */
+  @Test
+  void testReindexWithOptimizationDisabled_SkipsNodeStatsAndSettingsWrites() throws Exception {
+    when(buildIndicesConfig.isReindexOptimizationEnabled()).thenReturn(false);
+
+    ESIndexBuilder optimizationDisabledIndexBuilder =
+        new ESIndexBuilder(
+            searchClient,
+            elasticSearchConfiguration,
+            TEST_ES_STRUCT_PROPS_DISABLED,
+            Map.of(),
+            gitVersion);
+
+    ReindexConfig indexState = mock(ReindexConfig.class);
+    when(indexState.exists()).thenReturn(true);
+    when(indexState.requiresApplyMappings()).thenReturn(true);
+    when(indexState.requiresApplySettings()).thenReturn(true);
+    when(indexState.requiresReindex()).thenReturn(true);
+    when(indexState.name()).thenReturn(TEST_INDEX_NAME);
+    when(indexState.targetMappings()).thenReturn(createTestMappings());
+    when(indexState.targetSettings()).thenReturn(createTestTargetSettings());
+    when(indexState.indexPattern()).thenReturn(null);
+
+    CreateIndexResponse createResponse = mock(CreateIndexResponse.class);
+    when(createResponse.isAcknowledged()).thenReturn(true);
+    when(searchClient.createIndex(any(CreateIndexRequest.class), any(RequestOptions.class)))
+        .thenReturn(createResponse);
+
+    // Non-zero doc count drives execution through submitReindex -> setReindexOptimalSettings,
+    // which is the code path guarded by the flag.
+    CountResponse countResponse = mock(CountResponse.class);
+    when(countResponse.getCount()).thenReturn(100L);
+    when(searchClient.count(any(CountRequest.class), any(RequestOptions.class)))
+        .thenReturn(countResponse);
+
+    org.opensearch.action.admin.cluster.node.tasks.list.ListTasksResponse taskListResponse =
+        mock(org.opensearch.action.admin.cluster.node.tasks.list.ListTasksResponse.class);
+    when(taskListResponse.getTasks()).thenReturn(new ArrayList<>());
+    when(searchClient.listTasks(
+            any(org.opensearch.action.admin.cluster.node.tasks.list.ListTasksRequest.class), any()))
+        .thenReturn(taskListResponse);
+
+    org.opensearch.action.admin.indices.refresh.RefreshResponse refreshResponse =
+        mock(org.opensearch.action.admin.indices.refresh.RefreshResponse.class);
+    when(searchClient.refreshIndex(any(), any(RequestOptions.class))).thenReturn(refreshResponse);
+
+    AcknowledgedResponse settingsUpdateResponse = mock(AcknowledgedResponse.class);
+    when(settingsUpdateResponse.isAcknowledged()).thenReturn(true);
+    when(searchClient.updateIndexSettings(
+            any(UpdateSettingsRequest.class), any(RequestOptions.class)))
+        .thenReturn(settingsUpdateResponse);
+
+    when(searchClient.submitReindexTask(any(ReindexRequest.class), any())).thenReturn("task1");
+
+    GetAliasesResponse getAliasesResponse = mock(GetAliasesResponse.class);
+    when(getAliasesResponse.getAliases()).thenReturn(Map.of());
+    when(searchClient.getIndexAliases(any(GetAliasesRequest.class), any(RequestOptions.class)))
+        .thenReturn(getAliasesResponse);
+
+    AcknowledgedResponse aliasResponse = mock(AcknowledgedResponse.class);
+    when(aliasResponse.isAcknowledged()).thenReturn(true);
+    when(searchClient.updateIndexAliases(
+            any(IndicesAliasesRequest.class), any(RequestOptions.class)))
+        .thenReturn(aliasResponse);
+
+    ReindexResult result = optimizationDisabledIndexBuilder.buildIndex(indexState);
+
+    // Reindex is still submitted - only the pre-reindex optimizations are skipped.
+    assertEquals(result, ReindexResult.REINDEXING);
+    verify(searchClient).submitReindexTask(any(ReindexRequest.class), any());
+
+    // Critical: the cluster-level /_nodes/stats heap query must not be issued. This is the
+    // call that fails in reduced-permission deployments and was previously uncaught.
+    verify(searchClient, never())
+        .performLowLevelRequest(
+            argThat(req -> req != null && req.getEndpoint().contains("_nodes/stats")));
+
+    // None of the optimization settings should be written to the temp index.
+    verify(searchClient, never())
+        .updateIndexSettings(
+            argThat(
+                request ->
+                    request != null
+                        && request.indices().length == 1
+                        && request.indices()[0].contains(TEST_INDEX_NAME + "_")
+                        && "0".equals(request.settings().get("index.number_of_replicas"))),
+            any(RequestOptions.class));
+    verify(searchClient, never())
+        .updateIndexSettings(
+            argThat(
+                request ->
+                    request != null
+                        && request.indices().length == 1
+                        && request.indices()[0].contains(TEST_INDEX_NAME + "_")
+                        && "-1".equals(request.settings().get("index.refresh_interval"))),
+            any(RequestOptions.class));
+    verify(searchClient, never())
+        .updateIndexSettings(
+            argThat(
+                request ->
+                    request != null
+                        && request.indices().length == 1
+                        && request.indices()[0].contains(TEST_INDEX_NAME + "_")
+                        && request.settings().get("index.translog.flush_threshold_size") != null),
+            any(RequestOptions.class));
+  }
+
   @Test
   void testBuildIndex_ReindexUsesConfigBatchSizeAndMaxSlices() throws Exception {
     when(buildIndicesConfig.getReindexBatchSize()).thenReturn(999);

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/indexbuilder/ESIndexBuilderTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/indexbuilder/ESIndexBuilderTest.java
@@ -1129,6 +1129,113 @@ public class ESIndexBuilderTest {
             any(RequestOptions.class));
   }
 
+  /**
+   * Defense-in-depth: even with reindexOptimizationEnabled=true, a failure of the cluster-level
+   * /_nodes/stats call (used to pick an optimal translog.flush_threshold_size) must not abort the
+   * reindex. The replica/refresh_interval tuning should still be applied, the flush_threshold
+   * tuning should be skipped, and the reindex should still be submitted.
+   */
+  @Test
+  void testReindexContinuesWhenNodeStatsFails() throws Exception {
+    // Override the @BeforeMethod stub: /_nodes/stats now fails.
+    when(searchClient.performLowLevelRequest(
+            argThat(req -> req != null && req.getEndpoint().contains("_nodes/stats"))))
+        .thenThrow(new IOException("permission denied on cluster:monitor/nodes/stats"));
+
+    ReindexConfig indexState = mock(ReindexConfig.class);
+    when(indexState.exists()).thenReturn(true);
+    when(indexState.requiresApplyMappings()).thenReturn(true);
+    when(indexState.requiresApplySettings()).thenReturn(true);
+    when(indexState.requiresReindex()).thenReturn(true);
+    when(indexState.name()).thenReturn(TEST_INDEX_NAME);
+    when(indexState.targetMappings()).thenReturn(createTestMappings());
+    when(indexState.targetSettings()).thenReturn(createTestTargetSettings());
+    when(indexState.indexPattern()).thenReturn(null);
+
+    CreateIndexResponse createResponse = mock(CreateIndexResponse.class);
+    when(createResponse.isAcknowledged()).thenReturn(true);
+    when(searchClient.createIndex(any(CreateIndexRequest.class), any(RequestOptions.class)))
+        .thenReturn(createResponse);
+
+    CountResponse countResponse = mock(CountResponse.class);
+    when(countResponse.getCount()).thenReturn(100L);
+    when(searchClient.count(any(CountRequest.class), any(RequestOptions.class)))
+        .thenReturn(countResponse);
+
+    org.opensearch.action.admin.cluster.node.tasks.list.ListTasksResponse taskListResponse =
+        mock(org.opensearch.action.admin.cluster.node.tasks.list.ListTasksResponse.class);
+    when(taskListResponse.getTasks()).thenReturn(new ArrayList<>());
+    when(searchClient.listTasks(
+            any(org.opensearch.action.admin.cluster.node.tasks.list.ListTasksRequest.class), any()))
+        .thenReturn(taskListResponse);
+
+    org.opensearch.action.admin.indices.refresh.RefreshResponse refreshResponse =
+        mock(org.opensearch.action.admin.indices.refresh.RefreshResponse.class);
+    when(searchClient.refreshIndex(any(), any(RequestOptions.class))).thenReturn(refreshResponse);
+
+    GetSettingsResponse getSettingsResponse = mock(GetSettingsResponse.class);
+    when(getSettingsResponse.getSetting(anyString(), eq("index.translog.flush_threshold_size")))
+        .thenReturn("512mb");
+    when(searchClient.getIndexSettings(any(GetSettingsRequest.class), any(RequestOptions.class)))
+        .thenReturn(getSettingsResponse);
+
+    AcknowledgedResponse settingsUpdateResponse = mock(AcknowledgedResponse.class);
+    when(settingsUpdateResponse.isAcknowledged()).thenReturn(true);
+    when(searchClient.updateIndexSettings(
+            any(UpdateSettingsRequest.class), any(RequestOptions.class)))
+        .thenReturn(settingsUpdateResponse);
+
+    when(searchClient.submitReindexTask(any(ReindexRequest.class), any())).thenReturn("task1");
+
+    GetAliasesResponse getAliasesResponse = mock(GetAliasesResponse.class);
+    when(getAliasesResponse.getAliases()).thenReturn(Map.of());
+    when(searchClient.getIndexAliases(any(GetAliasesRequest.class), any(RequestOptions.class)))
+        .thenReturn(getAliasesResponse);
+
+    AcknowledgedResponse aliasResponse = mock(AcknowledgedResponse.class);
+    when(aliasResponse.isAcknowledged()).thenReturn(true);
+    when(searchClient.updateIndexAliases(
+            any(IndicesAliasesRequest.class), any(RequestOptions.class)))
+        .thenReturn(aliasResponse);
+
+    ReindexResult result = indexBuilder.buildIndex(indexState);
+
+    // Reindex is still submitted - the node-stats failure is swallowed.
+    assertEquals(result, ReindexResult.REINDEXING);
+    verify(searchClient).submitReindexTask(any(ReindexRequest.class), any());
+
+    // Replica/refresh_interval tuning is still applied (they don't depend on heap stats).
+    verify(searchClient)
+        .updateIndexSettings(
+            argThat(
+                request ->
+                    request != null
+                        && request.indices().length == 1
+                        && request.indices()[0].contains(TEST_INDEX_NAME + "_")
+                        && "0".equals(request.settings().get("index.number_of_replicas"))),
+            any(RequestOptions.class));
+    verify(searchClient)
+        .updateIndexSettings(
+            argThat(
+                request ->
+                    request != null
+                        && request.indices().length == 1
+                        && request.indices()[0].contains(TEST_INDEX_NAME + "_")
+                        && "-1".equals(request.settings().get("index.refresh_interval"))),
+            any(RequestOptions.class));
+
+    // Flush threshold optimization should be skipped because the heap query failed.
+    verify(searchClient, never())
+        .updateIndexSettings(
+            argThat(
+                request ->
+                    request != null
+                        && request.indices().length == 1
+                        && request.indices()[0].contains(TEST_INDEX_NAME + "_")
+                        && request.settings().get("index.translog.flush_threshold_size") != null),
+            any(RequestOptions.class));
+  }
+
   @Test
   void testBuildIndex_ReindexUsesConfigBatchSizeAndMaxSlices() throws Exception {
     when(buildIndicesConfig.getReindexBatchSize()).thenReturn(999);


### PR DESCRIPTION
Avoids issues where reduced permissions in the non-blocking job reindex pathway cause errors when pulling node stats JVM metrics.
