### PR TITLE
feat(ingest/sigma): add formula bracket-ref extractor (state-machine impl)

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/formula_parser.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/formula_parser.py
@@ -7,13 +7,93 @@ It does NOT parse operators, function calls, literals, or any non-bracket
 syntax. Across the M0 probe of 127 DM-element columns, every observed
 cross-column dependency appeared inside brackets; the remaining 2.4% are
 sibling-column transforms that are also bracket-based.
+
+=============================================================================
+State Transition Table
+=============================================================================
+
+States:
+  NORMAL          — outside any bracket or string
+  IN_BRACKET      — between [ and ]; accumulating into source_buf or column_buf
+  IN_DOUBLE_STR   — between " and "; brackets here are NOT references
+  IN_SINGLE_STR   — between ' and '; brackets here are NOT references
+
+Within IN_BRACKET, an internal flag `seen_slash` tracks whether the first
+unescaped `/` has been consumed yet. Before the first `/`, characters
+accumulate into source_buf; after, into column_buf.
+
+Backslash handling: in IN_BRACKET, IN_DOUBLE_STR, IN_SINGLE_STR, a `\\` consumes
+the NEXT character verbatim (literal append; the `\\` itself is dropped
+in IN_BRACKET to support `\\/` and `\\]` unescape semantics, and dropped
+in strings to support `\\"` / `\\'` / `\\\\`). In NORMAL, `\\` has no
+special meaning.
+
+Transitions (rows = state, columns = next char OR EOF):
+
+                     | [              | ]                  | "             | '             | \\                      | /                                           | other          | EOF
+NORMAL               | enter IN_BRACKET; reset bufs | noop | enter IN_DBL_STR | enter IN_SGL_STR | noop      | noop                                        | noop           | done
+IN_BRACKET           | append literal `[` to active buf | finish_bracket: emit_or_skip; -> NORMAL | append literal `"` | append literal `'` | escape_peek: append next raw char to active buf | first slash: set seen_slash, switch active buf to column_buf; subsequent: append literal `/` to column_buf | append to active buf | unterminated_bracket: emit nothing; done
+IN_DOUBLE_STR        | noop           | noop               | -> NORMAL     | noop          | escape_peek: drop both  | noop                                        | noop           | unterminated_string: emit nothing; done
+IN_SINGLE_STR        | noop           | noop               | noop          | -> NORMAL     | escape_peek: drop both  | noop                                        | noop           | unterminated_string: emit nothing; done
+
+Invariants:
+- **Quotes inside brackets are literal column-name characters.** This is the fix
+  for the paired-quote bug: `[col"x"col]` in a formula that has another `"` elsewhere
+  no longer gets mutilated by a pre-pass string stripper.
+- **`\\X` inside a bracket appends `X` literally to the active buffer.** `\\/` becomes
+  `/`, `\\]` becomes `]`, `\\\\` becomes `\\`. The fix for the `A\\\\/B` bug: the first
+  `\\` is escape-peek, consuming the second `\\` literally; the next `/` is then a real
+  (unescaped) slash separator.
+- **`/` inside a bracket is the source/column separator on first occurrence only.**
+  Subsequent `/` characters become literal members of the column buffer (so
+  `[a/b/c]` → source=`a`, column=`b/c`).
+- **Whitespace around source and column is stripped** when emitting
+  `BracketRef.source` / `.column`. `BracketRef.raw` preserves the original text
+  including whitespace.
+
+=============================================================================
+Empty-String and Degenerate-Input Decision Matrix
+=============================================================================
+
+Every row is an explicit decision. Rows marked "skip" emit no BracketRef and
+increment no counter (a debug-level log line suffices; a dedicated counter is
+deferred to a follow-up if production telemetry warrants it).
+
+| Input                   | Old regex behavior                                        | Decision                                | Rationale                                                                  |
+|-------------------------|-----------------------------------------------------------|-----------------------------------------|----------------------------------------------------------------------------|
+| formula = None          | early-return []                                           | preserve ([])                           | defensive null-handling; part of the public contract                       |
+| formula = ""            | return [] (no match)                                      | preserve ([])                           | empty input → empty output                                                 |
+| []                      | no match (regex required `+`)                             | skip silently                           | empty body; no reference to resolve                                        |
+| [ ]                     | source "" after strip                                     | skip silently                           | whitespace-only body → empty source after strip; same as empty             |
+| [/col]                  | source "", column "col"                                   | skip                                    | empty source; resolver cannot look up a column with no DM name             |
+| [source/]               | source "source", column ""                                | skip                                    | empty column; resolver cannot downstream to an empty column name           |
+| [ / ]                   | source "", column "" after strip                          | skip                                    | both parts empty after strip; falls under empty-source rule                |
+| [\\\\]                  | body `\\\\` → unescape produces `\\`                      | emit (source=`\\`)                      | single non-empty backslash; degenerate but resolver handles gracefully     |
+| [\\] (lone escape)      | body `\\]` (the `]` consumed by escape) → no closing `]` | skip (unterminated bracket)             | escape_peek consumes `]`; scanner reaches EOF in IN_BRACKET → unterminated |
+| Unterminated `[…`       | regex doesn't match                                       | skip; debug log only                    | no closing `]` before EOF; emit nothing                                    |
+| Unterminated `"…`       | string regex doesn't match; brackets after may parse      | skip remaining refs inside the string   | treat as if string pairs at EOF; intentional behavior change from regex:   |
+|                         |                                                           |                                         | once `"` opens IN_DOUBLE_STR, everything through EOF is inside-string;     |
+|                         |                                                           |                                         | brackets inside are NOT parsed (previously they were, since regex left     |
+|                         |                                                           |                                         | the unterminated string unstripped and the bracket regex grabbed them)     |
+| [col"name]              | mutilated to `col   col` (literal-stripper BUG)           | emit col"name                           | quotes inside brackets are literal; reviewer-predicted fix                 |
+| [A\\\\/B]               | source=`A\\/B`, column=None (lookbehind BUG)              | emit source=`A\\`, column=`B`           | escape_peek handles literal `\\` before separator; reviewer-predicted fix  |
+| [a"b]+[innocent]+"hi"   | 0 refs (literal-stripper spans from `"` to `"`, BUG)      | emit 2 refs: `a"b`, `innocent`          | reviewer's strongest demo; state machine emits correctly                   |
+| [a[b]c]                 | regex matches innermost [b] only                          | emit source=`a[b`                       | `[` in IN_BRACKET is literal; first `]` closes; behavior change vs regex   |
+| [P_foo] (P_* heuristic) | is_parameter=True (source.startswith("P_") and no column) | preserve is_parameter=True              | ambiguity unresolvable from formula alone; keep heuristic for downstream  |
 """
 
 from __future__ import annotations
 
-import re
+import logging
 from dataclasses import dataclass
 from typing import List, Optional
+
+log = logging.getLogger(__name__)
+
+_NORMAL = 0
+_IN_BRACKET = 1
+_IN_DOUBLE_STR = 2
+_IN_SINGLE_STR = 3
 
 
 @dataclass(frozen=True)
@@ -38,71 +118,90 @@ class BracketRef:
     is_parameter: bool
 
 
-_BRACKET_RE = re.compile(r"\[((?:[^\[\]\\]|\\.)+)\]")
-
-# Matches double- or single-quoted string literals, respecting backslash escapes.
-# Brackets inside string literals are not column refs and must be ignored.
-# Known limitation: a column name that itself contains a quote character and
-# happens to pair with a quote elsewhere in the formula can be silently
-# mutilated. Sigma column names containing literal quotes are not observed in
-# production; document the edge case rather than defend against it.
-# TODO: replace with a left-to-right stateful scanner if quote-bearing column
-# names are encountered in the wild.
-_STRING_LITERAL_RE = re.compile(r'"(?:[^"\\]|\\.)*"|\'(?:[^\'\\]|\\.)*\'')
-
-
-def _strip_string_literals(formula: str) -> str:
-    """Replace string literals with spaces to neutralise bracket-like content.
-
-    Preserves overall string length so any future positional debugging stays
-    accurate.
-    """
-    return _STRING_LITERAL_RE.sub(lambda m: " " * len(m.group()), formula)
-
-
-def _split_unescaped_slash(body: str) -> List[str]:
-    r"""Split a bracket body on `/`, but treat `\/` as a literal slash.
-
-    Note: the single-character lookbehind does not handle a literal backslash
-    immediately before `/` (e.g. ``A\\/B`` meaning source ``A\`` + column
-    ``B``). Column names with a trailing literal ``\`` are not observed in
-    production.
-    # TODO: upgrade to a stateful scan if such names appear in the wild.
-    """
-    return re.split(r"(?<!\\)/", body)
-
-
-def _unescape(s: str) -> str:
-    r"""Convert ``\/`` to ``/`` and ``\]`` to ``]`` in a bracket body segment.
-
-    Conservative: only unescapes the specific sequences observed in Sigma's
-    formula language.
-    """
-    return s.replace(r"\/", "/").replace(r"\]", "]")
-
-
 def extract_bracket_refs(formula: Optional[str]) -> List[BracketRef]:
     """Extract every bracket reference from a Sigma formula.
 
     Returns an empty list for None / empty / no-bracket formulas. Order
     matches appearance in the source string. Leading/trailing whitespace
     in source and column is stripped; ``raw`` preserves the original text.
