### PR TITLE
fix(security): floor lxml for CVE-2026-41066 in docker bundled venvs

### DIFF
--- a/docker/snippets/ingestion/constraints.txt
+++ b/docker/snippets/ingestion/constraints.txt
@@ -47,6 +47,9 @@ google-cloud-aiplatform>=1.133.0
 langgraph>=1.0.10
 langgraph-checkpoint>=4.0.0
 langsmith>=0.6.3
+# CVE-2026-41066: lxml 6.0.x default entity resolution; fixed in 6.1.0. Major cap until reviewed.
+# (unstructured / HTML parsing; bundled venvs such as datahub-documents-bundled.)
+lxml>=6.1.0,<7.0.0
 # mlflow-skinny: CVE-2025-14287, CVE-2025-15031, CVE-2026-2033 (fixed >=3.9.0)
 mlflow-skinny>=3.9.0,<4.0.0
 # ujson: parsing huge out-of-range integers leaked memory in 5.4.0–5.11.0; indent handling


### PR DESCRIPTION
Add lxml>=6.1.0,<7.0.0 to docker/snippets/ingestion/constraints.txt (bundled pip installs e.g. datahub-documents-bundled). CVE-2026-41066: unsafe defaults in lxml 6.0.x iterparse/ETCompatXMLParser; fixed in 6.1.0.

Made-with: Cursor

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
