### PR TITLE
refactor(ingest/snowplow): split deployment_environment into two configs

### DIFF
--- a/datahub-web-react/src/app/ingest/source/builder/sources.json
+++ b/datahub-web-react/src/app/ingest/source/builder/sources.json
@@ -441,7 +441,7 @@
         "displayName": "Snowplow",
         "description": "Import Schemas, Event Specifications, Tracking Plans, Pipelines, and Enrichments from Snowplow BDP.",
         "docsUrl": "https://docs.datahub.com/docs/generated/ingestion/sources/snowplow",
-        "recipe": "source:\n  type: snowplow\n  config:\n    # BDP Console API connection\n    bdp_connection:\n      organization_id: \"YOUR_ORG_UUID\"\n      api_key_id: \"${SNOWPLOW_API_KEY_ID}\"\n      api_key: \"${SNOWPLOW_API_KEY}\"\n\n    # Optional: Filter by Snowplow deployment environment (PROD, DEV)\n    # deployment_environment: PROD\n\n    # Optional: Filter event specifications by status\n    # event_spec_statuses:\n    #   - published\n\n    # Optional: Filter schemas by vendor/name pattern\n    # schema_pattern:\n    #   allow:\n    #     - \"com\\\\.mycompany\\\\..*\"\n\n    stateful_ingestion:\n      enabled: true",
+        "recipe": "source:\n  type: snowplow\n  config:\n    # BDP Console API connection\n    bdp_connection:\n      organization_id: \"YOUR_ORG_UUID\"\n      api_key_id: \"${SNOWPLOW_API_KEY_ID}\"\n      api_key: \"${SNOWPLOW_API_KEY}\"\n\n    # Optional: Filter schemas by Snowplow deployment environment (PROD, DEV)\n    # deployment_environment: PROD\n\n    # Optional: Filter pipelines by Snowplow pipeline label (commonly the env, e.g. prod)\n    # pipeline_label: prod\n\n    # Optional: Filter event specifications by status\n    # event_spec_statuses:\n    #   - published\n\n    # Optional: Filter schemas by vendor/name pattern\n    # schema_pattern:\n    #   allow:\n    #     - \"com\\\\.mycompany\\\\..*\"\n\n    stateful_ingestion:\n      enabled: true",
         "category": "Data Collector",
         "isPopular": false,
         "isNew": true

--- a/datahub-web-react/src/app/ingestV2/source/builder/sources.json
+++ b/datahub-web-react/src/app/ingestV2/source/builder/sources.json
@@ -607,7 +607,7 @@
         "displayName": "Snowplow",
         "description": "Import Schemas, Event Specifications, Tracking Plans, Pipelines, and Enrichments from Snowplow BDP.",
         "docsUrl": "https://docs.datahub.com/docs/generated/ingestion/sources/snowplow",
-        "recipe": "source:\n  type: snowplow\n  config:\n    # BDP Console API connection\n    bdp_connection:\n      organization_id: \"YOUR_ORG_UUID\"\n      api_key_id: \"${SNOWPLOW_API_KEY_ID}\"\n      api_key: \"${SNOWPLOW_API_KEY}\"\n\n    # Optional: Filter by Snowplow deployment environment (PROD, DEV)\n    # deployment_environment: PROD\n\n    # Optional: Filter event specifications by status\n    # event_spec_statuses:\n    #   - published\n\n    # Optional: Filter schemas by vendor/name pattern\n    # schema_pattern:\n    #   allow:\n    #     - \"com\\\\.mycompany\\\\..*\"\n\n    stateful_ingestion:\n      enabled: true",
+        "recipe": "source:\n  type: snowplow\n  config:\n    # BDP Console API connection\n    bdp_connection:\n      organization_id: \"YOUR_ORG_UUID\"\n      api_key_id: \"${SNOWPLOW_API_KEY_ID}\"\n      api_key: \"${SNOWPLOW_API_KEY}\"\n\n    # Optional: Filter schemas by Snowplow deployment environment (PROD, DEV)\n    # deployment_environment: PROD\n\n    # Optional: Filter pipelines by Snowplow pipeline label (commonly the env, e.g. prod)\n    # pipeline_label: prod\n\n    # Optional: Filter event specifications by status\n    # event_spec_statuses:\n    #   - published\n\n    # Optional: Filter schemas by vendor/name pattern\n    # schema_pattern:\n    #   allow:\n    #     - \"com\\\\.mycompany\\\\..*\"\n\n    stateful_ingestion:\n      enabled: true",
         "category": "Data Collector",
         "isPopular": false,
         "isNew": true

