### PR TITLE
chore(smoke-test): update stale image

### DIFF
--- a/docker/datahub-ingestion-base/smoke.Dockerfile
+++ b/docker/datahub-ingestion-base/smoke.Dockerfile
@@ -1,4 +1,4 @@
-FROM acryldata/datahub-ingestion-base as base
+FROM acryldata/datahub-ingestion:head-slim AS base
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     sudo \
@@ -7,10 +7,9 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     libgtk-3-0 \
     libgbm-dev \
     libnotify-dev \
-    libgconf-2-4 \
     libnss3 \
     libxss1 \
-    libasound2 \
+    libasound2t64 \
     libxtst6 \
     xauth \
     xvfb \

--- a/docker/datahub-ingestion-base/smoke.Dockerfile
+++ b/docker/datahub-ingestion-base/smoke.Dockerfile
@@ -1,5 +1,6 @@
 FROM acryldata/datahub-ingestion:head-slim AS base
 
+USER 0
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     sudo \
     python3-dev \
@@ -16,6 +17,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     openjdk-21-jdk && \
     rm -rf /var/lib/apt/lists/* /var/cache/apk/*
 
+USER datahub
 COPY . /datahub-src
 ARG RELEASE_VERSION
 RUN cd /datahub-src && \


### PR DESCRIPTION
https://hub.docker.com/r/acryldata/datahub-ingestion-base/ , has not been updated in a year now. 
And has been removed here https://github.com/datahub-project/datahub/pull/13146
Switching it for the newer slim [image](https://hub.docker.com/r/acryldata/datahub-ingestion-base/). 