### PR TITLE
fix(ui/ownership): fix ownership type creation form retains previous name

### DIFF
--- a/datahub-web-react/src/app/entityV2/ownership/OwnershipBuilderModal.tsx
+++ b/datahub-web-react/src/app/entityV2/ownership/OwnershipBuilderModal.tsx
@@ -52,8 +52,7 @@ export const OwnershipBuilderModal = ({ isOpen, onClose, refetch, ownershipType 
                 },
             })
                 .then(() => {
-                    setName('');
-                    setDescription('');
+                    setOwnershipTypeBuilderState({ name: '', description: '' });
                     onClose();
                     toast.success('Successfully created ownership type.');
                     setTimeout(() => {
@@ -78,8 +77,7 @@ export const OwnershipBuilderModal = ({ isOpen, onClose, refetch, ownershipType 
                 },
             })
                 .then(() => {
-                    setName('');
-                    setDescription('');
+                    setOwnershipTypeBuilderState({ name: '', description: '' });
                     onClose();
                     toast.success('Successfully updated ownership type.');
                     setTimeout(() => {


### PR DESCRIPTION
**Linear ticket:**
https://linear.app/acryl-data/issue/CAT-1688/ownership-type-creation-form-retains-previous-name-after-submission-in

**Video:**

https://github.com/user-attachments/assets/7d45bb12-73df-4dfa-965a-c2af363b5782


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