--- a/metadata-ingestion/src/datahub/ingestion/source/snowplow/processors/pipeline_processor.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowplow/processors/pipeline_processor.py
@@ -120,31 +120,33 @@ class PipelineProcessor(EntityProcessor):
                 )
                 return
 
-            # Filter pipelines by label matching deployment_environment (if set)
-            # deployment_environment is already normalized to uppercase by config validator
-            if self.config.deployment_environment:
-                target_env = self.config.deployment_environment
+            # Filter pipelines by their Snowplow `label` field (if set).
+            # The label is free-form text set by the operator — not a structured
+            # env field — so we match case-insensitively. The config validator
+            # already uppercases pipeline_label.
+            if self.config.pipeline_label:
+                target_label = self.config.pipeline_label
                 matching_pipelines = []
                 for p in physical_pipelines:
                     if not p.label:
-                        # Pipeline has no environment label — include by default
+                        # Pipeline has no label — include by default
                         logger.info(
                             f"Pipeline '{p.name}' has no label, including it "
-                            f"(cannot determine if it matches deployment_environment='{target_env}')"
+                            f"(cannot determine if it matches pipeline_label='{target_label}')"
                         )
                         matching_pipelines.append(p)
-                    elif p.label.upper() != target_env:
+                    elif p.label.upper() != target_label:
                         logger.info(
                             f"Filtering out pipeline '{p.name}' "
-                            f"(label='{p.label}' does not match deployment_environment='{target_env}')"
+                            f"(label='{p.label}' does not match pipeline_label='{target_label}')"
                         )
