### PR TITLE
fix(search): route entity index writes by docId to avoid version_conflict corruption

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/update/ESWriteDAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/update/ESWriteDAO.java
@@ -100,7 +100,11 @@ public class ESWriteDAO {
             .doc(document, XContentType.JSON)
             .retryOnConflict(config.getBulkProcessor().getNumRetries());
 
-    bulkProcessor.add(updateRequest);
+    // Route by docId (URL-encoded URN) so repeated aspect writes for the same entity
+    // land on the same bulk processor thread. Without this, concurrent same-URN updates
+    // race on OpenSearch's seqNo and retryOnConflict cannot converge — partial updates
+    // are silently dropped and the indexed doc ends up with only bootstrap fields.
+    bulkProcessor.add(docId, updateRequest);
   }
 
   /**
@@ -124,7 +128,7 @@ public class ESWriteDAO {
             .doc(document, XContentType.JSON)
             .retryOnConflict(config.getBulkProcessor().getNumRetries());
 
-    bulkProcessor.add(updateRequest);
+    bulkProcessor.add(docId, updateRequest);
   }
 
   /**
@@ -139,7 +143,7 @@ public class ESWriteDAO {
       log.warn(READ_ONLY_LOG);
       return;
     }
-    bulkProcessor.add(new DeleteRequest(toIndexName(opContext, entityName)).id(docId));
+    bulkProcessor.add(docId, new DeleteRequest(toIndexName(opContext, entityName)).id(docId));
   }
 
   /**
@@ -154,7 +158,7 @@ public class ESWriteDAO {
       log.warn(READ_ONLY_LOG);
       return;
     }
-    bulkProcessor.add(new DeleteRequest(indexName).id(docId));
+    bulkProcessor.add(docId, new DeleteRequest(indexName).id(docId));
   }
 
   /**
@@ -197,8 +201,10 @@ public class ESWriteDAO {
             .doc(document, XContentType.JSON)
             .retryOnConflict(config.getBulkProcessor().getNumRetries());
 
-    // Use URN-aware routing for entity document consistency
-    bulkProcessor.add(updateRequest);
+    // URN-aware routing — docId is the URL-encoded entity URN, stable per entity, so
+    // using it as the routing key serializes concurrent aspect writes for the same URN
+    // on one bulk processor thread (preventing version_conflict_engine_exception).
+    bulkProcessor.add(docId, updateRequest);
   }
 
   /**
@@ -215,8 +221,8 @@ public class ESWriteDAO {
       log.warn(READ_ONLY_LOG);
       return;
     }
-    // Use URN-aware routing for entity document consistency
-    bulkProcessor.add(new DeleteRequest(toIndexNameV3(opContext, searchGroup)).id(docId));
+    // URN-aware routing — see upsertDocumentBySearchGroup above.
+    bulkProcessor.add(docId, new DeleteRequest(toIndexNameV3(opContext, searchGroup)).id(docId));
   }
 
   /** Applies a script to a particular document */