+
+    Implemented as a single left-to-right stateful scanner driven by the
+    transition table in the module docstring. No backtracking; no regex.
     """
     if not formula:
         return []
     out: List[BracketRef] = []
-    for raw_body in _BRACKET_RE.findall(_strip_string_literals(formula)):
-        parts = _split_unescaped_slash(raw_body)
-        source_raw = parts[0]
-        column_raw = "/".join(parts[1:]) if len(parts) > 1 else None
-        source = _unescape(source_raw).strip()
-        column = _unescape(column_raw).strip() if column_raw is not None else None
-        out.append(
-            BracketRef(
-                raw=f"[{raw_body}]",
-                source=source,
-                column=column,
-                is_parameter=source.startswith("P_") and column is None,
-            )
-        )
+    state = _NORMAL
+    bracket_start_idx = 0
+    source_buf: List[str] = []
+    column_buf: List[str] = []
+    seen_slash = False
+    i = 0
+    n = len(formula)
+    while i < n:
+        ch = formula[i]
+        if state == _NORMAL:
+            if ch == "[":
+                state = _IN_BRACKET
+                bracket_start_idx = i
+                source_buf = []
+                column_buf = []
+                seen_slash = False
+            elif ch == '"':
+                state = _IN_DOUBLE_STR
+            elif ch == "'":
+                state = _IN_SINGLE_STR
+            # else: noop — NORMAL state, non-special char
+        elif state == _IN_BRACKET:
+            buf = column_buf if seen_slash else source_buf
+            if ch == "]":
+                # finish_bracket: emit_or_skip per decision matrix
+                source = "".join(source_buf).strip()
+                column = "".join(column_buf).strip() if seen_slash else None
+                if source and (column is None or column):
+                    out.append(
+                        BracketRef(
+                            raw=formula[bracket_start_idx : i + 1],
+                            source=source,
+                            column=column,
+                            is_parameter=source.startswith("P_") and column is None,
+                        )
+                    )
+                else:
+                    log.debug(
+                        "sigma formula_parser: skipping malformed bracket ref %r",
+                        formula[bracket_start_idx : i + 1],
+                    )
+                state = _NORMAL
+            elif ch == "\\":
+                # escape_peek: consume next char literally into active buffer
+                if i + 1 < n:
+                    buf.append(formula[i + 1])
+                    i += 2
+                    continue
+                # lone backslash at EOF → unterminated bracket; loop ends naturally
+            elif ch == "/" and not seen_slash:
+                # first unescaped slash: switch accumulation to column_buf
+                seen_slash = True
+            else:
+                # covers '[', '"', "'", subsequent '/', and all other chars
+                buf.append(ch)
+        elif state == _IN_DOUBLE_STR:
+            if ch == '"':
+                state = _NORMAL
+            elif ch == "\\":
+                # escape_peek inside string: drop both chars
+                i += 2
+                continue
+            # else: noop — inside string literal
+        elif state == _IN_SINGLE_STR:
+            if ch == "'":
+                state = _NORMAL
+            elif ch == "\\":
+                # escape_peek inside string: drop both chars
+                i += 2
+                continue
+            # else: noop — inside string literal
+        i += 1
+    # EOF: any open IN_BRACKET or IN_*_STR state is silently discarded
     return out

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/formula_parser.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/formula_parser.py
@@ -108,8 +108,17 @@ class BracketRef:
     the whole bracket body and `column` is None (sibling-column reference
     within the same element).
 
-    `is_parameter` is True for `[P_*]` parameter refs (no column part),
-    which lineage resolvers should skip.
+    `column` is everything after the first unescaped `/`, with leading/
+    trailing whitespace stripped. If the body contains multiple unescaped
+    ``/`` characters, only the first separates source from column; the
+    rest become literal ``/`` within ``column`` (e.g. ``[a/b/c]`` →
+    source=``a``, column=``b/c``). ``column`` is None when no ``/`` is
+    present.
+
+    `is_parameter` is True when ``source`` starts with ``"P_"`` (case-sensitive)
+    AND ``column`` is None. This is a heuristic for Sigma parameter refs, which
+    lineage resolvers should skip. `[p_foo]` (lowercase) is NOT flagged;
+    `[P_X/col]` (has column part) is NOT flagged.
     """
 
     raw: str

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/formula_parser.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/formula_parser.py
@@ -1,0 +1,78 @@
+"""Sigma formula bracket-reference extraction.
+
+Sigma calculated columns carry formulas like `[Source/Column]` or `[Column]`.
+This module extracts the bracket references for downstream lineage resolvers.
+
+It does NOT parse operators, function calls, literals, or any non-bracket
+syntax. The bracket refs alone are sufficient for column-level lineage
+because every cross-column dependency in a Sigma formula appears inside
+brackets.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import List, Optional
+
+
+@dataclass(frozen=True)
+class BracketRef:
+    """A single `[...]` reference inside a Sigma formula.
+
+    `source` is the part before the first unescaped `/`. If the formula has
+    no `/`, `source` is the whole bracket body and `column` is None (this
+    is a sibling-column reference within the same element).
+
+    `is_parameter` is True for `[P_*]` parameter refs, which lineage
+    resolvers should skip.
+    """
+
+    raw: str
+    source: str
+    column: Optional[str]
+    is_parameter: bool
+
+
+_BRACKET_RE = re.compile(r"\[((?:[^\[\]\\]|\\.)+)\]")
+_PARAM_RE = re.compile(r"^P_")
+
+
+def _split_unescaped_slash(body: str) -> List[str]:
+    """Split a bracket body on `/`, but treat `\\/` as a literal."""
+    return re.split(r"(?<!\\)/", body)
+
+
+def _unescape(s: str) -> str:
+    """Convert `\\/` to `/` and `\\]` to `]` in a bracket body segment.
+
+    Conservative: only unescapes the specific sequences observed in Sigma's
+    formula language.
+    """
+    return s.replace(r"\/", "/").replace(r"\]", "]")
+
+
+def extract_bracket_refs(formula: Optional[str]) -> List[BracketRef]:
+    """Extract every bracket reference from a Sigma formula.
+
+    Returns an empty list for None / empty / no-bracket formulas. Order
+    matches appearance in the source string.
+    """
+    if not formula:
+        return []
+    out: List[BracketRef] = []
+    for raw_body in _BRACKET_RE.findall(formula):
+        parts = _split_unescaped_slash(raw_body)
+        source_raw = parts[0]
+        column_raw = "/".join(parts[1:]) if len(parts) > 1 else None
+        source = _unescape(source_raw)
+        column = _unescape(column_raw) if column_raw is not None else None
+        out.append(
+            BracketRef(
+                raw=raw_body,
+                source=source,
+                column=column,
+                is_parameter=bool(_PARAM_RE.match(source)) and column is None,
+            )
+        )
+    return out

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/formula_parser.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/formula_parser.py
@@ -36,6 +36,17 @@ class BracketRef:
 
 _BRACKET_RE = re.compile(r"\[((?:[^\[\]\\]|\\.)+)\]")
 _PARAM_RE = re.compile(r"^P_")
+# Matches a double-quoted string literal, respecting `\"` escapes.
+# Sigma uses double quotes for string literals; brackets inside them are not column refs.
+_STRING_LITERAL_RE = re.compile(r'"(?:[^"\\]|\\.)*"')
+
+
+def _strip_string_literals(formula: str) -> str:
+    """Replace double-quoted string literals with spaces to neutralise bracket-like content.
+
+    Preserves overall string length so any future positional debugging stays accurate.
+    """
+    return _STRING_LITERAL_RE.sub(lambda m: " " * len(m.group()), formula)
 
 
 def _split_unescaped_slash(body: str) -> List[str]:
@@ -61,7 +72,7 @@ def extract_bracket_refs(formula: Optional[str]) -> List[BracketRef]:
     if not formula:
         return []
     out: List[BracketRef] = []
-    for raw_body in _BRACKET_RE.findall(formula):
+    for raw_body in _BRACKET_RE.findall(_strip_string_literals(formula)):
         parts = _split_unescaped_slash(raw_body)
         source_raw = parts[0]
         column_raw = "/".join(parts[1:]) if len(parts) > 1 else None

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/formula_parser.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/formula_parser.py
@@ -4,9 +4,9 @@ Sigma calculated columns carry formulas like `[Source/Column]` or `[Column]`.
 This module extracts the bracket references for downstream lineage resolvers.
 
 It does NOT parse operators, function calls, literals, or any non-bracket
-syntax. The bracket refs alone are sufficient for column-level lineage
-because every cross-column dependency in a Sigma formula appears inside
-brackets.
+syntax. Across the M0 probe of 127 DM-element columns, every observed
+cross-column dependency appeared inside brackets; the remaining 2.4% are
+sibling-column transforms that are also bracket-based.
 """
 
 from __future__ import annotations
