### PR TITLE
fix(documents): render Tags and linked assets in native Document sidebar

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/knowledge/DocumentMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/knowledge/DocumentMapper.java
@@ -143,9 +143,13 @@ public class DocumentMapper {
     // Map Global Tags aspect
     final EnvelopedAspect envelopedGlobalTags = aspects.get(Constants.GLOBAL_TAGS_ASPECT_NAME);
     if (envelopedGlobalTags != null) {
-      result.setTags(
+      final com.linkedin.datahub.graphql.generated.GlobalTags mappedTags =
           GlobalTagsMapper.map(
-              context, new GlobalTags(envelopedGlobalTags.getValue().data()), entityUrn));
+              context, new GlobalTags(envelopedGlobalTags.getValue().data()), entityUrn);
+      result.setTags(mappedTags);
+      // Populate the deprecated `globalTags` alias for parity with Dataset / DataProduct /
+      // Domain. See DatasetMapper for the same pattern.
+      result.setGlobalTags(mappedTags);
     }
 
     // Map Glossary Terms aspect

--- a/datahub-graphql-core/src/main/resources/documents.graphql
+++ b/datahub-graphql-core/src/main/resources/documents.graphql
@@ -130,6 +130,12 @@ type Document implements Entity {
   tags: GlobalTags
 
   """
+  Deprecated, use tags field instead.
+  The structured tags associated with the Document.
+  """
+  globalTags: GlobalTags @deprecated(reason: "Use tags field instead")
+
+  """
   Glossary terms associated with the Document
   """
   glossaryTerms: GlossaryTerms

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/knowledge/DocumentMapperTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/knowledge/DocumentMapperTest.java
@@ -15,8 +15,11 @@ import com.linkedin.common.InstitutionalMemoryMetadata;
 import com.linkedin.common.InstitutionalMemoryMetadataArray;
 import com.linkedin.common.MetadataAttribution;
 import com.linkedin.common.Ownership;
+import com.linkedin.common.TagAssociation;
+import com.linkedin.common.TagAssociationArray;
 import com.linkedin.common.url.Url;
 import com.linkedin.common.urn.DataPlatformUrn;
+import com.linkedin.common.urn.TagUrn;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
@@ -797,6 +800,33 @@ public class DocumentMapperTest {
       assertEquals(result.getInstitutionalMemory().getElements().size(), 1);
       assertEquals(
           result.getInstitutionalMemory().getElements().get(0).getUrl(), "https://example.com/doc");
+    }
+  }
+
+  @Test
+  public void testMapPopulatesDeprecatedGlobalTagsAlias() throws URISyntaxException {
+    // The shared sidebar tags section reads the deprecated `globalTags` alias (matching
+    // Dataset / DataProduct / Domain), so Document must populate both `tags` and
+    // `globalTags` from the GlobalTags aspect.
+    EntityResponse entityResponse = createBasicEntityResponse();
+
+    GlobalTags globalTags = new GlobalTags();
+    globalTags.setTags(
+        new TagAssociationArray(
+            com.google.common.collect.ImmutableList.of(
+                new TagAssociation().setTag(new TagUrn("bug-repro-a")))));
+    addAspectToResponse(entityResponse, GLOBAL_TAGS_ASPECT_NAME, globalTags);
+
+    try (MockedStatic<AuthorizationUtils> authUtilsMock = mockStatic(AuthorizationUtils.class)) {
+      authUtilsMock.when(() -> AuthorizationUtils.canView(any(), eq(documentUrn))).thenReturn(true);
+
+      Document result = DocumentMapper.map(mockQueryContext, entityResponse);
+
+      assertNotNull(result.getTags(), "tags field must be populated");
+      assertNotNull(result.getGlobalTags(), "deprecated globalTags alias must also be populated");
+      // Both fields must point to the same mapped instance — guards against regressions where
+      // only one of the two setter calls is kept.
+      assertSame(result.getGlobalTags(), result.getTags());
     }
   }
 

