### PR TITLE
feat(): Adding views for service accounts, ensuring user default view honored 

### DIFF
--- a/datahub-agent-context/src/datahub_agent_context/mcp_tools/base.py
+++ b/datahub-agent-context/src/datahub_agent_context/mcp_tools/base.py
@@ -257,7 +257,6 @@ def fetch_global_default_view(graph: DataHubGraph) -> Optional[str]:
     Cached for VIEW_CACHE_TTL_SECONDS seconds.
     Returns None if disabled or if no default view is configured.
     """
-    # Return None immediately if feature is disabled
     if DISABLE_DEFAULT_VIEW:
         return None
 
@@ -278,6 +277,62 @@ def fetch_global_default_view(graph: DataHubGraph) -> Optional[str]:
             return view_urn
     logger.debug("No global default view configured")
     return None
+
+
+_user_view_cache: cachetools.TTLCache = cachetools.TTLCache(
+    maxsize=64, ttl=VIEW_CACHE_TTL_SECONDS
+)
+
+
+@cachetools.cached(cache=_user_view_cache)
+def fetch_user_default_view(graph: DataHubGraph) -> Optional[str]:
+    """Fetch the authenticated user's personal default view URN.
+
+    Uses the ``me`` query so the result depends on the token behind *graph*
+    (works for both regular users and service accounts).
+    Cached per graph instance for VIEW_CACHE_TTL_SECONDS seconds.
+    """
+    if DISABLE_DEFAULT_VIEW:
+        return None
+
+    query = """
+    query getUserDefaultView {
+        me {
+            corpUser {
+                settings {
+                    views {
+                        defaultView {
+                            urn
+                        }
+                    }
+                }
+            }
+        }
+    }
+    """
+
+    try:
+        result = execute_graphql(graph, query=query)
+    except Exception:
+        logger.warning("Failed to fetch user default view, skipping", exc_info=True)
+        return None
+
+    me = result.get("me") or {}
+    corp_user = me.get("corpUser") or {}
+    settings = corp_user.get("settings") or {}
+    views = settings.get("views") or {}
+    default_view = views.get("defaultView") or {}
+    urn = default_view.get("urn")
+    if urn:
+        logger.debug("Fetched user default view: %s", urn)
+    else:
+        logger.debug("No user default view configured")
+    return urn
+
+
+def resolve_default_view(graph: DataHubGraph) -> Optional[str]:
+    """Resolve the effective default view: user personal first, then org global."""
+    return fetch_user_default_view(graph) or fetch_global_default_view(graph)
 
 
 def clean_gql_response(response: Any) -> Any:

--- a/datahub-agent-context/src/datahub_agent_context/mcp_tools/documents.py
+++ b/datahub-agent-context/src/datahub_agent_context/mcp_tools/documents.py
@@ -14,7 +14,7 @@ from datahub_agent_context.context import get_graph
 from datahub_agent_context.mcp_tools.base import (
     clean_gql_response,
     execute_graphql,
-    fetch_global_default_view,
+    resolve_default_view,
 )
 from datahub_agent_context.mcp_tools.search_filter_parser import (
     FILTER_DOCS,
@@ -470,8 +470,8 @@ def _search_documents_impl(
     parsed_filter = parse_filter_string(filter.strip()) if filter else None
     _, or_filters = compile_filters(parsed_filter)
 
-    # Fetch and apply default view
-    view_urn = fetch_global_default_view(graph)
+    # Fetch and apply default view: user personal first, then org global
+    view_urn = resolve_default_view(graph)
 
     # Choose search strategy
     if search_strategy == "semantic":

--- a/datahub-agent-context/src/datahub_agent_context/mcp_tools/search.py
+++ b/datahub-agent-context/src/datahub_agent_context/mcp_tools/search.py
@@ -10,7 +10,7 @@ from datahub_agent_context.context import get_graph
 from datahub_agent_context.mcp_tools.base import (
     clean_gql_response,
     execute_graphql,
-    fetch_global_default_view,
+    resolve_default_view,
 )
 from datahub_agent_context.mcp_tools.search_filter_parser import (
     FILTER_DOCS,
@@ -124,8 +124,8 @@ def search(
 
     types, compiled_filters = compile_filters(parsed_filter)
 
-    # Fetch and apply default view (returns None if disabled or not configured)
-    view_urn = fetch_global_default_view(graph)
+    # Fetch and apply default view: user personal first, then org global
+    view_urn = resolve_default_view(graph)
     if view_urn:
         logger.debug(f"Applying default view: {view_urn}")
     else:

--- a/datahub-agent-context/tests/unit/mcp_tools/test_base.py
+++ b/datahub-agent-context/tests/unit/mcp_tools/test_base.py
@@ -5,7 +5,13 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from datahub_agent_context.mcp_tools.base import _is_datahub_cloud
+from datahub_agent_context.mcp_tools.base import (
+    _is_datahub_cloud,
+    _user_view_cache,
+    fetch_global_default_view,
+    fetch_user_default_view,
+    resolve_default_view,
+)
 
 
 @pytest.fixture
@@ -70,3 +76,100 @@ def test_is_datahub_cloud_with_value_error(mock_client_with_frontend_url):
 
     result = _is_datahub_cloud(mock_client_with_frontend_url.graph)
     assert result is False
+
+
+# --- Default view resolution tests ---
+
+
+@pytest.fixture(autouse=True)
+def _clear_view_caches():
+    """Clear all view caches before each test to avoid cross-test pollution."""
+    fetch_global_default_view.cache.clear()  # type: ignore[attr-defined]
+    _user_view_cache.clear()
+
+
+@pytest.fixture
+def mock_graph():
+    mock = Mock()
+    mock.frontend_base_url = None
+    mock.execute_graphql = Mock()
+    return mock
+
+
+def test_fetch_user_default_view_returns_urn(mock_graph):
+    mock_graph.execute_graphql.return_value = {
+        "me": {
+            "corpUser": {
+                "settings": {
+                    "views": {"defaultView": {"urn": "urn:li:dataHubView:my-view"}}
+                }
+            }
+        }
+    }
+    assert fetch_user_default_view(mock_graph) == "urn:li:dataHubView:my-view"
+
+
+def test_fetch_user_default_view_returns_none_when_not_set(mock_graph):
+    mock_graph.execute_graphql.return_value = {
+        "me": {"corpUser": {"settings": {"views": {"defaultView": None}}}}
+    }
+    assert fetch_user_default_view(mock_graph) is None
+
+
+def test_fetch_user_default_view_returns_none_on_error(mock_graph):
+    mock_graph.execute_graphql.side_effect = Exception("network error")
+    assert fetch_user_default_view(mock_graph) is None
+
+
+@patch("datahub_agent_context.mcp_tools.base.DISABLE_DEFAULT_VIEW", True)
+def test_fetch_user_default_view_disabled(mock_graph):
+    _user_view_cache.clear()
+    assert fetch_user_default_view(mock_graph) is None
+    mock_graph.execute_graphql.assert_not_called()
+
+
+def test_resolve_default_view_prefers_user_over_global(mock_graph):
+    """User personal view takes priority over org global view."""
+    with (
+        patch(
+            "datahub_agent_context.mcp_tools.base.fetch_user_default_view",
+            return_value="urn:li:dataHubView:user-view",
+        ),
+        patch(
+            "datahub_agent_context.mcp_tools.base.fetch_global_default_view",
+            return_value="urn:li:dataHubView:global-view",
+        ),
+    ):
+        result = resolve_default_view(mock_graph)
+    assert result == "urn:li:dataHubView:user-view"
+
+
+def test_resolve_default_view_falls_back_to_global(mock_graph):
+    """When no user view, falls back to org global view."""
+    with (
+        patch(
+            "datahub_agent_context.mcp_tools.base.fetch_user_default_view",
+            return_value=None,
+        ),
+        patch(
+            "datahub_agent_context.mcp_tools.base.fetch_global_default_view",
+            return_value="urn:li:dataHubView:global-view",
+        ),
+    ):
+        result = resolve_default_view(mock_graph)
+    assert result == "urn:li:dataHubView:global-view"
+
+
+def test_resolve_default_view_returns_none_when_neither_set(mock_graph):
+    with (
+        patch(
+            "datahub_agent_context.mcp_tools.base.fetch_user_default_view",
+            return_value=None,
+        ),
+        patch(
+            "datahub_agent_context.mcp_tools.base.fetch_global_default_view",
+            return_value=None,
+        ),
+    ):
+        result = resolve_default_view(mock_graph)
+    assert result is None

--- a/datahub-agent-context/tests/unit/mcp_tools/test_search.py
+++ b/datahub-agent-context/tests/unit/mcp_tools/test_search.py
@@ -74,7 +74,7 @@ def test_search_with_filters(mock_client, mock_search_response):
         result = search(query="*", filter="entity_type = dataset")
 
     assert result is not None
-    # Note: execute_graphql is called twice - once for fetch_global_default_view, once for search
+    # Note: execute_graphql is called for resolve_default_view (user + global) then search
     assert mock_client._graph.execute_graphql.called
 
 
@@ -140,7 +140,7 @@ def test_search_with_complex_filters(mock_client, mock_search_response):
         )
 
     assert result is not None
-    # Note: execute_graphql is called twice - once for fetch_global_default_view, once for search
+    # Note: execute_graphql is called for resolve_default_view (user + global) then search
     assert mock_client._graph.execute_graphql.called
 
 
@@ -152,7 +152,7 @@ def test_search_with_string_filters(mock_client, mock_search_response):
         result = search(query="*", filter="entity_type = dataset")
 
     assert result is not None
-    # Note: execute_graphql is called twice - once for fetch_global_default_view, once for search
+    # Note: execute_graphql is called for resolve_default_view (user + global) then search
     assert mock_client._graph.execute_graphql.called
 
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -47,6 +47,7 @@ import com.linkedin.datahub.graphql.resolvers.auth.GetServiceAccountResolver;
 import com.linkedin.datahub.graphql.resolvers.auth.ListAccessTokensResolver;
 import com.linkedin.datahub.graphql.resolvers.auth.ListServiceAccountsResolver;
 import com.linkedin.datahub.graphql.resolvers.auth.RevokeAccessTokenResolver;
+import com.linkedin.datahub.graphql.resolvers.auth.UpdateServiceAccountDefaultViewResolver;
 import com.linkedin.datahub.graphql.resolvers.browse.BrowsePathsResolver;
 import com.linkedin.datahub.graphql.resolvers.browse.BrowseResolver;
 import com.linkedin.datahub.graphql.resolvers.browse.EntityBrowsePathsResolver;
@@ -1350,6 +1351,10 @@ public class GmsGraphQLEngine {
               .dataFetcher(
                   "deleteServiceAccount", new DeleteServiceAccountResolver(this.entityClient))
               .dataFetcher(
+                  "updateServiceAccountDefaultView",
+                  new UpdateServiceAccountDefaultViewResolver(
+                      this.settingsService, this.entityClient, this.viewService))
+              .dataFetcher(
                   "createIngestionSource", new UpsertIngestionSourceResolver(this.entityClient))
               .dataFetcher(
                   "updateIngestionSource", new UpsertIngestionSourceResolver(this.entityClient))
@@ -2176,8 +2181,19 @@ public class GmsGraphQLEngine {
     builder.type(
         "ServiceAccount",
         typeWiring ->
-            typeWiring.dataFetcher(
-                "relationships", new EntityRelationshipsResultResolver(graphClient)));
+            typeWiring
+                .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient))
+                .dataFetcher(
+                    "defaultView",
+                    new LoadableTypeResolver<>(
+                        dataHubViewType,
+                        (env) -> {
+                          final ServiceAccount sa = env.getSource();
+                          if (sa.getDefaultView() != null) {
+                            return sa.getDefaultView().getUrn();
+                          }
+                          return null;
+                        })));
   }
 
   /**

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/auth/ServiceAccountUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/auth/ServiceAccountUtils.java
@@ -1,11 +1,14 @@
 package com.linkedin.datahub.graphql.resolvers.auth;
 
 import com.linkedin.common.SubTypes;
+import com.linkedin.datahub.graphql.generated.DataHubView;
 import com.linkedin.datahub.graphql.generated.EntityType;
 import com.linkedin.datahub.graphql.generated.ServiceAccount;
 import com.linkedin.entity.EntityResponse;
 import com.linkedin.entity.EnvelopedAspect;
+import com.linkedin.identity.CorpUserAppearanceSettings;
 import com.linkedin.identity.CorpUserInfo;
+import com.linkedin.identity.CorpUserSettings;
 import com.linkedin.metadata.Constants;
 import java.util.UUID;
 import javax.annotation.Nonnull;
@@ -110,6 +113,19 @@ public final class ServiceAccountUtils {
   }
 
   /**
+   * Returns the given settings if non-null, otherwise creates a new empty {@link CorpUserSettings}
+   * with the default appearance preset.
+   */
+  @Nonnull
+  public static CorpUserSettings getOrCreateSettings(@Nullable CorpUserSettings existing) {
+    if (existing != null) {
+      return existing;
+    }
+    return new CorpUserSettings()
+        .setAppearance(new CorpUserAppearanceSettings().setShowSimplifiedHomepage(false));
+  }
+
+  /**
    * Maps an EntityResponse to a ServiceAccount GraphQL object.
    *
    * @param response The entity response to map
@@ -143,6 +159,26 @@ public final class ServiceAccountUtils {
       } catch (Exception e) {
         log.warn(
             "Failed to parse corpUserInfo for service account: {}",
+            response.getUrn().toString(),
+            e);
+      }
+    }
+
+    // Extract default view from corpUserSettings aspect
+    final EnvelopedAspect settingsAspect =
+        response.getAspects().get(Constants.CORP_USER_SETTINGS_ASPECT_NAME);
+    if (settingsAspect != null) {
+      try {
+        final CorpUserSettings settings = new CorpUserSettings(settingsAspect.getValue().data());
+        if (settings.hasViews() && settings.getViews().hasDefaultView()) {
+          final DataHubView viewStub = new DataHubView();
+          viewStub.setUrn(settings.getViews().getDefaultView().toString());
+          viewStub.setType(EntityType.DATAHUB_VIEW);
+          serviceAccount.setDefaultView(viewStub);
+        }
+      } catch (Exception e) {
+        log.warn(
+            "Failed to parse corpUserSettings for service account: {}",
             response.getUrn().toString(),
             e);
       }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/auth/UpdateServiceAccountDefaultViewResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/auth/UpdateServiceAccountDefaultViewResolver.java
@@ -1,0 +1,135 @@
+package com.linkedin.datahub.graphql.resolvers.auth;
+
+import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.*;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.SetMode;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
+import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
+import com.linkedin.datahub.graphql.exception.AuthorizationException;
+import com.linkedin.datahub.graphql.generated.UpdateServiceAccountDefaultViewInput;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.identity.CorpUserSettings;
+import com.linkedin.identity.CorpUserViewsSettings;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.service.SettingsService;
+import com.linkedin.metadata.service.ViewService;
+import com.linkedin.view.DataHubViewInfo;
+import com.linkedin.view.DataHubViewType;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nonnull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Resolver for setting or clearing the default view on a service account. Requires the
+ * MANAGE_SERVICE_ACCOUNTS platform privilege.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class UpdateServiceAccountDefaultViewResolver
+    implements DataFetcher<CompletableFuture<Boolean>> {
+
+  private final SettingsService _settingsService;
+  private final EntityClient _entityClient;
+  private final ViewService _viewService;
+
+  @Override
+  public CompletableFuture<Boolean> get(DataFetchingEnvironment environment) throws Exception {
+    final QueryContext context = environment.getContext();
+    final UpdateServiceAccountDefaultViewInput input =
+        bindArgument(environment.getArgument("input"), UpdateServiceAccountDefaultViewInput.class);
+
+    return GraphQLConcurrencyUtils.supplyAsync(
+        () -> {
+          if (!AuthorizationUtils.canManageServiceAccounts(context)) {
+            throw new AuthorizationException(
+                "Unauthorized to manage service accounts. "
+                    + "Please contact your DataHub administrator.");
+          }
+
+          final Urn serviceAccountUrn = UrnUtils.getUrn(input.getUrn());
+          validateServiceAccount(context, serviceAccountUrn);
+
+          if (input.getDefaultView() != null) {
+            validateGlobalView(context, UrnUtils.getUrn(input.getDefaultView()));
+          }
+
+          try {
+            final CorpUserSettings settings =
+                ServiceAccountUtils.getOrCreateSettings(
+                    _settingsService.getCorpUserSettings(
+                        context.getOperationContext(), serviceAccountUrn));
+
+            final CorpUserViewsSettings viewsSettings =
+                settings.hasViews() ? settings.getViews() : new CorpUserViewsSettings();
+
+            viewsSettings.setDefaultView(
+                input.getDefaultView() != null ? UrnUtils.getUrn(input.getDefaultView()) : null,
+                SetMode.REMOVE_IF_NULL);
+
+            settings.setViews(viewsSettings);
+
+            _settingsService.updateCorpUserSettings(
+                context.getOperationContext(), serviceAccountUrn, settings);
+
+            return true;
+          } catch (AuthorizationException | IllegalArgumentException e) {
+            throw e;
+          } catch (Exception e) {
+            log.error(
+                "Failed to update default view for service account {}: {}",
+                input.getUrn(),
+                e.getMessage());
+            throw new RuntimeException(
+                String.format(
+                    "Failed to update default view for service account %s", input.getUrn()),
+                e);
+          }
+        },
+        this.getClass().getSimpleName(),
+        "get");
+  }
+
+  private void validateServiceAccount(
+      @Nonnull QueryContext context, @Nonnull Urn serviceAccountUrn) {
+    try {
+      final EntityResponse response =
+          _entityClient.getV2(
+              context.getOperationContext(),
+              Constants.CORP_USER_ENTITY_NAME,
+              serviceAccountUrn,
+              Set.of(Constants.SUB_TYPES_ASPECT_NAME));
+
+      if (!ServiceAccountUtils.isServiceAccount(response)) {
+        throw new IllegalArgumentException(
+            String.format("URN %s is not a service account.", serviceAccountUrn));
+      }
+    } catch (IllegalArgumentException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new RuntimeException(
+          String.format("Failed to validate service account %s", serviceAccountUrn), e);
+    }
+  }
+
+  /** Only global (public) views may be set as a service account default. */
+  private void validateGlobalView(@Nonnull QueryContext context, @Nonnull Urn viewUrn) {
+    final DataHubViewInfo viewInfo =
+        _viewService.getViewInfo(context.getOperationContext(), viewUrn);
+    if (viewInfo == null) {
+      throw new IllegalArgumentException(String.format("View %s does not exist.", viewUrn));
+    }
+    if (!DataHubViewType.GLOBAL.equals(viewInfo.getType())) {
+      throw new IllegalArgumentException(
+          "Only public (global) views can be set as the default view for a service account. "
+              + "Personal views are not supported.");
+    }
+  }
+}

--- a/datahub-graphql-core/src/main/resources/auth.graphql
+++ b/datahub-graphql-core/src/main/resources/auth.graphql
@@ -58,6 +58,31 @@ extend type Mutation {
   Deletes a service account by URN.
   """
   deleteServiceAccount(urn: String!): Boolean!