@@ -20,12 +20,16 @@ from typing import List, Optional
 class BracketRef:
     """A single `[...]` reference inside a Sigma formula.
 
-    `source` is the part before the first unescaped `/`. If the formula has
-    no `/`, `source` is the whole bracket body and `column` is None (this
-    is a sibling-column reference within the same element).
+    `raw` is the full bracket substring as it appears in the formula,
+    including the surrounding ``[`` and ``]`` (e.g. ``[Source/col]``).
 
-    `is_parameter` is True for `[P_*]` parameter refs, which lineage
-    resolvers should skip.
+    `source` is the part before the first unescaped `/`, with leading/
+    trailing whitespace stripped. If the formula has no `/`, `source` is
+    the whole bracket body and `column` is None (sibling-column reference
+    within the same element).
+
+    `is_parameter` is True for `[P_*]` parameter refs (no column part),
+    which lineage resolvers should skip.
     """
 
     raw: str
@@ -35,27 +39,41 @@ class BracketRef:
 
 
 _BRACKET_RE = re.compile(r"\[((?:[^\[\]\\]|\\.)+)\]")
-_PARAM_RE = re.compile(r"^P_")
-# Matches a double-quoted string literal, respecting `\"` escapes.
-# Sigma uses double quotes for string literals; brackets inside them are not column refs.
-_STRING_LITERAL_RE = re.compile(r'"(?:[^"\\]|\\.)*"')
+
+# Matches double- or single-quoted string literals, respecting backslash escapes.
+# Brackets inside string literals are not column refs and must be ignored.
+# Known limitation: a column name that itself contains a quote character and
+# happens to pair with a quote elsewhere in the formula can be silently
+# mutilated. Sigma column names containing literal quotes are not observed in
+# production; document the edge case rather than defend against it.
+# TODO: replace with a left-to-right stateful scanner if quote-bearing column
+# names are encountered in the wild.
+_STRING_LITERAL_RE = re.compile(r'"(?:[^"\\]|\\.)*"|\'(?:[^\'\\]|\\.)*\'')
 
 
 def _strip_string_literals(formula: str) -> str:
