### PR TITLE
feat(docker): harden datahub-actions locked image and Wolfi base

### DIFF
--- a/docker/datahub-actions/Dockerfile
+++ b/docker/datahub-actions/Dockerfile
@@ -37,6 +37,13 @@ RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \
     unzip \
     bash
 
+# PAM's unix_chkpwd is setuid/setgid in many images for interactive logins. This container does
+# not rely on PAM password checks; clearing bits avoids ABC/DoD-style SUID-SGID file findings
+# (e.g. suid_or_guid_set on /usr/bin/unix_chkpwd) without affecting the DataHub app runtime.
+RUN for f in /usr/bin/unix_chkpwd /usr/sbin/unix_chkpwd; do \
+    if [ -f "$f" ]; then chmod u-s,g-s "$f"; fi; \
+  done
+
 RUN ln -sf /usr/bin/python${PYTHON_VERSION} /usr/bin/python3 && \
     ln -sf /usr/bin/python3 /usr/bin/python
 
@@ -380,7 +387,18 @@ RUN --mount=type=bind,source=./python-build/version_updater.py,target=/version_u
 RUN --mount=type=cache,target=$HOME/.cache/uv,uid=1000,gid=1000,id=datahub-actions,sharing=private \
   uv pip install -e '/datahub-actions/[all]'
 
-# Block network access to PyPI - locked variant has no runtime pip installs for ingestion CLI
+# No uv/pip in the final locked image: build is done; package managers are unnecessary attack surface.
+# Script file avoids Docker RUN treating $v / $sp as empty Docker env vars (see docker/snippets/strip_pip_uv_from_venvs.sh).
+USER root
+COPY ./docker/snippets/strip_pip_uv_from_venvs.sh /tmp/strip_pip_uv_from_venvs.sh
+RUN chmod 755 /tmp/strip_pip_uv_from_venvs.sh
+USER datahub
+RUN sh /tmp/strip_pip_uv_from_venvs.sh
+USER 0
+RUN rm -f /tmp/strip_pip_uv_from_venvs.sh && apk del --no-cache uv
+USER datahub
+
+# Defense in depth: if any pip/uv-style tool is reintroduced, default index URL is unusable.
 ENV UV_INDEX_URL=http://127.0.0.1:1/simple
 ENV PIP_INDEX_URL=http://127.0.0.1:1/simple
 

--- a/docker/snippets/strip_pip_uv_from_venvs.sh
+++ b/docker/snippets/strip_pip_uv_from_venvs.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# Remove pip/uv packages and launchers from Python venvs (locked / hardened image builds).
+# Shared snippet: use from Dockerfiles via COPY, then `sh /path/strip_pip_uv_from_venvs.sh`.
+# Kept as a .sh file so RUN does not treat $v / $sp as empty Docker env vars.
+
+strip_venv() {
+    v="$1"
+    if [ ! -d "$v" ] || [ ! -x "$v/bin/python" ]; then
+        return 0
+    fi
+    ("$v/bin/python" -m pip uninstall -y pip) 2>/dev/null || true
+    for b in "$v/bin/uv" "$v/bin/uvx" "$v/bin/pip" "$v/bin/pip3"; do
+        [ -e "$b" ] && rm -f "$b"
+    done
+    find "$v/bin" -maxdepth 1 -name 'pip3.*' -delete 2>/dev/null || true
+    for sp in "$v"/lib/python*/site-packages; do
+        [ -d "$sp" ] || continue
+        find "$sp" -mindepth 1 -maxdepth 1 -name 'pip' -exec rm -rf {} + 2>/dev/null || true
+        find "$sp" -mindepth 1 -maxdepth 1 -name 'uv' -exec rm -rf {} + 2>/dev/null || true
+        find "$sp" -mindepth 1 -maxdepth 1 -name 'pip-*.dist-info' -exec rm -rf {} + 2>/dev/null || true
+        find "$sp" -mindepth 1 -maxdepth 1 -name 'uv-*.dist-info' -exec rm -rf {} + 2>/dev/null || true
+        find "$sp" -mindepth 1 -maxdepth 1 -name 'pip-*.data' -exec rm -rf {} + 2>/dev/null || true
+    done
+    rm -rf "$v/.cache/pip" "$v/.cache/uv" 2>/dev/null || true
+}
+
+strip_venv /home/datahub/.venv
+if [ -d /opt/datahub/venvs ]; then
+    for d in /opt/datahub/venvs/*; do
+        [ -d "$d" ] && strip_venv "$d" || true
+    done
+fi
+
+rm -rf /home/datahub/.cache/pip /home/datahub/.cache/uv \
+    /home/datahub/.local/share/uv /home/datahub/.local/pip \
+    /home/datahub/.config/pip /home/datahub/.config/uv 2>/dev/null || true
+
+if [ -d /home/datahub/.local ]; then
+    find /home/datahub/.local -type d -name 'site-packages' 2>/dev/null | while IFS= read -r sproot; do
+        [ -d "$sproot" ] || continue
+        find "$sproot" -mindepth 1 -maxdepth 1 -name 'pip' -exec rm -rf {} + 2>/dev/null || true
+        find "$sproot" -mindepth 1 -maxdepth 1 -name 'uv' -exec rm -rf {} + 2>/dev/null || true
+        find "$sproot" -mindepth 1 -maxdepth 1 -name 'pip-*.dist-info' -exec rm -rf {} + 2>/dev/null || true
+        find "$sproot" -mindepth 1 -maxdepth 1 -name 'uv-*.dist-info' -exec rm -rf {} + 2>/dev/null || true
+        find "$sproot" -mindepth 1 -maxdepth 1 -name 'pip-*.data' -exec rm -rf {} + 2>/dev/null || true
+    done
+fi


### PR DESCRIPTION
- Clear setuid/setgid on PAM unix_chkpwd in Wolfi base to satisfy SUID/SGID policies.
- For the locked variant, run a shared strip script to remove pip/uv from venvs and caches, then apk del uv; keep dummy PyPI index env vars for defense in depth.
- Add docker/snippets/strip_pip_uv_from_venvs.sh for reuse and to avoid Docker RUN variable-substitution issues with shell locals.

Made-with: Cursor

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