+
+  """
+  Sets or clears the default view for a service account.
+  Requires the MANAGE_SERVICE_ACCOUNTS platform privilege.
+  Pass null for defaultView to clear the current default.
+  """
+  updateServiceAccountDefaultView(
+    input: UpdateServiceAccountDefaultViewInput!
+  ): Boolean!
+}
+
+"""
+Input required to update a service account's default view.
+"""
+input UpdateServiceAccountDefaultViewInput {
+  """
+  The URN of the service account to update.
+  """
+  urn: String!
+
+  """
+  The URN of the DataHub View to set as the default.
+  If null, the current default view will be removed.
+  """
+  defaultView: String
 }
 
 """
@@ -489,6 +514,12 @@ type ServiceAccount implements Entity {
   The time when the service account was last updated.
   """
   updatedAt: Long
+
+  """
+  The default DataHub View applied when this service account performs searches
+  via the MCP server. Null when no default is configured.
+  """
+  defaultView: DataHubView
 
   """
   Granular API for querying edges extending from this entity

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/auth/ServiceAccountUtilsTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/auth/ServiceAccountUtilsTest.java
@@ -6,6 +6,7 @@ import static org.testng.Assert.*;
 
 import com.linkedin.common.SubTypes;
 import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.data.template.StringArray;
 import com.linkedin.datahub.graphql.generated.EntityType;
 import com.linkedin.datahub.graphql.generated.ServiceAccount;
@@ -13,7 +14,10 @@ import com.linkedin.entity.Aspect;
 import com.linkedin.entity.EntityResponse;
 import com.linkedin.entity.EnvelopedAspect;
 import com.linkedin.entity.EnvelopedAspectMap;
+import com.linkedin.identity.CorpUserAppearanceSettings;
 import com.linkedin.identity.CorpUserInfo;
+import com.linkedin.identity.CorpUserSettings;
+import com.linkedin.identity.CorpUserViewsSettings;
 import com.linkedin.metadata.Constants;
 import org.testng.annotations.Test;
 
@@ -103,6 +107,77 @@ public class ServiceAccountUtilsTest {
     assertEquals(result.getName(), TEST_SERVICE_ACCOUNT_NAME);
     assertNull(result.getDisplayName());
     assertNull(result.getDescription());
+  }
+
+  @Test
+  public void testMapToServiceAccountWithDefaultView() throws Exception {
+    String viewUrn = "urn:li:dataHubView:my-view";
+    EntityResponse response = createMockEntityResponse(true, true);
+
+    // Add corpUserSettings with a default view
+    CorpUserViewsSettings viewsSettings = new CorpUserViewsSettings();
+    viewsSettings.setDefaultView(UrnUtils.getUrn(viewUrn));
+    CorpUserSettings settings = new CorpUserSettings();
+    settings.setViews(viewsSettings);
+    EnvelopedAspect settingsAspect = new EnvelopedAspect();
+    settingsAspect.setValue(new Aspect(settings.data()));
+    response.getAspects().put(Constants.CORP_USER_SETTINGS_ASPECT_NAME, settingsAspect);
+
+    ServiceAccount result = ServiceAccountUtils.mapToServiceAccount(response);
+
+    assertNotNull(result);
+    assertNotNull(result.getDefaultView());
+    assertEquals(result.getDefaultView().getUrn(), viewUrn);
+    assertEquals(result.getDefaultView().getType(), EntityType.DATAHUB_VIEW);
+  }
+
+  @Test
+  public void testMapToServiceAccountWithNoDefaultView() throws Exception {
+    EntityResponse response = createMockEntityResponse(true, true);
+
+    // Add corpUserSettings without a default view
+    CorpUserSettings settings = new CorpUserSettings();
+    settings.setViews(new CorpUserViewsSettings());
+    EnvelopedAspect settingsAspect = new EnvelopedAspect();
+    settingsAspect.setValue(new Aspect(settings.data()));
+    response.getAspects().put(Constants.CORP_USER_SETTINGS_ASPECT_NAME, settingsAspect);
+
+    ServiceAccount result = ServiceAccountUtils.mapToServiceAccount(response);
+
+    assertNotNull(result);
+    assertNull(result.getDefaultView());
+  }
+
+  @Test
+  public void testMapToServiceAccountWithNoSettingsAspect() throws Exception {
+    // No corpUserSettings aspect at all — defaultView should be null
+    EntityResponse response = createMockEntityResponse(true, false);
+
+    ServiceAccount result = ServiceAccountUtils.mapToServiceAccount(response);
+
+    assertNotNull(result);
+    assertNull(result.getDefaultView());
+  }
+
+  @Test
+  public void testGetOrCreateSettingsWithNull() {
+    CorpUserSettings result = ServiceAccountUtils.getOrCreateSettings(null);
+    assertNotNull(result);
+    assertTrue(result.hasAppearance());
+    assertFalse(result.getAppearance().isShowSimplifiedHomepage());
+  }
+
+  @Test
+  public void testGetOrCreateSettingsWithExisting() {
+    CorpUserSettings existing =
+        new CorpUserSettings()
+            .setAppearance(new CorpUserAppearanceSettings().setShowSimplifiedHomepage(true))
+            .setViews(
+                new CorpUserViewsSettings()
+                    .setDefaultView(UrnUtils.getUrn("urn:li:dataHubView:existing")));
+
+    CorpUserSettings result = ServiceAccountUtils.getOrCreateSettings(existing);
+    assertSame(result, existing);
   }
 
   private EntityResponse createMockEntityResponse(

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/auth/UpdateServiceAccountDefaultViewResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/auth/UpdateServiceAccountDefaultViewResolverTest.java
@@ -1,0 +1,228 @@
+package com.linkedin.datahub.graphql.resolvers.auth;
+
+import static com.linkedin.datahub.graphql.TestUtils.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+import com.linkedin.common.SubTypes;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.StringArray;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.exception.AuthorizationException;
+import com.linkedin.datahub.graphql.generated.UpdateServiceAccountDefaultViewInput;
+import com.linkedin.entity.Aspect;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspect;
+import com.linkedin.entity.EnvelopedAspectMap;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.identity.CorpUserAppearanceSettings;
+import com.linkedin.identity.CorpUserSettings;
+import com.linkedin.identity.CorpUserViewsSettings;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.service.SettingsService;
+import com.linkedin.metadata.service.ViewService;
+import com.linkedin.view.DataHubViewInfo;
+import com.linkedin.view.DataHubViewType;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class UpdateServiceAccountDefaultViewResolverTest {
+
+  private static final String TEST_ACTOR_URN = "urn:li:corpuser:test";
+  private static final String TEST_SERVICE_ACCOUNT_URN =
+      "urn:li:corpuser:service_ingestion-pipeline";
+  private static final String TEST_VIEW_URN = "urn:li:dataHubView:my-view";
+
+  private SettingsService mockSettingsService;
+  private EntityClient mockEntityClient;
+  private ViewService mockViewService;
+  private DataFetchingEnvironment mockEnv;
+  private UpdateServiceAccountDefaultViewResolver resolver;
+
+  @BeforeMethod
+  public void setup() {
+    mockSettingsService = mock(SettingsService.class);
+    mockEntityClient = mock(EntityClient.class);
+    mockViewService = mock(ViewService.class);
+    mockEnv = mock(DataFetchingEnvironment.class);
+    resolver =
+        new UpdateServiceAccountDefaultViewResolver(
+            mockSettingsService, mockEntityClient, mockViewService);
+  }
+
+  @Test
+  public void testSetDefaultViewSuccess() throws Exception {
+    QueryContext mockContext = getMockAllowContext(TEST_ACTOR_URN);
+    when(mockEnv.getContext()).thenReturn(mockContext);
+
+    UpdateServiceAccountDefaultViewInput input = new UpdateServiceAccountDefaultViewInput();
+    input.setUrn(TEST_SERVICE_ACCOUNT_URN);
+    input.setDefaultView(TEST_VIEW_URN);
+    when(mockEnv.getArgument("input")).thenReturn(input);
+
+    mockServiceAccountEntity(true);
+    mockViewInfo(TEST_VIEW_URN, DataHubViewType.GLOBAL);
+    when(mockSettingsService.getCorpUserSettings(any(), any())).thenReturn(null);
+
+    Boolean result = resolver.get(mockEnv).get();
+    assertTrue(result);
+
+    Urn saUrn = UrnUtils.getUrn(TEST_SERVICE_ACCOUNT_URN);
+    verify(mockSettingsService)
+        .updateCorpUserSettings(
+            any(),
+            eq(saUrn),
+            argThat(
+                settings ->
+                    settings.hasViews()
+                        && settings.getViews().hasDefaultView()
+                        && settings.getViews().getDefaultView().toString().equals(TEST_VIEW_URN)));
+  }
+
+  @Test
+  public void testClearDefaultViewSuccess() throws Exception {
+    QueryContext mockContext = getMockAllowContext(TEST_ACTOR_URN);
+    when(mockEnv.getContext()).thenReturn(mockContext);
+
+    UpdateServiceAccountDefaultViewInput input = new UpdateServiceAccountDefaultViewInput();
+    input.setUrn(TEST_SERVICE_ACCOUNT_URN);
+    input.setDefaultView(null);
+    when(mockEnv.getArgument("input")).thenReturn(input);
+
+    mockServiceAccountEntity(true);
+    CorpUserSettings existing =
+        new CorpUserSettings()
+            .setAppearance(new CorpUserAppearanceSettings().setShowSimplifiedHomepage(false))
+            .setViews(new CorpUserViewsSettings().setDefaultView(UrnUtils.getUrn(TEST_VIEW_URN)));
+    when(mockSettingsService.getCorpUserSettings(any(), any())).thenReturn(existing);
+
+    Boolean result = resolver.get(mockEnv).get();
+    assertTrue(result);
+
+    verify(mockSettingsService)
+        .updateCorpUserSettings(
+            any(),
+            eq(UrnUtils.getUrn(TEST_SERVICE_ACCOUNT_URN)),
+            argThat(settings -> settings.hasViews() && !settings.getViews().hasDefaultView()));
+  }
+
+  @Test
+  public void testUnauthorized() throws Exception {
+    QueryContext mockContext = getMockDenyContext(TEST_ACTOR_URN);
+    when(mockEnv.getContext()).thenReturn(mockContext);
+
+    UpdateServiceAccountDefaultViewInput input = new UpdateServiceAccountDefaultViewInput();
+    input.setUrn(TEST_SERVICE_ACCOUNT_URN);
+    input.setDefaultView(TEST_VIEW_URN);
+    when(mockEnv.getArgument("input")).thenReturn(input);
+
+    try {
+      resolver.get(mockEnv).get();
+      fail("Expected ExecutionException");
+    } catch (ExecutionException e) {
+      assertTrue(e.getCause() instanceof AuthorizationException);
+    }
+
+    verify(mockSettingsService, never()).updateCorpUserSettings(any(), any(), any());
+  }
+
+  @Test
+  public void testRejectsPersonalView() throws Exception {
+    QueryContext mockContext = getMockAllowContext(TEST_ACTOR_URN);
+    when(mockEnv.getContext()).thenReturn(mockContext);
+
+    UpdateServiceAccountDefaultViewInput input = new UpdateServiceAccountDefaultViewInput();
+    input.setUrn(TEST_SERVICE_ACCOUNT_URN);
+    input.setDefaultView(TEST_VIEW_URN);
+    when(mockEnv.getArgument("input")).thenReturn(input);
+
+    mockServiceAccountEntity(true);
+    mockViewInfo(TEST_VIEW_URN, DataHubViewType.PERSONAL);
+
+    try {
+      resolver.get(mockEnv).get();
+      fail("Expected ExecutionException for personal view");
+    } catch (ExecutionException e) {
+      assertTrue(e.getCause() instanceof IllegalArgumentException);
+      assertTrue(e.getCause().getMessage().contains("Only public (global) views"));
+    }
+
+    verify(mockSettingsService, never()).updateCorpUserSettings(any(), any(), any());
+  }
+
+  @Test
+  public void testRejectsNonExistentView() throws Exception {
+    QueryContext mockContext = getMockAllowContext(TEST_ACTOR_URN);
+    when(mockEnv.getContext()).thenReturn(mockContext);
+
+    UpdateServiceAccountDefaultViewInput input = new UpdateServiceAccountDefaultViewInput();
+    input.setUrn(TEST_SERVICE_ACCOUNT_URN);
+    input.setDefaultView("urn:li:dataHubView:does-not-exist");
+    when(mockEnv.getArgument("input")).thenReturn(input);
+
+    mockServiceAccountEntity(true);
+    when(mockViewService.getViewInfo(any(), any())).thenReturn(null);
+
+    try {
+      resolver.get(mockEnv).get();
+      fail("Expected ExecutionException for non-existent view");
+    } catch (ExecutionException e) {
+      assertTrue(e.getCause() instanceof IllegalArgumentException);
+      assertTrue(e.getCause().getMessage().contains("does not exist"));
+    }
+
+    verify(mockSettingsService, never()).updateCorpUserSettings(any(), any(), any());
+  }
+
+  @Test
+  public void testTargetIsNotServiceAccount() throws Exception {
+    QueryContext mockContext = getMockAllowContext(TEST_ACTOR_URN);
+    when(mockEnv.getContext()).thenReturn(mockContext);
+
+    UpdateServiceAccountDefaultViewInput input = new UpdateServiceAccountDefaultViewInput();
+    input.setUrn("urn:li:corpuser:regular-user");
+    input.setDefaultView(TEST_VIEW_URN);
+    when(mockEnv.getArgument("input")).thenReturn(input);
+
+    // Return entity without SERVICE_ACCOUNT sub-type
+    EntityResponse response = mock(EntityResponse.class);
+    when(response.getUrn()).thenReturn(Urn.createFromString("urn:li:corpuser:regular-user"));
+    EnvelopedAspectMap aspectMap = new EnvelopedAspectMap();
+    when(response.getAspects()).thenReturn(aspectMap);
+    when(mockEntityClient.getV2(any(), eq(Constants.CORP_USER_ENTITY_NAME), any(), any()))
+        .thenReturn(response);
+
+    assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
+    verify(mockSettingsService, never()).updateCorpUserSettings(any(), any(), any());
+  }
+
+  private void mockServiceAccountEntity(boolean isServiceAccount) throws Exception {
+    EntityResponse response = mock(EntityResponse.class);
+    when(response.getUrn()).thenReturn(Urn.createFromString(TEST_SERVICE_ACCOUNT_URN));
+    EnvelopedAspectMap aspectMap = new EnvelopedAspectMap();
+
+    if (isServiceAccount) {
+      SubTypes subTypes = new SubTypes();
+      subTypes.setTypeNames(new StringArray(ServiceAccountUtils.SERVICE_ACCOUNT_SUB_TYPE));
+      EnvelopedAspect subTypesAspect = new EnvelopedAspect();
+      subTypesAspect.setValue(new Aspect(subTypes.data()));
+      aspectMap.put(Constants.SUB_TYPES_ASPECT_NAME, subTypesAspect);
+    }
+
+    when(response.getAspects()).thenReturn(aspectMap);
+    when(mockEntityClient.getV2(any(), eq(Constants.CORP_USER_ENTITY_NAME), any(), any()))
+        .thenReturn(response);
+  }
+
+  private void mockViewInfo(String viewUrn, DataHubViewType viewType) {
+    DataHubViewInfo viewInfo = mock(DataHubViewInfo.class);
+    when(viewInfo.getType()).thenReturn(viewType);
+    when(mockViewService.getViewInfo(any(), eq(UrnUtils.getUrn(viewUrn)))).thenReturn(viewInfo);
+  }
+}

--- a/datahub-web-react/src/app/identity/serviceAccount/ServiceAccountList.components.tsx
+++ b/datahub-web-react/src/app/identity/serviceAccount/ServiceAccountList.components.tsx
@@ -10,9 +10,21 @@ import styled from 'styled-components/macro';
 
 import SimpleSelectRole from '@app/identity/user/SimpleSelectRole';
 import CreateTokenModal from '@app/settingsV2/CreateTokenModal';
-import { Avatar, Button, Icon, Modal, Pagination, SearchBar, Table, Text } from '@src/alchemy-components';
+import {
+    Avatar,
+    Button,
+    Icon,
+    Modal,
+    Pagination,
+    SearchBar,
+    SimpleSelect,
+    Table,
+    Text,
+    Tooltip,
+} from '@src/alchemy-components';
 import { Menu } from '@src/alchemy-components/components/Menu';
 import { ItemType } from '@src/alchemy-components/components/Menu/types';
+import { SelectOption } from '@src/alchemy-components/components/Select/types';
 
 import { AccessTokenType, DataHubRole, ServiceAccount } from '@types';
 
@@ -28,6 +40,11 @@ const TableContainer = styled.div`
     flex-direction: column;
     min-height: 0;
     overflow: hidden;
+
+    table {
+        table-layout: fixed;
+        width: 100%;
+    }
 `;
 
 const FiltersHeader = styled.div`
@@ -60,12 +77,15 @@ const ServiceAccountInfo = styled.div`
     display: flex;
     align-items: center;
     gap: 16px;
+    overflow: hidden;
 `;
 
 const ServiceAccountDetails = styled.div`
     display: flex;
     flex-direction: column;
     color: ${(props) => props.theme.colors.textSecondary};
+    overflow: hidden;
+    min-width: 0;
 `;
 
 const ActionsButtonStyle = {
@@ -74,7 +94,15 @@ const ActionsButtonStyle = {
     boxShadow: 'none',
 };
 
-const EmptyStateContainer = styled.div`
+const EllipsisText = styled(Text)`
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 100%;
+    display: block;
+`;
+
+export const EmptyStateContainer = styled.div`
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -95,9 +123,11 @@ const ServiceAccountNameCell = ({ serviceAccount }: ServiceAccountNameCellProps)
         <ServiceAccountInfo>
             <Avatar size="xl" name={displayName} />
             <ServiceAccountDetails>
-                <Text size="md" weight="semiBold" lineHeight="xs">
-                    {displayName}
-                </Text>
+                <Tooltip title={displayName} showArrow={false}>
+                    <EllipsisText size="md" weight="semiBold" lineHeight="xs">
+                        {displayName}
+                    </EllipsisText>
+                </Tooltip>
             </ServiceAccountDetails>
         </ServiceAccountInfo>
     );
@@ -107,11 +137,21 @@ type ServiceAccountDescriptionCellProps = {
     serviceAccount: ServiceAccount;
 };
 
-const ServiceAccountDescriptionCell = ({ serviceAccount }: ServiceAccountDescriptionCellProps) => {
+export const ServiceAccountDescriptionCell = ({ serviceAccount }: ServiceAccountDescriptionCellProps) => {
+    if (!serviceAccount.description) {
+        return (
+            <Text color="gray" size="md">
+                -
+            </Text>
+        );
+    }
+
     return (
-        <Text color="gray" size="md">
-            {serviceAccount.description || '-'}
-        </Text>
+        <Tooltip title={serviceAccount.description} showArrow={false}>
+            <EllipsisText color="gray" size="md">
+                {serviceAccount.description}
+            </EllipsisText>
+        </Tooltip>
     );
 };
 
@@ -128,7 +168,7 @@ const ServiceAccountRoleCell = ({
     optimisticRoleUrn,
     onRoleChange,
 }: ServiceAccountRoleCellProps) => {
-    // Extract current role from relationships (server data)
+    // TODO: Remove cast once GraphQL codegen includes roles on ServiceAccount
     const castedServiceAccount = serviceAccount as any;
     const roleRelationships = castedServiceAccount?.roles?.relationships;
     const serverRole =
@@ -151,6 +191,49 @@ const ServiceAccountRoleCell = ({
             size="md"
             width="fit-content"
         />
+    );
+};
+
+const DEFAULT_VIEW_TOOLTIP =
+    'Set a default view for the service account. If a view is selected, the account will focus on ' +
+    'browsing assets within the view when accessing DataHub using an AI agent (MCP server). ' +
+    'Only public (global) views are supported.';
+
+type ServiceAccountDefaultViewCellProps = {
+    serviceAccount: ServiceAccount;
+    viewOptions: SelectOption[];
+    onDefaultViewChange: (serviceAccountUrn: string, viewUrn: string | null) => void;
+};
+
+export const ServiceAccountDefaultViewCell = ({
+    serviceAccount,
+    viewOptions,
+    onDefaultViewChange,
+}: ServiceAccountDefaultViewCellProps) => {
+    const currentViewUrn = serviceAccount.defaultView?.urn;
+    const resolvedValue = viewOptions.some((o) => o.value === currentViewUrn) ? currentViewUrn : undefined;
+
+    return (
+        <Tooltip title={DEFAULT_VIEW_TOOLTIP} showArrow={false}>
+            <div>
+                <SimpleSelect
+                    options={viewOptions}
+                    values={resolvedValue ? [resolvedValue] : []}
+                    placeholder="No view"
+                    onUpdate={(values) => {
+                        const nextView = values[0] ?? null;
+                        if (nextView !== currentViewUrn) {
+                            onDefaultViewChange(serviceAccount.urn, nextView);
+                        }
+                    }}
+                    onClear={() => onDefaultViewChange(serviceAccount.urn, null)}
+                    size="md"
+                    width="fit-content"
+                    showClear={!!resolvedValue}
+                    showSearch
+                />
+            </div>
+        </Tooltip>
     );
 };
 
@@ -270,6 +353,7 @@ type ServiceAccountTableProps = {
     serviceAccounts: ServiceAccount[];
     selectRoleOptions: DataHubRole[];
     optimisticRoles: Record<string, string>;
+    viewOptions: SelectOption[];
     loading: boolean;
     page: number;
     pageSize: number;
@@ -277,6 +361,8 @@ type ServiceAccountTableProps = {
     onChangePage: (page: number) => void;
     onDelete: (urn: string) => void;
     onRoleChange?: (serviceAccountUrn: string, newRoleUrn: string, originalRoleUrn: string) => void;
+    onDefaultViewChange: (serviceAccountUrn: string, viewUrn: string | null) => void;
+    refetch?: () => void;
 };
 
 export const ServiceAccountTable = ({
@@ -286,6 +372,7 @@ export const ServiceAccountTable = ({
     serviceAccounts,
     selectRoleOptions,
     optimisticRoles,
+    viewOptions,
     loading,
     page,
     pageSize,
@@ -293,20 +380,22 @@ export const ServiceAccountTable = ({
     onChangePage,
     onDelete,
     onRoleChange,
+    onDefaultViewChange,
+    refetch: _refetch,
 }: ServiceAccountTableProps) => {
     const columns = [
         {
             title: 'Name',
             dataIndex: 'name',
             key: 'name',
-            minWidth: '30%',
+            width: '25%',
             render: (serviceAccount: ServiceAccount) => <ServiceAccountNameCell serviceAccount={serviceAccount} />,
         },
         {
             title: 'Description',
             dataIndex: 'description',
             key: 'description',
-            minWidth: '35%',
+            width: '30%',
             render: (serviceAccount: ServiceAccount) => (
                 <ServiceAccountDescriptionCell serviceAccount={serviceAccount} />
             ),
@@ -314,7 +403,7 @@ export const ServiceAccountTable = ({
         {
             title: 'Role',
             key: 'role',
-            minWidth: '15%',
+            width: '15%',
             render: (serviceAccount: ServiceAccount) => (
                 <ServiceAccountRoleCell
                     serviceAccount={serviceAccount}
@@ -325,9 +414,25 @@ export const ServiceAccountTable = ({
             ),
         },
         {
+            title: (
+                <Tooltip title={DEFAULT_VIEW_TOOLTIP} showArrow={false}>
+                    <span>Default View</span>
+                </Tooltip>
+            ),
+            key: 'defaultView',
+            width: '20%',
+            render: (serviceAccount: ServiceAccount) => (
+                <ServiceAccountDefaultViewCell
+                    serviceAccount={serviceAccount}
+                    viewOptions={viewOptions}
+                    onDefaultViewChange={onDefaultViewChange}
+                />
+            ),
+        },
+        {
             title: '',
             key: 'actions',
-            minWidth: '5%',
+            width: '10%',
             render: (serviceAccount: ServiceAccount) => (
                 <ActionsContainer>
                     <ServiceAccountActionsMenu serviceAccount={serviceAccount} onDelete={onDelete} />

--- a/datahub-web-react/src/app/identity/serviceAccount/ServiceAccountList.hooks.tsx
+++ b/datahub-web-react/src/app/identity/serviceAccount/ServiceAccountList.hooks.tsx
@@ -1,17 +1,25 @@
 import { useApolloClient } from '@apollo/client';
 import { message } from 'antd';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDebounce } from 'react-use';
 
+import { buildViewSelectOptions } from '@app/chat/utils/chatViews';
 import { useUserContext } from '@app/context/useUserContext';
+import { DEFAULT_LIST_VIEWS_PAGE_SIZE } from '@app/entityV2/view/utils';
 import { removeServiceAccountFromListCache } from '@app/identity/serviceAccount/cacheUtils';
 import { clearRoleListCache } from '@app/permissions/roles/cacheUtils';
 import { scrollToTop } from '@app/shared/searchUtils';
+import { SelectOption } from '@src/alchemy-components/components/Select/types';
 
-import { useDeleteServiceAccountMutation, useListServiceAccountsQuery } from '@graphql/auth.generated';
+import {
+    useDeleteServiceAccountMutation,
+    useListServiceAccountsQuery,
+    useUpdateServiceAccountDefaultViewMutation,
+} from '@graphql/auth.generated';
 import { useBatchAssignRoleMutation } from '@graphql/mutations.generated';
 import { useListRolesQuery } from '@graphql/role.generated';
-import { DataHubRole, ServiceAccount } from '@types';
+import { useListGlobalViewsQuery } from '@graphql/view.generated';
+import { DataHubRole, DataHubView } from '@types';
 
 const DEFAULT_PAGE_SIZE = 10;
 const NO_ROLE_URN = 'urn:li:dataHubRole:NoRole';
@@ -102,7 +110,7 @@ export function useServiceAccountListData(page: number, pageSize: number, deboun
 
     const selectRoleOptions = rolesData?.listRoles?.roles?.map((role) => role as DataHubRole) || [];
     const totalServiceAccounts = data?.listServiceAccounts?.total || 0;
-    const serviceAccounts = (data?.listServiceAccounts?.serviceAccounts || []) as ServiceAccount[];
+    const serviceAccounts = data?.listServiceAccounts?.serviceAccounts || [];
 
     const handleDelete = useCallback(
         async (urn: string) => {
@@ -244,4 +252,44 @@ export function useServiceAccountRoleAssignment(
         onCancelRoleAssignment,
         onConfirmRoleAssignment,
     };
+}
+
+export function useServiceAccountViewOptions(): { viewOptions: SelectOption[]; loading: boolean } {
+    const { data, loading } = useListGlobalViewsQuery({
+        variables: { start: 0, count: DEFAULT_LIST_VIEWS_PAGE_SIZE },
+        fetchPolicy: 'cache-first',
+    });
+
+    const viewOptions = useMemo(() => {
+        const views = (data?.listGlobalViews?.views ?? []) as DataHubView[];
+        return buildViewSelectOptions(views);
+    }, [data]);
+
+    return { viewOptions, loading };
+}
+
+export function useServiceAccountDefaultView(refetch: () => void) {
+    const [updateDefaultView] = useUpdateServiceAccountDefaultViewMutation();
+
+    const handleDefaultViewChange = useCallback(
+        async (serviceAccountUrn: string, viewUrn: string | null) => {
+            try {
+                await updateDefaultView({
+                    variables: {
+                        input: {
+                            urn: serviceAccountUrn,
+                            defaultView: viewUrn,
+                        },
+                    },
+                });
+                message.success(viewUrn ? 'Default view updated' : 'Default view removed');
+                refetch();
+            } catch (e: any) {
+                message.error(`Failed to update default view: ${e.message || ''}`);
+            }
+        },
+        [updateDefaultView, refetch],
+    );
+
+    return { handleDefaultViewChange };
 }

--- a/datahub-web-react/src/app/identity/serviceAccount/ServiceAccountList.hooks.tsx
+++ b/datahub-web-react/src/app/identity/serviceAccount/ServiceAccountList.hooks.tsx
@@ -3,7 +3,6 @@ import { message } from 'antd';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDebounce } from 'react-use';
 
-import { buildViewSelectOptions } from '@app/chat/utils/chatViews';
 import { useUserContext } from '@app/context/useUserContext';
 import { DEFAULT_LIST_VIEWS_PAGE_SIZE } from '@app/entityV2/view/utils';
 import { removeServiceAccountFromListCache } from '@app/identity/serviceAccount/cacheUtils';
@@ -262,7 +261,11 @@ export function useServiceAccountViewOptions(): { viewOptions: SelectOption[]; l
 
     const viewOptions = useMemo(() => {
         const views = (data?.listGlobalViews?.views ?? []) as DataHubView[];
-        return buildViewSelectOptions(views);
+        return views.map((view) => ({
+            value: view.urn,
+            label: view.name,
+            description: view.description || undefined,
+        }));
     }, [data]);
 
     return { viewOptions, loading };

--- a/datahub-web-react/src/app/identity/serviceAccount/ServiceAccountList.tsx
+++ b/datahub-web-react/src/app/identity/serviceAccount/ServiceAccountList.tsx
@@ -5,9 +5,11 @@ import styled from 'styled-components/macro';
 import CreateServiceAccountModal from '@app/identity/serviceAccount/CreateServiceAccountModal';
 import { ModalFooter, ServiceAccountTable } from '@app/identity/serviceAccount/ServiceAccountList.components';
 import {
+    useServiceAccountDefaultView,
     useServiceAccountListData,
     useServiceAccountListState,
     useServiceAccountRoleAssignment,
+    useServiceAccountViewOptions,
 } from '@app/identity/serviceAccount/ServiceAccountList.hooks';
 import { Message } from '@app/shared/Message';
 import { Button, Icon, Modal, Text } from '@src/alchemy-components';
@@ -80,6 +82,9 @@ export const ServiceAccountList = ({
         refetch,
     );
 
+    const { viewOptions } = useServiceAccountViewOptions();
+    const { handleDefaultViewChange } = useServiceAccountDefaultView(refetch);
+
     const handleCreateComplete = () => {
         setIsCreatingServiceAccount(false);
     };
@@ -126,6 +131,7 @@ export const ServiceAccountList = ({
                 serviceAccounts={serviceAccounts}
                 selectRoleOptions={selectRoleOptions}
                 optimisticRoles={optimisticRoles}
+                viewOptions={viewOptions}
                 loading={loading}
                 page={page}
                 pageSize={pageSize}
@@ -135,6 +141,8 @@ export const ServiceAccountList = ({
                 }}
                 onDelete={handleDelete}
                 onRoleChange={handleRoleChange}
+                onDefaultViewChange={handleDefaultViewChange}
+                refetch={refetch}
             />
 
             {isCreatingServiceAccount && (

--- a/datahub-web-react/src/app/identity/serviceAccount/__tests__/ServiceAccountList.hooks.test.tsx
+++ b/datahub-web-react/src/app/identity/serviceAccount/__tests__/ServiceAccountList.hooks.test.tsx
@@ -5,15 +5,28 @@ import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+    useServiceAccountDefaultView,
     useServiceAccountListData,
     useServiceAccountListState,
     useServiceAccountRoleAssignment,
+    useServiceAccountViewOptions,
 } from '@app/identity/serviceAccount/ServiceAccountList.hooks';
 
 import { ListServiceAccountsDocument } from '@graphql/auth.generated';
 import { BatchAssignRoleDocument } from '@graphql/mutations.generated';
 import { ListRolesDocument } from '@graphql/role.generated';
-import { DataHubRole, EntityType } from '@types';
+import { ListGlobalViewsDocument } from '@graphql/view.generated';
+import { DataHubRole, DataHubViewType, EntityType } from '@types';
+
+// Mock the generated mutation that requires codegen
+const mockUpdateDefaultViewMutation = vi.fn();
+vi.mock('@graphql/auth.generated', async () => {
+    const actual = await vi.importActual('@graphql/auth.generated');
+    return {
+        ...actual,
+        useUpdateServiceAccountDefaultViewMutation: () => [mockUpdateDefaultViewMutation],
+    };
+});
 
 // Mock the user context
 const mockUserContext = {
@@ -54,6 +67,7 @@ const mockServiceAccounts = [
         createdBy: 'urn:li:corpuser:datahub',
         createdAt: Date.now(),
         updatedAt: null,
+        defaultView: null,
         roles: {
             __typename: 'EntityRelationshipsResult',
             start: 0,
@@ -377,5 +391,139 @@ describe('useServiceAccountRoleAssignment', () => {
 
         // Should not throw and not call any setters
         expect(mockSetOptimisticRoles).not.toHaveBeenCalled();
+    });
+});
+
+const mockGlobalViews = [
+    {
+        __typename: 'DataHubView',
+        urn: 'urn:li:dataHubView:global-1',
+        type: EntityType.DatahubView,
+        name: 'Global View 1',
+        viewType: DataHubViewType.Global,
+        description: 'A global view',
+        definition: null,
+    },
+    {
+        __typename: 'DataHubView',
+        urn: 'urn:li:dataHubView:global-2',
+        type: EntityType.DatahubView,
+        name: 'Global View 2',
+        viewType: DataHubViewType.Global,
+        description: null,
+        definition: null,
+    },
+];
+
+describe('useServiceAccountViewOptions', () => {
+    const viewMocks = [
+        {
+            request: {
+                query: ListGlobalViewsDocument,
+                variables: { start: 0, count: 1000 },
+            },
+            result: {
+                data: {
+                    listGlobalViews: {
+                        __typename: 'ListViewsResult',
+                        start: 0,
+                        count: 1000,
+                        total: 2,
+                        views: mockGlobalViews,
+                    },
+                },
+            },
+        },
+    ];
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <MockedProvider mocks={viewMocks} addTypename={false}>
+            {children}
+        </MockedProvider>
+    );
+
+    it('should return loading state initially', () => {
+        const { result } = renderHook(() => useServiceAccountViewOptions(), { wrapper });
+        expect(result.current.loading).toBe(true);
+        expect(result.current.viewOptions).toEqual([]);
+    });
+
+    it('should return view options after loading', async () => {
+        const { result } = renderHook(() => useServiceAccountViewOptions(), { wrapper });
+
+        await waitFor(() => expect(result.current.loading).toBe(false), { timeout: 5000 });
+
+        expect(result.current.viewOptions).toHaveLength(2);
+        expect(result.current.viewOptions[0].value).toBe('urn:li:dataHubView:global-1');
+        expect(result.current.viewOptions[0].label).toBe('Global View 1');
+        expect(result.current.viewOptions[1].value).toBe('urn:li:dataHubView:global-2');
+        expect(result.current.viewOptions[1].label).toBe('Global View 2');
+    });
+});
+
+describe('useServiceAccountDefaultView', () => {
+    const mockRefetch = vi.fn().mockResolvedValue(undefined);
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockUpdateDefaultViewMutation.mockReset();
+    });
+
+    it('should call mutation and show success message when setting a view', async () => {
+        const { message } = await import('antd');
+        mockUpdateDefaultViewMutation.mockResolvedValue({ data: { updateServiceAccountDefaultView: true } });
+
+        const { result } = renderHook(() => useServiceAccountDefaultView(mockRefetch));
+
+        await act(async () => {
+            await result.current.handleDefaultViewChange('urn:li:corpuser:service_test', 'urn:li:dataHubView:global-1');
+        });
+
+        expect(mockUpdateDefaultViewMutation).toHaveBeenCalledWith({
+            variables: {
+                input: {
+                    urn: 'urn:li:corpuser:service_test',
+                    defaultView: 'urn:li:dataHubView:global-1',
+                },
+            },
+        });
+        expect(message.success).toHaveBeenCalledWith('Default view updated');
+        expect(mockRefetch).toHaveBeenCalled();
+    });
+
+    it('should call mutation and show success message when clearing a view', async () => {
+        const { message } = await import('antd');
+        mockUpdateDefaultViewMutation.mockResolvedValue({ data: { updateServiceAccountDefaultView: true } });
+
+        const { result } = renderHook(() => useServiceAccountDefaultView(mockRefetch));
+
+        await act(async () => {
+            await result.current.handleDefaultViewChange('urn:li:corpuser:service_test', null);
+        });
+
+        expect(mockUpdateDefaultViewMutation).toHaveBeenCalledWith({
+            variables: {
+                input: {
+                    urn: 'urn:li:corpuser:service_test',
+                    defaultView: null,
+                },
+            },
+        });
+        expect(message.success).toHaveBeenCalledWith('Default view removed');
+        expect(mockRefetch).toHaveBeenCalled();
+    });
+
+    it('should show error message when mutation fails', async () => {
+        const { message } = await import('antd');
+        mockUpdateDefaultViewMutation.mockRejectedValue(new Error('Unauthorized'));
+
+        const { result } = renderHook(() => useServiceAccountDefaultView(mockRefetch));
+
+        await act(async () => {
+            await result.current.handleDefaultViewChange('urn:li:corpuser:service_test', 'urn:li:dataHubView:global-1');
+        });
+
+        expect(message.error).toHaveBeenCalledWith(expect.stringContaining('Failed to update default view'));
+        expect(mockRefetch).not.toHaveBeenCalled();
     });
 });

--- a/datahub-web-react/src/app/identity/serviceAccount/__tests__/ServiceAccountList.test.tsx
+++ b/datahub-web-react/src/app/identity/serviceAccount/__tests__/ServiceAccountList.test.tsx
@@ -10,7 +10,19 @@ import theme from '@src/alchemy-components/theme';
 
 import { ListServiceAccountsDocument } from '@graphql/auth.generated';
 import { ListRolesDocument } from '@graphql/role.generated';
+import { ListGlobalViewsDocument } from '@graphql/view.generated';
 import { EntityType } from '@types';
+
+// Mock the generated mutation that requires codegen
+vi.mock('@graphql/auth.generated', async () => {
+    const actual = await vi.importActual('@graphql/auth.generated');
+    return {
+        ...actual,
+        useUpdateServiceAccountDefaultViewMutation: () => [
+            vi.fn().mockResolvedValue({ data: { updateServiceAccountDefaultView: true } }),
+        ],
+    };
+});
 
 // Mock the user context
 const mockUserContext = {
@@ -88,6 +100,7 @@ const mockServiceAccounts = [
         createdBy: 'urn:li:corpuser:datahub',
         createdAt: Date.now(),
         updatedAt: null,
+        defaultView: null,
         roles: {
             __typename: 'EntityRelationshipsResult',
             start: 0,
@@ -106,6 +119,7 @@ const mockServiceAccounts = [
         createdBy: 'urn:li:corpuser:datahub',
         createdAt: Date.now(),
         updatedAt: null,
+        defaultView: null,
         roles: {
             __typename: 'EntityRelationshipsResult',
             start: 0,
@@ -173,6 +187,26 @@ const mocks = [
                             description: 'Editor role',
                         },
                     ],
+                },
+            },
+        },
+    },
+    {
+        request: {
+            query: ListGlobalViewsDocument,
+            variables: {
+                start: 0,
+                count: 1000,
+            },
+        },
+        result: {
+            data: {
+                listGlobalViews: {
+                    __typename: 'ListViewsResult',
+                    start: 0,
+                    count: 1000,
+                    total: 0,
+                    views: [],
                 },
             },
         },

--- a/datahub-web-react/src/app/identity/serviceAccount/__tests__/cacheUtils.test.ts
+++ b/datahub-web-react/src/app/identity/serviceAccount/__tests__/cacheUtils.test.ts
@@ -89,6 +89,7 @@ describe('Service Account Cache Utils', () => {
                                 createdBy: null,
                                 createdAt: null,
                                 updatedAt: null,
+                                defaultView: null,
                                 roles: {
                                     __typename: 'EntityRelationshipsResult',
                                     start: 0,
@@ -171,6 +172,7 @@ describe('Service Account Cache Utils', () => {
                                 createdBy: null,
                                 createdAt: null,
                                 updatedAt: null,
+                                defaultView: null,
                                 roles: {
                                     __typename: 'EntityRelationshipsResult',
                                     start: 0,
@@ -189,6 +191,7 @@ describe('Service Account Cache Utils', () => {
                                 createdBy: null,
                                 createdAt: null,
                                 updatedAt: null,
+                                defaultView: null,
                                 roles: {
                                     __typename: 'EntityRelationshipsResult',
                                     start: 0,

--- a/datahub-web-react/src/app/identity/serviceAccount/cacheUtils.ts
+++ b/datahub-web-react/src/app/identity/serviceAccount/cacheUtils.ts
@@ -31,7 +31,7 @@ function createFullServiceAccount(newServiceAccount: CreatedServiceAccountData) 
         createdBy: newServiceAccount.createdBy || null,
         createdAt: newServiceAccount.createdAt || null,
         updatedAt: null,
-        // Match the structure of the roles field from the GraphQL query
+        defaultView: null,
         roles: {
             __typename: 'EntityRelationshipsResult',
             start: 0,

--- a/datahub-web-react/src/graphql/auth.graphql
+++ b/datahub-web-react/src/graphql/auth.graphql
@@ -63,6 +63,9 @@ query listServiceAccounts($input: ListServiceAccountsInput!) {
             createdBy
             createdAt
             updatedAt
+            defaultView {
+                ...view
+            }
             roles: relationships(input: { types: ["IsMemberOfRole"], direction: OUTGOING, start: 0, count: 1 }) {
                 start
                 count
@@ -108,4 +111,8 @@ mutation createServiceAccount($input: CreateServiceAccountInput!) {
 
 mutation deleteServiceAccount($urn: String!) {
     deleteServiceAccount(urn: $urn)
+}
+
+mutation updateServiceAccountDefaultView($input: UpdateServiceAccountDefaultViewInput!) {
+    updateServiceAccountDefaultView(input: $input)
 }

--- a/smoke-test/tests/service_accounts/test_service_accounts.py
+++ b/smoke-test/tests/service_accounts/test_service_accounts.py
@@ -207,6 +207,34 @@ def _ensure_service_account_exists(session, urn: str):
     return res_data
 
 
+@tenacity.retry(
+    stop=tenacity.stop_after_attempt(sleep_times), wait=tenacity.wait_fixed(sleep_sec)
+)
+def _ensure_service_account_default_view(
+    session, service_account_urn: str, expected_view_urn: Optional[str]
+):
+    """Wait for a service account's default view to reach the expected state."""
+    res_data = list_service_accounts_with_default_view(session)
+    assert res_data.get("data"), f"Failed to list service accounts: {res_data}"
+    assert "errors" not in res_data, f"Unexpected errors: {res_data.get('errors')}"
+
+    accounts = res_data["data"]["listServiceAccounts"]["serviceAccounts"]
+    matching = [sa for sa in accounts if sa["urn"] == service_account_urn]
+    assert len(matching) == 1, f"Expected to find service account {service_account_urn}"
+
+    default_view = matching[0]["defaultView"]
+    if expected_view_urn is None:
+        assert default_view is None, (
+            f"Expected defaultView to be null, got: {default_view}"
+        )
+    else:
+        assert default_view is not None, "Expected defaultView to be set"
+        assert default_view["urn"] == expected_view_urn, (
+            f"Expected view {expected_view_urn}, got {default_view['urn']}"
+        )
+    return matching[0]
+
+
 # Tests
 
 
