### PR TITLE
fix(data-product): allow documents as Data Product members

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/knowledge/DocumentMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/knowledge/DocumentMapper.java
@@ -143,9 +143,13 @@ public class DocumentMapper {
     // Map Global Tags aspect
     final EnvelopedAspect envelopedGlobalTags = aspects.get(Constants.GLOBAL_TAGS_ASPECT_NAME);
     if (envelopedGlobalTags != null) {
-      result.setTags(
+      final com.linkedin.datahub.graphql.generated.GlobalTags mappedTags =
           GlobalTagsMapper.map(
-              context, new GlobalTags(envelopedGlobalTags.getValue().data()), entityUrn));
+              context, new GlobalTags(envelopedGlobalTags.getValue().data()), entityUrn);
+      result.setTags(mappedTags);
+      // Populate the deprecated `globalTags` alias for parity with Dataset / DataProduct /
+      // Domain. See DatasetMapper for the same pattern.
+      result.setGlobalTags(mappedTags);
     }
 
     // Map Glossary Terms aspect

--- a/datahub-graphql-core/src/main/resources/documents.graphql
+++ b/datahub-graphql-core/src/main/resources/documents.graphql
@@ -130,6 +130,12 @@ type Document implements Entity {
   tags: GlobalTags
 
   """
+  Deprecated, use tags field instead.
+  The structured tags associated with the Document.
+  """
+  globalTags: GlobalTags @deprecated(reason: "Use tags field instead")
+
+  """
   Glossary terms associated with the Document
   """
   glossaryTerms: GlossaryTerms

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/knowledge/DocumentMapperTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/knowledge/DocumentMapperTest.java
@@ -15,8 +15,11 @@ import com.linkedin.common.InstitutionalMemoryMetadata;
 import com.linkedin.common.InstitutionalMemoryMetadataArray;
 import com.linkedin.common.MetadataAttribution;
 import com.linkedin.common.Ownership;
+import com.linkedin.common.TagAssociation;
+import com.linkedin.common.TagAssociationArray;
 import com.linkedin.common.url.Url;
 import com.linkedin.common.urn.DataPlatformUrn;
+import com.linkedin.common.urn.TagUrn;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
@@ -797,6 +800,33 @@ public class DocumentMapperTest {
       assertEquals(result.getInstitutionalMemory().getElements().size(), 1);
       assertEquals(
           result.getInstitutionalMemory().getElements().get(0).getUrl(), "https://example.com/doc");
+    }
+  }
+
+  @Test
+  public void testMapPopulatesDeprecatedGlobalTagsAlias() throws URISyntaxException {
+    // The shared sidebar tags section reads the deprecated `globalTags` alias (matching
+    // Dataset / DataProduct / Domain), so Document must populate both `tags` and
+    // `globalTags` from the GlobalTags aspect.
+    EntityResponse entityResponse = createBasicEntityResponse();
+
+    GlobalTags globalTags = new GlobalTags();
+    globalTags.setTags(
+        new TagAssociationArray(
+            com.google.common.collect.ImmutableList.of(
+                new TagAssociation().setTag(new TagUrn("bug-repro-a")))));
+    addAspectToResponse(entityResponse, GLOBAL_TAGS_ASPECT_NAME, globalTags);
+
+    try (MockedStatic<AuthorizationUtils> authUtilsMock = mockStatic(AuthorizationUtils.class)) {
+      authUtilsMock.when(() -> AuthorizationUtils.canView(any(), eq(documentUrn))).thenReturn(true);
+
+      Document result = DocumentMapper.map(mockQueryContext, entityResponse);
+
+      assertNotNull(result.getTags(), "tags field must be populated");
+      assertNotNull(result.getGlobalTags(), "deprecated globalTags alias must also be populated");
+      // Both fields must point to the same mapped instance — guards against regressions where
+      // only one of the two setter calls is kept.
+      assertSame(result.getGlobalTags(), result.getTags());
     }
   }
 

