### PR TITLE
docs(s3,glue): add comprehensive cross-account role authentication documentation

### DIFF
--- a/metadata-ingestion/docs/sources/glue/glue_post.md
+++ b/metadata-ingestion/docs/sources/glue/glue_post.md
@@ -2,6 +2,81 @@
 
 Use the **Important Capabilities** table above as the source of truth for supported features and whether additional configuration is required.
 
+#### Cross-Account Lineage
+
+When ingesting Glue metadata from different AWS accounts, the connector can establish lineage relationships across account boundaries. This is particularly useful for tracking data flows in multi-account AWS environments.
+
+**How it works:**
+
+When you ingest a Glue catalog that references storage (e.g., S3 buckets) or other resources in different accounts, the connector creates lineage edges to those resources. For example:
+
+- Account A has a Glue table pointing to an S3 bucket in Account A
+- Account B has shared access to Account A's Glue catalog (using `catalog_id`)
+- When you ingest from Account B, DataHub creates lineage from the Glue table to the S3 bucket
+
+**URN resolution and entity merging:**
+
+The connector's behavior depends on your `platform_instance` configuration:
+
+- **Without platform instance**: If you ingest the same Glue catalog from different accounts without setting `platform_instance`, DataHub recognizes them as the same entities and creates a single dataset. Lineage to S3 (or other storage) is preserved regardless of which account performed the ingestion.
+
+  ```yaml
+  # Account A ingestion
+  source:
+    type: glue
+    config:
+      aws_config:
+        aws_region: us-east-1
+  ```
+
+  ```yaml
+  # Account B ingestion (using catalog_id)
+  source:
+    type: glue
+    config:
+      catalog_id: "111111111111" # Account A's ID
+      aws_config:
+        aws_region: us-east-1
+  ```
+
+  Result: Single Glue table entity with lineage to S3.
+
+- **With platform instance**: Using different `platform_instance` values creates separate dataset entities with distinct URNs. This is useful for tracking the same data through different access paths or maintaining separate views per account.
+
+  ```yaml
+  # Account A ingestion
+  source:
+    type: glue
+    config:
+      platform_instance: account-a
+      aws_config:
+        aws_region: us-east-1
+  ```
+
+  ```yaml
+  # Account B ingestion
+  source:
+    type: glue
+    config:
+      catalog_id: "111111111111" # Account A's ID
+      platform_instance: account-b
+      aws_config:
+        aws_region: us-east-1
+  ```
+
+  Result: Two separate Glue table entities (one per platform instance), each with its own lineage edges.
+
+**Storage lineage:**
+
+To see lineage between Glue tables and their underlying S3 locations, you must:
+
+1. Set `emit_storage_lineage: true` in the Glue connector config
+2. Ingest S3 separately using the [S3 connector](https://docs.datahub.com/docs/generated/ingestion/sources/s3)
+
+The S3 connector creates dataset entities for the storage locations, and the Glue connector creates lineage edges connecting Glue tables to those S3 datasets. This works seamlessly across account boundaries when both connectors are configured correctly.
+
+For cross-account S3 access, refer to the [S3 connector's cross-account documentation](https://docs.datahub.com/docs/generated/ingestion/sources/s3#cross-account-access).
+
 #### Compatibility
 
 To capture lineage across Glue jobs and databases, a requirements must be met – otherwise the AWS API is unable to report any lineage. The job must be created in Glue Studio with the "Generate classic script" option turned on (this option can be accessed in the "Script" tab). Any custom scripts that do not have the proper annotations will not have reported lineage.

--- a/metadata-ingestion/docs/sources/glue/glue_pre.md
+++ b/metadata-ingestion/docs/sources/glue/glue_pre.md
@@ -62,19 +62,89 @@ For profiling datasets, the following additional permissions are required:
 }
 ```
 
-#### Glue Cross-account Access
+#### Cross-Account Access
 
-Glue ingestion supports cross-account access and lineage by allowing you to specify the target AWS account's Glue catalog using the `catalog_id` parameter in the ingestion recipe. This enables ingestion of Glue metadata from different AWS accounts, supporting cross-account lineage scenarios. You must ensure the correct IAM roles and permissions are set up for cross-account access.
+The Glue connector supports cross-account access via AWS STS AssumeRole. This allows DataHub running in one AWS account to ingest Glue metadata from a catalog in a different AWS account.
 
-Example: There are 2 AWS accounts A and B, A has shared metadata with B. Account A has Glue table - tableA. If you ingest account A using Glue it will create dataset tableA in DataHub. If you want to ingest tableA via account B you can pass `catalog_id` parameter in recipe with A's catalog id.
+**Setup steps:**
 
-Ingestion without platform instance parameter
+1. **In the target account** (where the Glue catalog lives), create an IAM role with:
+   - The Glue permissions policy shown above
+   - A trust policy allowing the source account to assume the role:
 
-- If both catalogs are ingested without platform instance parameter, DataHub should be able to understand that the database and tables are same
-- DataHub will create single entity for table tableA
-- It should show lineage between Glue and S3. You have to ingest S3 as separate source (https://docs.datahub.com/docs/generated/ingestion/sources/s3)
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::SOURCE-ACCOUNT-ID:role/DataHubExecutionRole"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "sts:ExternalId": "your-unique-external-id"
+        }
+      }
+    }
+  ]
+}
+```
 
-Ingestion with platform instance parameter
+2. **In the ingestion recipe**, configure `aws_config.aws_role` with the target role ARN:
 
-- It will create separate entities for tableA as it will have different URN path
-- It should show lineage between Glue and S3
+**Simple ARN format:**
+
+```yaml
+source:
+  type: glue
+  config:
+    aws_config:
+      aws_role: "arn:aws:iam::TARGET-ACCOUNT-ID:role/DataHubGlueReadRole"
+```
+
+**With External ID** (recommended for security):
+
+```yaml
+source:
+  type: glue
+  config:
+    aws_config:
+      aws_role:
+        RoleArn: "arn:aws:iam::TARGET-ACCOUNT-ID:role/DataHubGlueReadRole"
+        ExternalId: "your-unique-external-id"
+```
+
+**Role chaining** (assume multiple roles in sequence):
+
+```yaml
+source:
+  type: glue
+  config:
+    aws_config:
+      aws_role:
+        - "arn:aws:iam::INTERMEDIARY-ACCOUNT-ID:role/IntermediateRole"
+        - RoleArn: "arn:aws:iam::TARGET-ACCOUNT-ID:role/DataHubGlueReadRole"
+          ExternalId: "your-unique-external-id"
+```
+
+The connector uses [boto3's assume_role](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sts.html#STS.Client.assume_role), so additional parameters like `RoleSessionName`, `DurationSeconds`, and `Policy` are also supported.
+
+**Cross-account catalog access:**
+
+For accessing a specific Glue catalog in another account (without assuming a role), use the `catalog_id` parameter:
+
+```yaml
+source:
+  type: glue
+  config:
+    catalog_id: "123456789012" # Target account's AWS account ID
+```
+
+This is useful when Account A has shared its Glue catalog with Account B. If you're running ingestion from Account B and want to access Account A's catalog, specify Account A's ID in `catalog_id`.
+
+**Platform instance considerations:**
+
+- **Without platform instance**: If you ingest the same Glue catalog from different accounts without setting `platform_instance`, DataHub recognizes them as the same entities and creates a single dataset.
+- **With platform instance**: Using different `platform_instance` values creates separate dataset entities with distinct URNs, useful for tracking the same data through different access paths.

--- a/metadata-ingestion/docs/sources/s3/s3_pre.md
+++ b/metadata-ingestion/docs/sources/s3/s3_pre.md
@@ -48,3 +48,78 @@ Attach the policy to the IAM user or role used by the S3 ingestion source.
 **3. Configure the Source**
 
 Use the IAM user/role credentials in your S3 ingestion recipe.
+
+#### Cross-Account Access
+
+The S3 connector supports cross-account access via AWS STS AssumeRole. This allows DataHub running in one AWS account to ingest S3 metadata from buckets in a different AWS account.
+
+**Setup steps:**
+
+1. **In the target account** (where the S3 bucket lives), create an IAM role with:
+   - The S3 permissions policy shown above
+   - A trust policy allowing the source account to assume the role:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::SOURCE-ACCOUNT-ID:role/DataHubExecutionRole"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "sts:ExternalId": "your-unique-external-id"
+        }
+      }
+    }
+  ]
+}
+```
+
+2. **In the ingestion recipe**, configure `aws_config.aws_role` with the target role ARN:
+
+**Simple ARN format:**
+
+```yaml
+source:
+  type: s3
+  config:
+    aws_config:
+      aws_role: "arn:aws:iam::TARGET-ACCOUNT-ID:role/DataHubS3ReadRole"
+    path_specs:
+      - include: "s3://target-account-bucket/**"
+```
+
+**With External ID** (recommended for security):
+
+```yaml
+source:
+  type: s3
+  config:
+    aws_config:
+      aws_role:
+        RoleArn: "arn:aws:iam::TARGET-ACCOUNT-ID:role/DataHubS3ReadRole"
+        ExternalId: "your-unique-external-id"
+    path_specs:
+      - include: "s3://target-account-bucket/**"
+```
+
+**Role chaining** (assume multiple roles in sequence):
+
+```yaml
+source:
+  type: s3
+  config:
+    aws_config:
+      aws_role:
+        - "arn:aws:iam::INTERMEDIARY-ACCOUNT-ID:role/IntermediateRole"
+        - RoleArn: "arn:aws:iam::TARGET-ACCOUNT-ID:role/DataHubS3ReadRole"
+          ExternalId: "your-unique-external-id"
+    path_specs:
+      - include: "s3://target-account-bucket/**"
+```
+
+The connector uses [boto3's assume_role](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sts.html#STS.Client.assume_role), so additional parameters like `RoleSessionName`, `DurationSeconds`, and `Policy` are also supported.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Problem

Both the S3 and Glue connectors support cross-account access via AWS STS AssumeRole through the shared `AwsConnectionConfig`, but this capability was either missing or poorly documented:

- **S3**: No documentation whatsoever about cross-account role authentication
- **Glue**: Mentioned cross-account access but conflated authentication setup with lineage behavior, making it unclear how to configure each

Users had no way to discover these features except by reading the source code or asking support.

### Solution

Properly separated and documented cross-account authentication and cross-account lineage as distinct but related topics:

**S3 connector (`s3_pre.md`):**
- New "Cross-Account Access" subsection in Prerequisites
- Step-by-step setup instructions for target account (IAM role + trust policy)
- Three configuration examples (simple ARN, with External ID, role chaining)
- Reference to boto3's `assume_role` documentation

**Glue connector - Prerequisites (`glue_pre.md`):**
- Rewrote "Cross-Account Access" section focusing on authentication setup
- Aligned structure and examples with S3 connector
- Same three configuration patterns for `aws_role`
- Added distinction between role assumption (`aws_role`) and catalog access (`catalog_id`)
- Simplified platform instance explanation (moved detailed behavior to Capabilities)

**Glue connector - Capabilities (`glue_post.md`):**
- New "Cross-Account Lineage" section explaining feature behavior
- Detailed explanation of how lineage works across account boundaries
- Complete URN resolution and entity merging behavior with examples
- Platform instance impact on cross-account scenarios with concrete config examples
- Storage lineage setup instructions with link to S3 connector docs

### Key improvements

**Separation of concerns:**
- **Authentication (Prerequisites)**: How to set up cross-account access using IAM roles
- **Lineage behavior (Capabilities)**: How the feature works and what DataHub creates

**Consistent documentation:**
- S3 and Glue authentication sections now have identical structure and narrative
- Both explain the same three authentication patterns
- Terminology and examples are aligned

**Complete information:**
- Restored cross-account lineage documentation that was previously lost
- Explained platform instance impact with before/after examples
- Clarified the relationship between Glue and S3 ingestion for storage lineage

### Testing

- Verified markdown formatting passes Prettier checks
- Documentation follows the established patterns in `docs/sources/AGENTS.md`
- Cross-referenced with the actual `AwsConnectionConfig` implementation to ensure accuracy
- Confirmed both connectors use the same underlying authentication mechanism

### Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly PR Title Format)
- [x] Docs related to the changes have been added/updated
- [x] No breaking changes or code modifications
- [x] Documentation is aligned across both connectors
- [x] Cross-account lineage information preserved and enhanced
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://datahub.slack.com/archives/C09SXGVD605/p1776969628951349?thread_ts=1776969628.951349&cid=C09SXGVD605)

<div><a href="https://cursor.com/agents/bc-77219f17-b0df-5f8b-80b9-01a02ca9f8ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77219f17-b0df-5f8b-80b9-01a02ca9f8ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