@@ -530,20 +558,12 @@ def test_service_account_default_view(auth_session):
         assert res_data["data"]["updateServiceAccountDefaultView"] is True
         logger.info("Default view set successfully")
 
-        # Step 4: List and verify the default view is returned
-        res_data = list_service_accounts_with_default_view(auth_session)
-        assert res_data.get("data"), f"Failed to list service accounts: {res_data}"
-        assert "errors" not in res_data
-
-        accounts = res_data["data"]["listServiceAccounts"]["serviceAccounts"]
-        matching = [sa for sa in accounts if sa["urn"] == service_account_urn]
-        assert len(matching) == 1, (
-            f"Expected to find service account {service_account_urn}"
+        # Step 4: List and verify the default view is returned (with retry for eventual consistency)
+        matched = _ensure_service_account_default_view(
+            auth_session, service_account_urn, view_urn
         )
-        assert matching[0]["defaultView"] is not None, "Expected defaultView to be set"
-        assert matching[0]["defaultView"]["urn"] == view_urn
-        assert matching[0]["defaultView"]["name"] == view_name
-        logger.info(f"Verified default view in list: {matching[0]['defaultView']}")
+        assert matched["defaultView"]["name"] == view_name
+        logger.info(f"Verified default view in list: {matched['defaultView']}")
 
         # Step 5: Clear the default view
         res_data = update_service_account_default_view(
@@ -554,15 +574,8 @@ def test_service_account_default_view(auth_session):
         assert res_data["data"]["updateServiceAccountDefaultView"] is True
         logger.info("Default view cleared successfully")
 
-        # Step 6: Verify it's cleared
-        res_data = list_service_accounts_with_default_view(auth_session)
-        assert res_data.get("data")
-        accounts = res_data["data"]["listServiceAccounts"]["serviceAccounts"]
-        matching = [sa for sa in accounts if sa["urn"] == service_account_urn]
-        assert len(matching) == 1
-        assert matching[0]["defaultView"] is None, (
-            f"Expected defaultView to be null after clearing, got: {matching[0]['defaultView']}"
-        )
+        # Step 6: Verify it's cleared (with retry for eventual consistency)
+        _ensure_service_account_default_view(auth_session, service_account_urn, None)
         logger.info("Verified default view is cleared")
 
     finally:

--- a/smoke-test/tests/service_accounts/test_service_accounts.py
+++ b/smoke-test/tests/service_accounts/test_service_accounts.py
@@ -9,11 +9,14 @@ Tests the following operations:
 - createAccessToken for service account: Generate API token for a service account
 """
 
+import logging
 from typing import Optional
 
 import tenacity
 
 from tests.utils import get_sleep_info
+
+logger = logging.getLogger(__name__)
 
 sleep_sec, sleep_times = get_sleep_info()
 
@@ -227,10 +230,10 @@ def test_create_list_get_delete_service_account(auth_session):
         f"Unexpected errors in list: {res_data.get('errors')}"
     )
     before_count = res_data["data"]["listServiceAccounts"]["total"]
-    print(f"Initial service account count: {before_count}")
+    logger.info(f"Initial service account count: {before_count}")
 
     # Step 1: Create service account (ID is auto-generated as UUID)
-    print("Creating service account with auto-generated ID")
+    logger.info("Creating service account with auto-generated ID")
     res_data = create_service_account(
         auth_session,
         display_name=display_name,
@@ -253,11 +256,11 @@ def test_create_list_get_delete_service_account(auth_session):
     )
 
     service_account_urn = created_account["urn"]
-    print(f"Created service account with URN: {service_account_urn}")
+    logger.info(f"Created service account with URN: {service_account_urn}")
 
     # Step 2: List service accounts and verify count increased
     _ensure_service_account_count(auth_session, before_count + 1)
-    print("Verified service account count increased")
+    logger.info("Verified service account count increased")
 
     # Step 3: Get the service account by URN
     res_data = _ensure_service_account_exists(auth_session, service_account_urn)
@@ -265,10 +268,10 @@ def test_create_list_get_delete_service_account(auth_session):
     assert fetched_account["urn"] == service_account_urn
     assert fetched_account["displayName"] == display_name
     assert fetched_account["description"] == description
-    print(f"Successfully retrieved service account: {fetched_account}")
+    logger.info(f"Successfully retrieved service account: {fetched_account}")
 
     # Step 4: Delete the service account
-    print(f"Deleting service account: {service_account_urn}")
+    logger.info(f"Deleting service account: {service_account_urn}")
     res_data = delete_service_account(auth_session, service_account_urn)
     assert res_data, "Failed to delete service account"
     assert res_data.get("data"), f"Response missing data: {res_data}"
@@ -278,11 +281,11 @@ def test_create_list_get_delete_service_account(auth_session):
     assert res_data["data"]["deleteServiceAccount"] is True, (
         f"deleteServiceAccount returned {res_data['data']['deleteServiceAccount']}"
     )
-    print("Service account deleted successfully")
+    logger.info("Service account deleted successfully")
 
     # Step 5: Verify count is back to original
     _ensure_service_account_count(auth_session, before_count)
-    print("Verified service account count is back to original")
+    logger.info("Verified service account count is back to original")
 
 
 def test_create_access_token_for_service_account(auth_session):
@@ -295,7 +298,7 @@ def test_create_access_token_for_service_account(auth_session):
     5. Delete the service account
     """
     # Step 1: Create service account (ID is auto-generated)
-    print("Creating service account for token test")
+    logger.info("Creating service account for token test")
     res_data = create_service_account(
         auth_session,
         display_name="Token Test Service Account",
@@ -305,13 +308,13 @@ def test_create_access_token_for_service_account(auth_session):
     assert "errors" not in res_data, f"Errors in create: {res_data.get('errors')}"
 
     service_account_urn = res_data["data"]["createServiceAccount"]["urn"]
-    print(f"Created service account: {service_account_urn}")
+    logger.info(f"Created service account: {service_account_urn}")
 
     # Wait for it to be indexed
     _ensure_service_account_exists(auth_session, service_account_urn)
 
     # Step 2: Create access token for service account
-    print(f"Creating access token for: {service_account_urn}")
+    logger.info(f"Creating access token for: {service_account_urn}")
     res_data = create_access_token_for_service_account(
         auth_session,
         actor_urn=service_account_urn,
@@ -328,22 +331,22 @@ def test_create_access_token_for_service_account(auth_session):
     )
 
     token_id = token_result["metadata"]["id"]
-    print(f"Created access token with ID: {token_id}")
+    logger.info(f"Created access token with ID: {token_id}")
 
     # Step 3: Revoke the token
-    print(f"Revoking access token: {token_id}")
+    logger.info(f"Revoking access token: {token_id}")
     res_data = revoke_access_token(auth_session, token_id)
     assert res_data.get("data"), f"Failed to revoke token: {res_data}"
     assert "errors" not in res_data, f"Errors in revoke: {res_data.get('errors')}"
     assert res_data["data"]["revokeAccessToken"] is True
-    print("Token revoked successfully")
+    logger.info("Token revoked successfully")
 
     # Step 4: Clean up - delete service account
-    print(f"Deleting service account: {service_account_urn}")
+    logger.info(f"Deleting service account: {service_account_urn}")
     res_data = delete_service_account(auth_session, service_account_urn)
     assert res_data.get("data"), f"Failed to delete service account: {res_data}"
     assert "errors" not in res_data, f"Errors in delete: {res_data.get('errors')}"
-    print("Service account deleted successfully")
+    logger.info("Service account deleted successfully")
 
 
 def test_get_nonexistent_service_account(auth_session):
@@ -353,14 +356,14 @@ def test_get_nonexistent_service_account(auth_session):
     res_data = get_service_account(auth_session, fake_urn)
     # Should either return null or an error
     if res_data.get("errors"):
-        print(
+        logger.info(
             f"Got expected error for nonexistent service account: {res_data['errors']}"
         )
     else:
         assert res_data["data"]["getServiceAccount"] is None, (
             f"Expected null for nonexistent service account, got: {res_data['data']['getServiceAccount']}"
         )
-        print("Got expected null for nonexistent service account")
+        logger.info("Got expected null for nonexistent service account")
 
 
 def test_delete_nonexistent_service_account(auth_session):
@@ -370,12 +373,203 @@ def test_delete_nonexistent_service_account(auth_session):
     res_data = delete_service_account(auth_session, fake_urn)
     # Should return an error for non-existent service account
     if res_data.get("errors"):
-        print(
+        logger.info(
             f"Got expected error for deleting nonexistent service account: {res_data['errors']}"
         )
     else:
         # Some implementations might return false instead of an error
-        print(f"Delete returned: {res_data}")
+        logger.info(f"Delete returned: {res_data}")
+
+
+def update_service_account_default_view(
+    session, urn: str, default_view: Optional[str] = None
+):
+    """Set or clear the default view for a service account."""
+    input_data: dict = {"urn": urn}
+    if default_view is not None:
+        input_data["defaultView"] = default_view
+
+    json_data = {
+        "query": """mutation updateServiceAccountDefaultView($input: UpdateServiceAccountDefaultViewInput!) {
+            updateServiceAccountDefaultView(input: $input)
+        }""",
+        "variables": {"input": input_data},
+    }
+
+    response = session.post(f"{session.frontend_url()}/api/v2/graphql", json=json_data)
+    response.raise_for_status()
+    return response.json()
+
+
+def list_service_accounts_with_default_view(
+    session, start: int = 0, count: int = 20, query: Optional[str] = None
+):
+    """List service accounts including the defaultView field."""
+    input_data: dict = {"start": start, "count": count}
+    if query:
+        input_data["query"] = query
+
+    json_data = {
+        "query": """query listServiceAccounts($input: ListServiceAccountsInput!) {
+            listServiceAccounts(input: $input) {
+                start
+                count
+                total
+                serviceAccounts {
+                    urn
+                    name
+                    displayName
+                    defaultView {
+                        urn
+                        name
+                        viewType
+                    }
+                }
+            }
+        }""",
+        "variables": {"input": input_data},
+    }
+
+    response = session.post(f"{session.frontend_url()}/api/v2/graphql", json=json_data)
+    response.raise_for_status()
+    return response.json()
+
+
+def create_global_view(session, name: str):
+    """Create a global view for testing."""
+    json_data = {
+        "query": """mutation createView($input: CreateViewInput!) {
+            createView(input: $input) {
+                urn
+                name
+            }
+        }""",
+        "variables": {
+            "input": {
+                "viewType": "GLOBAL",
+                "name": name,
+                "description": "Test view for service account default view",
+                "definition": {
+                    "entityTypes": ["DATASET"],
+                    "filter": {
+                        "operator": "AND",
+                        "filters": [
+                            {
+                                "field": "tags",
+                                "values": ["urn:li:tag:test"],
+                                "negated": False,
+                                "condition": "EQUAL",
+                            }
+                        ],
+                    },
+                },
+            }
+        },
+    }
+
+    response = session.post(f"{session.frontend_url()}/api/v2/graphql", json=json_data)
+    response.raise_for_status()
+    return response.json()
+
+
+def delete_view(session, urn: str):
+    """Delete a view."""
+    json_data = {
+        "query": """mutation deleteView($urn: String!) {
+            deleteView(urn: $urn)
+        }""",
+        "variables": {"urn": urn},
+    }
+
+    response = session.post(f"{session.frontend_url()}/api/v2/graphql", json=json_data)
+    response.raise_for_status()
+    return response.json()
+
+
+def test_service_account_default_view(auth_session):
+    """
+    Test setting and clearing the default view for a service account:
+    1. Create a service account
+    2. Create a global view
+    3. Set the default view on the service account
+    4. List service accounts and verify the default view is returned
+    5. Clear the default view
+    6. Verify it's cleared
+    7. Clean up
+    """
+    # Step 1: Create service account
+    res_data = create_service_account(
+        auth_session,
+        display_name="Default View Test SA",
+        description="Testing default view feature",
+    )
+    assert res_data.get("data"), f"Failed to create service account: {res_data}"
+    assert "errors" not in res_data
+    service_account_urn = res_data["data"]["createServiceAccount"]["urn"]
+    logger.info(f"Created service account: {service_account_urn}")
+
+    _ensure_service_account_exists(auth_session, service_account_urn)
+
+    # Step 2: Create a global view
+    res_data = create_global_view(auth_session, "SA Default View Test")
+    assert res_data.get("data"), f"Failed to create view: {res_data}"
+    assert "errors" not in res_data
+    view_urn = res_data["data"]["createView"]["urn"]
+    view_name = res_data["data"]["createView"]["name"]
+    logger.info(f"Created view: {view_urn} ({view_name})")
+
+    try:
+        # Step 3: Set default view on the service account
+        res_data = update_service_account_default_view(
+            auth_session, service_account_urn, view_urn
+        )
+        assert res_data.get("data"), f"Failed to set default view: {res_data}"
+        assert "errors" not in res_data, (
+            f"Errors setting default view: {res_data.get('errors')}"
+        )
+        assert res_data["data"]["updateServiceAccountDefaultView"] is True
+        logger.info("Default view set successfully")
+
+        # Step 4: List and verify the default view is returned
+        res_data = list_service_accounts_with_default_view(auth_session)
+        assert res_data.get("data"), f"Failed to list service accounts: {res_data}"
+        assert "errors" not in res_data
+
+        accounts = res_data["data"]["listServiceAccounts"]["serviceAccounts"]
+        matching = [sa for sa in accounts if sa["urn"] == service_account_urn]
+        assert len(matching) == 1, (
+            f"Expected to find service account {service_account_urn}"
+        )
+        assert matching[0]["defaultView"] is not None, "Expected defaultView to be set"
+        assert matching[0]["defaultView"]["urn"] == view_urn
+        assert matching[0]["defaultView"]["name"] == view_name
+        logger.info(f"Verified default view in list: {matching[0]['defaultView']}")
+
+        # Step 5: Clear the default view
+        res_data = update_service_account_default_view(
+            auth_session, service_account_urn, None
+        )
+        assert res_data.get("data"), f"Failed to clear default view: {res_data}"
+        assert "errors" not in res_data
+        assert res_data["data"]["updateServiceAccountDefaultView"] is True
+        logger.info("Default view cleared successfully")
+
+        # Step 6: Verify it's cleared
+        res_data = list_service_accounts_with_default_view(auth_session)
+        assert res_data.get("data")
+        accounts = res_data["data"]["listServiceAccounts"]["serviceAccounts"]
+        matching = [sa for sa in accounts if sa["urn"] == service_account_urn]
+        assert len(matching) == 1
+        assert matching[0]["defaultView"] is None, (
+            f"Expected defaultView to be null after clearing, got: {matching[0]['defaultView']}"
+        )
+        logger.info("Verified default view is cleared")
+
+    finally:
+        # Clean up
+        delete_service_account(auth_session, service_account_urn)
+        delete_view(auth_session, view_urn)
+        logger.info("Cleaned up service account and view")
 
 
 def test_list_service_accounts_with_query(auth_session):
@@ -408,7 +602,7 @@ def test_list_service_accounts_with_query(auth_session):
         f"Expected to find service account with URN '{service_account_urn}' in list results"
     )
     assert matching[0]["displayName"] == unique_display_name
-    print(f"Found service account in list: {matching[0]}")
+    logger.info(f"Found service account in list: {matching[0]}")
 
     # Clean up
     delete_service_account(auth_session, service_account_urn)


### PR DESCRIPTION
# Summary

In this PR, we add support for defining default views for Service Accounts. In addition, we align agent context kit with DataHub Cloud with respect to handling default view injection. Now we inject the user's PERSONAL default view first if one exists, otherwise fall back to the global org default (if the view resolution env variable is true) 

<img width="1101" height="376" alt="Screenshot 2026-04-24 at 11 31 46 AM" src="https://github.com/user-attachments/assets/70f96ade-9dac-478c-a24f-d88bb98c5b25" />

# Status

Ready for review. 

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
