### PR TITLE
fix: secrets can paginate now

### DIFF
--- a/datahub-web-react/src/app/ingestV2/secret/SecretsList.tsx
+++ b/datahub-web-react/src/app/ingestV2/secret/SecretsList.tsx
@@ -357,7 +357,7 @@ export const SecretsList = ({ showCreateModal: isCreatingSecret, setShowCreateMo
                             itemsPerPage={pageSize}
                             total={totalSecrets}
                             showLessItems
-                            onChange={onChangePage}
+                            onPageChange={onChangePage}
                             showSizeChanger={false}
                             hideOnSinglePage
                         />


### PR DESCRIPTION
What: Secrets view
Before: "2" page is available in the bottom "scroller" but I can't click it, nor the > button.
After: paginates properly

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