-    """Replace double-quoted string literals with spaces to neutralise bracket-like content.
+    """Replace string literals with spaces to neutralise bracket-like content.
 
-    Preserves overall string length so any future positional debugging stays accurate.
+    Preserves overall string length so any future positional debugging stays
+    accurate.
     """
     return _STRING_LITERAL_RE.sub(lambda m: " " * len(m.group()), formula)
 
 
 def _split_unescaped_slash(body: str) -> List[str]:
-    """Split a bracket body on `/`, but treat `\\/` as a literal."""
+    r"""Split a bracket body on `/`, but treat `\/` as a literal slash.
+
+    Note: the single-character lookbehind does not handle a literal backslash
+    immediately before `/` (e.g. ``A\\/B`` meaning source ``A\`` + column
+    ``B``). Column names with a trailing literal ``\`` are not observed in
+    production.
+    # TODO: upgrade to a stateful scan if such names appear in the wild.
+    """
     return re.split(r"(?<!\\)/", body)
 
 
 def _unescape(s: str) -> str:
-    """Convert `\\/` to `/` and `\\]` to `]` in a bracket body segment.
+    r"""Convert ``\/`` to ``/`` and ``\]`` to ``]`` in a bracket body segment.
 
     Conservative: only unescapes the specific sequences observed in Sigma's
     formula language.
@@ -67,7 +85,8 @@ def extract_bracket_refs(formula: Optional[str]) -> List[BracketRef]:
     """Extract every bracket reference from a Sigma formula.
 
     Returns an empty list for None / empty / no-bracket formulas. Order