-                        self.report.report_pipeline_filtered_by_env(p.name)
+                        self.report.report_pipeline_filtered_by_label(p.name)
                     else:
                         matching_pipelines.append(p)
 
                 if not matching_pipelines:
                     logger.warning(
-                        f"No pipelines match deployment_environment={target_env} "
+                        f"No pipelines match pipeline_label={target_label} "
                         f"(found {len(physical_pipelines)} pipelines with labels: "
                         f"{[p.label for p in physical_pipelines]}). "
                         "Skipping pipeline extraction."

--- a/metadata-ingestion/src/datahub/ingestion/source/snowplow/snowplow_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowplow/snowplow_config.py
@@ -360,9 +360,21 @@ class SnowplowSourceConfig(
     deployment_environment: Optional[str] = Field(
         default=None,
         description="Filter schemas by Snowplow deployment environment. "
-        "Only schemas deployed to this environment will be ingested. "
-        "Common values from BDP API: 'PROD', 'DEV'. "
+        "Matches the `env` field on a data structure deployment "
+        "(e.g. `PROD`, `DEV`). "
+        "Only schemas with a matching deployment will be ingested; schemas "
+        "with no deployment info (e.g. drafts) are included. "
         "Case-insensitive. When not set, schemas from all environments are included.",
+    )
+
+    pipeline_label: Optional[str] = Field(
+        default=None,
+        description="Filter Snowplow pipelines by their `label` field in the BDP "
+        "API. The label is free-form text set by the operator (commonly the "
+        "deployment env, e.g. `prod` or `dev`, but not enforced by Snowplow). "
+        "Only pipelines matching this label will be ingested; pipelines with "
+        "no label are included by default. "
+        "Case-insensitive. When not set, all pipelines are included.",
     )
 
     event_spec_statuses: Optional[List[str]] = Field(
@@ -537,10 +549,10 @@ class SnowplowSourceConfig(
                 )
         return v
 
-    @field_validator("deployment_environment", mode="after")
+    @field_validator("deployment_environment", "pipeline_label", mode="after")
     @classmethod
-    def validate_deployment_environment(cls, v: Optional[str]) -> Optional[str]:
-        """Normalize deployment environment: strip whitespace, uppercase, reject empty."""
+    def _normalize_env_filter(cls, v: Optional[str]) -> Optional[str]:
+        """Strip whitespace, uppercase, and treat empty strings as None."""
         if v is not None:
             v = v.strip().upper()
             if not v:

--- a/metadata-ingestion/src/datahub/ingestion/source/snowplow/snowplow_report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowplow/snowplow_report.py
@@ -197,8 +197,8 @@ class SnowplowSourceReport(StaleEntityRemovalSourceReport):
     # Environment filtering stats
     num_schemas_filtered_by_env: int = 0
     filtered_schemas_by_env: List[str] = field(default_factory=list)
-    num_pipelines_filtered_by_env: int = 0
-    filtered_pipelines_by_env: List[str] = field(default_factory=list)
+    num_pipelines_filtered_by_label: int = 0
+    filtered_pipelines_by_label: List[str] = field(default_factory=list)
 
     # Hidden schemas
     num_hidden_schemas: int = 0
@@ -298,10 +298,10 @@ class SnowplowSourceReport(StaleEntityRemovalSourceReport):
         self.num_schemas_filtered_by_env += 1
         self.filtered_schemas_by_env.append(schema_name)
 
-    def report_pipeline_filtered_by_env(self, pipeline_name: str) -> None:
-        """Record that a pipeline was filtered out by environment label."""
-        self.num_pipelines_filtered_by_env += 1
-        self.filtered_pipelines_by_env.append(pipeline_name)
+    def report_pipeline_filtered_by_label(self, pipeline_name: str) -> None:
+        """Record that a pipeline was filtered out because its label didn't match pipeline_label."""
+        self.num_pipelines_filtered_by_label += 1
+        self.filtered_pipelines_by_label.append(pipeline_name)
 
     def report_warehouse_lineage_extracted(self) -> None:
         """Record that warehouse lineage was extracted."""

--- a/metadata-ingestion/tests/unit/snowplow/test_feature_flag_combinations.py
+++ b/metadata-ingestion/tests/unit/snowplow/test_feature_flag_combinations.py
@@ -46,6 +46,7 @@ class TestEnrichmentsWithoutEventSpecProcessor:
         deps = Mock()
         deps.config = Mock()
         deps.config.deployment_environment = None
+        deps.config.pipeline_label = None
         deps.config.event_spec_statuses = None
         # Key config: extract_event_specifications is FALSE but extract_enrichments is TRUE
         deps.config.extract_event_specifications = False
@@ -292,6 +293,7 @@ class TestAllEventSpecsProcessed:
         deps = Mock()
         deps.config = Mock()
         deps.config.deployment_environment = None
+        deps.config.pipeline_label = None
         deps.config.event_spec_statuses = None
         deps.config.extract_event_specifications = True
         deps.config.bdp_connection = Mock()
@@ -385,6 +387,7 @@ class TestProcessorCoordination:
         deps = Mock()
         deps.config = Mock()
         deps.config.deployment_environment = None
+        deps.config.pipeline_label = None
         deps.config.event_spec_statuses = None
         deps.config.extract_event_specifications = True
         deps.config.bdp_connection = Mock()
@@ -410,6 +413,7 @@ class TestProcessorCoordination:
         deps = Mock()
         deps.config = Mock()
         deps.config.deployment_environment = None
+        deps.config.pipeline_label = None
         deps.config.event_spec_statuses = None
         deps.config.extract_event_specifications = True
         deps.config.extract_pipelines = True

--- a/metadata-ingestion/tests/unit/snowplow/test_pipeline_processor.py
+++ b/metadata-ingestion/tests/unit/snowplow/test_pipeline_processor.py
@@ -55,7 +55,7 @@ class TestPipelineProcessorIsEnabled:
         """Create mock dependencies."""
         deps = Mock()
         deps.config = Mock()
-        deps.config.deployment_environment = None
+        deps.config.pipeline_label = None
         deps.config.event_spec_statuses = None
         deps.config.extract_pipelines = True
         deps.config.extract_enrichments = False
@@ -107,7 +107,7 @@ class TestPipelineProcessorExtract:
         """Create mock dependencies."""
         deps = Mock()
         deps.config = Mock()
-        deps.config.deployment_environment = None
+        deps.config.pipeline_label = None
         deps.config.event_spec_statuses = None
         deps.config.extract_pipelines = True
         deps.config.extract_enrichments = False
@@ -173,7 +173,7 @@ class TestPipelineProcessorEnrichments:
         """Create mock dependencies."""
         deps = Mock()
         deps.config = Mock()
-        deps.config.deployment_environment = None
+        deps.config.pipeline_label = None
         deps.config.event_spec_statuses = None
         deps.config.extract_pipelines = False
         deps.config.extract_enrichments = True
@@ -222,7 +222,7 @@ class TestPipelineProcessorDataFlowCreation:
         """Create mock dependencies."""
         deps = Mock()
         deps.config = Mock()
-        deps.config.deployment_environment = None
+        deps.config.pipeline_label = None
         deps.config.event_spec_statuses = None
         deps.config.extract_pipelines = True
         deps.config.extract_enrichments = False
@@ -388,7 +388,7 @@ class TestExpandFieldUrnsToAllEventSpecs:
         """Create mock dependencies."""
         deps = Mock()
         deps.config = Mock()
-        deps.config.deployment_environment = None
+        deps.config.pipeline_label = None
         deps.config.event_spec_statuses = None
         deps.config.extract_pipelines = True
         deps.config.extract_enrichments = True
@@ -624,7 +624,7 @@ class TestFieldMatches:
         """Create mock dependencies."""
         deps = Mock()
         deps.config = Mock()
-        deps.config.deployment_environment = None
+        deps.config.pipeline_label = None
         deps.config.event_spec_statuses = None
         deps.config.extract_pipelines = True
         deps.config.extract_enrichments = True
@@ -693,7 +693,7 @@ class TestFindEventSpecsWithField:
         """Create mock dependencies."""
         deps = Mock()
         deps.config = Mock()
-        deps.config.deployment_environment = None
+        deps.config.pipeline_label = None
         deps.config.event_spec_statuses = None
         deps.config.extract_pipelines = True
         deps.config.extract_enrichments = True
@@ -813,7 +813,7 @@ class TestExtractFieldNameFromUrn:
         """Create mock dependencies."""
         deps = Mock()
         deps.config = Mock()
-        deps.config.deployment_environment = None
+        deps.config.pipeline_label = None
         deps.config.event_spec_statuses = None
         deps.config.extract_pipelines = True
         deps.config.extract_enrichments = True
@@ -868,7 +868,7 @@ class TestEmitCollectorDataJob:
         """Create mock dependencies."""
         deps = Mock()
         deps.config = Mock()
-        deps.config.deployment_environment = None
+        deps.config.pipeline_label = None
         deps.config.event_spec_statuses = None
         deps.config.extract_pipelines = True
         deps.config.extract_enrichments = True


### PR DESCRIPTION
## Summary

Follow-up to #17056 addressing a review nit from @sgomezvillamor ([comment](https://github.com/datahub-project/datahub/pull/17056/files#r3117791080)).

`deployment_environment` was being used to filter two semantically different fields:

| Usage | Filtered against |
|---|---|
| Schemas | `DataStructureDeployment.env` — structured env field from the BDP API |
| Pipelines | `Pipeline.label` — free-form text set by the operator (not a structured env) |

Using one config for both is misleading, especially for users whose pipeline labels don't happen to match env names.

## Changes

- New `pipeline_label` config filters pipelines by their `pipeline.label`. `deployment_environment` is narrowed to schemas only.
- Shared validator (`_normalize_env_filter`) handles whitespace/uppercase/empty normalization for both.
- Report fields `num_pipelines_filtered_by_env` / `filtered_pipelines_by_env` / `report_pipeline_filtered_by_env` renamed to `..._by_label` for consistency. Schema-side fields are unchanged.
- UI source builder recipe examples (`sources.json` in both `ingest/` and `ingestV2/`) updated to show both options.

No migration path needed — `deployment_environment` was introduced in #17056 and has not shipped in a release.

## Test plan

- [x] `./gradlew :metadata-ingestion:lintFix` — clean
- [x] `pytest tests/unit/snowplow/` — 659 passed
- [ ] CI green