### PR TITLE
feat(ingest/sigma): emit entity-level workbook->DataModel and element->DataModel lineage

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
@@ -140,6 +140,12 @@ class SigmaSourceReport(StaleEntityRemovalSourceReport):
     data_models: EntityFilterReport = EntityFilterReport.field(type="data_model")
     skipped_warehouse_table_upstreams: int = 0
 
+    workbook_data_model_upstream_edges_emitted: int = 0
+    workbook_data_model_upstream_missed_dm_id: int = 0
+    element_data_model_upstream_edges_emitted: int = 0
+    element_source_id_unresolved: int = 0
+    element_source_id_warehouse: int = 0
+
     number_of_files_metadata: Dict[str, int] = field(default_factory=dict)
     empty_workspaces: List[str] = field(default_factory=list)
 

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/data_classes.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/data_classes.py
@@ -96,6 +96,7 @@ class File(BaseModel):
     parentId: str
     path: str
     type: str
+    urlId: Optional[str] = None
     badge: Optional[str] = None
     workspaceId: Optional[str] = None
 
@@ -125,6 +126,9 @@ class SigmaDataModel(BaseModel):
     workspaceId: Optional[str] = None
     path: Optional[str] = None
     badge: Optional[str] = None
+    # Populated from file metadata urlId; used by T2.5 element→DM sourceIds prefix matching.
+    # Sigma's /workbooks/{id}/lineage element entries carry sourceIds[0] = "<dataModelUrlId>/<opaque>".
+    dataModelUrlId: Optional[str] = None
     columns: List[SigmaDataModelColumn] = []
     sources: List[SigmaDataModelSource] = []
 

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, Iterable, List, Optional
+from typing import Dict, Iterable, List, Optional, Tuple
 
 import datahub.emitter.mce_builder as builder
 from datahub.configuration.common import ConfigurationError
@@ -33,6 +33,7 @@ from datahub.ingestion.source.common.subtypes import (
     SourceCapabilityModifier,
 )
 from datahub.ingestion.source.sigma.config import (
+    Constant,
     PlatformDetail,
     SigmaSourceConfig,
     SigmaSourceReport,
@@ -131,6 +132,8 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         self.config = config
         self.reporter = SigmaSourceReport()
         self.dataset_upstream_urn_mapping: Dict[str, List[str]] = {}
+        self.data_model_id_to_urn: Dict[str, str] = {}
+        self.data_model_url_id_to_urn: Dict[str, str] = {}
         try:
             self.sigma_api = SigmaAPI(self.config, self.reporter)
         except Exception as e:
@@ -419,6 +422,10 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
     ) -> Iterable[MetadataWorkUnit]:
         data_model_urn = self._gen_sigma_dataset_urn(data_model.get_urn_part())
 
+        self.data_model_id_to_urn[data_model.dataModelId] = data_model_urn
+        if data_model.dataModelUrlId:
+            self.data_model_url_id_to_urn[data_model.dataModelUrlId] = data_model_urn
+
         yield self._gen_entity_status_aspect(data_model_urn)
 
         dm_properties = DatasetProperties(
@@ -484,6 +491,74 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                     tags=[TagAssociationClass(builder.make_tag_urn(data_model.badge))]
                 ),
             ).as_workunit()