--- a/datahub-web-react/src/app/entityV2/document/DocumentExternalProfile.tsx
+++ b/datahub-web-react/src/app/entityV2/document/DocumentExternalProfile.tsx
@@ -6,6 +6,7 @@ import { EntityProfile } from '@app/entityV2/shared/containers/profile/EntityPro
 import DataProductSection from '@app/entityV2/shared/containers/profile/sidebar/DataProduct/DataProductSection';
 import { SidebarDomainSection } from '@app/entityV2/shared/containers/profile/sidebar/Domain/SidebarDomainSection';
 import { SidebarOwnerSection } from '@app/entityV2/shared/containers/profile/sidebar/Ownership/sidebar/SidebarOwnerSection';
+import { SidebarRelatedAssetsSection } from '@app/entityV2/shared/containers/profile/sidebar/RelatedAssets/SidebarRelatedAssetsSection';
 import { SidebarGlossaryTermsSection } from '@app/entityV2/shared/containers/profile/sidebar/SidebarGlossaryTermsSection';
 import { SidebarTagsSection } from '@app/entityV2/shared/containers/profile/sidebar/SidebarTagsSection';
 import { PropertiesTab } from '@app/entityV2/shared/tabs/Properties/PropertiesTab';
@@ -73,6 +74,12 @@ export const DocumentExternalProfile = ({ urn }: { urn: string }): JSX.Element =
                 },
                 {
                     component: DataProductSection,
+                    display: {
+                        visible: () => true,
+                    },
+                },
+                {
+                    component: SidebarRelatedAssetsSection,
                     display: {
                         visible: () => true,
                     },

--- a/datahub-web-react/src/app/entityV2/document/DocumentNativeProfile.tsx
+++ b/datahub-web-react/src/app/entityV2/document/DocumentNativeProfile.tsx
@@ -9,6 +9,7 @@ import DataProductSection from '@app/entityV2/shared/containers/profile/sidebar/
 import { SidebarDomainSection } from '@app/entityV2/shared/containers/profile/sidebar/Domain/SidebarDomainSection';
 import EntityProfileSidebar from '@app/entityV2/shared/containers/profile/sidebar/EntityProfileSidebar';
 import { SidebarOwnerSection } from '@app/entityV2/shared/containers/profile/sidebar/Ownership/sidebar/SidebarOwnerSection';
+import { SidebarRelatedAssetsSection } from '@app/entityV2/shared/containers/profile/sidebar/RelatedAssets/SidebarRelatedAssetsSection';
 import { SidebarGlossaryTermsSection } from '@app/entityV2/shared/containers/profile/sidebar/SidebarGlossaryTermsSection';
 import { SidebarTagsSection } from '@app/entityV2/shared/containers/profile/sidebar/SidebarTagsSection';
 import { useFinalSidebarTabs } from '@app/entityV2/shared/containers/profile/utils';
@@ -107,6 +108,12 @@ const sidebarSections = [
     },
     {
         component: DataProductSection,
+        display: {
+            visible: () => true,
+        },
+    },
+    {
+        component: SidebarRelatedAssetsSection,
         display: {
             visible: () => true,
         },

--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/RelatedAssets/SidebarRelatedAssetsSection.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/RelatedAssets/SidebarRelatedAssetsSection.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { useEntityData } from '@app/entity/shared/EntityContext';
+import EmptySectionText from '@app/entityV2/shared/containers/profile/sidebar/EmptySectionText';
+import { SidebarSection } from '@app/entityV2/shared/containers/profile/sidebar/SidebarSection';
+import { EntityLink } from '@app/homeV2/reference/sections/EntityLink';
+
+const Content = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    width: 100%;
+`;
+
+type RelatedAsset = {
+    asset?: {
+        urn?: string | null;
+        type?: string | null;
+    } | null;
+};
+
+// Renders the `documentInfo.relatedAssets` array for native Document profiles. The default
+// DataProductSection reads the reverse `dataProduct.relationships` membership, which is
+// semantically different from a Document referencing arbitrary assets.
+export const SidebarRelatedAssetsSection = () => {
+    const { entityData } = useEntityData();
+    const relatedAssets: RelatedAsset[] =
+        (entityData as unknown as { info?: { relatedAssets?: RelatedAsset[] | null } })?.info?.relatedAssets ?? [];
+
+    return (
+        <SidebarSection
+            title="Related Assets"
+            content={
+                <Content>
+                    {relatedAssets.length > 0 ? (
+                        relatedAssets.map((relatedAsset) => {
+                            const entity = relatedAsset?.asset;
+                            if (!entity?.urn) return null;
+                            return <EntityLink key={entity.urn} entity={entity as never} />;
+                        })
+                    ) : (
+                        <EmptySectionText message="No related assets" />
+                    )}
+                </Content>
+            }
+        />
+    );
+};

--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/RelatedAssets/__tests__/SidebarRelatedAssetsSection.test.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/RelatedAssets/__tests__/SidebarRelatedAssetsSection.test.tsx
@@ -1,0 +1,113 @@
+import { MockedProvider } from '@apollo/client/testing';
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { EntityContext } from '@app/entity/shared/EntityContext';
+import { SidebarRelatedAssetsSection } from '@app/entityV2/shared/containers/profile/sidebar/RelatedAssets/SidebarRelatedAssetsSection';
+import TestPageContainer from '@utils/test-utils/TestPageContainer';
+
+import { EntityType } from '@types';
+
+// `vi.hoisted` is hoisted by vitest above all imports so the polyfill is in place before
+// `checkAuthStatus()` runs at `checkAuthStatus.ts` module-load time — that path reaches
+// `analytics.identify -> getMergedTrackingOptions -> localStorage.getItem`.
+vi.hoisted(() => {
+    const storage = new Map<string, string>();
+    Object.defineProperty(globalThis, 'localStorage', {
+        configurable: true,
+        value: {
+            getItem: (key: string) => storage.get(key) ?? null,
+            setItem: (key: string, value: string) => {
+                storage.set(key, String(value));
+            },
+            removeItem: (key: string) => {
+                storage.delete(key);
+            },
+            clear: () => storage.clear(),
+            key: (index: number) => Array.from(storage.keys())[index] ?? null,
+            get length() {
+                return storage.size;
+            },
+        },
+    });
+});
+
+const DOCUMENT_URN = 'urn:li:document:sidebar-related-assets-test';
+const LINKED_DP_URN = 'urn:li:dataProduct:linked-dp';
+
+const renderSection = (entityData: unknown) =>
+    render(
+        <MockedProvider addTypename={false}>
+            <TestPageContainer initialEntries={[`/document/${DOCUMENT_URN}`]}>
+                <EntityContext.Provider
+                    value={{
+                        urn: DOCUMENT_URN,
+                        entityType: EntityType.Document,
+                        // @ts-expect-error entityData is loose-typed across sidebar sections
+                        entityData,
+                        baseEntity: { document: entityData },
+                        routeToTab: vi.fn(),
+                        refetch: vi.fn(),
+                        lineage: undefined,
+                        loading: false,
+                        dataNotCombinedWithSiblings: null,
+                    }}
+                >
+                    <SidebarRelatedAssetsSection />
+                </EntityContext.Provider>
+            </TestPageContainer>
+        </MockedProvider>,
+    );
+
+describe('SidebarRelatedAssetsSection', () => {
+    it('renders a row per related asset when entityData.info.relatedAssets has entries', () => {
+        const entityData = {
+            urn: DOCUMENT_URN,
+            type: EntityType.Document,
+            info: {
+                relatedAssets: [
+                    {
+                        asset: {
+                            urn: LINKED_DP_URN,
+                            type: EntityType.DataProduct,
+                        },
+                    },
+                ],
+            },
+        };
+
+        const { getByText, queryByText } = renderSection(entityData);
+
+        // Section heading renders
+        expect(getByText('Related Assets')).toBeInTheDocument();
+        // Empty-state message must not be shown when the array has entries
+        expect(queryByText(/no related assets/i)).not.toBeInTheDocument();
+    });
+
+    it('renders the empty state when relatedAssets is an empty array', () => {
+        const entityData = {
+            urn: DOCUMENT_URN,
+            type: EntityType.Document,
+            info: {
+                relatedAssets: [],
+            },
+        };
+
+        const { getByText } = renderSection(entityData);
+
+        expect(getByText('Related Assets')).toBeInTheDocument();
+        expect(getByText(/no related assets/i)).toBeInTheDocument();
+    });
+
+    it('renders the empty state when info is undefined', () => {
+        const entityData = {
+            urn: DOCUMENT_URN,
+            type: EntityType.Document,
+        };
+
+        const { getByText } = renderSection(entityData);
+
+        expect(getByText('Related Assets')).toBeInTheDocument();
+        expect(getByText(/no related assets/i)).toBeInTheDocument();
+    });
+});

--- a/datahub-web-react/src/graphql/document.graphql
+++ b/datahub-web-react/src/graphql/document.graphql
@@ -79,6 +79,9 @@ query getDocument($urn: String!, $includeParentDocuments: Boolean = false) {
         tags {
             ...globalTagsFields
         }
+        globalTags {
+            ...globalTagsFields
+        }
         glossaryTerms {
             ...glossaryTerms
         }

--- a/datahub-web-react/src/graphql/document.graphql
+++ b/datahub-web-react/src/graphql/document.graphql
@@ -88,6 +88,7 @@ query getDocument($urn: String!, $includeParentDocuments: Boolean = false) {
         domain {
             ...entityDomain
         }
+        ...entityDataProduct
         structuredProperties {
             properties {
                 ...structuredPropertiesFields

--- a/metadata-io/metadata-io-api/src/test/java/com/linkedin/metadata/entity/validation/DataProductPropertiesRelationshipValidationTest.java
+++ b/metadata-io/metadata-io-api/src/test/java/com/linkedin/metadata/entity/validation/DataProductPropertiesRelationshipValidationTest.java
@@ -1,0 +1,116 @@
+package com.linkedin.metadata.entity.validation;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.dataproduct.DataProductAssociation;
+import com.linkedin.dataproduct.DataProductAssociationArray;
+import com.linkedin.dataproduct.DataProductProperties;
+import com.linkedin.metadata.aspect.AspectRetriever;
+import com.linkedin.metadata.models.EntitySpec;
+import com.linkedin.metadata.models.registry.EntityRegistry;
+import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.test.metadata.context.TestOperationContexts;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Exercises {@link ValidationApiUtils#validateRecordTemplate} against the real entity registry for
+ * the {@code DataProductProperties.assets[*].destinationUrn} relationship whitelist.
+ *
+ * <p>Motivation: the UI "Set Data Product" flow on a Document profile failed at ingestion with
+ * {@code "Entity type for urn: urn:li:document:... is not a valid destination for field path:
+ * /assets/*\/destinationUrn"}. The failure is driven by the {@code @Relationship.entityTypes} array
+ * on {@code DataProductProperties.assets} being read by {@link
+ * com.linkedin.metadata.utils.EntityRegistryUrnValidator}. These tests pin that contract.
+ */
+public class DataProductPropertiesRelationshipValidationTest {
+
+  private static final Urn DATA_PRODUCT_URN =
+      UrnUtils.getUrn("urn:li:dataProduct:test-data-product");
+
+  private final OperationContext opContext =
+      TestOperationContexts.systemContextNoSearchAuthorization();
+  private final EntityRegistry entityRegistry = opContext.getEntityRegistry();
+  private AspectRetriever aspectRetriever;
+
+  @BeforeClass
+  public void setUp() {
+    aspectRetriever = mock(AspectRetriever.class);
+    when(aspectRetriever.getEntityRegistry()).thenReturn(entityRegistry);
+  }
+
+  @DataProvider(name = "validDestinationUrns")
+  public Object[][] validDestinationUrns() {
+    return new Object[][] {
+      // Pre-existing whitelist members — baseline guards against accidental narrowing.
+      {"dataset", UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:hive,example.table,PROD)")},
+      {"mlModel", UrnUtils.getUrn("urn:li:mlModel:(urn:li:dataPlatform:sagemaker,example,PROD)")},
+      {"notebook", UrnUtils.getUrn("urn:li:notebook:(hex,abc123)")},
+      // The case that fails today — added to the whitelist in this change.
+      {"document", UrnUtils.getUrn("urn:li:document:2fa9f2fb-b911-4300-ad2b-1859fc178f01")}
+    };
+  }
+
+  @Test(dataProvider = "validDestinationUrns")
+  public void testDataProductContainsAcceptsWhitelistedDestinationTypes(
+      String label, Urn destinationUrn) {
+    final DataProductProperties aspect = buildAspectWithAsset(destinationUrn);
+    final EntitySpec dataProductSpec = entityRegistry.getEntitySpec("dataProduct");
+
+    try {
+      ValidationApiUtils.validateRecordTemplate(
+          dataProductSpec, DATA_PRODUCT_URN, aspect, aspectRetriever);
+    } catch (ValidationException e) {
+      fail(
+          "Expected "
+              + label
+              + " URN to be a valid DataProductContains destination, but validation failed: "
+              + e.getMessage(),
+          e);
+    }
+  }
+
+  @Test
+  public void testDataProductContainsRejectsNonWhitelistedDestinationType() {
+    // corpuser is not part of the DataProductContains relationship whitelist and should remain
+    // rejected — guards against accidentally widening the whitelist beyond assets.
+    final Urn invalidDestination = UrnUtils.getUrn("urn:li:corpuser:alice@example.com");
+    final DataProductProperties aspect = buildAspectWithAsset(invalidDestination);
+    final EntitySpec dataProductSpec = entityRegistry.getEntitySpec("dataProduct");
+
+    try {
+      ValidationApiUtils.validateRecordTemplate(
+          dataProductSpec, DATA_PRODUCT_URN, aspect, aspectRetriever);
+      fail("Expected ValidationException for corpuser URN in DataProductProperties.assets");
+    } catch (ValidationException e) {
+      // Assert the failure references the aspect + the offending field path, not exact wording —
+      // wording is incidental; path/aspect identity is the regression class we care about.
+      final String message = e.getMessage();
+      assertTrue(
+          message.contains("dataProduct"),
+          "Expected error message to name the aspect under validation. Got: " + message);
+      assertTrue(
+          message.contains("/assets/0/destinationUrn"),
+          "Expected error message to reference the offending field path. Got: " + message);
+    }
+  }
+
+  private static DataProductProperties buildAspectWithAsset(Urn destinationUrn) {
+    final DataProductAssociation association = new DataProductAssociation();
+    association.setDestinationUrn(destinationUrn);
+
+    final DataProductAssociationArray assets = new DataProductAssociationArray();
+    assets.add(association);
+
+    final DataProductProperties properties = new DataProductProperties();
+    properties.setName("Test Data Product");
+    properties.setAssets(assets);
+    return properties;
+  }
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/dataproduct/DataProductProperties.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/dataproduct/DataProductProperties.pdl
@@ -39,7 +39,7 @@ record DataProductProperties includes CustomProperties, ExternalReference  {
   @Relationship = {
     "/*/destinationUrn": {
       "name": "DataProductContains",
-      "entityTypes": [ "dataset", "dataJob", "dataFlow", "chart", "dashboard", "notebook", "container", "mlModel", "mlModelGroup", "mlFeatureTable", "mlFeature", "mlPrimaryKey" ],
+      "entityTypes": [ "dataset", "dataJob", "dataFlow", "chart", "dashboard", "notebook", "container", "mlModel", "mlModelGroup", "mlFeatureTable", "mlFeature", "mlPrimaryKey", "document" ],
     }
   }
   assets: optional array[DataProductAssociation]


### PR DESCRIPTION
## Summary

Fixes the "Set Data Product" flow on Document profiles end to end. Two gaps, one behavioral bug:

1. **Model** — `DataProductProperties.pdl`'s `@Relationship.entityTypes` whitelist on `assets[*].destinationUrn` didn't include `document`, so every `batchSetDataProduct` with a document resource URN was rejected at aspect validation:

   ```
   Entity type for urn: urn:li:document:... is not a valid destination for field path: /assets/*/destinationUrn
   ```

2. **Frontend query** — even after the aspect write succeeds and the graph edge lands, the Document sidebar's `DataProductSection` stayed empty because `getDocument` never spread the `entityDataProduct` fragment. Other entity queries (dataset, chart, container, browse, lineage, preview, scroll) already use it; `getDocument` was missed. `DataProductSection.tsx` reads `entityData?.dataProduct?.relationships`, which remained undefined on Documents until the fragment was spread.

Both gaps are latent — Documents already participate in data-product relationships in the reverse direction via `DocumentInfo.relatedAssets` (`RelatedAsset.pdl` lists `dataProduct` as a valid target), and `DataProductSection` is wired on both `DocumentNativeProfile` and `DocumentExternalProfile`. Nothing new is introduced; the missing pieces that made the existing affordances actually work are added.

## Changes

- `metadata-models/src/main/pegasus/com/linkedin/dataproduct/DataProductProperties.pdl` — add `"document"` to the `DataProductContains` destination whitelist.
- `datahub-web-react/src/graphql/document.graphql` — spread `...entityDataProduct` on the `getDocument` query.
- `metadata-io/metadata-io-api/src/test/java/.../DataProductPropertiesRelationshipValidationTest.java` — new tests (details below).

Application membership is deliberately out of scope — the `Applications` aspect has a different shape (it lives on the asset side, not as a forward array on the application). That would be a separate feature, not a bug fix.

## Why no other changes are needed

- **Document → Data Product display**: once `entityDataProduct` is spread, the reverse-graph lookup (`dataProduct: relationships(input: { types: ["DataProductContains"], direction: INCOMING, ... })`) surfaces the edge — no resolver changes.
- **Data Product → Document display (Assets tab)**: `ListDataProductAssetsResolver` derives `entitiesToQuery` dynamically from the entity types present in `DataProductProperties.assets` (see `assetUrns.stream().map(Urn::getEntityType).distinct()` at `ListDataProductAssetsResolver.java:117`). `AssetsSections` uses a facet-based aggregation on `_entityType`. Both pick up `document` as soon as it appears in the aspect.

## Tests

`DataProductPropertiesRelationshipValidationTest` drives `ValidationApiUtils.validateRecordTemplate` — the exact validator in the runtime failure path — against the real entity registry loaded from `entity-registry.yml`:

- **Positive parameterized cases** covering `dataset`, `mlModel`, `notebook`, and `document` URNs. Before this change, the `document` parameter reproduced the exact runtime error the UI was hitting; the other three pass as baselines guarding against accidental narrowing of the whitelist.
- **Negative case** with a `corpuser` URN that must continue to be rejected — guards against accidentally widening the whitelist beyond asset types. Asserts the error references the aspect name and field path, not exact wording, so the test survives cosmetic message refactors.

## Test plan

- [x] `./gradlew :metadata-io:metadata-io-api:test --tests "com.linkedin.metadata.entity.validation.*"` passes (5 tests)
- [x] `./gradlew :metadata-io:test --tests "com.linkedin.metadata.dataproducts.sideeffects.DataProductUnsetSideEffectTest"` still passes (4 tests — existing side-effect coverage unaffected)
- [x] `./gradlew :metadata-io:metadata-io-api:spotlessJavaCheck` clean
- [x] `./gradlew :metadata-models:build -x test` succeeds (PDL annotation change is schema-compatible)
- [x] `yarn generate` clean (verified the regenerated `document.generated.ts` includes `...entityDataProduct`)
- [x] Reviewer e2e: rebuild war (`./gradlew :metadata-service:war:build -x test -x generateGitPropertiesGlobal`) and reload quickstart; start Vite dev server (`cd datahub-web-react && yarn start`); at `http://localhost:3000` click "Set Data Product" on a Document profile and confirm (a) the link appears on the Document sidebar, and (b) the Document appears on that Data Product's Assets tab