### PR TITLE
fix(structured-properties): enable search on single-select structured property dropdown

### DIFF
--- a/datahub-web-react/src/app/entity/shared/components/styled/StructuredProperty/SingleSelectInput.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/StructuredProperty/SingleSelectInput.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import styled from 'styled-components';
 
 import DropdownLabel from '@app/entity/shared/components/styled/StructuredProperty/DropdownLabel';
-import { ANTD_GRAY_V2 } from '@app/entity/shared/constants';
 import ValueDescription from '@app/entity/shared/entityForm/prompts/StructuredPropertyPrompt/ValueDescription';
 import { getStructuredPropertyValue } from '@app/entity/shared/utils';
 
@@ -12,7 +11,7 @@ import { AllowedValue } from '@types';
 const StyledRadio = styled(Radio)`
     display: block;
     .ant-radio-inner {
-        border-color: ${ANTD_GRAY_V2[8]};
+        border-color: ${(props) => props.theme.colors.radioButtonBorder};
     }
 `;
 
@@ -32,6 +31,10 @@ export default function SingleSelectInput({ selectSingleValue, allowedValues, se
             value={selectedValues}
             onSelect={(value) => selectSingleValue(value)}
             optionLabelProp="value"
+            showSearch
+            filterOption={(input, option) =>
+                option?.value?.toString().toLowerCase().includes(input.toLowerCase()) ?? false
+            }
         >
             {allowedValues.map((allowedValue) => (
                 <Select.Option value={getStructuredPropertyValue(allowedValue.value)}>

--- a/datahub-web-react/src/app/entity/shared/components/styled/StructuredProperty/__tests__/SingleSelectInput.test.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/StructuredProperty/__tests__/SingleSelectInput.test.tsx
@@ -1,0 +1,124 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import SingleSelectInput from '@app/entity/shared/components/styled/StructuredProperty/SingleSelectInput';
+import CustomThemeProvider from '@src/CustomThemeProvider';
+
+import { AllowedValue } from '@types';
+
+const makeStringAllowedValue = (value: string, description?: string): AllowedValue => ({
+    value: { __typename: 'StringValue', stringValue: value },
+    description: description ?? null,
+});
+
+const SIX_ALLOWED_VALUES: AllowedValue[] = [
+    makeStringAllowedValue('Apple', 'A fruit'),
+    makeStringAllowedValue('Banana', 'Another fruit'),
+    makeStringAllowedValue('Cherry'),
+    makeStringAllowedValue('Date'),
+    makeStringAllowedValue('Elderberry'),
+    makeStringAllowedValue('Fig'),
+];
+
+function renderSelect(props?: Partial<React.ComponentProps<typeof SingleSelectInput>>) {
+    return render(
+        <CustomThemeProvider>
+            <SingleSelectInput
+                selectedValues={[]}
+                allowedValues={SIX_ALLOWED_VALUES}
+                selectSingleValue={vi.fn()}
+                {...props}
+            />
+        </CustomThemeProvider>,
+    );
+}
+
+describe('SingleSelectInput', () => {
+    describe('Select dropdown (> 5 allowed values)', () => {
+        it('renders a Select combobox instead of radio buttons', () => {
+            renderSelect();
+            expect(screen.getByRole('combobox')).toBeInTheDocument();
+            expect(screen.queryByRole('radio')).not.toBeInTheDocument();
+        });
+
+        it('shows all options when dropdown is opened', async () => {
+            renderSelect();
+            const combobox = screen.getByRole('combobox');
+            fireEvent.mouseDown(combobox);
+
+            // Antd duplicates option text into accessible aria elements for visible options,
+            // so some values appear twice in the DOM. Use getAllByText (length check) to handle
+            // this gracefully regardless of how many aria elements antd creates.
+            await waitFor(() => {
+                expect(screen.queryAllByText('Apple').length).toBeGreaterThan(0);
+                expect(screen.queryAllByText('Banana').length).toBeGreaterThan(0);
+                expect(screen.queryAllByText('Fig').length).toBeGreaterThan(0);
+            });
+        });
+
+        it('filters options when user types in the search input', async () => {
+            renderSelect();
+            const combobox = screen.getByRole('combobox');
+            fireEvent.mouseDown(combobox);
+            fireEvent.change(combobox, { target: { value: 'an' } });
+
+            await waitFor(() => {
+                expect(screen.getByRole('option', { name: 'Banana' })).toBeInTheDocument();
+            });
+
+            // Options not containing 'an' should be filtered out
+            expect(screen.queryByRole('option', { name: 'Cherry' })).not.toBeInTheDocument();
+            expect(screen.queryByRole('option', { name: 'Date' })).not.toBeInTheDocument();
+            expect(screen.queryByRole('option', { name: 'Fig' })).not.toBeInTheDocument();
+        });
+
+        it('is case-insensitive when filtering', async () => {
+            renderSelect();
+            const combobox = screen.getByRole('combobox');
+            fireEvent.mouseDown(combobox);
+            fireEvent.change(combobox, { target: { value: 'APPLE' } });
+
+            await waitFor(() => {
+                expect(screen.getByRole('option', { name: 'Apple' })).toBeInTheDocument();
+            });
+
+            expect(screen.queryByRole('option', { name: 'Banana' })).not.toBeInTheDocument();
+        });
+
+        it('shows no options when filter matches nothing', async () => {
+            renderSelect();
+            const combobox = screen.getByRole('combobox');
+            fireEvent.mouseDown(combobox);
+            fireEvent.change(combobox, { target: { value: 'zzz' } });
+
+            await waitFor(() => {
+                expect(screen.queryByRole('option', { name: 'Apple' })).not.toBeInTheDocument();
+                expect(screen.queryByRole('option', { name: 'Banana' })).not.toBeInTheDocument();
+            });
+        });
+
+        it('calls selectSingleValue with the correct value when an option is clicked', async () => {
+            const mockSelect = vi.fn();
+            renderSelect({ selectSingleValue: mockSelect });
+            const combobox = screen.getByRole('combobox');
+            fireEvent.mouseDown(combobox);
+
+            // Cherry is not the first option so it has no aria-activedescendant element.
+            // Find it by visible text in the DropdownLabel, which appears exactly once.
+            await waitFor(() => screen.getByText('Cherry'));
+            fireEvent.click(screen.getByText('Cherry'));
+
+            expect(mockSelect).toHaveBeenCalledWith('Cherry');
+        });
+    });
+
+    describe('Radio group (<= 5 allowed values)', () => {
+        const FIVE_VALUES: AllowedValue[] = SIX_ALLOWED_VALUES.slice(0, 5);
+
+        it('renders radio buttons when there are 5 or fewer allowed values', () => {
+            renderSelect({ allowedValues: FIVE_VALUES });
+            expect(screen.getAllByRole('radio')).toHaveLength(5);
+            expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+        });
+    });
+});

--- a/smoke-test/tests/cypress/cypress/e2e/structured_properties/structured_properties.js
+++ b/smoke-test/tests/cypress/cypress/e2e/structured_properties/structured_properties.js
@@ -310,4 +310,106 @@ describe("Verify manage structured properties functionalities", () => {
     cy.goToStructuredProperties();
     cy.deleteStructuredProperty(property);
   });
+
+  it("Verify single-select dropdown supports search/filter on allowed values", () => {
+    const propName = "Cypress SingleSelect Search Test";
+    const propQualifiedName = "cypress_singleselect_search_test";
+    const allowedValues = [
+      "Alpha",
+      "Bravo",
+      "Charlie",
+      "Delta",
+      "Echo",
+      "Foxtrot",
+    ];
+    let createdUrn;
+
+    // Create structured property with 6 allowed values via GraphQL (6 values triggers Select dropdown)
+    cy.request({
+      method: "POST",
+      url: "/api/v2/graphql",
+      body: {
+        query: `
+          mutation createStructuredProperty($input: CreateStructuredPropertyInput!) {
+            createStructuredProperty(input: $input) {
+              urn
+            }
+          }
+        `,
+        variables: {
+          input: {
+            id: propQualifiedName,
+            qualifiedName: propQualifiedName,
+            displayName: propName,
+            valueType: "urn:li:dataType:datahub.string",
+            cardinality: "SINGLE",
+            entityTypes: ["urn:li:entityType:datahub.dataset"],
+            allowedValues: allowedValues.map((v) => ({ stringValue: v })),
+          },
+        },
+      },
+    }).then((resp) => {
+      expect(resp.status).to.eq(200);
+      createdUrn = resp.body.data.createStructuredProperty.urn;
+    });
+
+    // Navigate to dataset and open Properties tab
+    cy.goToDataset(datasetUrn, datasetName);
+    cy.get('[data-testid="Properties-entity-tab-header"]').click();
+    cy.get('[data-testid="add-structured-prop-button"]').click();
+
+    // Select our test property from the dropdown menu
+    cy.get("body .ant-dropdown-menu")
+      .should("be.visible")
+      .within(() => {
+        cy.contains(propName).click();
+      });
+
+    // Open the single-select dropdown and verify the search input exists
+    cy.get(".ant-select-selector").last().click();
+    cy.get(".ant-select-dropdown")
+      .should("be.visible")
+      .within(() => {
+        cy.get(".ant-select-item").should("have.length", allowedValues.length);
+      });
+
+    // Type a search term and verify filtering works
+    cy.get(".ant-select-selection-search-input").last().type("Cha");
+    cy.get(".ant-select-dropdown")
+      .should("be.visible")
+      .within(() => {
+        cy.contains(".ant-select-item", "Charlie").should("be.visible");
+        cy.contains(".ant-select-item", "Alpha").should("not.exist");
+        cy.contains(".ant-select-item", "Foxtrot").should("not.exist");
+      });
+
+    // Select "Charlie" and confirm it is applied
+    cy.get(".ant-select-dropdown")
+      .contains(".ant-select-item", "Charlie")
+      .click();
+    cy.get(".ant-select-selector").last().should("contain.text", "Charlie");
+
+    // Close modal without saving (escape key) to avoid polluting dataset data
+    cy.get("body").type("{esc}");
+
+    // Cleanup: delete the structured property via GraphQL
+    cy.then(() => {
+      cy.request({
+        method: "POST",
+        url: "/api/v2/graphql",
+        body: {
+          query: `
+            mutation deleteStructuredProperty($input: DeleteStructuredPropertyInput!) {
+              deleteStructuredProperty(input: $input)
+            }
+          `,
+          variables: {
+            input: { urn: createdUrn },
+          },
+        },
+      }).then((resp) => {
+        expect(resp.status).to.eq(200);
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- **Root cause:** Ant Design's `<Select>` only auto-enables search for `mode="multiple"`. Single-mode requires explicit `showSearch` — it was missing from `SingleSelectInput.tsx`, so users had to manually scroll all allowed values when a single-select structured property had more than 5 options (the threshold above which `SingleSelectInput` renders a dropdown instead of radio buttons).
- **Fix:** Added `showSearch` and a case-insensitive `filterOption` (string match against `option.value`) to the `<Select>`. The `optionLabelProp="value"` was already in place so the selected value displays correctly as plain text.
- **Lint cleanup:** Replaced the deprecated `ANTD_GRAY_V2[8]` border-color on the `StyledRadio` with the `radioButtonBorder` semantic theme token, per the frontend theming guideline in `AGENTS.md`.

**Before fix:** No search input in single-select dropdowns — users had to manually scroll all allowed values.
**After fix:** Typing filters the list in real time, matching multi-select UX.

## Files changed

| File | Change |
|------|--------|
| `datahub-web-react/src/app/entity/shared/components/styled/StructuredProperty/SingleSelectInput.tsx` | Add `showSearch` + `filterOption` to `<Select>`; migrate `ANTD_GRAY_V2[8]` to `radioButtonBorder` semantic token |
| `datahub-web-react/src/app/entity/shared/components/styled/StructuredProperty/__tests__/SingleSelectInput.test.tsx` | New Vitest unit-test suite (124 lines) |
| `smoke-test/tests/cypress/cypress/e2e/structured_properties/structured_properties.js` | New Cypress regression test for single-select search |

## Test plan

- [x] Unit: `yarn test SingleSelectInput --run` — all 7 cases pass
- [x] Lint: `./gradlew :datahub-web-react:yarnLint` — clean on changed files
- [x] Pre-commit: passes on the three changed files
- [ ] Cypress: `npx cypress run --spec cypress/e2e/structured_properties/structured_properties.js` — new test asserts search input exists, `Cha` filters to `Charlie` while `Alpha`/`Foxtrot` are hidden, then deletes the property via `deleteStructuredProperty`
- [ ] Manual: open dataset with single-select structured property (≥6 allowed values) → confirm search input appears and filters correctly
- [ ] Regression: multi-select dropdown unchanged (`MultiSelectInput.tsx` not touched)

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added (Vitest unit tests + Cypress regression test)
- [x] No public-API breaking changes