### PR TITLE
docs: Update CTA announcement bar link to April Town Hall registration

### DIFF
--- a/docs-website/docusaurus.config.js
+++ b/docs-website/docusaurus.config.js
@@ -100,7 +100,7 @@ module.exports = {
     announcementBar: {
       id: "announcement-3",
       content:
-        '<div class="shimmer-banner"><span>March Townhall</span><a href="https://youtu.be/MAyldt2n3R8?si=uCrPBd80IjomzjTm?utm_term=docs" target="_blank" class="button"><div>Watch the Recording<span> →</span></div></a></div>',
+        '<div class="shimmer-banner"><span>April Town Hall 4/23</span><a href="https://luma.com/2yinw29m?utm_term=docs" target="_blank" class="button"><div>Register Here<span> →</span></div></a></div>',
       backgroundColor: "transparent",
       textColor: "#ffffff",
       isCloseable: false,


### PR DESCRIPTION
## Summary

Updates the CTA announcement bar to promote registration for the **April Town Hall (4/23)**, replacing the previous "Watch the Recording" link from the February Town Hall.

## Changes

- `docs-website/docusaurus.config.js` — updated `announcementBar` content:
  - Text: `February Town Hall 2/26` → `April Town Hall 4/23`
  - CTA: `Watch the Recording` → `Register Here`
  - Link: YouTube recording URL → Luma registration URL (`https://luma.com/2yinw29m?utm_term=docs`)

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (PR title uses `Docs:` prefix)
- [x] No tests needed (content-only update)
- [x] No docs updates needed (this *is* the docs site config)
- [x] No breaking changes