### PR TITLE
fix(kafka-connect): fall back to configured topics when runtime API returns empty list for Snowflake and ClickHouse sink connectors

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/sink_connectors.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/sink_connectors.py
@@ -214,17 +214,29 @@ class SnowflakeSinkConnector(BaseConnector):
         # Get topics the connector subscribes to from its configuration
         subscribed_topics = set(self.get_topics_from_config())
 
-        # Filter available topics to only those the connector subscribes to
         if subscribed_topics:
-            topic_list = list(available_topics.intersection(subscribed_topics))
-            logger.debug(
-                f"Filtered to {len(topic_list)} subscribed topics for {connector_manifest.name}: {topic_list}"
-            )
+            if available_topics:
+                # Runtime topic data available — intersect to exclude stale topics
+                topic_list = list(available_topics.intersection(subscribed_topics))
+                logger.debug(
+                    f"Resolved {len(topic_list)} topics for {connector_manifest.name} "
+                    f"(intersection of {len(available_topics)} runtime topics and "
+                    f"{len(subscribed_topics)} configured topics)"
+                )
+            else:
+                # Runtime /topics API returned nothing (connector hasn't processed
+                # messages yet, or topics were reset) — trust the config directly
+                topic_list = list(subscribed_topics)
+                logger.debug(
+                    f"Runtime topics empty for {connector_manifest.name}, "
+                    f"using {len(topic_list)} topics from connector config"
+                )
         else:
-            # If no subscription config, use all available topics (OSS behavior)
+            # No subscription config found — use whatever the runtime API returned
             topic_list = list(available_topics)
             logger.debug(
-                f"No subscription filter found, using all {len(topic_list)} available topics"
+                f"No subscription config found for {connector_manifest.name}, "
+                f"using all {len(topic_list)} available topics"
             )
         transform_result = get_transform_pipeline().apply_forward(
             topic_list, connector_manifest.config
@@ -374,12 +386,31 @@ class ClickHouseSinkConnector(BaseConnector):
             self.all_cluster_topics or connector_manifest.topic_names
         )
 
-        # Filter to subscribed topics
         subscribed_topics = set(self.get_topics_from_config())
         if subscribed_topics:
-            topic_list = list(available_topics.intersection(subscribed_topics))
+            if available_topics:
+                # Runtime topic data available — intersect to exclude stale topics
+                topic_list = list(available_topics.intersection(subscribed_topics))
+                logger.debug(
+                    f"Resolved {len(topic_list)} topics for {connector_manifest.name} "
+                    f"(intersection of {len(available_topics)} runtime topics and "
+                    f"{len(subscribed_topics)} configured topics)"
+                )
+            else:
+                # Runtime /topics API returned nothing (connector hasn't processed
+                # messages yet, or topics were reset) — trust the config directly
+                topic_list = list(subscribed_topics)
+                logger.debug(
+                    f"Runtime topics empty for {connector_manifest.name}, "
+                    f"using {len(topic_list)} topics from connector config"
+                )
         else:
+            # No subscription config found — use whatever the runtime API returned
             topic_list = list(available_topics)
