### PR TITLE
feat(sql-setup): align metadata_aspect_v2 indexes for Postgres and MySQL

### DIFF
--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/CreateTablesStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/CreateTablesStep.java
@@ -73,11 +73,18 @@ public class CreateTablesStep implements UpgradeStep {
       dbOps.selectDatabase(args.getDatabaseName(), connection);
     }
 
-    // Create metadata_aspect_v2 table and indexes
+    // Create metadata_aspect_v2 table (and inline indexes for engines that define them in DDL)
     java.util.List<String> createTableStatements =
         dbOps.createTableSqlStatements(args.createSchemaVersionIndex());
     for (String sql : createTableStatements) {
       server.sqlUpdate(sql).execute();
+    }
+
+    try (Connection connection = server.dataSource().getConnection()) {
+      dbOps.dropLegacyAspectTableIndexes(connection);
+    }
+    try (Connection connection = server.dataSource().getConnection()) {
+      dbOps.ensureAspectIndexes(connection);
     }
 
     if (args.createSchemaVersionIndex()) {

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/DatabaseOperations.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/DatabaseOperations.java
@@ -108,6 +108,27 @@ public interface DatabaseOperations {
   java.util.List<String> createTableSqlStatements(boolean createSchemaVersionIndex);
 
   /**
+   * Drops legacy secondary indexes on {@code metadata_aspect_v2} that SqlSetup no longer creates
+   * (e.g. single-column {@code urn}/{@code aspect}/{@code version} indexes from older DDL).
+   * Defaults to a no-op.
+   *
+   * @param connection open JDBC connection to the target database
+   */
+  default void dropLegacyAspectTableIndexes(Connection connection) throws SQLException {}
+
+  /**
+   * Creates current {@code metadata_aspect_v2} secondary indexes when they are missing. On
+   * PostgreSQL these use {@code CREATE INDEX CONCURRENTLY} so builds on populated tables avoid long
+   * exclusive locks. On MySQL, indexes that are normally inlined in {@link
+   * #createTableSqlStatements} are added with {@code ALTER TABLE ... ADD INDEX} only when absent
+   * (so existing databases that predate those indexes still get them). Defaults to a no-op when
+   * there is nothing to ensure beyond inline DDL.
+   *
+   * @param connection open JDBC connection to the target database
+   */
+  default void ensureAspectIndexes(Connection connection) throws SQLException {}
+
+  /**
    * Called after table creation to create any indexes that must run outside a transaction (e.g.
    * CONCURRENTLY). Defaults to a no-op.
    *

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/MySqlDatabaseOperations.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/MySqlDatabaseOperations.java
@@ -111,11 +111,60 @@ public class MySqlDatabaseOperations implements DatabaseOperations {
           createdfor                    varchar(255),
           CONSTRAINT pk_metadata_aspect_v2 PRIMARY KEY (urn, aspect, version),
           INDEX timeIndex (createdon),
-          INDEX urnIndex (urn),
-          INDEX aspectIndex (aspect),
-          INDEX versionIndex (version)
+          INDEX idx_version_urn_aspect (version, urn, aspect)
         ) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
         """);
+  }
+
+  @Override
+  public void dropLegacyAspectTableIndexes(Connection connection) throws SQLException {
+    String checkSql =
+        "SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'metadata_aspect_v2' AND index_name = ?";
+    String[] legacyIndexNames = {"urnIndex", "aspectIndex", "versionIndex"};
+    for (String indexName : legacyIndexNames) {
+      try (PreparedStatement stmt = connection.prepareStatement(checkSql)) {
+        stmt.setString(1, indexName);
+        try (ResultSet rs = stmt.executeQuery()) {
+          if (rs.next() && rs.getInt(1) > 0) {
+            log.info("Dropping legacy index {} on metadata_aspect_v2", indexName);
+            try (java.sql.Statement alterStmt = connection.createStatement()) {
+              alterStmt.execute(
+                  "ALTER TABLE metadata_aspect_v2 DROP INDEX " + escapeMysqlIdentifier(indexName));
+            }
+          }
+        }
+      }
+    }
+  }
+
+  @Override
+  public void ensureAspectIndexes(Connection connection) throws SQLException {
+    // CREATE TABLE IF NOT EXISTS does not add new indexes to an already-existing table; align
+    // upgraded databases with current DDL for secondary indexes not covered by the primary key.
+    ensureMysqlIndexIfAbsent(connection, "timeIndex", "(createdon)");
+    ensureMysqlIndexIfAbsent(connection, "idx_version_urn_aspect", "(version, urn, aspect)");
+  }
+
+  private void ensureMysqlIndexIfAbsent(
+      Connection connection, String indexName, String indexColumnListWithParens)
+      throws SQLException {
+    String checkSql =
+        "SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'metadata_aspect_v2' AND index_name = ?";
+    try (PreparedStatement stmt = connection.prepareStatement(checkSql)) {
+      stmt.setString(1, indexName);
+      try (ResultSet rs = stmt.executeQuery()) {
+        if (rs.next() && rs.getInt(1) == 0) {
+          log.info("Adding index {} on metadata_aspect_v2", indexName);
+          try (java.sql.Statement alterStmt = connection.createStatement()) {
+            alterStmt.execute(
+                "ALTER TABLE metadata_aspect_v2 ADD INDEX "
+                    + escapeMysqlIdentifier(indexName)
+                    + " "
+                    + indexColumnListWithParens);
+          }
+        }
+      }
+    }
   }
 
   @Override

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/PostgresDatabaseOperations.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/PostgresDatabaseOperations.java
@@ -127,7 +127,9 @@ public class PostgresDatabaseOperations implements DatabaseOperations {
 
   @Override
   public java.util.List<String> createTableSqlStatements(boolean createSchemaVersionIndex) {
-    return java.util.Arrays.asList(
+    // Secondary indexes are created in ensureAspectIndexes() via CREATE INDEX CONCURRENTLY so
+    // existing populated tables are not blocked by long exclusive locks during index builds.
+    return java.util.List.of(
         """
         CREATE TABLE IF NOT EXISTS metadata_aspect_v2 (
           urn                           varchar(500) not null,
@@ -140,11 +142,40 @@ public class PostgresDatabaseOperations implements DatabaseOperations {
           createdfor                    varchar(255),
           CONSTRAINT pk_metadata_aspect_v2 PRIMARY KEY (urn, aspect, version)
         );
-        """,
-        "CREATE INDEX IF NOT EXISTS timeIndex ON metadata_aspect_v2 (createdon);",
-        "CREATE INDEX IF NOT EXISTS urnIndex ON metadata_aspect_v2 (urn);",
-        "CREATE INDEX IF NOT EXISTS aspectIndex ON metadata_aspect_v2 (aspect);",
-        "CREATE INDEX IF NOT EXISTS versionIndex ON metadata_aspect_v2 (version);");
+        """);
+  }
+
+  @Override
+  public void dropLegacyAspectTableIndexes(Connection connection) throws SQLException {
+    // DROP INDEX CONCURRENTLY cannot run inside a transaction block.
+    boolean prevAutoCommit = connection.getAutoCommit();
+    connection.setAutoCommit(true);
+    try (java.sql.Statement stmt = connection.createStatement()) {
+      stmt.execute("DROP INDEX CONCURRENTLY IF EXISTS urnindex");
+      stmt.execute("DROP INDEX CONCURRENTLY IF EXISTS aspectindex");
+      stmt.execute("DROP INDEX CONCURRENTLY IF EXISTS versionindex");
+    } finally {
+      connection.setAutoCommit(prevAutoCommit);
+    }
+  }
+
+  @Override
+  public void ensureAspectIndexes(Connection connection) throws SQLException {
+    // CREATE INDEX CONCURRENTLY cannot run inside a transaction block.
+    boolean prevAutoCommit = connection.getAutoCommit();
+    connection.setAutoCommit(true);
+    try (java.sql.Statement stmt = connection.createStatement()) {
+      stmt.execute(
+          "CREATE INDEX CONCURRENTLY IF NOT EXISTS timeIndex ON metadata_aspect_v2 (createdon);");
+      stmt.execute(
+          "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_v0_urn_aspect ON metadata_aspect_v2 (urn, aspect) WHERE version = 0;");
+      stmt.execute(
+          "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_corpuser_aspect_v0 ON metadata_aspect_v2 (urn, aspect) WHERE urn LIKE 'urn:li:corpuser:%' AND version = 0;");
+      stmt.execute(
+          "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_corpgroup_aspect_v0 ON metadata_aspect_v2 (urn, aspect) WHERE urn LIKE 'urn:li:corpGroup:%' AND version = 0;");
+    } finally {
+      connection.setAutoCommit(prevAutoCommit);
+    }
   }
 
   @Override
@@ -183,10 +214,6 @@ public class PostgresDatabaseOperations implements DatabaseOperations {
     try (java.sql.Statement stmt = connection.createStatement()) {
       stmt.execute(
           "CREATE INDEX CONCURRENTLY IF NOT EXISTS schemaVersionIndex ON metadata_aspect_v2 ((systemmetadata::jsonb ->> 'schemaVersion'));");
-      stmt.execute(
-          "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_corpuser_aspect_v0 ON metadata_aspect_v2 (urn, aspect) WHERE urn LIKE 'urn:li:corpuser:%' AND version = 0;");
-      stmt.execute(
-          "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_corpgroup_aspect_v0 ON metadata_aspect_v2 (urn, aspect) WHERE urn LIKE 'urn:li:corpGroup:%' AND version = 0;");
     } finally {
       connection.setAutoCommit(prevAutoCommit);
     }

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/sqlsetup/CreateTablesStepTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/sqlsetup/CreateTablesStepTest.java
@@ -15,6 +15,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.function.Function;
 import javax.sql.DataSource;
 import org.mockito.Mock;
@@ -31,6 +32,7 @@ public class CreateTablesStepTest {
   @Mock private Connection mockConnection;
   @Mock private PreparedStatement mockPreparedStatement;
   @Mock private ResultSet mockResultSet;
+  @Mock private Statement mockStatement;
   @Mock private SqlUpdate mockSqlUpdate;
 
   private CreateTablesStep createTablesStep;
@@ -38,6 +40,16 @@ public class CreateTablesStepTest {
   @BeforeMethod
   public void setUp() throws SQLException {
     MockitoAnnotations.openMocks(this);
+    reset(
+        mockDatabase,
+        mockDataSource,
+        mockConnection,
+        mockPreparedStatement,
+        mockResultSet,
+        mockStatement,
+        mockSqlUpdate,
+        mockUpgradeContext,
+        mockUpgradeReport);
     SqlSetupArgs defaultSetupArgs =
         new SqlSetupArgs(
             true, // createTables
@@ -65,6 +77,9 @@ public class CreateTablesStepTest {
     when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
     when(mockPreparedStatement.executeUpdate()).thenReturn(1);
     when(mockResultSet.next()).thenReturn(false); // Default: database doesn't exist
+
+    when(mockConnection.createStatement()).thenReturn(mockStatement);
+    when(mockStatement.execute(anyString())).thenReturn(false);
 
     // Setup mock to return SqlUpdate mock when sqlUpdate is called (for table creation)
     when(mockDatabase.sqlUpdate(anyString())).thenReturn(mockSqlUpdate);
@@ -225,7 +240,8 @@ public class CreateTablesStepTest {
     verify(mockConnection)
         .prepareStatement(contains("SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA"));
     verify(mockPreparedStatement).setString(1, "testdb");
-    verify(mockPreparedStatement).executeQuery();
+    verify(mockPreparedStatement, times(6))
+        .executeQuery(); // schema + 3 legacy drops + 2 ensureAspectIndexes existence checks
     verify(mockConnection).prepareStatement(contains("CREATE DATABASE"));
     verify(mockConnection).prepareStatement("USE `testdb`");
     verify(mockPreparedStatement, times(2))
@@ -336,6 +352,8 @@ public class CreateTablesStepTest {
 
     // Mock that database exists (ResultSet.next() returns true)
     when(mockResultSet.next()).thenReturn(true);
+    // Legacy index counts 0 (nothing to drop); timeIndex + idx_version_urn_aspect already present
+    when(mockResultSet.getInt(1)).thenReturn(0, 0, 0, 1, 1);
 
     Function<UpgradeContext, UpgradeStepResult> executable = createTablesStep.executable();
     UpgradeStepResult result = executable.apply(mockUpgradeContext);
@@ -344,7 +362,8 @@ public class CreateTablesStepTest {
     verify(mockConnection)
         .prepareStatement(contains("SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA"));
     verify(mockPreparedStatement).setString(1, "testdb");
-    verify(mockPreparedStatement).executeQuery();
+    verify(mockPreparedStatement, times(6))
+        .executeQuery(); // schema + 3 legacy + 2 ensureAspectIndexes
   }
 
   @Test
@@ -383,8 +402,16 @@ public class CreateTablesStepTest {
   @Test
   public void testCreateDatabaseIfNotExistsMysqlDatabaseCheckFails() throws SQLException {
 
-    // Mock database check failure - PreparedStatement throws exception
-    when(mockPreparedStatement.executeQuery()).thenThrow(new SQLException("Check failed"));
+    // First executeQuery (schema existence check) fails; fallback create path runs.
+    // Subsequent executeQuery calls are from dropLegacyAspectTableIndexes and must succeed.
+    when(mockPreparedStatement.executeQuery())
+        .thenThrow(new SQLException("Check failed"))
+        .thenReturn(mockResultSet)
+        .thenReturn(mockResultSet)
+        .thenReturn(mockResultSet)
+        .thenReturn(mockResultSet)
+        .thenReturn(mockResultSet);
+    when(mockResultSet.next()).thenReturn(false);
 
     Function<UpgradeContext, UpgradeStepResult> executable = createTablesStep.executable();
     UpgradeStepResult result = executable.apply(mockUpgradeContext);
@@ -393,6 +420,118 @@ public class CreateTablesStepTest {
     verify(mockConnection)
         .prepareStatement(contains("SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA"));
     verify(mockPreparedStatement).setString(1, "testdb");
-    verify(mockPreparedStatement).executeQuery();
+    verify(mockPreparedStatement, times(6)).executeQuery();
+  }
+
+  @Test
+  public void testCreateTablesMysqlAcquiresFourConnectionsWhenCreateDatabaseEnabled()
+      throws SQLException {
+    SqlSetupArgs args =
+        new SqlSetupArgs(
+            true,
+            true,
+            false,
+            false,
+            DatabaseType.MYSQL,
+            false,
+            "datahub_cdc",
+            "datahub_cdc",
+            null,
+            null,
+            "localhost",
+            3306,
+            "testdb",
+            false);
+    CreateTablesStep step = new CreateTablesStep(mockDatabase, args);
+
+    SqlSetupResult result = step.createTables(args);
+
+    assertEquals(result.getTablesCreated(), 1);
+    assertTrue(result.getExecutionTimeMs() >= 0);
+    verify(mockDataSource, times(4)).getConnection();
+  }
+
+  @Test
+  public void testCreateTablesMysqlAcquiresThreeConnectionsWhenCreateDatabaseDisabled()
+      throws SQLException {
+    SqlSetupArgs args =
+        new SqlSetupArgs(
+            true,
+            false,
+            false,
+            false,
+            DatabaseType.MYSQL,
+            false,
+            "datahub_cdc",
+            "datahub_cdc",
+            null,
+            null,
+            "localhost",
+            3306,
+            "testdb",
+            false);
+    CreateTablesStep step = new CreateTablesStep(mockDatabase, args);
+
+    step.createTables(args);
+
+    verify(mockDataSource, times(3)).getConnection();
+  }
+
+  @Test
+  public void testCreateTablesPostgresRunsConcurrentDropAndEnsureIndexStatements()
+      throws SQLException {
+    SqlSetupArgs args =
+        new SqlSetupArgs(
+            true,
+            true,
+            false,
+            false,
+            DatabaseType.POSTGRES,
+            false,
+            "datahub_cdc",
+            "datahub_cdc",
+            null,
+            null,
+            "localhost",
+            5432,
+            "testdb",
+            false);
+    CreateTablesStep step = new CreateTablesStep(mockDatabase, args);
+
+    step.createTables(args);
+
+    verify(mockDatabase, times(1)).sqlUpdate(contains("CREATE TABLE IF NOT EXISTS"));
+    verify(mockStatement, times(7)).execute(anyString());
+  }
+
+  @Test
+  public void testCreateTablesPostgresWithSchemaVersionAcquiresFifthConnectionAndRunsPostSetup()
+      throws SQLException {
+    SqlSetupArgs args =
+        new SqlSetupArgs(
+            true,
+            true,
+            false,
+            false,
+            DatabaseType.POSTGRES,
+            false,
+            "datahub_cdc",
+            "datahub_cdc",
+            null,
+            null,
+            "localhost",
+            5432,
+            "testdb",
+            true);
+    CreateTablesStep step = new CreateTablesStep(mockDatabase, args);
+    when(mockResultSet.next()).thenReturn(false);
+
+    step.createTables(args);
+
+    verify(mockDataSource, times(5)).getConnection();
+    verify(mockStatement, times(8)).execute(anyString());
+    verify(mockStatement)
+        .execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS schemaVersionIndex ON metadata_aspect_v2 ((systemmetadata::jsonb ->> 'schemaVersion'));");
   }
 }

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/sqlsetup/DatabaseOperationsTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/sqlsetup/DatabaseOperationsTest.java
@@ -1,9 +1,14 @@
 package com.linkedin.datahub.upgrade.sqlsetup;
 
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
@@ -11,7 +16,8 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import javax.sql.DataSource;
+import java.sql.Statement;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeMethod;
@@ -20,10 +26,10 @@ import org.testng.annotations.Test;
 /** Unit tests for DatabaseOperations implementations. */
 public class DatabaseOperationsTest {
 
-  @Mock private DataSource mockDataSource;
   @Mock private Connection mockConnection;
   @Mock private PreparedStatement mockPreparedStatement;
   @Mock private ResultSet mockResultSet;
+  @Mock private Statement mockStatement;
 
   private PostgresDatabaseOperations postgresOps;
   private MySqlDatabaseOperations mysqlOps;
@@ -141,9 +147,9 @@ public class DatabaseOperationsTest {
   public void testPostgresCreateTableSqlStatements() {
     java.util.List<String> statements = postgresOps.createTableSqlStatements(false);
     assertNotNull(statements);
-    assertTrue(statements.size() >= 2); // At least table creation + one index
+    assertEquals(statements.size(), 1);
     assertTrue(statements.get(0).contains("CREATE TABLE IF NOT EXISTS metadata_aspect_v2"));
-    assertTrue(statements.get(1).contains("CREATE INDEX IF NOT EXISTS timeIndex"));
+    assertTrue(statements.stream().noneMatch(s -> s.contains("CREATE INDEX")));
     assertTrue(statements.stream().noneMatch(s -> s.contains("schemaVersionIndex")));
   }
 
@@ -152,6 +158,85 @@ public class DatabaseOperationsTest {
     // schemaVersionIndex is created via postSetup, not in the statement list
     java.util.List<String> statements = postgresOps.createTableSqlStatements(true);
     assertTrue(statements.stream().noneMatch(s -> s.contains("schemaVersionIndex")));
+  }
+
+  @Test
+  public void testPostgresDropLegacyAspectTableIndexes() throws SQLException {
+    when(mockConnection.createStatement()).thenReturn(mockStatement);
+    postgresOps.dropLegacyAspectTableIndexes(mockConnection);
+    verify(mockStatement).execute("DROP INDEX CONCURRENTLY IF EXISTS urnindex");
+    verify(mockStatement).execute("DROP INDEX CONCURRENTLY IF EXISTS aspectindex");
+    verify(mockStatement).execute("DROP INDEX CONCURRENTLY IF EXISTS versionindex");
+  }
+
+  @Test
+  public void testPostgresDropLegacyRestoresAutoCommitWhenInitiallyOff() throws SQLException {
+    when(mockConnection.getAutoCommit()).thenReturn(false);
+    when(mockConnection.createStatement()).thenReturn(mockStatement);
+    postgresOps.dropLegacyAspectTableIndexes(mockConnection);
+    InOrder order = inOrder(mockConnection);
+    order.verify(mockConnection).getAutoCommit();
+    order.verify(mockConnection).setAutoCommit(true);
+    order.verify(mockConnection).setAutoCommit(false);
+  }
+
+  @Test
+  public void testPostgresEnsureAspectIndexes() throws SQLException {
+    when(mockConnection.createStatement()).thenReturn(mockStatement);
+    postgresOps.ensureAspectIndexes(mockConnection);
+    verify(mockStatement, atLeastOnce())
+        .execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS timeIndex ON metadata_aspect_v2 (createdon);");
+    verify(mockStatement)
+        .execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_v0_urn_aspect ON metadata_aspect_v2 (urn, aspect) WHERE version = 0;");
+    verify(mockStatement)
+        .execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_corpuser_aspect_v0 ON metadata_aspect_v2 (urn, aspect) WHERE urn LIKE 'urn:li:corpuser:%' AND version = 0;");
+    verify(mockStatement)
+        .execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_corpgroup_aspect_v0 ON metadata_aspect_v2 (urn, aspect) WHERE urn LIKE 'urn:li:corpGroup:%' AND version = 0;");
+  }
+
+  @Test
+  public void testPostgresEnsureAspectIndexesRestoresAutoCommitWhenInitiallyOff()
+      throws SQLException {
+    when(mockConnection.getAutoCommit()).thenReturn(false);
+    when(mockConnection.createStatement()).thenReturn(mockStatement);
+    postgresOps.ensureAspectIndexes(mockConnection);
+    InOrder order = inOrder(mockConnection);
+    order.verify(mockConnection).getAutoCommit();
+    order.verify(mockConnection).setAutoCommit(true);
+    order.verify(mockConnection).setAutoCommit(false);
+  }
+
+  @Test
+  public void testMysqlEnsureAspectIndexesAddsWhenAbsent() throws SQLException {
+    when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
+    when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
+    when(mockResultSet.next()).thenReturn(true);
+    when(mockResultSet.getInt(1)).thenReturn(0);
+    when(mockConnection.createStatement()).thenReturn(mockStatement);
+
+    mysqlOps.ensureAspectIndexes(mockConnection);
+
+    verify(mockStatement)
+        .execute("ALTER TABLE metadata_aspect_v2 ADD INDEX `timeIndex` (createdon)");
+    verify(mockStatement)
+        .execute(
+            "ALTER TABLE metadata_aspect_v2 ADD INDEX `idx_version_urn_aspect` (version, urn, aspect)");
+  }
+
+  @Test
+  public void testMysqlEnsureAspectIndexesSkipsWhenPresent() throws SQLException {
+    when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
+    when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
+    when(mockResultSet.next()).thenReturn(true);
+    when(mockResultSet.getInt(1)).thenReturn(1);
+
+    mysqlOps.ensureAspectIndexes(mockConnection);
+
+    verify(mockConnection, never()).createStatement();
   }
 
   @Test
@@ -182,7 +267,7 @@ public class DatabaseOperationsTest {
 
     postgresOps.postSetup(mockConnection);
 
-    verify(mockPreparedStatement, never()).execute("DROP INDEX CONCURRENTLY schemaVersionIndex");
+    verify(mockPreparedStatement, never()).execute("DROP INDEX CONCURRENTLY schemaversionindex");
     verify(mockPreparedStatement)
         .execute(
             "CREATE INDEX CONCURRENTLY IF NOT EXISTS schemaVersionIndex ON metadata_aspect_v2 ((systemmetadata::jsonb ->> 'schemaVersion'));");
@@ -195,6 +280,38 @@ public class DatabaseOperationsTest {
     assertEquals(statements.size(), 1); // MySQL creates table with indexes in one statement
     assertTrue(statements.get(0).contains("CREATE TABLE IF NOT EXISTS metadata_aspect_v2"));
     assertTrue(statements.get(0).contains("INDEX timeIndex (createdon)"));
+    assertTrue(statements.get(0).contains("INDEX idx_version_urn_aspect (version, urn, aspect)"));
+    String ddl = statements.get(0);
+    assertFalse(ddl.contains("idx_corpuser_aspect_v0"));
+    assertFalse(ddl.contains("idx_corpgroup_aspect_v0"));
+  }
+
+  @Test
+  public void testMysqlDropLegacyAspectTableIndexesSkipsWhenAbsent() throws SQLException {
+    when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
+    when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
+    when(mockResultSet.next()).thenReturn(true);
+    when(mockResultSet.getInt(1)).thenReturn(0);
+
+    mysqlOps.dropLegacyAspectTableIndexes(mockConnection);
+
+    verify(mockConnection, never()).createStatement();
+  }
+
+  @Test
+  public void testMysqlDropLegacyAspectTableIndexesDropsWhenPresent() throws SQLException {
+    when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
+    when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
+    when(mockResultSet.next()).thenReturn(true);
+    when(mockResultSet.getInt(1)).thenReturn(1);
+    when(mockConnection.createStatement()).thenReturn(mockStatement);
+
+    mysqlOps.dropLegacyAspectTableIndexes(mockConnection);
+
+    verify(mockStatement, times(3)).execute(anyString());
+    verify(mockStatement).execute("ALTER TABLE metadata_aspect_v2 DROP INDEX `urnIndex`");
+    verify(mockStatement).execute("ALTER TABLE metadata_aspect_v2 DROP INDEX `aspectIndex`");
+    verify(mockStatement).execute("ALTER TABLE metadata_aspect_v2 DROP INDEX `versionIndex`");
   }
 
   @Test


### PR DESCRIPTION
## Problem

- legacy single-column indexes (`urnIndex`, `aspectIndex`, `versionIndex`) from older incorrect DDL are redundant.
- **PostgreSQL:** Secondary indexes on large `metadata_aspect_v2` tables should avoid long exclusive locks during SqlSetup; 
- **MySQL:** `CREATE TABLE IF NOT EXISTS` does **not** add new inline indexes to an **existing** table, so upgraded databases could miss `timeIndex` and `idx_version_urn_aspect` even when DDL was updated.

## Improvement

The new metadata_aspect_v2 index speeds up the aspect reads that restore indices and metadata-tests exercise, so those paths spend less time scanning large tables.

## What changed

### `CreateTablesStep`

After running table DDL, the step now:

1. `dropLegacyAspectTableIndexes(connection)`
2. `ensureAspectIndexes(connection)`
3. `postSetup(connection)` (unchanged role, e.g. optional `schemaVersionIndex` on Postgres)

### PostgreSQL (`PostgresDatabaseOperations`)

- **Table DDL:** `CREATE TABLE` only (no heavy secondary indexes in the same transactional `sqlUpdate` path).
- **`ensureAspectIndexes`:** `CREATE INDEX CONCURRENTLY IF NOT EXISTS` for:
  - `timeIndex` on `(createdon)`
  - Partial `idx_v0_urn_aspect` on `(urn, aspect) WHERE version = 0`
  - Partial corp user / corp group helper indexes on `(urn, aspect)` with `urn LIKE` filters and `version = 0`
- **`dropLegacyAspectTableIndexes`:** `DROP INDEX CONCURRENTLY IF EXISTS` for legacy `urnIndex`, `aspectIndex`, `versionIndex` when present.
- Connection uses autocommit where required for `CONCURRENTLY`.

### MySQL (`MySqlDatabaseOperations`)

- **Table DDL:** `timeIndex (createdon)` and composite `idx_version_urn_aspect (version, urn, aspect)` for **new** installs.
- **`dropLegacyAspectTableIndexes`:** If `urnIndex` / `aspectIndex` / `versionIndex` exist (via `information_schema.statistics`), `ALTER TABLE ... DROP INDEX`.
- **`ensureAspectIndexes`:** If `timeIndex` or `idx_version_urn_aspect` is missing, `ALTER TABLE metadata_aspect_v2 ADD INDEX ...` so **existing** databases converge without manual SQL.