-    matches appearance in the source string.
+    matches appearance in the source string. Leading/trailing whitespace
+    in source and column is stripped; ``raw`` preserves the original text.
     """
     if not formula:
         return []
@@ -76,14 +95,14 @@ def extract_bracket_refs(formula: Optional[str]) -> List[BracketRef]:
         parts = _split_unescaped_slash(raw_body)
         source_raw = parts[0]
         column_raw = "/".join(parts[1:]) if len(parts) > 1 else None
-        source = _unescape(source_raw)
-        column = _unescape(column_raw) if column_raw is not None else None
+        source = _unescape(source_raw).strip()
+        column = _unescape(column_raw).strip() if column_raw is not None else None
         out.append(
             BracketRef(
-                raw=raw_body,
+                raw=f"[{raw_body}]",
                 source=source,
                 column=column,
-                is_parameter=bool(_PARAM_RE.match(source)) and column is None,
+                is_parameter=source.startswith("P_") and column is None,
             )
         )
     return out

--- a/metadata-ingestion/tests/unit/sigma/test_formula_parser.py
+++ b/metadata-ingestion/tests/unit/sigma/test_formula_parser.py
@@ -1,0 +1,115 @@
+"""Tests for the Sigma formula bracket-reference extractor."""
+
+from datahub.ingestion.source.sigma.formula_parser import extract_bracket_refs
+
+
+def test_none_formula_returns_empty() -> None:
+    assert extract_bracket_refs(None) == []
+
+
+def test_empty_formula_returns_empty() -> None:
+    assert extract_bracket_refs("") == []
+
+
+def test_literal_only_returns_empty() -> None:
+    assert extract_bracket_refs("42") == []
+
+
+def test_sibling_ref() -> None:
+    result = extract_bracket_refs("[col]")
+    assert len(result) == 1
+    ref = result[0]
+    assert ref.source == "col"
+    assert ref.column is None
+    assert ref.is_parameter is False
+
+
+def test_cross_element_ref() -> None:
+    result = extract_bracket_refs("[Source/col]")
+    assert len(result) == 1
+    ref = result[0]
+    assert ref.source == "Source"
+    assert ref.column == "col"
+    assert ref.is_parameter is False
+
+
+def test_real_tenant_sample_m0() -> None:
+    """Verifies the M0 probe sample: 97.6% of 127 observed formulas follow this pattern."""
+    result = extract_bracket_refs("[Union of 1 Sources/win_by_runs]")
+    assert len(result) == 1
+    ref = result[0]
+    assert ref.source == "Union of 1 Sources"
+    assert ref.column == "win_by_runs"
+
+
+def test_two_refs_in_order() -> None:
+    result = extract_bracket_refs("[a] + [b]")
+    assert len(result) == 2
+    assert result[0].source == "a"
+    assert result[1].source == "b"
+
+
+def test_ref_inside_function() -> None:
+    result = extract_bracket_refs("Count([x])")
+    assert len(result) == 1
+    assert result[0].source == "x"
+    assert result[0].column is None
+
+
+def test_two_refs_around_literal_slash_operator() -> None:
+    """The `/` between brackets is an arithmetic operator, not a source/column separator."""
+    result = extract_bracket_refs("[Selected Metric] / [Successful Runs]")
+    assert len(result) == 2
+    assert result[0].source == "Selected Metric"
+    assert result[0].column is None
+    assert result[1].source == "Successful Runs"
+    assert result[1].column is None
+
+
+def test_escaped_slash_in_column_name_no_split() -> None:
+    r"""A `\/` inside a bracket body is a literal `/`, not a source/column separator."""
+    result = extract_bracket_refs(r"[Rank of MAR \/ Modified]")
+    assert len(result) == 1
+    ref = result[0]
+    assert ref.source == "Rank of MAR / Modified"
+    assert ref.column is None
+
+
+def test_escaped_slash_only_in_column_part() -> None:
+    r"""Source ends at the first unescaped `/`; the `\/` in the column part becomes a literal `/`."""
+    result = extract_bracket_refs(r"[Source/with \/ slash]")
+    assert len(result) == 1
+    ref = result[0]
+    assert ref.source == "Source"
+    assert ref.column == "with / slash"
+
+
+def test_parameter_ref() -> None:
+    result = extract_bracket_refs("[P_MyParam]")
+    assert len(result) == 1
+    ref = result[0]
+    assert ref.is_parameter is True
+
+
+def test_parameter_with_slash_is_not_parameter() -> None:
+    """A `P_*` ref with a column part is NOT treated as a parameter per our defensive rule."""
+    result = extract_bracket_refs("[P_X/col]")
+    assert len(result) == 1
+    ref = result[0]
+    assert ref.source == "P_X"
+    assert ref.column == "col"
+    assert ref.is_parameter is False
+
+
+def test_multiline_formula() -> None:
+    formula = "If(\n  [a] > 0,\n  [b],\n  [c]\n)"
+    result = extract_bracket_refs(formula)
+    assert len(result) == 3
+    assert result[0].source == "a"
+    assert result[1].source == "b"
+    assert result[2].source == "c"
+
+
+def test_empty_bracket_skipped() -> None:
+    """Empty brackets `[]` don't match — the body must be 1+ chars."""
+    assert extract_bracket_refs("[]") == []

--- a/metadata-ingestion/tests/unit/sigma/test_formula_parser.py
+++ b/metadata-ingestion/tests/unit/sigma/test_formula_parser.py
@@ -188,14 +188,180 @@ def test_whitespace_inside_brackets_stripped() -> None:
     assert result2[0].column == "col"
 
 
-def test_bracket_body_with_quote_pins_current_behavior() -> None:
-    """A quote inside a bracket body may be mutilated if it pairs with a quote elsewhere.
+def test_bracket_body_with_unpaired_quote() -> None:
+    """A lone `"` inside a bracket body is a literal column-name character.
 