+            logger.debug(
+                f"No subscription config found for {connector_manifest.name}, "
+                f"using all {len(topic_list)} available topics"
+            )
 
         # Apply transforms
         transform_result = get_transform_pipeline().apply_forward(

--- a/metadata-ingestion/tests/unit/test_kafka_connect.py
+++ b/metadata-ingestion/tests/unit/test_kafka_connect.py
@@ -428,6 +428,72 @@ class TestSnowflakeSinkConnector:
         assert lineage.target_dataset == "ANALYTICS.RAW.APPLICATION_logs"
         assert lineage.target_platform == "snowflake"
 
+    def test_snowflake_sink_empty_runtime_topics_falls_back_to_config(self) -> None:
+        """When the runtime /topics API returns nothing, fall back to configured topics.
+
+        Regression test for CUS-8682: connectors that haven't processed messages yet
+        (or whose topic list was temporarily reset) returned an empty topic_names list,
+        causing zero DATA_JOBs to be emitted and breaking downstream lineage.
+        """
+        connector_config: Dict[str, str] = {
+            "connector.class": "com.snowflake.kafka.connector.SnowflakeSinkConnector",
+            "snowflake.database.name": "PROD",
+            "snowflake.schema.name": "RAW",
+            "topics": "betler.production_dw_jackpot_compliance_state",
+        }
+        manifest = ConnectorManifest(
+            name="snowflake-sink-no-runtime-topics",
+            type="sink",
+            config=connector_config,
+            tasks=[],
+            topic_names=[],  # runtime /topics API returned nothing
+        )
+        config: Mock = create_mock_kafka_connect_config()
+        report: Mock = Mock(spec=KafkaConnectSourceReport)
+
+        connector: SnowflakeSinkConnector = SnowflakeSinkConnector(
+            manifest, config, report
+        )
+        lineages: List = connector.extract_lineages()
+
+        assert len(lineages) == 1
+        assert (
+            lineages[0].source_dataset
+            == "betler.production_dw_jackpot_compliance_state"
+        )
+        assert lineages[0].source_platform == "kafka"
+        assert lineages[0].target_platform == "snowflake"
+
+    def test_snowflake_sink_stale_topic_excluded_when_runtime_topics_available(
+        self,
+    ) -> None:
+        """When runtime topics are available, intersect to exclude topics no longer subscribed."""
+        connector_config: Dict[str, str] = {
+            "connector.class": "com.snowflake.kafka.connector.SnowflakeSinkConnector",
+            "snowflake.database.name": "PROD",
+            "snowflake.schema.name": "RAW",
+            "topics": "topic_a,topic_b",
+        }
+        manifest = ConnectorManifest(
+            name="snowflake-sink-with-runtime-topics",
+            type="sink",
+            config=connector_config,
+            tasks=[],
+            topic_names=["topic_a", "topic_b", "old_stale_topic"],
+        )
+        config: Mock = create_mock_kafka_connect_config()
+        report: Mock = Mock(spec=KafkaConnectSourceReport)
+
+        connector: SnowflakeSinkConnector = SnowflakeSinkConnector(
+            manifest, config, report
+        )
+        lineages: List = connector.extract_lineages()
+
+        source_datasets = {lin.source_dataset for lin in lineages}
+        assert "topic_a" in source_datasets
+        assert "topic_b" in source_datasets
+        assert "old_stale_topic" not in source_datasets
+
 
 class TestClickHouseSinkConnector:
     """Test ClickHouse sink connector lineage extraction."""
@@ -584,6 +650,58 @@ class TestClickHouseSinkConnector:
 
         connector = ClickHouseSinkConnector(manifest, config, report)
         assert connector.get_platform() == "clickhouse"
+
+    def test_clickhouse_sink_empty_runtime_topics_falls_back_to_config(self) -> None:
+        """When the runtime /topics API returns nothing, fall back to configured topics.
+
+        Regression test for CUS-8682: mirrors the same fix applied to SnowflakeSinkConnector.
+        """
+        connector_config: Dict[str, str] = {
+            "connector.class": "com.clickhouse.kafka.connect.ClickHouseSinkConnector",
+            "topics": "events,user_updates",
+        }
+        manifest = ConnectorManifest(
+            name="clickhouse-sink-no-runtime-topics",
+            type="sink",
+            config=connector_config,
+            tasks=[],
+            topic_names=[],  # runtime /topics API returned nothing
+        )
+        config: Mock = create_mock_kafka_connect_config()
+        report: Mock = Mock(spec=KafkaConnectSourceReport)
+
+        connector = ClickHouseSinkConnector(manifest, config, report)
+        lineages: List = connector.extract_lineages()
+
+        source_datasets = {lin.source_dataset for lin in lineages}
+        assert "events" in source_datasets
+        assert "user_updates" in source_datasets
+
+    def test_clickhouse_sink_stale_topic_excluded_when_runtime_topics_available(
+        self,
+    ) -> None:
+        """When runtime topics are available, intersect to exclude stale topics."""
+        connector_config: Dict[str, str] = {
+            "connector.class": "com.clickhouse.kafka.connect.ClickHouseSinkConnector",
+            "topics": "events,user_updates",
+        }
+        manifest = ConnectorManifest(
+            name="clickhouse-sink-with-runtime-topics",
+            type="sink",
+            config=connector_config,
+            tasks=[],
+            topic_names=["events", "user_updates", "deprecated_topic"],
+        )
+        config: Mock = create_mock_kafka_connect_config()
+        report: Mock = Mock(spec=KafkaConnectSourceReport)
+
+        connector = ClickHouseSinkConnector(manifest, config, report)
+        lineages: List = connector.extract_lineages()
+
+        source_datasets = {lin.source_dataset for lin in lineages}
+        assert "events" in source_datasets
+        assert "user_updates" in source_datasets
+        assert "deprecated_topic" not in source_datasets
 
 
 class TestJDBCSourceConnector:


### PR DESCRIPTION
## Summary

Fixes **CUS-8682**: `SnowflakeSinkConnector` and `ClickHouseSinkConnector` were emitting zero `DATA_JOB` entities (and therefore zero lineage edges) whenever the Kafka Connect runtime `/topics` API returned an empty list.

**Root cause:** Both connectors computed `topic_list` as `available_topics.intersection(subscribed_topics)`. When `available_topics` was empty (connector hasn't started consuming yet, topics were temporarily reset, or Cloud's topic-list API returned nothing), the intersection yielded `[]` — even though the connector config explicitly listed the topics to consume.

**Fix:** Mirror the pattern already applied to `JdbcSinkConnector` (PR #16557):
- If `available_topics` is non-empty → intersect with `subscribed_topics` to exclude stale/removed topics (existing behavior, preserved)
- If `available_topics` is empty → fall back to `subscribed_topics` from connector config directly

## Files changed

- `metadata-ingestion/src/datahub/ingestion/source/kafka_connect/sink_connectors.py` — fix `SnowflakeSinkConnector.get_parser()` and `ClickHouseSinkConnector.get_parser()`
- `metadata-ingestion/tests/unit/test_kafka_connect.py` — 4 new regression tests (2 per connector: empty-runtime-topics fallback + stale-topic exclusion)

## Test plan

- [x] `TestSnowflakeSinkConnector::test_snowflake_sink_empty_runtime_topics_falls_back_to_config` — asserts lineage is produced when `topic_names=[]`
- [x] `TestSnowflakeSinkConnector::test_snowflake_sink_stale_topic_excluded_when_runtime_topics_available` — asserts stale topics are still filtered when runtime data is present
- [x] `TestClickHouseSinkConnector::test_clickhouse_sink_empty_runtime_topics_falls_back_to_config`
- [x] `TestClickHouseSinkConnector::test_clickhouse_sink_stale_topic_excluded_when_runtime_topics_available`
- [x] All existing Snowflake and ClickHouse tests pass

## Related

- Fixes: CUS-8682 (kafka-connect-datajob-missing-preventing-lineage-between-kafka-topic)
- Prior fix for JDBC: #16557

🤖 Generated with [Claude Code](https://claude.com/claude-code)