--- a/datahub-web-react/src/app/entityV2/document/DocumentExternalProfile.tsx
+++ b/datahub-web-react/src/app/entityV2/document/DocumentExternalProfile.tsx
@@ -6,6 +6,7 @@ import { EntityProfile } from '@app/entityV2/shared/containers/profile/EntityPro
 import DataProductSection from '@app/entityV2/shared/containers/profile/sidebar/DataProduct/DataProductSection';
 import { SidebarDomainSection } from '@app/entityV2/shared/containers/profile/sidebar/Domain/SidebarDomainSection';
 import { SidebarOwnerSection } from '@app/entityV2/shared/containers/profile/sidebar/Ownership/sidebar/SidebarOwnerSection';
+import { SidebarRelatedAssetsSection } from '@app/entityV2/shared/containers/profile/sidebar/RelatedAssets/SidebarRelatedAssetsSection';
 import { SidebarGlossaryTermsSection } from '@app/entityV2/shared/containers/profile/sidebar/SidebarGlossaryTermsSection';
 import { SidebarTagsSection } from '@app/entityV2/shared/containers/profile/sidebar/SidebarTagsSection';
 import { PropertiesTab } from '@app/entityV2/shared/tabs/Properties/PropertiesTab';
@@ -73,6 +74,12 @@ export const DocumentExternalProfile = ({ urn }: { urn: string }): JSX.Element =
                 },
                 {
                     component: DataProductSection,
+                    display: {
+                        visible: () => true,
+                    },
+                },
+                {
+                    component: SidebarRelatedAssetsSection,
                     display: {
                         visible: () => true,
                     },

--- a/datahub-web-react/src/app/entityV2/document/DocumentNativeProfile.tsx
+++ b/datahub-web-react/src/app/entityV2/document/DocumentNativeProfile.tsx
@@ -9,6 +9,7 @@ import DataProductSection from '@app/entityV2/shared/containers/profile/sidebar/
 import { SidebarDomainSection } from '@app/entityV2/shared/containers/profile/sidebar/Domain/SidebarDomainSection';
 import EntityProfileSidebar from '@app/entityV2/shared/containers/profile/sidebar/EntityProfileSidebar';
 import { SidebarOwnerSection } from '@app/entityV2/shared/containers/profile/sidebar/Ownership/sidebar/SidebarOwnerSection';
+import { SidebarRelatedAssetsSection } from '@app/entityV2/shared/containers/profile/sidebar/RelatedAssets/SidebarRelatedAssetsSection';
 import { SidebarGlossaryTermsSection } from '@app/entityV2/shared/containers/profile/sidebar/SidebarGlossaryTermsSection';
 import { SidebarTagsSection } from '@app/entityV2/shared/containers/profile/sidebar/SidebarTagsSection';
 import { useFinalSidebarTabs } from '@app/entityV2/shared/containers/profile/utils';
@@ -107,6 +108,12 @@ const sidebarSections = [
     },
     {
         component: DataProductSection,
+        display: {
+            visible: () => true,
+        },
+    },
+    {
+        component: SidebarRelatedAssetsSection,
         display: {
             visible: () => true,
         },

--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/RelatedAssets/SidebarRelatedAssetsSection.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/RelatedAssets/SidebarRelatedAssetsSection.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { useEntityData } from '@app/entity/shared/EntityContext';
+import EmptySectionText from '@app/entityV2/shared/containers/profile/sidebar/EmptySectionText';
+import { SidebarSection } from '@app/entityV2/shared/containers/profile/sidebar/SidebarSection';
+import { EntityLink } from '@app/homeV2/reference/sections/EntityLink';
+
+const Content = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    width: 100%;
+`;
+
+type RelatedAsset = {
+    asset?: {
+        urn?: string | null;
+        type?: string | null;
+    } | null;
+};
+
+// Renders the `documentInfo.relatedAssets` array for native Document profiles. The default
+// DataProductSection reads the reverse `dataProduct.relationships` membership, which is
+// semantically different from a Document referencing arbitrary assets.
+export const SidebarRelatedAssetsSection = () => {
+    const { entityData } = useEntityData();
+    const relatedAssets: RelatedAsset[] =
+        (entityData as unknown as { info?: { relatedAssets?: RelatedAsset[] | null } })?.info?.relatedAssets ?? [];
+
+    return (
+        <SidebarSection
+            title="Related Assets"
+            content={
+                <Content>
+                    {relatedAssets.length > 0 ? (
+                        relatedAssets.map((relatedAsset) => {
+                            const entity = relatedAsset?.asset;
+                            if (!entity?.urn) return null;
+                            return <EntityLink key={entity.urn} entity={entity as never} />;
+                        })
+                    ) : (
+                        <EmptySectionText message="No related assets" />
+                    )}
+                </Content>
+            }
+        />
+    );
+};

--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/RelatedAssets/__tests__/SidebarRelatedAssetsSection.test.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/RelatedAssets/__tests__/SidebarRelatedAssetsSection.test.tsx
@@ -1,0 +1,113 @@
+import { MockedProvider } from '@apollo/client/testing';
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { EntityContext } from '@app/entity/shared/EntityContext';
+import { SidebarRelatedAssetsSection } from '@app/entityV2/shared/containers/profile/sidebar/RelatedAssets/SidebarRelatedAssetsSection';
+import TestPageContainer from '@utils/test-utils/TestPageContainer';
+
+import { EntityType } from '@types';
+
+// `vi.hoisted` is hoisted by vitest above all imports so the polyfill is in place before
+// `checkAuthStatus()` runs at `checkAuthStatus.ts` module-load time — that path reaches
+// `analytics.identify -> getMergedTrackingOptions -> localStorage.getItem`.
+vi.hoisted(() => {
+    const storage = new Map<string, string>();
+    Object.defineProperty(globalThis, 'localStorage', {
+        configurable: true,
+        value: {
+            getItem: (key: string) => storage.get(key) ?? null,
+            setItem: (key: string, value: string) => {
+                storage.set(key, String(value));
+            },
+            removeItem: (key: string) => {
+                storage.delete(key);
+            },
+            clear: () => storage.clear(),
+            key: (index: number) => Array.from(storage.keys())[index] ?? null,
+            get length() {
+                return storage.size;
+            },
+        },
+    });
+});
+
+const DOCUMENT_URN = 'urn:li:document:sidebar-related-assets-test';
+const LINKED_DP_URN = 'urn:li:dataProduct:linked-dp';
+
+const renderSection = (entityData: unknown) =>
+    render(
+        <MockedProvider addTypename={false}>
+            <TestPageContainer initialEntries={[`/document/${DOCUMENT_URN}`]}>
+                <EntityContext.Provider
+                    value={{
+                        urn: DOCUMENT_URN,
+                        entityType: EntityType.Document,
+                        // @ts-expect-error entityData is loose-typed across sidebar sections
+                        entityData,
+                        baseEntity: { document: entityData },
+                        routeToTab: vi.fn(),
+                        refetch: vi.fn(),
+                        lineage: undefined,
+                        loading: false,
+                        dataNotCombinedWithSiblings: null,
+                    }}
+                >
+                    <SidebarRelatedAssetsSection />
+                </EntityContext.Provider>
+            </TestPageContainer>
+        </MockedProvider>,
+    );
+
+describe('SidebarRelatedAssetsSection', () => {
+    it('renders a row per related asset when entityData.info.relatedAssets has entries', () => {
+        const entityData = {
+            urn: DOCUMENT_URN,
+            type: EntityType.Document,
+            info: {
+                relatedAssets: [
+                    {
+                        asset: {
+                            urn: LINKED_DP_URN,
+                            type: EntityType.DataProduct,
+                        },
+                    },
+                ],
+            },
+        };
+
+        const { getByText, queryByText } = renderSection(entityData);
+
+        // Section heading renders
+        expect(getByText('Related Assets')).toBeInTheDocument();
+        // Empty-state message must not be shown when the array has entries
+        expect(queryByText(/no related assets/i)).not.toBeInTheDocument();
+    });
+
+    it('renders the empty state when relatedAssets is an empty array', () => {
+        const entityData = {
+            urn: DOCUMENT_URN,
+            type: EntityType.Document,
+            info: {
+                relatedAssets: [],
+            },
+        };
+
+        const { getByText } = renderSection(entityData);
+
+        expect(getByText('Related Assets')).toBeInTheDocument();
+        expect(getByText(/no related assets/i)).toBeInTheDocument();
+    });
+
+    it('renders the empty state when info is undefined', () => {
+        const entityData = {
+            urn: DOCUMENT_URN,
+            type: EntityType.Document,
+        };
+
+        const { getByText } = renderSection(entityData);
+
+        expect(getByText('Related Assets')).toBeInTheDocument();
+        expect(getByText(/no related assets/i)).toBeInTheDocument();
+    });
+});

--- a/datahub-web-react/src/graphql/document.graphql
+++ b/datahub-web-react/src/graphql/document.graphql
@@ -79,6 +79,9 @@ query getDocument($urn: String!, $includeParentDocuments: Boolean = false) {
         tags {
             ...globalTagsFields
         }
+        globalTags {
+            ...globalTagsFields
+        }
         glossaryTerms {
             ...glossaryTerms
         }


### PR DESCRIPTION
> Stacked on top of #17148 (must merge first or this PR needs to be rebased onto master after #17148 lands).

## Summary

Fixes two rendering gaps in the Asset Summary sidebar on native `Document` profiles:

1. **Tags section was empty** even when the `globalTags` aspect was populated. The shared `SidebarTagsSection` reads `entityData.globalTags` (matching Dataset / DataProduct / Domain), but the `Document` GraphQL type only exposed `tags`. Adds a `globalTags: GlobalTags @deprecated` alias to the Document schema, populates it from `DocumentMapper`, and updates the `getDocument` query to fetch it.
2. **Assets linked from `documentInfo.relatedAssets` were invisible** in the sidebar. `DataProductSection` only reads the reverse `dataProduct.relationships` membership edge — a Document referencing arbitrary assets is semantically different. Adds a new `SidebarRelatedAssetsSection` that renders each `relatedAsset.asset` via `EntityLink`, registered on both the native and external Document profiles.

## Changes

**Backend**
- `documents.graphql`: add `globalTags: GlobalTags @deprecated` on `Document`
- `DocumentMapper.java`: set both `tags` and `globalTags` to the same mapped `GlobalTags` instance (matches `DatasetMapper` pattern)

**Frontend**
- `document.graphql`: fetch `globalTags` alongside `tags`
- `RelatedAssets/SidebarRelatedAssetsSection.tsx`: new sidebar section reading `entityData.info.relatedAssets`
- `DocumentNativeProfile.tsx` and `DocumentExternalProfile.tsx`: register the new section after `DataProductSection`

## Test plan

- [x] `DocumentMapperTest.testMapPopulatesDeprecatedGlobalTagsAlias` — asserts both `tags` and `globalTags` are populated with the same mapped instance; guards against regressions where one setter call is dropped. All 18 tests in the class pass.
- [x] `SidebarRelatedAssetsSection.test.tsx` — three cases: renders rows when `info.relatedAssets` has entries; renders empty state when the array is empty; renders empty state when `info` is absent. 3/3 pass.
- [x] `yarn type-check` clean
- [x] `./gradlew :datahub-graphql-core:spotlessApply` clean
- [x] `yarn format` clean
- [x] Manual UI verification — emit a Document with `globalTags` + `documentInfo.relatedAssets`, open its profile, confirm both sections render populated data. Confirm a Dataset profile is unaffected (regression check on the shared tags path).

## Notes

- `DataProductSection` is preserved on both profiles — external ingested documents may still participate in Data Product membership via the entity-relationship graph, which is genuinely distinct from `relatedAssets`.
- The sidebar-closed-by-default behavior on `DocumentNativeProfile` is intentional per current product spec and untouched.
- The frontend test required one adjustment vs. the original authoring: the inline `localStorage` polyfill is wrapped in `vi.hoisted(...)` so vitest hoists it above the transitive import of `checkAuthStatus` (which triggers `analytics.identify -> localStorage.getItem` at module-load). Without the hoist the polyfill installed too late under this repo's vitest setup and the test crashed before any assertions ran.