### PR TITLE
fix(ui/filters): fix applied filter dropdown does not allow switching to other options

### DIFF
--- a/datahub-web-react/src/app/searchV2/filters/SelectedFilter.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/SelectedFilter.tsx
@@ -11,6 +11,7 @@ import { FilterOperatorType, FilterPredicate, FilterValue } from '@app/searchV2/
 import { getIsDateRangeFilter, useFilterDisplayName } from '@app/searchV2/filters/utils';
 import ValueName from '@app/searchV2/filters/value/ValueName';
 import ValueSelector from '@app/searchV2/filters/value/ValueSelector';
+import { useLoadAggregationOptions } from '@app/searchV2/filters/value/utils';
 import DatePicker from '@utils/DayjsDatePicker';
 import dayjs from '@utils/dayjs';
 
@@ -83,12 +84,18 @@ export default function SelectedFilter({
     onRemoveFilter,
     isCompact,
 }: SelectedFilterProps) {
-    const { field, operator, values, defaultValueOptions } = predicate;
+    const { field, operator, values } = predicate;
     const showValueSelector = operatorRequiresValues(predicate.operator) || false;
     const displayName = useFilterDisplayName(predicate.field);
     const isDateRangeFilter = getIsDateRangeFilter(predicate.field);
 
     const useDatePicker = field.useDatePicker || isDateRangeFilter;
+
+    const { options: aggregatedOptions } = useLoadAggregationOptions({
+        field,
+        visible: true,
+        includeCounts: true,
+    });
 
     return (
         <Container
@@ -115,7 +122,7 @@ export default function SelectedFilter({
                 <ValueSelector
                     field={field}
                     values={values}
-                    defaultOptions={defaultValueOptions}
+                    defaultOptions={aggregatedOptions}
                     onChangeValues={onChangeValues}
                 >
                     <Values>


### PR DESCRIPTION
**Linear ticket:**
https://linear.app/acryl-data/issue/CAT-1705/applied-platform-filter-dropdown-does-not-allow-switching-to-other

**Description:**

Selected filters were not showing other values to select and update the filters. This PR updates the selected filters to fetch aggregated options and show them to allow updating the filters.

Bringing [this](https://github.com/acryldata/datahub-fork/pull/9140) PR back to OSS

**Screenshots:**

Before:

<img width="495" height="267" alt="image" src="https://github.com/user-attachments/assets/47efec20-9606-463e-af74-2614b0c35597" />



After:

<img width="617" height="524" alt="image" src="https://github.com/user-attachments/assets/c44b9441-6166-4c66-943d-8543a49ce94c" />

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