+
+    def _get_workbook_dm_lineage_data(
+        self, workbook: Workbook
+    ) -> Tuple[List[str], Dict[str, str]]:
+        """
+        Returns (dm_urns_for_workbook, element_id_to_dm_urn) by calling
+        GET /workbooks/{id}/lineage once per workbook.
+
+        Skipped when ingest_data_models=False (no DM URN map to look up against).
+        Sigma type strings are uniformly kebab-case — Constant.DATA_MODEL = "data-model".
+        Using camelCase "dataModel" silently returns 0 results.
+        """
+        if not self.config.ingest_data_models:
+            return [], {}
+
+        workbook_dm_urns: List[str] = []
+        element_dm_map: Dict[str, str] = {}
+        missed_dm_ids: List[str] = []
+
+        for entry in self.sigma_api.get_workbook_lineage(workbook.workbookId):
+            entry_type = entry.get("type", "")
+
+            if entry_type == Constant.DATA_MODEL:
+                dm_id = entry.get("dataModelId", "")
+                if not dm_id:
+                    continue
+                dm_urn = self.data_model_id_to_urn.get(dm_id)
+                if dm_urn:
+                    workbook_dm_urns.append(dm_urn)
+                    self.reporter.workbook_data_model_upstream_edges_emitted += 1
+                else:
+                    missed_dm_ids.append(dm_id)
+                    self.reporter.workbook_data_model_upstream_missed_dm_id += 1
+
+            elif entry_type == "element":
+                element_id = entry.get("elementId", "")
+                if not element_id:
+                    continue
+                source_ids = entry.get("sourceIds", [])
+                if not source_ids:
+                    continue
+                source_id_0 = source_ids[0]
+                if "/" not in source_id_0:
+                    self.reporter.element_source_id_unresolved += 1
+                    continue
+                prefix, _ = source_id_0.split("/", 1)
+                if prefix.startswith("inode-"):
+                    # Warehouse table reference — T3's territory, not T2.5.
+                    self.reporter.element_source_id_warehouse += 1
+                    continue
+                dm_urn = self.data_model_url_id_to_urn.get(prefix)
+                if dm_urn:
+                    element_dm_map[element_id] = dm_urn
+                    self.reporter.element_data_model_upstream_edges_emitted += 1
+                else:
+                    self.reporter.element_source_id_unresolved += 1
+
+        if missed_dm_ids:
+            self.reporter.warning(
+                message=(
+                    f"Workbook '{workbook.name}' references Data Model ID(s) not in "
+                    f"ingested DMs; upstream edges skipped: {missed_dm_ids}"
+                ),
+                title="Unresolved workbook Data Model upstream",
+                context=workbook.workbookId,
+            )
+
+        return workbook_dm_urns, element_dm_map
 
     def get_workunit_processors(self) -> List[Optional[MetadataWorkUnitProcessor]]:
         return [
@@ -597,6 +672,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         workbook: Workbook,
         all_input_fields: List[InputFieldClass],
         paths: List[str],
+        element_dm_map: Optional[Dict[str, str]] = None,
     ) -> Iterable[MetadataWorkUnit]:
         """
         Map Sigma page element to Datahub Chart
@@ -618,6 +694,11 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             inputs: Dict[str, List[str]] = self._get_element_input_details(
                 element, workbook
             )
+
+            if element_dm_map:
+                dm_urn = element_dm_map.get(element.elementId)
+                if dm_urn and dm_urn not in inputs:
+                    inputs[dm_urn] = []
 
             yield MetadataChangeProposalWrapper(
                 entityUrn=chart_urn,
@@ -672,7 +753,10 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             all_input_fields.extend(element_input_fields)
 
     def _gen_pages_workunit(
-        self, workbook: Workbook, paths: List[str]
+        self,
+        workbook: Workbook,
+        paths: List[str],
+        element_dm_map: Optional[Dict[str, str]] = None,
     ) -> Iterable[MetadataWorkUnit]:
         """
         Map Sigma workbook page to Datahub dashboard
@@ -701,7 +785,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                 )
 
             yield from self._gen_elements_workunit(
-                page.elements, workbook, all_input_fields, paths
+                page.elements, workbook, all_input_fields, paths, element_dm_map
             )
 
             yield MetadataChangeProposalWrapper(
@@ -728,6 +812,8 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             actor="urn:li:corpuser:datahub",
         )
 
+        workbook_dm_urns, element_dm_map = self._get_workbook_dm_lineage_data(workbook)
+
         dashboard_info_cls = DashboardInfoClass(
             title=workbook.name,
             description=workbook.description if workbook.description else "",
@@ -738,6 +824,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                 )
                 for page in workbook.pages
             ],
