### PR TITLE
test(patch): Properly construct JsonPatch for patch builders with array primary keys

### DIFF
--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/builder/AbstractMultiFieldPatchBuilder.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/builder/AbstractMultiFieldPatchBuilder.java
@@ -9,17 +9,16 @@ import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.ByteString;
 import com.linkedin.events.metadata.ChangeType;
+import com.linkedin.metadata.aspect.patch.GenericJsonPatch;
 import com.linkedin.mxe.GenericAspect;
 import com.linkedin.mxe.MetadataChangeProposal;
 import jakarta.json.Json;
-import jakarta.json.JsonArrayBuilder;
-import jakarta.json.JsonObjectBuilder;
-import jakarta.json.JsonPatch;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
@@ -145,23 +144,26 @@ public abstract class AbstractMultiFieldPatchBuilder<T extends AbstractMultiFiel
   }
 
   @VisibleForTesting
-  public JsonPatch getJsonPatch() {
-    JsonArrayBuilder arrayBuilder = Json.createArrayBuilder();
-    List<ImmutableTriple<String, String, JsonNode>> triples = getPathValues();
-    triples.forEach(
-        triple -> {
-          JsonObjectBuilder opBuilder =
-              Json.createObjectBuilder().add(OP_KEY, triple.left).add(PATH_KEY, triple.middle);
-          if (triple.right != null) {
-            opBuilder.add(
-                VALUE_KEY,
-                Json.createReader(new StringReader(triple.right.toString())).readValue());
-          } else {
-            opBuilder.addNull(VALUE_KEY);
-          }
-          arrayBuilder.add(opBuilder);
-        });
-    return Json.createPatch(arrayBuilder.build());
+  public GenericJsonPatch getJsonPatch() {
+    Map<String, List<String>> apk =
+        arrayPrimaryKeysOverride != null ? arrayPrimaryKeysOverride : getArrayPrimaryKeys();
+
+    List<GenericJsonPatch.PatchOp> patchOps =
+        getPathValues().stream()
+            .map(
+                triple -> {
+                  GenericJsonPatch.PatchOp op = new GenericJsonPatch.PatchOp();
+                  op.setOp(triple.left);
+                  op.setPath(triple.middle);
+                  if (triple.right != null) {
+                    op.setValue(
+                        Json.createReader(new StringReader(triple.right.toString())).readValue());
+                  }
+                  return op;
+                })
+            .collect(Collectors.toList());
+
+    return GenericJsonPatch.builder().arrayPrimaryKeys(apk).patch(patchOps).build();
   }
 
   /**

--- a/metadata-io/metadata-io-api/src/main/java/com/linkedin/metadata/entity/ebean/batch/PatchItemImpl.java
+++ b/metadata-io/metadata-io-api/src/main/java/com/linkedin/metadata/entity/ebean/batch/PatchItemImpl.java
@@ -215,6 +215,11 @@ public class PatchItemImpl implements PatchMCP {
       return this;
     }
 
+    public PatchItemImpl.PatchItemImplBuilder patch(GenericJsonPatch genericPatch) {
+      this.genericJsonPatch = genericPatch;
+      return patch(genericPatch.getJsonPatch());
+    }
+
     public PatchItemImpl build(EntityRegistry entityRegistry) {
       urn(ValidationApiUtils.validateUrn(entityRegistry, this.urn));
       log.debug("entity type = {}", this.urn.getEntityType());

--- a/metadata-io/metadata-io-api/src/test/java/com/linkedin/metadata/entity/ebean/batch/PatchItemImplTest.java
+++ b/metadata-io/metadata-io-api/src/test/java/com/linkedin/metadata/entity/ebean/batch/PatchItemImplTest.java
@@ -416,7 +416,7 @@ public class PatchItemImplTest {
         .urn(urn)
         .aspectName(DATASET_PROPERTIES_ASPECT_NAME)
         .auditStamp(auditStamp)
-        .patch(null)
+        .patch((JsonPatch) null)
         .build(entityRegistry);
   }
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/EntityServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/EntityServiceTest.java
@@ -106,7 +106,6 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -3455,20 +3454,5 @@ public abstract class EntityServiceTest<T_AD extends AspectDao, T_RS extends Ret
     RecordTemplate recordTemplate =
         RecordUtils.toRecordTemplate(clazz, objectMapper.writeValueAsString(aspect));
     return new Pair<>(AspectGenerationUtils.getAspectName(aspect), recordTemplate);
-  }
-
-  private static GenericJsonPatch.PatchOp tagPatchOp(PatchOperationType op, Urn tagUrn) {
-    GenericJsonPatch.PatchOp patchOp = new GenericJsonPatch.PatchOp();
-    patchOp.setOp(op.getValue());
-    patchOp.setPath(String.format("/tags/%s", tagUrn));
-    if (PatchOperationType.ADD.equals(op)) {
-      // Create a proper TagAssociation structure
-      Map<String, Object> tagAssociation = new HashMap<>();
-      tagAssociation.put("tag", tagUrn.toString());
-      // Add optional context field with a non-null value to avoid coercion issues
-      tagAssociation.put("context", "test-context");
-      patchOp.setValue(tagAssociation);
-    }
-    return patchOp;
   }
 }


### PR DESCRIPTION
Fix tests that were constructing PatchItemImpl but not setting genericJsonPatch properly

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
