### PR TITLE
fix(ci): strip test class name from pytest JUnit XML classname when parsing failed modules

### DIFF
--- a/.github/scripts/parse_failed_pytest_tests.py
+++ b/.github/scripts/parse_failed_pytest_tests.py
@@ -53,10 +53,17 @@ def parse_failed_modules(input_dir: Path) -> Optional[Set[str]]:
                     if not classname:
                         continue
 
-                    # Convert classname from dotted format to file path
-                    # Example: tests.structured_properties.test_structured_properties
-                    #       -> tests/structured_properties/test_structured_properties.py
-                    module_path = classname.replace('.', '/') + '.py'
+                    # Convert classname from dotted format to file path.
+                    # For class-based tests, pytest includes the class name in classname:
+                    #   tests.my_module.MyTestClass -> tests/my_module.py
+                    # For function-based tests, classname is just the module:
+                    #   tests.my_module -> tests/my_module.py
+                    # Python class names are PascalCase (start uppercase); module names are
+                    # snake_case (lowercase), so strip the trailing component if it's a class.
+                    parts = classname.split('.')
+                    if parts and parts[-1][0].isupper():
+                        parts = parts[:-1]
+                    module_path = '/'.join(parts) + '.py'
                     failed_modules.add(module_path)
 
         except ET.ParseError as e:


### PR DESCRIPTION
## Summary

- The CI retry mechanism for pytest smoke tests was broken: retries reported **0 tests found** even when the failed-modules file correctly identified a failure.
- Root cause: `parse_failed_pytest_tests.py` naively replaced all dots in the JUnit XML `classname` attribute with slashes, including the trailing test class name. For a class-based test like `tests.propagation.logical_models.test_logical_propagation_legacy.TestLogicalDatatypePropagation`, this produced the wrong path `tests/propagation/logical_models/test_logical_propagation_legacy/TestLogicalDatatypePropagation.py` instead of `tests/propagation/logical_models/test_logical_propagation_legacy.py`.
- Fix: strip the trailing component from the dotted classname if it starts with an uppercase letter (PascalCase = class name), before converting to a file path. This correctly handles both class-based and function-based test cases.

## Test plan

- [ ] Verify locally: run `parse_failed_pytest_tests.py` against a JUnit XML with class-based test failures and confirm output paths end in `.py` at the module level (not the class level).
- [ ] Re-trigger a failing CI batch that contains class-based test failures and confirm retry picks up the correct test modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)