### PR TITLE
fix(build): fix uv pip constraints as well as build-constraints

### DIFF
--- a/metadata-ingestion/build.gradle
+++ b/metadata-ingestion/build.gradle
@@ -8,7 +8,7 @@ ext {
   python_executable = 'python3'
   venv_name = 'venv'
   // Constrain setuptools<82 in build isolation environments (e.g. when building flatdict from source)
-  uv_build_constraints = '--build-constraint build-constraints.txt'
+  uv_constraints = '--build-constraint build-constraints.txt --constraint constraints.txt'
 }
 
 ext.venv_activate_command = "set +x && source ${venv_name}/bin/activate && set -x && "
@@ -41,7 +41,7 @@ task installPackageOnly(type: Exec, dependsOn: environmentSetup) {
   outputs.file(sentinel_file)
   commandLine 'bash', '-c',
     venv_activate_command +
-    "uv pip install ${uv_build_constraints} -e . &&" +
+    "uv pip install ${uv_constraints} -e . &&" +
     "touch ${sentinel_file}"
 }
 
@@ -51,7 +51,7 @@ task installPackage(type: Exec, dependsOn: installPackageOnly) {
   outputs.file(sentinel_file)
   commandLine 'bash', '-c',
     venv_activate_command +
-    "uv pip install ${uv_build_constraints} -e . ${extra_pip_requirements} && " +
+    "uv pip install ${uv_constraints} -e . ${extra_pip_requirements} && " +
     "touch ${sentinel_file}"
 }
 
@@ -69,7 +69,7 @@ task customPackageGenerate(type: Exec, dependsOn: [environmentSetup, installPack
   def package_version = project.findProperty('package_version')
   commandLine 'bash', '-c',
     venv_activate_command +
-    "uv pip install ${uv_build_constraints} build && " +
+    "uv pip install ${uv_constraints} build && " +
     "./scripts/custom_package_codegen.sh '${package_name}' '${package_version}'"
 }
 
@@ -81,7 +81,7 @@ task installDev(type: Exec, dependsOn: [install]) {
   outputs.file(sentinel_file)
   commandLine 'bash', '-c',
     venv_activate_command +
-    "uv pip install ${uv_build_constraints} -e .[dev] ${extra_pip_requirements} && " +
+    "uv pip install ${uv_constraints} -e .[dev] ${extra_pip_requirements} && " +
     "touch ${sentinel_file}"
 }
 
@@ -91,7 +91,7 @@ task installAll(type: Exec, dependsOn: [install]) {
   outputs.file(sentinel_file)
   commandLine 'bash', '-c',
     venv_activate_command +
-    "uv pip install ${uv_build_constraints} -e .[all] ${extra_pip_requirements} && " +
+    "uv pip install ${uv_constraints} -e .[all] ${extra_pip_requirements} && " +
     "touch ${sentinel_file}"
 }
 
@@ -226,7 +226,7 @@ task installDocs(type: Exec, dependsOn: [install]) {
   outputs.file(sentinel_file)
   commandLine 'bash', '-c',
     venv_activate_command +
-    "uv pip install ${uv_build_constraints} -e .[docs] ${extra_pip_requirements} && " +
+    "uv pip install ${uv_constraints} -e .[docs] ${extra_pip_requirements} && " +
     "touch ${sentinel_file}"
 }
 
@@ -237,7 +237,7 @@ task installDevTest(type: Exec, dependsOn: [install]) {
   outputs.file(sentinel_file)
   commandLine 'bash', '-c',
     venv_activate_command +
-    "uv pip install ${uv_build_constraints} -e .[dev,integration-tests] ${extra_pip_requirements} && " +
+    "uv pip install ${uv_constraints} -e .[dev,integration-tests] ${extra_pip_requirements} && " +
     "touch ${sentinel_file}"
 }
 
@@ -342,7 +342,7 @@ task buildWheel(type: Exec, dependsOn: [install, codegen, cleanPythonCache, chec
   commandLine 'bash', '-c',
     venv_activate_command +
     "cp constraints.txt src/datahub/constraints.txt && " +
-    "uv pip install ${uv_build_constraints} build && " + 'RELEASE_VERSION="\${RELEASE_VERSION:-0.0.0.dev1}" RELEASE_SKIP_INSTALL=1 RELEASE_SKIP_UPLOAD=1 ./scripts/release.sh'
+    "uv pip install ${uv_constraints} build && " + 'RELEASE_VERSION="\${RELEASE_VERSION:-0.0.0.dev1}" RELEASE_SKIP_INSTALL=1 RELEASE_SKIP_UPLOAD=1 ./scripts/release.sh'
 }
 
 build.dependsOn install


### PR DESCRIPTION
This fix was prompted by a gradlew ... clean :metadata-ingest:installDev in a clean environment, which picked-up an upgraded jpype1 1.6.0 -> 1.7.0.

The 1.7.0 build is bad, missing wheels for MacOS ARM64, which triggers a build-from-source from cmake, and a missing ant dependency.

We should lock all the versions in the venv to prevent this kind of version float.

See also https://github.com/jpype-project/jpype/issues/1357 .

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
