### PR TITLE
fix(lineageV3): restore inputFields fallback for Chart endpoints

### DIFF
--- a/datahub-web-react/src/app/lineageV3/useComputeGraph/__tests__/getFineGrainedLineage.test.ts
+++ b/datahub-web-react/src/app/lineageV3/useComputeGraph/__tests__/getFineGrainedLineage.test.ts
@@ -160,7 +160,7 @@ describe('schemaFieldExists', () => {
         expect(schemaFieldExists('urn:li:dataset:1', 'USERID', nodes)).toBe(false);
     });
 
-    describe('inputFields fallback for Chart/Dashboard endpoints', () => {
+    describe('inputFields fallback for Chart endpoints', () => {
         const createChartNode = (
             urn: string,
             inputFieldPaths?: string[],
@@ -236,7 +236,11 @@ describe('schemaFieldExists', () => {
             expect(schemaFieldExists('urn:li:chart:1', 'revenue', nodes)).toBe(false);
         });
 
-        it('returns true for Dashboard with inputFields when schemaMetadata is absent', () => {
+        // T1.9 (Path 1) deliberately does NOT relax the gate for Dashboard
+        // endpoints. V3 GraphQL does not fetch Dashboard inputFields, so a
+        // TS fallback would be ineffective. Tracked separately for end-to-end
+        // fix.
+        it('returns false for Dashboard with inputFields (intentional gap — GraphQL does not fetch Dashboard inputFields)', () => {
             const urn = 'urn:li:dashboard:1';
             const node: LineageEntity = {
                 id: urn,
@@ -261,7 +265,7 @@ describe('schemaFieldExists', () => {
             };
             const nodes = new Map([[urn, node]]);
 
-            expect(schemaFieldExists(urn, 'kpi', nodes)).toBe(true);
+            expect(schemaFieldExists(urn, 'kpi', nodes)).toBe(false);
             expect(schemaFieldExists(urn, 'missing', nodes)).toBe(false);
         });
     });

--- a/datahub-web-react/src/app/lineageV3/useComputeGraph/__tests__/getFineGrainedLineage.test.ts
+++ b/datahub-web-react/src/app/lineageV3/useComputeGraph/__tests__/getFineGrainedLineage.test.ts
@@ -159,4 +159,110 @@ describe('schemaFieldExists', () => {
         expect(schemaFieldExists('urn:li:dataset:1', 'userid', nodes)).toBe(false);
         expect(schemaFieldExists('urn:li:dataset:1', 'USERID', nodes)).toBe(false);
     });
+
+    describe('inputFields fallback for Chart/Dashboard endpoints', () => {
+        const createChartNode = (
+            urn: string,
+            inputFieldPaths?: string[],
+            schemaFields?: { fieldPath: string }[],
+        ): LineageEntity => ({
+            id: urn,
+            urn,
+            type: EntityType.Chart,
+            entity: {
+                urn,
+                type: EntityType.Chart,
+                name: 'test chart',
+                ...(schemaFields ? { schemaMetadata: { fields: schemaFields } } : {}),
+                ...(inputFieldPaths
+                    ? {
+                          inputFields: {
+                              fields: inputFieldPaths.map((fp) => ({
+                                  schemaFieldUrn: `urn:li:schemaField:(urn:li:dataset:upstream,${fp})`,
+                                  schemaField: { fieldPath: fp },
+                              })),
+                          },
+                      }
+                    : {}),
+            } as any,
+            isExpanded: {} as any,
+            fetchStatus: {} as any,
+            filters: {} as any,
+        });
+
+        it('returns true for Chart with inputFields when schemaMetadata is absent', () => {
+            const nodes = new Map([['urn:li:chart:1', createChartNode('urn:li:chart:1', ['revenue', 'cost'])]]);
+
+            expect(schemaFieldExists('urn:li:chart:1', 'revenue', nodes)).toBe(true);
+            expect(schemaFieldExists('urn:li:chart:1', 'cost', nodes)).toBe(true);
+        });
+
+        it('returns false for Chart with inputFields when field name is not in inputFields', () => {
+            const nodes = new Map([['urn:li:chart:1', createChartNode('urn:li:chart:1', ['revenue', 'cost'])]]);
+
+            expect(schemaFieldExists('urn:li:chart:1', 'profit', nodes)).toBe(false);
+        });
+
+        it('returns false for Dataset with missing schemaMetadata (existing behavior preserved)', () => {
+            const node: LineageEntity = {
+                id: 'urn:li:dataset:1',
+                urn: 'urn:li:dataset:1',
+                type: EntityType.Dataset,
+                entity: {
+                    urn: 'urn:li:dataset:1',
+                    type: EntityType.Dataset,
+                    name: 'test dataset',
+                } as any,
+                isExpanded: {} as any,
+                fetchStatus: {} as any,
+                filters: {} as any,
+            };
+            const nodes = new Map([['urn:li:dataset:1', node]]);
+
+            expect(schemaFieldExists('urn:li:dataset:1', 'some_field', nodes)).toBe(false);
+        });
+
+        it('normalizes V2 field paths in inputFields comparison', () => {
+            const nodes = new Map([
+                ['urn:li:chart:1', createChartNode('urn:li:chart:1', ['[version=2.0].[type=string].revenue'])],
+            ]);
+
+            expect(schemaFieldExists('urn:li:chart:1', 'revenue', nodes)).toBe(true);
+        });
+
+        it('returns false for Chart with no inputFields and no schemaMetadata', () => {
+            const nodes = new Map([['urn:li:chart:1', createChartNode('urn:li:chart:1')]]);
+
+            expect(schemaFieldExists('urn:li:chart:1', 'revenue', nodes)).toBe(false);
+        });
+
+        it('returns true for Dashboard with inputFields when schemaMetadata is absent', () => {
+            const urn = 'urn:li:dashboard:1';
+            const node: LineageEntity = {
+                id: urn,
+                urn,
+                type: EntityType.Dashboard,
+                entity: {
+                    urn,
+                    type: EntityType.Dashboard,
+                    name: 'test dashboard',
+                    inputFields: {
+                        fields: [
+                            {
+                                schemaFieldUrn: 'urn:li:schemaField:(urn:li:dataset:1,kpi)',
+                                schemaField: { fieldPath: 'kpi' },
+                            },
+                        ],
+                    },
+                } as any,
+                isExpanded: {} as any,
+                fetchStatus: {} as any,
+                filters: {} as any,
+            };
+            const nodes = new Map([[urn, node]]);
+
+            expect(schemaFieldExists(urn, 'kpi', nodes)).toBe(true);
+            expect(schemaFieldExists(urn, 'missing', nodes)).toBe(false);
+        });
+    });
 });

--- a/datahub-web-react/src/app/lineageV3/useComputeGraph/__tests__/getFineGrainedLineage.test.ts
+++ b/datahub-web-react/src/app/lineageV3/useComputeGraph/__tests__/getFineGrainedLineage.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { LineageEntity, createEdgeId } from '@app/lineageV3/common';
-import getFineGrainedLineage, {
-    schemaFieldExists,
-} from '@app/lineageV3/useComputeGraph/getFineGrainedLineage';
+import getFineGrainedLineage, { schemaFieldExists } from '@app/lineageV3/useComputeGraph/getFineGrainedLineage';
 
 import { EntityType } from '@types';
 

--- a/datahub-web-react/src/app/lineageV3/useComputeGraph/__tests__/getFineGrainedLineage.test.ts
+++ b/datahub-web-react/src/app/lineageV3/useComputeGraph/__tests__/getFineGrainedLineage.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { LineageEntity } from '@app/lineageV3/common';
-import { schemaFieldExists } from '@app/lineageV3/useComputeGraph/getFineGrainedLineage';
+import { LineageEntity, createEdgeId } from '@app/lineageV3/common';
+import getFineGrainedLineage, {
+    schemaFieldExists,
+} from '@app/lineageV3/useComputeGraph/getFineGrainedLineage';
 
 import { EntityType } from '@types';
 
@@ -268,5 +270,74 @@ describe('schemaFieldExists', () => {
             expect(schemaFieldExists(urn, 'kpi', nodes)).toBe(false);
             expect(schemaFieldExists(urn, 'missing', nodes)).toBe(false);
         });
+    });
+});
+
+// Anti-phantom end-to-end tests: verify getFineGrainedLineage itself honours the gate.
+describe('getFineGrainedLineage — anti-phantom invariant', () => {
+    const datasetUrn = 'urn:li:dataset:(urn:li:dataPlatform:hive,D,PROD)';
+    const chartUrn = 'urn:li:chart:(sigma,C)';
+
+    const makeDatasetNode = (fields: string[]): LineageEntity => ({
+        id: datasetUrn,
+        urn: datasetUrn,
+        type: EntityType.Dataset,
+        entity: {
+            urn: datasetUrn,
+            type: EntityType.Dataset,
+            name: 'dataset_D',
+            schemaMetadata: { fields: fields.map((fieldPath) => ({ fieldPath })) },
+        } as any,
+        isExpanded: {} as any,
+        fetchStatus: {} as any,
+        filters: {} as any,
+    });
+
+    const makeChartNode = (inputFieldPaths: string[]): LineageEntity => ({
+        id: chartUrn,
+        urn: chartUrn,
+        type: EntityType.Chart,
+        entity: {
+            urn: chartUrn,
+            type: EntityType.Chart,
+            name: 'chart_C',
+            inputFields: {
+                fields: inputFieldPaths.map((fp) => ({
+                    schemaFieldUrn: `urn:li:schemaField:(${datasetUrn},${fp})`,
+                    schemaField: { fieldPath: fp },
+                })),
+            },
+        } as any,
+        isExpanded: {} as any,
+        fetchStatus: {} as any,
+        filters: {} as any,
+    });
+
+    it('drops column edge when upstream Dataset field is absent from schemaMetadata (phantom guard)', () => {
+        // Dataset D has only "real"; Chart C points at "ghost" — edge must be dropped.
+        const nodes = new Map([
+            [datasetUrn, makeDatasetNode(['real'])],
+            [chartUrn, makeChartNode(['ghost'])],
+        ]);
+
+        const result = getFineGrainedLineage({ nodes, edges: new Map(), rootType: EntityType.Dataset });
+
+        expect(result.indirect.downstream.size).toBe(0);
+        expect(result.indirect.upstream.size).toBe(0);
+    });
+
+    it('emits column edge when upstream Dataset field exists in schemaMetadata (T1.9 positive path)', () => {
+        // Dataset D has "revenue"; Chart C's inputField also points at "revenue" — edge must appear.
+        const nodes = new Map([
+            [datasetUrn, makeDatasetNode(['revenue'])],
+            [chartUrn, makeChartNode(['revenue'])],
+        ]);
+
+        const edges = new Map([[createEdgeId(datasetUrn, chartUrn), { isDisplayed: true } as any]]);
+
+        const result = getFineGrainedLineage({ nodes, edges, rootType: EntityType.Dataset });
+
+        // At least one column-level edge must be present in the downstream map.
+        expect(result.indirect.downstream.size).toBeGreaterThan(0);
     });
 });

--- a/datahub-web-react/src/app/lineageV3/useComputeGraph/getFineGrainedLineage.ts
+++ b/datahub-web-react/src/app/lineageV3/useComputeGraph/getFineGrainedLineage.ts
@@ -29,8 +29,6 @@ interface TentativeEdge {
     operationRef?: FineGrainedOperationRef;
 }
 
-const INPUTFIELDS_ENTITY_TYPES = new Set([EntityType.Chart, EntityType.Dashboard]);
-
 /**
  * Check if a schema field exists in a dataset's schema
  * @param datasetUrn URN of the dataset
@@ -54,11 +52,15 @@ export function schemaFieldExists(datasetUrn: string, fieldPath: string, nodes: 
         return true;
     }
 
-    // Chart and Dashboard entities carry columns via inputFields rather than schemaMetadata.
-    // Fall back to inputFields to restore the V1-era behavior removed in PR #16680.
-    // This preserves the anti-phantom intent of PR #6470 — the field must still exist somewhere.
-    if (INPUTFIELDS_ENTITY_TYPES.has(node.entity.type as EntityType)) {
-        return !!node.entity.inputFields?.fields?.some(
+    // Charts carry their column schema in `inputFields[].schemaField`, not
+    // `schemaMetadata.fields`. Fall back to that for Chart endpoints only.
+    // Dataset endpoints retain the strict schemaMetadata gate (anti-phantom).
+    // Dashboard endpoints are intentionally NOT included: V3 lineage GraphQL
+    // does not fetch `inputFields` on Dashboard, so a TS fallback would gate
+    // on data that never arrives. See follow-up ticket [TBD] for the
+    // end-to-end Dashboard fix.
+    if (node.entity.type === EntityType.Chart && node.entity.inputFields?.fields) {
+        return node.entity.inputFields.fields.some(
             (f) => f?.schemaField && downgradeV2FieldPath(f.schemaField.fieldPath) === normalizedFieldPath,
         );
     }

--- a/datahub-web-react/src/app/lineageV3/useComputeGraph/getFineGrainedLineage.ts
+++ b/datahub-web-react/src/app/lineageV3/useComputeGraph/getFineGrainedLineage.ts
@@ -57,8 +57,7 @@ export function schemaFieldExists(datasetUrn: string, fieldPath: string, nodes: 
     // Dataset endpoints retain the strict schemaMetadata gate (anti-phantom).
     // Dashboard endpoints are intentionally NOT included: V3 lineage GraphQL
     // does not fetch `inputFields` on Dashboard, so a TS fallback would gate
-    // on data that never arrives. See follow-up ticket [TBD] for the
-    // end-to-end Dashboard fix.
+    // on data that never arrives.
     if (node.entity.type === EntityType.Chart && node.entity.inputFields?.fields) {
         return node.entity.inputFields.fields.some(
             (f) => f?.schemaField && downgradeV2FieldPath(f.schemaField.fieldPath) === normalizedFieldPath,

--- a/datahub-web-react/src/app/lineageV3/useComputeGraph/getFineGrainedLineage.ts
+++ b/datahub-web-react/src/app/lineageV3/useComputeGraph/getFineGrainedLineage.ts
@@ -29,6 +29,8 @@ interface TentativeEdge {
     operationRef?: FineGrainedOperationRef;
 }
 
+const INPUTFIELDS_ENTITY_TYPES = new Set([EntityType.Chart, EntityType.Dashboard]);
+
 /**
  * Check if a schema field exists in a dataset's schema
  * @param datasetUrn URN of the dataset
@@ -38,16 +40,30 @@ interface TentativeEdge {
  */
 export function schemaFieldExists(datasetUrn: string, fieldPath: string, nodes: NodeContext['nodes']): boolean {
     const node = nodes.get(datasetUrn);
-    if (!node?.entity?.schemaMetadata?.fields) {
-        return false;
-    }
+    if (!node?.entity) return false;
 
     // Normalize both paths to V1 format for comparison, since fineGrainedLineages paths
     // are downgraded to V1 in EntityRegistry but schema field paths may still be V2
     const normalizedFieldPath = downgradeV2FieldPath(fieldPath);
-    return node.entity.schemaMetadata.fields.some(
-        (field) => downgradeV2FieldPath(field.fieldPath) === normalizedFieldPath,
-    );
+
+    if (
+        node.entity.schemaMetadata?.fields?.some(
+            (field) => downgradeV2FieldPath(field.fieldPath) === normalizedFieldPath,
+        )
+    ) {
+        return true;
+    }
+
+    // Chart and Dashboard entities carry columns via inputFields rather than schemaMetadata.
+    // Fall back to inputFields to restore the V1-era behavior removed in PR #16680.
+    // This preserves the anti-phantom intent of PR #6470 — the field must still exist somewhere.
+    if (INPUTFIELDS_ENTITY_TYPES.has(node.entity.type as EntityType)) {
+        return !!node.entity.inputFields?.fields?.some(
+            (f) => f?.schemaField && downgradeV2FieldPath(f.schemaField.fieldPath) === normalizedFieldPath,
+        );
+    }
+
+    return false;
 }
 
 /**


### PR DESCRIPTION


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