-    This test pins the CURRENT (imperfect) behavior. If this becomes a
-    production issue, replace _strip_string_literals with a stateful scanner.
+    The unbalanced quote can't form a string literal so the body is captured
+    intact. This case was handled correctly by the old regex impl; the scanner
+    preserves the behavior.
     """
-    # Unbalanced quote: the lone `"` inside the bracket can't form a string
-    # literal so the body is captured intact.
     result = extract_bracket_refs('[col"name]')
     assert len(result) == 1
     assert result[0].source == 'col"name'
+
+
+# --- Refactor regression tests (stateful scanner) ---
+
+
+def test_bracket_body_with_paired_quote() -> None:
+    """Regression for the layered-regex paired-quote bug.
+
+    Before refactor, the literal-stripper turned `"x"` into `   `, mutilating
+    the column name. The state machine treats the brackets as a single span;
+    quote characters inside the span are literal column-name characters.
+    """
+    result = extract_bracket_refs('If([col"x"col] = "x", 1, 0)')
+    assert len(result) == 1
+    assert result[0].source == 'col"x"col'
+    assert result[0].column is None
+
+
+def test_literal_backslash_before_slash() -> None:
+    r"""Regression for the lookbehind-cannot-distinguish-`\\/`-from-`\/` bug.
+
+    `\\/` means: literal backslash, then real (unescaped) slash separator.
+    The first `\` consumes the second `\` as a literal; the `/` is then
+    the first unescaped slash.
+    """
+    result = extract_bracket_refs(r"[A\\/B]")
+    assert len(result) == 1
+    assert result[0].source == "A\\"
+    assert result[0].column == "B"
+
+
+def test_balanced_quote_does_not_destroy_innocent_brackets() -> None:
+    """Regression for the literal-stripper-spans-multiple-brackets bug.
+
+    Layered regex: the string-literal pre-pass greedily matches from the
+    first `"` (inside `[a"b]`) to the next `"` (in `"hello"`), replacing
+    21 characters with spaces. Both `]`s and the entire `[innocent]` ref
+    are destroyed; the bracket regex finds 0 matches.
+
+    State machine: `"` inside IN_BRACKET is a literal column-name char,
+    so `[a"b]` parses cleanly with source='a"b'; `[innocent]` is a
+    separate untouched span; `"hello"` is a string-literal in NORMAL
+    state with no brackets inside. Emit 2 refs.
+    """
+    result = extract_bracket_refs('[a"b] + [innocent] + "hello"')
+    assert len(result) == 2
+    assert result[0].source == 'a"b'
+    assert result[0].column is None
+    assert result[1].source == "innocent"
+    assert result[1].column is None
+
+
+def test_nested_bracket_in_body_treated_as_literal() -> None:
+    """Decision: `[` inside IN_BRACKET is appended as a literal column-name
+    character; the FIRST `]` closes the outer bracket. Trailing `c]` after
+    the close becomes NORMAL-state noise.
+
+    Behavior change vs regex (which matched the innermost `[b]` only and
+    silently dropped `a` and `c]`). Documented in the module's decision
+    matrix.
+    """
+    result = extract_bracket_refs("[a[b]c]")
+    assert len(result) == 1
+    assert result[0].source == "a[b"
+    assert result[0].column is None
+
+
+def test_p_star_sibling_treated_as_parameter() -> None:
+    """Documented ambiguity: `[P_foo]` cannot be disambiguated from
+    formula text alone. The parser flags `is_parameter=True` on the
+    heuristic `source.startswith("P_") AND column is None`. The resolver
+    will skip parameter refs; a real column literally named `P_foo` will
+    be missed. Trade-off documented in the decision matrix; if a customer
+    hits this, file a follow-up to make the heuristic configurable.
+    """
+    result = extract_bracket_refs("[P_foo]")
+    assert len(result) == 1
+    assert result[0].source == "P_foo"
+    assert result[0].column is None
+    assert result[0].is_parameter is True
+
+
+# --- Decision matrix: explicit tests for every degenerate-input row ---
+
+
+def test_whitespace_only_bracket_skipped() -> None:
+    """Decision: whitespace-only bracket body is silently skipped (empty after strip)."""
+    assert extract_bracket_refs("[ ]") == []
+
+
+def test_empty_source_with_column_skipped() -> None:
+    """Decision: `[/col]` has empty source; skip rather than emit unresolvable ref."""
+    assert extract_bracket_refs("[/col]") == []
+
+
+def test_empty_column_after_slash_skipped() -> None:
+    """Decision: `[source/]` has empty column; skip rather than emit unresolvable ref."""
+    assert extract_bracket_refs("[source/]") == []
+
+
+def test_whitespace_only_around_slash_skipped() -> None:
+    """Decision: `[ / ]` has both source and column empty after strip; skip."""
+    assert extract_bracket_refs("[ / ]") == []
+
+
+def test_double_backslash_body_emits() -> None:
+    r"""Decision: `[\\]` — escape_peek consumes the second `\` as literal; source is
+    a single backslash character. Emitted since source is non-empty; the downstream
+    resolver will not find a column named `\` and will skip gracefully.
+
+    Behavior change from regex: old impl produced source='\\' (two backslashes,
+    no escape processing); scanner produces source='\' (one backslash).
+    """
+    result = extract_bracket_refs(r"[\\]")
+    assert len(result) == 1
+    assert result[0].source == "\\"
+
+
+def test_lone_escape_at_bracket_end_skipped() -> None:
+    r"""Decision: `[\]` — the `\` escape_peeks the `]`, consuming it as literal;
+    the scanner reaches EOF still in IN_BRACKET → unterminated bracket → skip.
+    """
+    assert extract_bracket_refs(r"[\]") == []
+
+
+def test_unterminated_bracket_skipped() -> None:
+    """Decision: unterminated `[` reaches EOF; emit nothing."""
+    assert extract_bracket_refs("foo [bar baz") == []
+
+
+def test_unterminated_string_continues_scanning() -> None:
+    """Decision: unterminated `"` is treated as if quote pairs at EOF; brackets
+    after the open-quote are inside-string and ignored.
+
+    Note: pre-refactor regex behavior would parse `[not_a_ref]` because the
+    literal-stripper non-greedy match required a closing quote. Document this
+    as an intentional behavior change.
+    """
+    assert extract_bracket_refs('foo "still in string [not_a_ref]') == []
+
+
+# --- Remaining Probe A cases not covered elsewhere ---
+
+
+def test_doubled_brackets_in_string_literal_ignored() -> None:
+    """Doubled brackets inside a double-quoted string literal produce no refs."""
+    result = extract_bracket_refs('Replace([col], "[[nested]]", "")')
+    assert len(result) == 1
+    assert result[0].source == "col"
+
+
+# --- Stable-ordering invariant ---
+
+
+def test_two_refs_stable_order() -> None:
+    """Single-pass scanner: refs are emitted in left-to-right formula order.
+
+    This is a structural guarantee of the scanner (not just a side-effect)
+    because refs are appended to `out` exactly when their closing `]` is
+    encountered, which happens left-to-right.
+    """
+    result = extract_bracket_refs("If([Source/A], [Source/B], 0)")
+    assert len(result) == 2
+    assert result[0].source == "Source"
+    assert result[0].column == "A"
+    assert result[1].source == "Source"
+    assert result[1].column == "B"

--- a/metadata-ingestion/tests/unit/sigma/test_formula_parser.py
+++ b/metadata-ingestion/tests/unit/sigma/test_formula_parser.py
@@ -113,3 +113,23 @@ def test_multiline_formula() -> None:
 def test_empty_bracket_skipped() -> None:
     """Empty brackets `[]` don't match — the body must be 1+ chars."""
     assert extract_bracket_refs("[]") == []
+
+
+def test_brackets_inside_string_literal_ignored() -> None:
+    """Brackets inside double-quoted string literals must not produce lineage refs.
+
+    `"[failed]"` is a string constant, not a column reference.
+    Regression for the quote-awareness review finding.
+    """
+    result = extract_bracket_refs('If([status] = "FAILURE", "[failed]", [fallback])')
+    assert len(result) == 2
+    assert result[0].source == "status"
+    assert result[1].source == "fallback"
+
+
+def test_escaped_quote_inside_string_literal() -> None:
+    r"""A `\"` escape inside a string literal should not prematurely close the string."""
+    result = extract_bracket_refs(r'If([a] = "say \"hi\"", [b], [c])')
+    assert len(result) == 3
+    sources = [r.source for r in result]
+    assert sources == ["a", "b", "c"]

--- a/metadata-ingestion/tests/unit/sigma/test_formula_parser.py
+++ b/metadata-ingestion/tests/unit/sigma/test_formula_parser.py
@@ -51,13 +51,6 @@ def test_two_refs_in_order() -> None:
     assert result[1].source == "b"
 
 
-def test_ref_inside_function() -> None:
-    result = extract_bracket_refs("Count([x])")
-    assert len(result) == 1
-    assert result[0].source == "x"
-    assert result[0].column is None
-
-
 def test_two_refs_around_literal_slash_operator() -> None:
     """The `/` between brackets is an arithmetic operator, not a source/column separator."""
     result = extract_bracket_refs("[Selected Metric] / [Successful Runs]")
@@ -103,6 +96,21 @@ def test_parameter_with_slash_is_not_parameter() -> None:
     assert ref.is_parameter is False
 
 
+def test_parameter_heuristic_is_case_sensitive() -> None:
+    """Lowercase `p_` prefix does NOT trigger the parameter heuristic."""
+    result = extract_bracket_refs("[p_foo]")
+    assert len(result) == 1
+    assert result[0].is_parameter is False
+
+
+def test_parameter_heuristic_bare_prefix() -> None:
+    """[P_] (P_ with no suffix) still matches the heuristic — source starts with 'P_'."""
+    result = extract_bracket_refs("[P_]")
+    assert len(result) == 1
+    assert result[0].source == "P_"
+    assert result[0].is_parameter is True
+
+
 def test_multiline_formula() -> None:
     formula = "If(\n  [a] > 0,\n  [b],\n  [c]\n)"
     result = extract_bracket_refs(formula)
@@ -113,7 +121,7 @@ def test_multiline_formula() -> None:
 
 
 def test_empty_bracket_skipped() -> None:
-    """Empty brackets `[]` don't match — the body must be 1+ chars."""
+    """Empty brackets `[]` are silently skipped — source is empty after strip."""
     assert extract_bracket_refs("[]") == []
 
 
@@ -145,9 +153,6 @@ def test_escaped_quote_inside_string_literal() -> None:
     assert sources == ["a", "b", "c"]
 
 
-# --- Missing-test additions from review ---
-
-
 def test_multi_slash_body() -> None:
     """A body with multiple `/` separators: source is first segment, column gets the rest."""
     result = extract_bracket_refs("[a/b/c]")
@@ -170,6 +175,7 @@ def test_escaped_close_bracket_in_body() -> None:
     result = extract_bracket_refs(r"[col\]name]")
     assert len(result) == 1
     ref = result[0]
+    assert ref.raw == r"[col\]name]"
     assert ref.source == "col]name"
     assert ref.column is None
 
@@ -225,6 +231,7 @@ def test_literal_backslash_before_slash() -> None:
     """
     result = extract_bracket_refs(r"[A\\/B]")
     assert len(result) == 1
+    assert result[0].raw == r"[A\\/B]"
     assert result[0].source == "A\\"
     assert result[0].column == "B"
 
@@ -298,11 +305,6 @@ def test_empty_column_after_slash_skipped() -> None:
     assert extract_bracket_refs("[source/]") == []
 
 
-def test_whitespace_only_around_slash_skipped() -> None:
-    """Decision: `[ / ]` has both source and column empty after strip; skip."""
-    assert extract_bracket_refs("[ / ]") == []
-
-
 def test_double_backslash_body_emits() -> None:
     r"""Decision: `[\\]` — escape_peek consumes the second `\` as literal; source is
     a single backslash character. Emitted since source is non-empty; the downstream
@@ -337,31 +339,3 @@ def test_unterminated_string_continues_scanning() -> None:
     as an intentional behavior change.
     """
     assert extract_bracket_refs('foo "still in string [not_a_ref]') == []
-
-
-# --- Remaining Probe A cases not covered elsewhere ---
-
-
-def test_doubled_brackets_in_string_literal_ignored() -> None:
-    """Doubled brackets inside a double-quoted string literal produce no refs."""
-    result = extract_bracket_refs('Replace([col], "[[nested]]", "")')
-    assert len(result) == 1
-    assert result[0].source == "col"
-
-
-# --- Stable-ordering invariant ---
-
-
-def test_two_refs_stable_order() -> None:
-    """Single-pass scanner: refs are emitted in left-to-right formula order.
-
-    This is a structural guarantee of the scanner (not just a side-effect)
-    because refs are appended to `out` exactly when their closing `]` is
-    encountered, which happens left-to-right.
-    """
-    result = extract_bracket_refs("If([Source/A], [Source/B], 0)")
-    assert len(result) == 2
-    assert result[0].source == "Source"
-    assert result[0].column == "A"
-    assert result[1].source == "Source"
-    assert result[1].column == "B"

--- a/metadata-ingestion/tests/unit/sigma/test_formula_parser.py
+++ b/metadata-ingestion/tests/unit/sigma/test_formula_parser.py
@@ -19,6 +19,7 @@ def test_sibling_ref() -> None:
     result = extract_bracket_refs("[col]")
     assert len(result) == 1
     ref = result[0]
+    assert ref.raw == "[col]"
     assert ref.source == "col"
     assert ref.column is None
     assert ref.is_parameter is False
@@ -28,6 +29,7 @@ def test_cross_element_ref() -> None:
     result = extract_bracket_refs("[Source/col]")
     assert len(result) == 1
     ref = result[0]
+    assert ref.raw == "[Source/col]"
     assert ref.source == "Source"
     assert ref.column == "col"
     assert ref.is_parameter is False
@@ -127,9 +129,73 @@ def test_brackets_inside_string_literal_ignored() -> None:
     assert result[1].source == "fallback"
 
 
+def test_brackets_inside_single_quoted_string_literal_ignored() -> None:
+    """Brackets inside single-quoted string literals are also ignored."""
+    result = extract_bracket_refs("If([a], '[dummy]', [b])")
+    assert len(result) == 2
+    assert result[0].source == "a"
+    assert result[1].source == "b"
+
+
 def test_escaped_quote_inside_string_literal() -> None:
     r"""A `\"` escape inside a string literal should not prematurely close the string."""
     result = extract_bracket_refs(r'If([a] = "say \"hi\"", [b], [c])')
     assert len(result) == 3
     sources = [r.source for r in result]
     assert sources == ["a", "b", "c"]