+            datasets=workbook_dm_urns if workbook_dm_urns else None,
             externalUrl=workbook.url,
             lastModified=ChangeAuditStampsClass(
                 created=created, lastModified=lastModified
@@ -798,7 +885,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                     entity_urn=dashboard_urn,
                 )
 
-        yield from self._gen_pages_workunit(workbook, paths)
+        yield from self._gen_pages_workunit(workbook, paths, element_dm_map)
 
     def _gen_sigma_dataset_upstream_lineage_workunit(
         self,

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
@@ -495,6 +495,7 @@ class SigmaAPI:
                         data_model.workspaceId = file_meta.workspaceId
                         data_model.path = file_meta.path
                         data_model.badge = file_meta.badge
+                        data_model.dataModelUrlId = file_meta.urlId
 
                     workspace = None
                     if data_model.workspaceId:
@@ -564,6 +565,25 @@ class SigmaAPI:
         except Exception as e:
             self._log_http_error(
                 message=f"Unable to fetch sigma data models. Exception: {e}"
+            )
+            return []
+
+    def get_workbook_lineage(self, workbook_id: str) -> List[Dict[str, Any]]:
+        """Fetch /workbooks/{id}/lineage and return the entries list."""
+        try:
+            response = self._get_api_call(
+                f"{self.config.api_url}/workbooks/{workbook_id}/lineage"
+            )
+            if response.status_code in (400, 403, 404, 500):
+                logger.debug(
+                    f"Workbook lineage not available for '{workbook_id}': HTTP {response.status_code}"
+                )
+                return []
+            response.raise_for_status()
+            return response.json().get("entries", [])
+        except Exception as e:
+            self._log_http_error(
+                message=f"Unable to fetch lineage for workbook '{workbook_id}'. Exception: {e}"
             )
             return []
 

--- a/metadata-ingestion/tests/integration/sigma/test_sigma.py
+++ b/metadata-ingestion/tests/integration/sigma/test_sigma.py
@@ -1252,3 +1252,391 @@ def test_dm_zero_columns(tmp_path, requests_mock):
         "datasetProperties must still be emitted"
     )
     assert "subTypes" in dm_aspect_names, "subTypes aspect must still be emitted"
