### PR TITLE
ci(ingestion): prevent jq syntax error in dispatch payload for connector-tests trigger

### DIFF
--- a/.github/workflows/connector-tests-trigger.yml
+++ b/.github/workflows/connector-tests-trigger.yml
@@ -310,7 +310,7 @@ jobs:
             --arg url "$WHEEL_URL" \
             --arg check_run_id "$CHECK_RUN_ID" \
             --arg connectors "$CONNECTORS" \
-            '{event_type: $event, client_payload: {pr_number: $pr, sha: $sha, source_repo: $repo, wheel_url: $url, check_run_id: $check_run_id} + (if $connectors != "" then {connectors: $connectors} else {} end)}' \
+            '{event_type: $event, client_payload: ({pr_number: $pr, sha: $sha, source_repo: $repo, wheel_url: $url, check_run_id: $check_run_id} + (if $connectors != "" then {connectors: $connectors} else {} end))}' \
           | gh api "/repos/acryldata/connector-tests/dispatches" --input -
 
           if [ -n "$CONNECTORS" ]; then


### PR DESCRIPTION
## Summary

Fixes a jq syntax error introduced in #17176 that caused every connector-tests dispatch to fail immediately.

**Root cause:** In the new dispatch step, the `client_payload` value expression was not wrapped in parentheses:

```jq
# BAD — jq parses the + as operating on the outer object, not as the client_payload value
{event_type: $event, client_payload: {pr_number: ...} + (if $connectors != "" then {connectors: $connectors} else {} end)}

# GOOD — explicit parentheses make the value expression unambiguous
{event_type: $event, client_payload: ({pr_number: ...} + (if $connectors != "" then {connectors: $connectors} else {} end))}
```

jq raised 3 compile errors, produced no output, and `gh api` received an empty body → HTTP 422. The dispatch step then exited with code 1, triggering the "On failure" handler which marked the `connector-tests` check run as failed within 1 second.

Confirmed from the live failure log at https://github.com/datahub-project/datahub/actions/runs/24896077190/job/72901122723#step:11:39

## Test plan

- [ ] Verify the jq expression locally: `jq -nc --arg connectors "snowflake" '{event_type: "e", client_payload: ({a: 1} + (if $connectors != "" then {connectors: $connectors} else {} end))}'` → `{"event_type":"e","client_payload":{"a":1,"connectors":"snowflake"}}`
- [ ] Next PR touching connector source files should show a successful selective dispatch in the connector-tests check

https://claude.ai/code/session_01X7ptd35qGcGqUHvkGbenVy

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7ptd35qGcGqUHvkGbenVy)_