### PR TITLE
chore(docker): bump datahub-upgrade kubectl to v1.35.4

### DIFF
--- a/docker/datahub-upgrade/Dockerfile
+++ b/docker/datahub-upgrade/Dockerfile
@@ -37,7 +37,7 @@ RUN apk --no-cache --update-cache --available upgrade \
     && cp /usr/lib/jvm/java-21-openjdk/lib/security/cacerts /tmp/kafka.client.truststore.jks
 COPY --from=powerman/dockerize:0.24 /usr/local/bin/dockerize /usr/local/bin
 
-ENV KUBECTL_VERSION=v1.34.5
+ENV KUBECTL_VERSION=v1.35.4
 RUN set -x \
   && APK_ARCH="$(cat /etc/apk/arch)" \
   && case "$APK_ARCH" in \


### PR DESCRIPTION
Align with dl.k8s.io/release/stable.txt. Validated linux/amd64 binary with:
  trivy rootfs --scanners vuln (gobinary kubectl: 0 vulnerabilities)

Made-with: Cursor

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