+
+
+# ---------------------------------------------------------------------------
+# T2.5 helpers and tests — workbook→DM and element→DM entity-level lineage
+# ---------------------------------------------------------------------------
+
+WORKBOOK_ID = "9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b"
+WORKSPACE_ID = "3ee61405-3be2-4000-ba72-60d36757b95b"
+
+
+def _dm_file_entry(dm_id: str, dm_url_id: str, workspace_id: str) -> dict:
+    return {
+        "id": dm_id,
+        "urlId": dm_url_id,
+        "name": "Test DM",
+        "type": "dataModel",
+        "parentId": workspace_id,
+        "parentUrlId": "1UGFyEQCHqwPfQoAec3xJ9",
+        "permission": "edit",
+        "path": "Acryl Data",
+        "badge": None,
+        "createdBy": "CPbEdA26GNQ2cM2Ra2BeO0fa5Awz1",
+        "updatedBy": "CPbEdA26GNQ2cM2Ra2BeO0fa5Awz1",
+        "createdAt": "2024-04-15T13:43:12.664Z",
+        "updatedAt": "2024-04-15T13:43:12.664Z",
+        "isArchived": False,
+    }
+
+
+def _dm_api_entry(dm_id: str) -> dict:
+    return {
+        "dataModelId": dm_id,
+        "name": "Test DM",
+        "description": "",
+        "createdBy": "CPbEdA26GNQ2cM2Ra2BeO0fa5Awz1",
+        "updatedBy": "CPbEdA26GNQ2cM2Ra2BeO0fa5Awz1",
+        "createdAt": "2024-04-15T13:43:12.664Z",
+        "updatedAt": "2024-04-15T13:43:12.664Z",
+        "url": f"https://app.sigmacomputing.com/acryldata/data-model/{dm_id}",
+        "isArchived": False,
+    }
+
+
+def _make_dm_overrides(
+    dm_ids: list, dm_url_ids: list, workspace_id: str
+) -> Dict[str, Dict]:
+    """Override data registering one or more DMs (columns/sources empty)."""
+    overrides: Dict[str, Dict] = {
+        "https://aws-api.sigmacomputing.com/v2/files?typeFilters=data-model": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "entries": [
+                    _dm_file_entry(dm_id, dm_url_id, workspace_id)
+                    for dm_id, dm_url_id in zip(dm_ids, dm_url_ids, strict=False)
+                ],
+                "total": len(dm_ids),
+                "nextPage": None,
+            },
+        },
+        "https://aws-api.sigmacomputing.com/v2/dataModels": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "entries": [_dm_api_entry(dm_id) for dm_id in dm_ids],
+                "total": len(dm_ids),
+                "nextPage": None,
+            },
+        },
+    }
+    for dm_id in dm_ids:
+        overrides[
+            f"https://aws-api.sigmacomputing.com/v2/dataModels/{dm_id}/columns"
+        ] = {
+            "method": "GET",
+            "status_code": 200,
+            "json": {"entries": [], "total": 0, "nextPage": None},
+        }
+        overrides[
+            f"https://aws-api.sigmacomputing.com/v2/dataModels/{dm_id}/sources"
+        ] = {
+            "method": "GET",
+            "status_code": 200,
+            "json": {"entries": [], "total": 0, "nextPageToken": None},
+        }
+    return overrides
+
+
+def _run_pipeline(tmp_path, requests_mock, override_data: dict, filename: str) -> tuple:
+    register_mock_api(request_mock=requests_mock, override_data=override_data)
+    output_path = str(tmp_path / filename)
+    pipeline = Pipeline.create(
+        {
+            "run_id": "sigma-test",
+            "source": {
+                "type": "sigma",
+                "config": {
+                    "client_id": "CLIENTID",
+                    "client_secret": "CLIENTSECRET",
+                    "ingest_data_models": True,
+                },
+            },
+            "sink": {"type": "file", "config": {"filename": output_path}},
+        }
+    )
+    pipeline.run()
+    pipeline.raise_from_status()
+    emitted = json.loads(open(output_path).read())
+    return pipeline.source.get_report(), emitted
+
+
+@pytest.mark.integration
+def test_workbook_dm_single_upstream(tmp_path, requests_mock):
+    """T2.5 Task A: workbook with one DM upstream emits DashboardInfo.datasets."""
+    dm_id = "aaaa1111-0000-0000-0000-000000000001"
+    dm_url_id = "dmUrlId01"
+
+    override_data = _make_dm_overrides([dm_id], [dm_url_id], WORKSPACE_ID)
+    override_data[
+        f"https://aws-api.sigmacomputing.com/v2/workbooks/{WORKBOOK_ID}/lineage"
+    ] = {
+        "method": "GET",
+        "status_code": 200,
+        "json": {
+            "entries": [
+                {"type": "data-model", "dataModelId": dm_id, "name": "Test DM"},
+            ]
+        },
+    }
+
+    report, emitted = _run_pipeline(
+        tmp_path, requests_mock, override_data, "wb_dm_single.json"
+    )
+
+    assert report.workbook_data_model_upstream_edges_emitted == 1
+
+    dm_urn = f"urn:li:dataset:(urn:li:dataPlatform:sigma,{dm_id},PROD)"
+    workbook_urn = f"urn:li:dashboard:(sigma,{WORKBOOK_ID})"
+    dashboard_info_mcps = [
+        mcp
+        for mcp in emitted
+        if mcp.get("entityUrn") == workbook_urn
+        and mcp.get("aspectName") == "dashboardInfo"
+    ]
+    assert len(dashboard_info_mcps) == 1, "Expected exactly one dashboardInfo MCP"
+    datasets = dashboard_info_mcps[0]["aspect"]["json"].get("datasets", [])
+    assert dm_urn in datasets, f"DM URN {dm_urn} must appear in dashboardInfo.datasets"
+
+
+@pytest.mark.integration
+def test_workbook_dm_two_upstreams(tmp_path, requests_mock):
+    """T2.5 Task A: workbook with two DM upstreams emits both in DashboardInfo.datasets."""
+    dm_id_1 = "aaaa2222-0000-0000-0000-000000000001"
+    dm_id_2 = "aaaa2222-0000-0000-0000-000000000002"
+    dm_url_id_1 = "dmUrlId02a"
+    dm_url_id_2 = "dmUrlId02b"
+
+    override_data = _make_dm_overrides(
+        [dm_id_1, dm_id_2], [dm_url_id_1, dm_url_id_2], WORKSPACE_ID
+    )
+    override_data[
+        f"https://aws-api.sigmacomputing.com/v2/workbooks/{WORKBOOK_ID}/lineage"
+    ] = {
+        "method": "GET",
+        "status_code": 200,
+        "json": {
+            "entries": [
+                {"type": "data-model", "dataModelId": dm_id_1, "name": "DM One"},
+                {"type": "data-model", "dataModelId": dm_id_2, "name": "DM Two"},
+            ]
+        },
+    }
+
+    report, emitted = _run_pipeline(
+        tmp_path, requests_mock, override_data, "wb_dm_two.json"
+    )
+
+    assert report.workbook_data_model_upstream_edges_emitted == 2
+
+    workbook_urn = f"urn:li:dashboard:(sigma,{WORKBOOK_ID})"
+    dashboard_info_mcps = [
+        mcp
+        for mcp in emitted
+        if mcp.get("entityUrn") == workbook_urn
+        and mcp.get("aspectName") == "dashboardInfo"
+    ]
+    assert len(dashboard_info_mcps) == 1
+    datasets = dashboard_info_mcps[0]["aspect"]["json"].get("datasets", [])
+    for dm_id in [dm_id_1, dm_id_2]:
+        dm_urn = f"urn:li:dataset:(urn:li:dataPlatform:sigma,{dm_id},PROD)"
+        assert dm_urn in datasets, f"DM URN {dm_urn} must appear in datasets"
+
+
+@pytest.mark.integration
+def test_workbook_dm_phantom_dm_filtered(tmp_path, requests_mock):
+    """T2.5 Task A: workbook references DM not in ingested map → warning, no phantom URN."""
+    missing_dm_id = "ffff0000-0000-0000-0000-000000000099"
+
+    # No DM mocks — data_model_id_to_urn stays empty.
+    override_data: Dict[str, Dict] = {
+        "https://aws-api.sigmacomputing.com/v2/files?typeFilters=data-model": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {"entries": [], "total": 0, "nextPage": None},
+        },
+        "https://aws-api.sigmacomputing.com/v2/dataModels": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {"entries": [], "total": 0, "nextPage": None},
+        },
+        f"https://aws-api.sigmacomputing.com/v2/workbooks/{WORKBOOK_ID}/lineage": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "entries": [
+                    {
+                        "type": "data-model",
+                        "dataModelId": missing_dm_id,
+                        "name": "Missing DM",
+                    }
+                ]
+            },
+        },
+    }
+
+    report, emitted = _run_pipeline(
+        tmp_path, requests_mock, override_data, "wb_dm_phantom.json"
+    )
+
+    assert report.workbook_data_model_upstream_missed_dm_id >= 1
+    assert any(
+        w.title == "Unresolved workbook Data Model upstream" for w in report.warnings
+    ), f"Expected unresolved-DM warning; got: {[w.title for w in report.warnings]}"
+
+    phantom_dm_urn = f"urn:li:dataset:(urn:li:dataPlatform:sigma,{missing_dm_id},PROD)"
+    all_urns = {mcp["entityUrn"] for mcp in emitted}
+    assert phantom_dm_urn not in all_urns, (
+        "Phantom DM URN must not appear in emitted MCPs"
+    )
+
+    workbook_urn = f"urn:li:dashboard:(sigma,{WORKBOOK_ID})"
+    dashboard_info_mcps = [
+        mcp
+        for mcp in emitted
+        if mcp.get("entityUrn") == workbook_urn
+        and mcp.get("aspectName") == "dashboardInfo"
+    ]
+    assert len(dashboard_info_mcps) == 1
+    datasets = dashboard_info_mcps[0]["aspect"]["json"].get("datasets") or []
+    assert phantom_dm_urn not in datasets, "Phantom URN must not appear in datasets"
+
+
+@pytest.mark.integration
+def test_element_dm_upstream_via_source_id(tmp_path, requests_mock):
+    """T2.5 Task B: element sourceIds[0] prefix matches DM urlId → element inputs includes DM URN."""
+    dm_id = "aaaa4444-0000-0000-0000-000000000001"
+    dm_url_id = "dmUrlId04"
+    # kH0MeihtGs is an element in page OSnGLBzL1i of the mock workbook.
+    element_id = "kH0MeihtGs"
+    opaque = "mdYJst_DFR"
+
+    override_data = _make_dm_overrides([dm_id], [dm_url_id], WORKSPACE_ID)
+    override_data[
+        f"https://aws-api.sigmacomputing.com/v2/workbooks/{WORKBOOK_ID}/lineage"
+    ] = {
+        "method": "GET",
+        "status_code": 200,
+        "json": {
+            "entries": [
+                {
+                    "type": "element",
+                    "elementId": element_id,
+                    "sourceIds": [f"{dm_url_id}/{opaque}"],
+                }
+            ]
+        },
+    }
+
+    report, emitted = _run_pipeline(
+        tmp_path, requests_mock, override_data, "element_dm_source_id.json"
+    )
+
+    assert report.element_data_model_upstream_edges_emitted >= 1
+
+    dm_urn = f"urn:li:dataset:(urn:li:dataPlatform:sigma,{dm_id},PROD)"
+    chart_urn = f"urn:li:chart:(sigma,{element_id})"
+    chart_info_mcps = [
+        mcp
+        for mcp in emitted
+        if mcp.get("entityUrn") == chart_urn and mcp.get("aspectName") == "chartInfo"
+    ]
+    assert len(chart_info_mcps) == 1, "Expected exactly one chartInfo MCP for element"
+    # ChartInfo.inputs is serialized as [{"string": "urn:..."}, ...] (Avro union).
+    raw_inputs = chart_info_mcps[0]["aspect"]["json"].get("inputs", [])
+    input_urns = [
+        item["string"] if isinstance(item, dict) else item for item in raw_inputs
+    ]
+    assert dm_urn in input_urns, (
+        f"DM URN {dm_urn} must appear in element chartInfo.inputs"
+    )
+
+
+@pytest.mark.integration
+def test_element_source_id_inode_prefix(tmp_path, requests_mock):
+    """T2.5 Task B: element sourceIds[0] with inode- prefix increments warehouse counter, no edge."""
+    dm_id = "aaaa5555-0000-0000-0000-000000000001"
+    dm_url_id = "dmUrlId05"
+    element_id = "kH0MeihtGs"
+
+    override_data = _make_dm_overrides([dm_id], [dm_url_id], WORKSPACE_ID)
+    override_data[
+        f"https://aws-api.sigmacomputing.com/v2/workbooks/{WORKBOOK_ID}/lineage"
+    ] = {
+        "method": "GET",
+        "status_code": 200,
+        "json": {
+            "entries": [
+                {
+                    "type": "element",
+                    "elementId": element_id,
+                    # inode- prefix = warehouse table reference (T3's territory)
+                    "sourceIds": ["inode-2Fby2MBLPM5jUMfBB15On1/ADOPTIONS"],
+                }
+            ]
+        },
+    }
+
+    report, emitted = _run_pipeline(
+        tmp_path, requests_mock, override_data, "element_inode_prefix.json"
+    )
+
+    assert report.element_source_id_warehouse >= 1, (
+        "inode- prefix must increment element_source_id_warehouse"
+    )
+    assert report.element_data_model_upstream_edges_emitted == 0, (
+        "No DM edge must be emitted for inode- prefix"
+    )
+
+    dm_urn = f"urn:li:dataset:(urn:li:dataPlatform:sigma,{dm_id},PROD)"
+    chart_urn = f"urn:li:chart:(sigma,{element_id})"
+    chart_info_mcps = [
+        mcp
+        for mcp in emitted
+        if mcp.get("entityUrn") == chart_urn and mcp.get("aspectName") == "chartInfo"
+    ]
+    if chart_info_mcps:
+        raw_inputs = chart_info_mcps[0]["aspect"]["json"].get("inputs", [])
+        input_urns = [
+            item["string"] if isinstance(item, dict) else item for item in raw_inputs
+        ]
+        assert dm_urn not in input_urns, (
+            "DM URN must not appear in inputs for inode- element"
+        )
+
+
+@pytest.mark.integration
+def test_element_source_id_unknown_format(tmp_path, requests_mock):
+    """T2.5 Task B: element sourceIds[0] in unknown format increments unresolved counter."""
+    dm_id = "aaaa6666-0000-0000-0000-000000000001"
+    dm_url_id = "dmUrlId06"
+    element_id = "kH0MeihtGs"
+
+    override_data = _make_dm_overrides([dm_id], [dm_url_id], WORKSPACE_ID)
+    override_data[
+        f"https://aws-api.sigmacomputing.com/v2/workbooks/{WORKBOOK_ID}/lineage"
+    ] = {
+        "method": "GET",
+        "status_code": 200,
+        "json": {
+            "entries": [
+                {
+                    "type": "element",
+                    "elementId": element_id,
+                    # No slash — unknown format
+                    "sourceIds": ["unknownFormatNoSlash"],
+                }
+            ]
+        },
+    }
+
+    report, emitted = _run_pipeline(
+        tmp_path, requests_mock, override_data, "element_unknown_format.json"
+    )
+
+    assert report.element_source_id_unresolved >= 1, (
+        "Unknown sourceId format must increment element_source_id_unresolved"
+    )
+    assert report.element_data_model_upstream_edges_emitted == 0