@@ -266,7 +272,8 @@ public class ESWriteDAO {
             .retryOnConflict(config.getBulkProcessor().getNumRetries())
             .script(script)
             .upsert(upsert);
-    bulkProcessor.add(updateRequest);
+    // URN-aware routing via docId — see upsertDocumentBySearchGroup above.
+    bulkProcessor.add(docId, updateRequest);
   }
 
   /**

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/update/ESWriteDAOTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/update/ESWriteDAOTest.java
@@ -98,7 +98,7 @@ public class ESWriteDAOTest {
     esWriteDAO.upsertDocument(opContext, TEST_ENTITY, document, TEST_DOC_ID);
 
     ArgumentCaptor<UpdateRequest> requestCaptor = ArgumentCaptor.forClass(UpdateRequest.class);
-    verify(mockBulkProcessor).add(requestCaptor.capture());
+    verify(mockBulkProcessor).add(eq(TEST_DOC_ID), requestCaptor.capture());
 
     UpdateRequest capturedRequest = requestCaptor.getValue();
     assertEquals(capturedRequest.index(), TEST_INDEX);
@@ -117,7 +117,7 @@ public class ESWriteDAOTest {
     esWriteDAO.deleteDocument(opContext, TEST_ENTITY, TEST_DOC_ID);
 
     ArgumentCaptor<DeleteRequest> requestCaptor = ArgumentCaptor.forClass(DeleteRequest.class);
-    verify(mockBulkProcessor).add(requestCaptor.capture());
+    verify(mockBulkProcessor).add(eq(TEST_DOC_ID), requestCaptor.capture());
 
     DeleteRequest capturedRequest = requestCaptor.getValue();
     assertEquals(capturedRequest.index(), TEST_INDEX);
@@ -136,7 +136,7 @@ public class ESWriteDAOTest {
         opContext, TEST_ENTITY, TEST_DOC_ID, scriptSource, scriptParams, upsert);
 
     ArgumentCaptor<UpdateRequest> requestCaptor = ArgumentCaptor.forClass(UpdateRequest.class);
-    verify(mockBulkProcessor).add(requestCaptor.capture());
+    verify(mockBulkProcessor).add(eq(TEST_DOC_ID), requestCaptor.capture());
 
     UpdateRequest capturedRequest = requestCaptor.getValue();
     assertEquals(TEST_INDEX, capturedRequest.index());
@@ -173,7 +173,7 @@ public class ESWriteDAOTest {
         opContext, searchGroup, TEST_DOC_ID, scriptSource, scriptParams, upsert);
 
     ArgumentCaptor<UpdateRequest> requestCaptor = ArgumentCaptor.forClass(UpdateRequest.class);
-    verify(mockBulkProcessor).add(requestCaptor.capture());
+    verify(mockBulkProcessor).add(eq(TEST_DOC_ID), requestCaptor.capture());
 
     UpdateRequest capturedRequest = requestCaptor.getValue();
     assertEquals("datasetindex_v3", capturedRequest.index());
@@ -917,10 +917,10 @@ public class ESWriteDAOTest {
 
     if (canWrite) {
       // When writable, bulkProcessor.add should be called
-      verify(mockBulkProcessor, times(1)).add(any(UpdateRequest.class));
+      verify(mockBulkProcessor, times(1)).add(any(String.class), any(UpdateRequest.class));
     } else {
       // When not writable, bulkProcessor.add should not be called
-      verify(mockBulkProcessor, never()).add(any(UpdateRequest.class));
+      verify(mockBulkProcessor, never()).add(any(String.class), any(UpdateRequest.class));
     }
   }
 
@@ -936,9 +936,9 @@ public class ESWriteDAOTest {
     esWriteDAO.upsertDocumentByIndexName(indexName, document, docId);
 
     if (canWrite) {
-      verify(mockBulkProcessor, times(1)).add(any(UpdateRequest.class));
+      verify(mockBulkProcessor, times(1)).add(any(String.class), any(UpdateRequest.class));
     } else {
-      verify(mockBulkProcessor, never()).add(any(UpdateRequest.class));
+      verify(mockBulkProcessor, never()).add(any(String.class), any(UpdateRequest.class));
     }
   }
 
@@ -952,9 +952,9 @@ public class ESWriteDAOTest {
     esWriteDAO.deleteDocument(opContext, TEST_ENTITY, docId);
 
     if (canWrite) {
-      verify(mockBulkProcessor, times(1)).add(any(DeleteRequest.class));
+      verify(mockBulkProcessor, times(1)).add(any(String.class), any(DeleteRequest.class));
     } else {
-      verify(mockBulkProcessor, never()).add(any(DeleteRequest.class));
+      verify(mockBulkProcessor, never()).add(any(String.class), any(DeleteRequest.class));
     }
   }
 
@@ -969,9 +969,9 @@ public class ESWriteDAOTest {
     esWriteDAO.deleteDocumentByIndexName(indexName, docId);
 
     if (canWrite) {
-      verify(mockBulkProcessor, times(1)).add(any(DeleteRequest.class));
+      verify(mockBulkProcessor, times(1)).add(any(String.class), any(DeleteRequest.class));
     } else {
-      verify(mockBulkProcessor, never()).add(any(DeleteRequest.class));
+      verify(mockBulkProcessor, never()).add(any(String.class), any(DeleteRequest.class));
     }
   }
 
@@ -986,9 +986,9 @@ public class ESWriteDAOTest {
     esWriteDAO.upsertDocumentBySearchGroup(opContext, searchGroup, document, docId);
 
     if (canWrite) {
-      verify(mockBulkProcessor, times(1)).add(any(UpdateRequest.class));
+      verify(mockBulkProcessor, times(1)).add(any(String.class), any(UpdateRequest.class));
     } else {
-      verify(mockBulkProcessor, never()).add(any(UpdateRequest.class));
+      verify(mockBulkProcessor, never()).add(any(String.class), any(UpdateRequest.class));
     }
   }
 
@@ -1002,9 +1002,9 @@ public class ESWriteDAOTest {
     esWriteDAO.deleteDocumentBySearchGroup(opContext, searchGroup, docId);
 
     if (canWrite) {
-      verify(mockBulkProcessor, times(1)).add(any(DeleteRequest.class));
+      verify(mockBulkProcessor, times(1)).add(any(String.class), any(DeleteRequest.class));
     } else {
-      verify(mockBulkProcessor, never()).add(any(DeleteRequest.class));
+      verify(mockBulkProcessor, never()).add(any(String.class), any(DeleteRequest.class));
     }
   }
 
@@ -1022,9 +1022,9 @@ public class ESWriteDAOTest {
         opContext, TEST_ENTITY, TEST_DOC_ID + description, scriptSource, scriptParams, upsert);
 
     if (canWrite) {
-      verify(mockBulkProcessor, times(1)).add(any(UpdateRequest.class));
+      verify(mockBulkProcessor, times(1)).add(any(String.class), any(UpdateRequest.class));
     } else {
-      verify(mockBulkProcessor, never()).add(any(UpdateRequest.class));
+      verify(mockBulkProcessor, never()).add(any(String.class), any(UpdateRequest.class));
     }
   }
 
@@ -1143,20 +1143,20 @@ public class ESWriteDAOTest {
 
     String document1 = "{\"field\":\"value1\"}";
     esWriteDAO.upsertDocument(opContext, TEST_ENTITY, document1, "doc1");
-    verify(mockBulkProcessor, times(1)).add(any(UpdateRequest.class));
+    verify(mockBulkProcessor, times(1)).add(any(String.class), any(UpdateRequest.class));
 
     esWriteDAO.setWritable(false);
 
     String document2 = "{\"field\":\"value2\"}";
     esWriteDAO.upsertDocument(opContext, TEST_ENTITY, document2, "doc2");
     // Still only 1 call
-    verify(mockBulkProcessor, times(1)).add(any(UpdateRequest.class));
+    verify(mockBulkProcessor, times(1)).add(any(String.class), any(UpdateRequest.class));
 
     esWriteDAO.setWritable(true);
 
     String document3 = "{\"field\":\"value3\"}";
     esWriteDAO.upsertDocument(opContext, TEST_ENTITY, document3, "doc3");
-    verify(mockBulkProcessor, times(2)).add(any(UpdateRequest.class));
+    verify(mockBulkProcessor, times(2)).add(any(String.class), any(UpdateRequest.class));
   }
 
   @Test
@@ -1168,32 +1168,32 @@ public class ESWriteDAOTest {
 
     // 1. upsertDocument
     esWriteDAO.upsertDocument(opContext, TEST_ENTITY, document, "doc1");
-    verify(mockBulkProcessor, never()).add(any(UpdateRequest.class));
+    verify(mockBulkProcessor, never()).add(any(String.class), any(UpdateRequest.class));
 
     // 2. upsertDocumentByIndexName
     esWriteDAO.upsertDocumentByIndexName("test_index", document, "doc2");
-    verify(mockBulkProcessor, never()).add(any(UpdateRequest.class));
+    verify(mockBulkProcessor, never()).add(any(String.class), any(UpdateRequest.class));
 
     // 3. deleteDocument
     esWriteDAO.deleteDocument(opContext, TEST_ENTITY, "doc3");
-    verify(mockBulkProcessor, never()).add(any(DeleteRequest.class));
+    verify(mockBulkProcessor, never()).add(any(String.class), any(DeleteRequest.class));
 
     // 4. deleteDocumentByIndexName
     esWriteDAO.deleteDocumentByIndexName("test_index", "doc4");
-    verify(mockBulkProcessor, never()).add(any(DeleteRequest.class));
+    verify(mockBulkProcessor, never()).add(any(String.class), any(DeleteRequest.class));
 
     // 5. upsertDocumentBySearchGroup
     esWriteDAO.upsertDocumentBySearchGroup(opContext, "group", document, "doc5");
-    verify(mockBulkProcessor, never()).add(any(UpdateRequest.class));
+    verify(mockBulkProcessor, never()).add(any(String.class), any(UpdateRequest.class));
 
     // 6. deleteDocumentBySearchGroup
     esWriteDAO.deleteDocumentBySearchGroup(opContext, "group", "doc6");
-    verify(mockBulkProcessor, never()).add(any(DeleteRequest.class));
+    verify(mockBulkProcessor, never()).add(any(String.class), any(DeleteRequest.class));
 
     // 7. applyScriptUpdate
     esWriteDAO.applyScriptUpdate(
         opContext, TEST_ENTITY, "doc7", "script", new HashMap<>(), new HashMap<>());
-    verify(mockBulkProcessor, never()).add(any(UpdateRequest.class));
+    verify(mockBulkProcessor, never()).add(any(String.class), any(UpdateRequest.class));
 
     // 8. clear
     String[] indices = new String[] {"index1"};
@@ -1258,7 +1258,7 @@ public class ESWriteDAOTest {
     assertFalse(syncResult.isSuccess());
 
     // No operations should have been executed
-    verify(mockBulkProcessor, never()).add(any());
+    verify(mockBulkProcessor, never()).add(any(String.class), any());
     verify(mockBulkProcessor, never()).deleteByQuery(any(), any());
     verify(mockSearchClient, never()).submitDeleteByQueryTask(any(), any());
     verify(mockSearchClient, never()).count(any(), any());
@@ -1267,7 +1267,7 @@ public class ESWriteDAOTest {
 
     // Writes should work again
     esWriteDAO.upsertDocument(opContext, TEST_ENTITY, document, "postMigrationDoc");
-    verify(mockBulkProcessor, times(1)).add(any(UpdateRequest.class));
+    verify(mockBulkProcessor, times(1)).add(any(String.class), any(UpdateRequest.class));
   }
 
   @Test
@@ -1280,8 +1280,8 @@ public class ESWriteDAOTest {
     esWriteDAO.upsertDocumentByIndexName("test_index", document, "seq2");
     esWriteDAO.deleteDocument(opContext, TEST_ENTITY, "seq3");
 
-    verify(mockBulkProcessor, times(2)).add(any(UpdateRequest.class));
-    verify(mockBulkProcessor, times(1)).add(any(DeleteRequest.class));
+    verify(mockBulkProcessor, times(2)).add(any(String.class), any(UpdateRequest.class));
+    verify(mockBulkProcessor, times(1)).add(any(String.class), any(DeleteRequest.class));
 
     esWriteDAO.setWritable(false);
 
@@ -1289,14 +1289,14 @@ public class ESWriteDAOTest {
     esWriteDAO.deleteDocument(opContext, TEST_ENTITY, "seq5");
 
     // Counts should not increase
-    verify(mockBulkProcessor, times(2)).add(any(UpdateRequest.class));
-    verify(mockBulkProcessor, times(1)).add(any(DeleteRequest.class));
+    verify(mockBulkProcessor, times(2)).add(any(String.class), any(UpdateRequest.class));
+    verify(mockBulkProcessor, times(1)).add(any(String.class), any(DeleteRequest.class));
 
     esWriteDAO.setWritable(true);
 
     // Operations should work again
     esWriteDAO.upsertDocument(opContext, TEST_ENTITY, document, "seq6");
-    verify(mockBulkProcessor, times(3)).add(any(UpdateRequest.class));
+    verify(mockBulkProcessor, times(3)).add(any(String.class), any(UpdateRequest.class));
   }
 
   @Test
@@ -1368,11 +1368,11 @@ public class ESWriteDAOTest {
 
     // First instance operations blocked
     esWriteDAO.upsertDocument(opContext, TEST_ENTITY, document, "doc1");
-    verify(mockBulkProcessor, never()).add(any(UpdateRequest.class));
+    verify(mockBulkProcessor, never()).add(any(String.class), any(UpdateRequest.class));
 
     // Second instance operations work
     secondDao.upsertDocument(opContext, TEST_ENTITY, document, "doc2");
-    verify(mockBulkProcessor, times(1)).add(any(UpdateRequest.class));
+    verify(mockBulkProcessor, times(1)).add(any(String.class), any(UpdateRequest.class));
   }
 
   @Test
@@ -1386,14 +1386,14 @@ public class ESWriteDAOTest {
     esWriteDAO.upsertDocumentByIndexName("test_index", document, docId);
     esWriteDAO.upsertDocumentBySearchGroup(opContext, "test_group", document, docId);
 
-    verify(mockBulkProcessor, never()).add(any(UpdateRequest.class));
+    verify(mockBulkProcessor, never()).add(any(String.class), any(UpdateRequest.class));
 
     esWriteDAO.setWritable(true);
 
     esWriteDAO.upsertDocumentByIndexName("test_index", document, docId);
     esWriteDAO.upsertDocumentBySearchGroup(opContext, "test_group", document, docId);
 
-    verify(mockBulkProcessor, times(2)).add(any(UpdateRequest.class));
+    verify(mockBulkProcessor, times(2)).add(any(String.class), any(UpdateRequest.class));
   }
 
   @Test
@@ -1406,14 +1406,14 @@ public class ESWriteDAOTest {
     esWriteDAO.deleteDocumentByIndexName("test_index", docId);
     esWriteDAO.deleteDocumentBySearchGroup(opContext, "test_group", docId);
 
-    verify(mockBulkProcessor, never()).add(any(DeleteRequest.class));
+    verify(mockBulkProcessor, never()).add(any(String.class), any(DeleteRequest.class));
 
     esWriteDAO.setWritable(true);
 
     esWriteDAO.deleteDocumentByIndexName("test_index", docId);
     esWriteDAO.deleteDocumentBySearchGroup(opContext, "test_group", docId);
 
-    verify(mockBulkProcessor, times(2)).add(any(DeleteRequest.class));
+    verify(mockBulkProcessor, times(2)).add(any(String.class), any(DeleteRequest.class));
   }
 
   @Test
@@ -1429,7 +1429,7 @@ public class ESWriteDAOTest {
     esWriteDAO.applyScriptUpdate(
         opContext, TEST_ENTITY, "scriptDoc", scriptSource, scriptParams, upsert);
 
-    verify(mockBulkProcessor, never()).add(any(UpdateRequest.class));
+    verify(mockBulkProcessor, never()).add(any(String.class), any(UpdateRequest.class));
   }
 
   @Test


### PR DESCRIPTION
## Summary

`ESWriteDAO` has seven entity-scoped index-write methods that advertise URN-aware routing in their comments but actually call the **non-URN-aware** `bulkProcessor.add(DocWriteRequest)` overload. When multiple MCPs for the same entity URN land in one MAE bulk batch (the common case for any caller that emits more than one aspect back-to-back), they round-robin across bulk processor threads and race on OpenSearch's `seqNo`/`primaryTerm` optimistic concurrency. `retryOnConflict(3)` **is** configured on the `UpdateRequest`, but is ineffective because the conflicting operation is not routed back to the same processor queue — so the retry never converges.

The observable symptom is severe and silent: the OpenSearch entity document ends up populated with **only the `urn` field** (plus a few bootstrap fields like `runId`, `id`, `systemCreated`). `title`, `relatedAssets`, `parentDocument`, `tags`, `owners`, `domains`, etc. are all missing, even though the aspects are correctly persisted in MySQL. GMS logs show `version_conflict_engine_exception` around the time of emission, but `BulkListener.afterBulk` logs `"Successfully fed bulk request"` because item-level failures are not surfaced — so the failure class is invisible in logs alone.

Downstream consequences (any read path that hits the search index):

- `DataProduct.relatedDocuments` returns `total: 0` even when a Document references the Data Product via `relatedAssets`.
- Parent/child folder hierarchy for Documents is invisible in the UI (the `parentDocument` reverse lookup finds nothing).
- Saved views and filters that target indexed fields other than `urn` silently return empty.
- Any ingestion that writes multiple aspects per entity quickly (native entity creation flows, Actions handlers, bootstrap steps) is exposed.

**This PR fixes the index write path with a one-file, zero-signature-change change** by passing `docId` (the URL-encoded entity URN — already in scope at every call site and stable per entity) as the routing key on every `bulkProcessor.add()` call. `ESBulkProcessor` already exposes the URN-aware `add(String, DocWriteRequest)` overload (lines 117-127); its docstring explicitly says it "routes all operations for the same URN to the same BulkProcessor to ensure consistent ordering and avoid conflicts when updating the same entity." This PR simply wires every entity-scoped call through that overload.

## Root cause

See `ESBulkProcessor.java` (unchanged in this PR):

```java
// Line 97 — default round-robin routing across processor threads
public ESBulkProcessor add(DocWriteRequest<?> request) { ... }

// Line 117 — URN-aware routing; docstring: "routes all operations for the same
// URN to the same BulkProcessor to ensure consistent ordering and avoid
// conflicts when updating the same entity."
public ESBulkProcessor add(@Nonnull String urn, @Nonnull DocWriteRequest<?> request) { ... }
```

`ESWriteDAO` had seven call sites using the wrong overload:

| Line (pre-fix) | Method | Comment above |
|---|---|---|
| 103 | `upsertDocument` | — |
| 127 | `upsertDocumentByIndexName` | — |
| 142 | `deleteDocument` | — |
| 157 | `deleteDocumentByIndexName` | — |
| 201 | `upsertDocumentBySearchGroup` | `// Use URN-aware routing for entity document consistency` |
| 219 | `deleteDocumentBySearchGroup` | `// Use URN-aware routing for entity document consistency` |
| 269 | `applyScriptUpdateByIndexName` | — (indirectly drives `applyScriptUpdate` and `applyScriptUpdateBySearchGroup`) |

Failure sequence when four aspects for the same URN flush together:

1. Write A (e.g. `DocumentInfo`) wins, advances `seqNo: 16 → 17`.
2. Write B (`DocumentSettings`) arrives with stale `seqNo: 16`; OpenSearch rejects with `version_conflict_engine_exception`.
3. `retryOnConflict(3)` retries — but because B was not routed back to A's queue, it does not observe the updated doc state. Retry loops until exhaustion, then is dropped.
4. Writes C and D repeat the same race independently.
5. `BulkListener.afterBulk` logs success because the outer bulk response completed; item-level failures are swallowed.

Net effect: the first write for a URN populates the index doc (often only the partial document derived from whichever aspect landed first), and subsequent aspect writes silently vanish.

## Fix

Every entity-scoped write routes through the URN-aware overload using `docId` as the routing key. `docId` is the URL-encoded URN (built by `IndexConvention.getEntityDocumentId(urn)` for V3 writes and by `URLEncoder.encode(urn)` in V2), stable per entity, and already available at every call site — so **no signature changes** anywhere in the call chain.

```java
// Before
bulkProcessor.add(updateRequest);

// After
bulkProcessor.add(docId, updateRequest);
```

Applied consistently across all seven methods in `ESWriteDAO`. Total diff: **+16/-9 lines in the production file**. No changes to `EntitySearchService`, `ElasticSearchService`, `UpdateIndicesV2Strategy`, `UpdateIndicesV3Strategy`, `IngestPoliciesStep`, `DeleteIndexDocumentsFix`, or any other caller — they all continue to call the existing method signatures, which now transparently do the right thing. `ESWriteDAOTest` is updated to assert the URN-aware overload is invoked with `docId` as the routing key on every write path.

## Reproduction

Minimum repro (works against any 1.x GMS without this fix):

```python
from datahub.emitter.mcp import MetadataChangeProposalWrapper
from datahub.ingestion.graph.client import DataHubGraph, DataHubGraphConfig
from datahub.metadata.schema_classes import (
    DocumentInfoClass, DocumentContentsClass, DocumentSourceClass, DocumentSourceTypeClass,
    DocumentStatusClass, DocumentStateClass, DocumentSettingsClass, AuditStampClass,
    RelatedAssetClass, ParentDocumentClass, OwnershipClass, OwnerClass, OwnershipTypeClass,
    GlobalTagsClass, TagAssociationClass,
)

graph = DataHubGraph(DataHubGraphConfig(server="http://localhost:8080", extra_headers=...))
urn = "urn:li:document:repro-test-1"
audit = AuditStampClass(time=int(time.time() * 1000), actor="urn:li:corpuser:__datahub_system")

# Emit four aspects back-to-back for the same URN
graph.emit(MetadataChangeProposalWrapper(entityUrn=urn, aspect=DocumentInfoClass(
    title="Repro",
    contents=DocumentContentsClass(text="..."),
    source=DocumentSourceClass(sourceType=DocumentSourceTypeClass.NATIVE),
    status=DocumentStatusClass(state=DocumentStateClass.PUBLISHED),
    created=audit, lastModified=audit,
    relatedAssets=[RelatedAssetClass(asset="urn:li:dataProduct:example-data-product")],
    parentDocument=ParentDocumentClass(document="urn:li:document:example-parent"),
)))
graph.emit(MetadataChangeProposalWrapper(entityUrn=urn, aspect=DocumentSettingsClass(showInGlobalContext=True)))
graph.emit(MetadataChangeProposalWrapper(entityUrn=urn, aspect=OwnershipClass(owners=[...])))
graph.emit(MetadataChangeProposalWrapper(entityUrn=urn, aspect=GlobalTagsClass(tags=[...])))
```

**Before fix** — `documentindex_v2` for this URN:

```json
{
  "urn": "urn:li:document:repro-test-1",
  "runId": ["no-run-id-provided"],
  "systemCreated": 1776849152787,
  "id": "repro-test-1",
  "showInGlobalContext": true,
  "browsePathV2": "␟Default"
}
```

GMS log around the same time:

```
OpenSearchException[version_conflict_engine_exception,
  reason=[urn%3Ali%3Adocument%3Arepro-test-1]:
  version conflict, required seqNo [16], primary term [1].
  current document has seqNo [17] and primary term [1]]
```

Despite this, `BulkListener` logs `"Successfully fed bulk request"`.

**After fix** — same four-MCP emission, `documentindex_v2`:

```json
{
  "urn": "urn:li:document:repro-test-1",
  "title": "Repro",
  "relatedAssets": ["urn:li:dataProduct:example-data-product"],
  "parentDocument": "urn:li:document:example-parent",
  "tags": ["urn:li:tag:example-tag"],
  "owners": ["urn:li:corpuser:alice@example.com"],
  "showInGlobalContext": true,
  ...
}
```

All fields present on first emission; no `version_conflict` in logs.

## Test plan

- [x] `./gradlew :metadata-io:compileJava :metadata-io:testClasses` — clean
- [x] `./gradlew :metadata-io:test --tests "com.linkedin.metadata.search.update.ESWriteDAOTest"` — 59/59 passing; assertions updated to verify the URN-aware overload is invoked with `docId` on every write path.
- [x] `./gradlew :metadata-service:war:build -x test` — builds clean
- [x] Smoke test against a running `quickstartDebug` GMS with the patched war: rapid four-MCP emission (`DocumentInfo` + `DocumentSettings` + `Ownership` + `GlobalTags`) produces a fully-populated OpenSearch doc on first try, no `version_conflict_engine_exception` in logs, and `DataProduct.relatedDocuments` returns the document via the reverse-relationship resolver.
- [x] Verified the fix is safe for documents already populated via `restoreIndices` bootstrap (recovery of pre-existing corrupt docs still works).
- [ ] Reviewers may want to run the full `metadata-io` test suite on CI to confirm no regression from the routing-key change. The `ESBulkProcessor.add(String, DocWriteRequest)` overload has been in the codebase for multiple releases and has existing test coverage.

## Scope notes — what this PR does not touch

- `ElasticSearchGraphService` and `ElasticSearchSystemMetadataService` write through their own DAOs (`GraphWriteDAO`, `ESDAO`) and are out of scope here. The same bug pattern may exist in those DAOs for the `graph_service_v2` and `system_metadata_service_v1` indices — worth a follow-up if any caller writes multiple records per URN in quick succession.
- **Secondary defect** (not fixed in this PR, flagged for follow-up): `BulkListener.afterBulk` logs `"Successfully fed bulk request"` whenever the outer bulk response succeeds, even if individual `BulkItemResponse.isFailed()` is true. This is how the root cause stayed hidden. A follow-up should iterate `response.getItems()` and log item-level failures at `WARN`.
- Recovery for existing corrupt docs on an affected deployment: `POST /openapi/operations/elasticSearch/restoreIndices` with `["<urn>"]` reindexes from MySQL. No schema or mapping changes needed.