+
+
+# --- Missing-test additions from review ---
+
+
+def test_multi_slash_body() -> None:
+    """A body with multiple `/` separators: source is first segment, column gets the rest."""
+    result = extract_bracket_refs("[a/b/c]")
+    assert len(result) == 1
+    ref = result[0]
+    assert ref.source == "a"
+    assert ref.column == "b/c"
+
+
+def test_adjacent_brackets() -> None:
+    """Two bracket refs with no whitespace between them both parse correctly."""
+    result = extract_bracket_refs("[a][b]")
+    assert len(result) == 2
+    assert result[0].source == "a"
+    assert result[1].source == "b"
+
+
+def test_escaped_close_bracket_in_body() -> None:
+    r"""A `\]` inside a body is unescaped to `]`; the bracket closes on the next unescaped `]`."""
+    result = extract_bracket_refs(r"[col\]name]")
+    assert len(result) == 1
+    ref = result[0]
+    assert ref.source == "col]name"
+    assert ref.column is None
+
+
+def test_whitespace_inside_brackets_stripped() -> None:
+    """Leading/trailing whitespace in source and column is stripped for exact-name lookup."""
+    result = extract_bracket_refs("[ col ]")
+    assert len(result) == 1
+    ref = result[0]
+    assert ref.raw == "[ col ]"  # raw preserves original
+    assert ref.source == "col"  # source is normalized
+
+    result2 = extract_bracket_refs("[ Source / col ]")
+    assert len(result2) == 1
+    assert result2[0].source == "Source"
+    assert result2[0].column == "col"
+
+
+def test_bracket_body_with_quote_pins_current_behavior() -> None:
+    """A quote inside a bracket body may be mutilated if it pairs with a quote elsewhere.
+
+    This test pins the CURRENT (imperfect) behavior. If this becomes a
+    production issue, replace _strip_string_literals with a stateful scanner.
+    """
+    # Unbalanced quote: the lone `"` inside the bracket can't form a string
+    # literal so the body is captured intact.
+    result = extract_bracket_refs('[col"name]')
+    assert len(result) == 1
+    assert result[0].source == 'col"name'


### PR DESCRIPTION
## Summary
   Adds a small, standalone utility module that extracts `[Source/Column]`
   bracket references from Sigma formula strings — the foundational piece         
   needed by the Sigma column-level-lineage program. 
                                                                                  
   Implemented as a single-pass, char-by-char state machine. The module
   docstring carries the explicit state transition table + degenerate-input       
   decision matrix as the implementation contract. 

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