--- a/metadata-ingestion/tests/integration/sigma/test_sigma.py
+++ b/metadata-ingestion/tests/integration/sigma/test_sigma.py
@@ -1,5 +1,6 @@
 import json
-from typing import Any, Dict, Optional
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
 
 import pytest
 
@@ -1340,7 +1341,9 @@ def _make_dm_overrides(
     return overrides
 
 
-def _run_pipeline(tmp_path, requests_mock, override_data: dict, filename: str) -> tuple:
+def _run_pipeline(
+    tmp_path: Path, requests_mock: Any, override_data: Dict, filename: str
+) -> Tuple[SigmaSourceReport, List[Any]]:
     register_mock_api(request_mock=requests_mock, override_data=override_data)
     output_path = str(tmp_path / filename)
     pipeline = Pipeline.create(
@@ -1359,8 +1362,10 @@ def _run_pipeline(tmp_path, requests_mock, override_data: dict, filename: str) -
     )
     pipeline.run()
     pipeline.raise_from_status()
-    emitted = json.loads(open(output_path).read())
-    return pipeline.source.get_report(), emitted
+    emitted: List[Any] = json.loads(open(output_path).read())
+    report = pipeline.source.get_report()
+    assert isinstance(report, SigmaSourceReport)
+    return report, emitted
 
 
 @pytest.mark.integration


### PR DESCRIPTION
- **Workbook → DM**: calls `GET /workbooks/{id}/lineage` once per workbook, filters `type="data-model"` entries (kebab-case — using camelCase silently returns 0), populates `DashboardInfo.datasets`.      
- **Element → DM**: parses `type="element"` entries from same response; splits `sourceIds[0]` on first `/`; prefix matching a known `dataModelUrlId` adds DM URN to `ChartInfo.inputs`. `inode-` prefixes (warehouse, T3 scope) are counted and skipped.                                                                    
- 5 new `SigmaSourceReport` counters for observability.                         
- 6 new integration tests (single DM, two DMs, phantom DM warning, element→DM, inode skip, unknown format).  

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
