### PR TITLE
ci(security): security scan workflow follow-ups

### DIFF
--- a/.github/scripts/security_scan_linear_sync.py
+++ b/.github/scripts/security_scan_linear_sync.py
@@ -14,7 +14,7 @@ Feature summary:
     commit SHA, and workflow run URL.
 - Raw scan report attachments on create:
   - For newly created issues, attach matching raw scanner JSON files (Trivy/Grype) when
-    ``--raw-report-paths`` is provided.
+    ``--raw-report-paths`` is passed once per raw file (repeat the flag).
   - Upload files via Linear signed upload URLs, then create issue attachments that reference the
     uploaded assets.
 - Existing issue reconciliation:
@@ -87,7 +87,6 @@ from utils.security_scan_utils import (
 
 LINEAR_GRAPHQL = "https://api.linear.app/graphql"
 MAX_TITLE_LEN = 250
-REFS_HTML_MARKER = "<!-- datahub-security-scan-refs -->"
 REFS_SECTION_HEADER = "### Git branch/tag scan history"
 REFS_SECTION_INTRO = (
     "CI records each **branch** or **tag** where this finding was reported (UTC timestamps). "
@@ -967,11 +966,7 @@ def _create_issue_relations_cve_or_pkg(
 
 
 def _comment_has_refs_anchor(body: str) -> bool:
-    if REFS_HTML_MARKER in body:
-        return True
-    if LEGACY_REFS_MARKER in body or REFS_SECTION_HEADER in body:
-        return True
-    return any(h in body for h in LEGACY_REFS_HEADERS)
+    return _comment_has_refs_anchor_util(body)
 
 
 def _get_marker_comment_id(
@@ -1118,12 +1113,12 @@ def main() -> int:
     )
     p.add_argument(
         "--raw-report-paths",
-        nargs="*",
+        action="append",
         type=Path,
-        default=[],
-        help="Optional raw scanner reports to upload as Linear issue attachments on create.",
+        help="Optional raw scanner report; repeat the flag for each file (uploaded as issue attachments on create).",
     )
     args = p.parse_args()
+    raw_report_path_list: list[Path] = list(args.raw_report_paths or [])
     scanner = args.scanner.strip().lower()
 
     api_key = os.environ.get("LINEAR_SECURITY_SCAN_API_KEY", "").strip()
@@ -1245,7 +1240,7 @@ def main() -> int:
             created += 1
             print(f"Created issue: {linear_title} ({issue_id})")
             issue_raw_reports = _raw_report_paths_for_occurrences(
-                args.raw_report_paths, occ, scanner
+                raw_report_path_list, occ, scanner
             )
             for raw_report in issue_raw_reports:
                 if not raw_report.is_file():

--- a/.github/scripts/test/test_linear_sync_utils.py
+++ b/.github/scripts/test/test_linear_sync_utils.py
@@ -23,10 +23,12 @@ def test_dedupe_preserve_order():
 def test_linear_priority_and_due_date_mappings():
     assert utils.linear_priority_for_scan_severity("CRITICAL") == 1
     assert utils.linear_priority_for_scan_severity("HIGH") == 2
-    assert utils.linear_priority_for_scan_severity("MEDIUM") is None
+    assert utils.linear_priority_for_scan_severity("MEDIUM") == 3
+    assert utils.linear_priority_for_scan_severity("LOW") == 4
     assert utils.linear_due_date_for_scan_severity("CRITICAL") is not None
     assert utils.linear_due_date_for_scan_severity("HIGH") is not None
-    assert utils.linear_due_date_for_scan_severity("MEDIUM") is None
+    assert utils.linear_due_date_for_scan_severity("MEDIUM") is not None
+    assert utils.linear_due_date_for_scan_severity("LOW") is not None
 
 
 def test_unique_repo_basenames_from_occurrences():
@@ -136,8 +138,14 @@ def test_attach_file_to_issue_uploads_then_attaches(monkeypatch, tmp_path: Path)
     )
     calls: dict[str, object] = {}
 
-    def fake_upload(upload_url: str, upload_headers: dict[str, str], payload: bytes):
-        calls["upload"] = (upload_url, upload_headers, payload)
+    def fake_upload(
+        upload_url: str,
+        upload_headers: dict[str, str] | None,
+        payload: bytes,
+        *,
+        content_type: str,
+    ) -> None:
+        calls["upload"] = (upload_url, upload_headers, payload, content_type)
 
     monkeypatch.setattr(utils, "upload_file_to_signed_url", fake_upload)
     monkeypatch.setattr(
@@ -151,3 +159,39 @@ def test_attach_file_to_issue_uploads_then_attaches(monkeypatch, tmp_path: Path)
     assert calls["upload"][0] == "https://upload.example"
     assert calls["upload"][1] == {"x-a": "1"}
     assert calls["upload"][2] == b'{"ok":true}'
+    assert calls["upload"][3] == "application/json"
+
+
+def test_merge_gcs_put_headers_adds_content_type_when_absent():
+    m = utils._merge_gcs_put_headers({}, "application/json")
+    assert m == {"Content-Type": "application/json"}
+
+
+def test_merge_gcs_put_headers_preserves_linear_headers():
+    m = utils._merge_gcs_put_headers(
+        {"Content-Type": "application/json", "X-Test": "1"},
+        "text/plain",
+    )
+    assert m["Content-Type"] == "application/json"
+    assert m["X-Test"] == "1"
+
+
+def test_upload_file_merges_content_type_for_gcs_put(monkeypatch):
+    got: dict[str, object] = {}
+
+    def fake_put(
+        url: str,
+        headers: dict[str, str] | None = None,
+        data: object = None,
+        timeout: int = 0,
+    ) -> object:
+        got["headers"] = dict(headers or {})
+        got["data"] = data
+        return type("R", (), {"ok": True, "status_code": 200, "text": ""})()
+
+    monkeypatch.setattr(utils.requests, "put", fake_put)
+    utils.upload_file_to_signed_url(
+        "https://example.com/put", {}, b"ab", content_type="application/json"
+    )
+    assert got["headers"]["Content-Type"] == "application/json"
+    assert got["data"] == b"ab"

--- a/.github/scripts/test/test_security_scan_linear_sync_utils.py
+++ b/.github/scripts/test/test_security_scan_linear_sync_utils.py
@@ -195,6 +195,14 @@ def test_merge_refs_comment_is_deduplicated():
     )
     assert second.count("**Branch**: `main`") == 1
     assert utils.comment_has_refs_anchor(second)
+    assert "[//]: # (datahub-security-scan-refs)" in second
+    assert "### Git branch/tag scan history" in second
+    assert "<!--" not in second
+
+
+def test_comment_has_refs_anchor_still_finds_legacy_html_block():
+    body = "<!-- datahub-security-scan-refs\n### Git branch/tag scan history\n-->\n"
+    assert utils.comment_has_refs_anchor(body)
 
 
 def test_issue_pairs_cve_or_pkg_connects_transitively():

--- a/.github/scripts/utils/linear_sync_utils.py
+++ b/.github/scripts/utils/linear_sync_utils.py
@@ -63,7 +63,7 @@ def split_image_ref(target: str) -> tuple[str, str]:
 
 
 def linear_priority_for_scan_severity(severity_upper: str | None) -> int | None:
-    """Map scanner severities to Linear numeric priority."""
+    """Map scanner severities to Linear numeric priority (0=none; 1–4 = urgent→low)."""
     if not severity_upper:
         return None
     s = severity_upper.strip().upper()
@@ -71,18 +71,26 @@ def linear_priority_for_scan_severity(severity_upper: str | None) -> int | None:
         return 1
     if s == "HIGH":
         return 2
+    if s == "MEDIUM":
+        return 3
+    if s == "LOW":
+        return 4
     return None
 
 
 def linear_due_date_for_scan_severity(severity_upper: str | None) -> str | None:
-    """Linear IssueCreateInput.dueDate (UTC YYYY-MM-DD)."""
+    """Linear IssueCreateInput.dueDate (UTC); today + 15/35/180/360 days for critical/high/medium/low."""
     if not severity_upper:
         return None
     s = severity_upper.strip().upper()
     if s == "CRITICAL":
-        days = 16
+        days = 15
     elif s == "HIGH":
-        days = 31
+        days = 35
+    elif s == "MEDIUM":
+        days = 180
+    elif s == "LOW":
+        days = 360
     else:
         return None
     day = datetime.now(timezone.utc).date() + timedelta(days=days)
@@ -286,11 +294,36 @@ mutation FileUpload($filename: String!, $contentType: String!, $size: Int!) {
     return upload_url, asset_url, hdrs
 
 
+def _merge_gcs_put_headers(
+    upload_headers: dict[str, str] | None, content_type: str
+) -> dict[str, str]:
+    """Ensure ``Content-Type`` is set; ``fileUpload`` may return empty ``headers`` (GCS PUT 400)."""
+    out: dict[str, str] = {}
+    for k, v in dict(upload_headers or {}).items():
+        if k.lower() == "content-type" and not (str(v).strip() if v is not None else ""):
+            continue
+        out[k] = v
+    if not any(name.lower() == "content-type" for name in out):
+        out["Content-Type"] = content_type
+    return out
+
+
 def upload_file_to_signed_url(
-    upload_url: str, upload_headers: dict[str, str], payload: bytes
+    upload_url: str,
+    upload_headers: dict[str, str] | None,
+    payload: bytes,
+    *,
+    content_type: str,
 ) -> None:
-    resp = requests.put(upload_url, headers=upload_headers, data=payload, timeout=300)
-    resp.raise_for_status()
+    merged = _merge_gcs_put_headers(upload_headers, content_type)
+    resp = requests.put(
+        upload_url, headers=merged, data=payload, timeout=300
+    )
+    if not resp.ok:
+        body = (resp.text or "")[:2000]
+        raise RuntimeError(
+            f"GCS upload failed: HTTP {resp.status_code} for {upload_url!r} — {body}"
+        )
 
 
 def create_issue_attachment(api_key: str, issue_id: str, title: str, url: str) -> str:
@@ -334,7 +367,9 @@ def attach_file_to_issue(api_key: str, issue_id: str, file_path: Path, title: st
         content_type=content_type,
         size=len(payload),
     )
-    upload_file_to_signed_url(upload_url, upload_headers, payload)
+    upload_file_to_signed_url(
+        upload_url, upload_headers, payload, content_type=content_type
+    )
     return create_issue_attachment(api_key, issue_id, title=title, url=asset_url)
 
 

--- a/.github/scripts/utils/security_scan_utils.py
+++ b/.github/scripts/utils/security_scan_utils.py
@@ -387,7 +387,10 @@ INTERNAL_VULN_KEYS: frozenset[str] = frozenset(
     {"_datahub_scanners", "_datahub_scanner_source"}
 )
 
-REFS_HTML_MARKER = "<!-- datahub-security-scan-refs -->"
+# Legacy comments may use HTML markers; Linear shows `<!--` as raw text, so new bodies use Markdown only.
+REFS_HTML_COMMENT_PREFIX = "<!-- datahub-security-scan-refs"
+# Standard Markdown line that most renderers omit (no raw `<!--` in Linear).
+REFS_MD_ANCHOR = "[//]: # (datahub-security-scan-refs)"
 REFS_SECTION_HEADER = "### Git branch/tag scan history"
 REFS_SECTION_INTRO = (
     "CI records each **branch** or **tag** where this finding was reported (UTC timestamps). "
@@ -690,10 +693,12 @@ def format_ref_line(
 
 
 def format_refs_comment_body(keys: dict[str, str]) -> str:
-    lines = [REFS_HTML_MARKER, REFS_SECTION_HEADER, "", REFS_SECTION_INTRO, ""]
+    """Plain Markdown ref history (no HTML block comments; Linear displays those as visible text)."""
     def _sort_key(item: str) -> tuple[str, str]:
         kind, name = item.split(":", 1)
         return (kind, name.lower())
+
+    lines = [REFS_MD_ANCHOR, "", REFS_SECTION_HEADER, "", REFS_SECTION_INTRO, ""]
     for key in sorted(keys.keys(), key=_sort_key):
         lines.append(keys[key])
     return "\n".join(lines).rstrip() + "\n"
@@ -719,11 +724,15 @@ def merge_refs_comment(
 
 
 def comment_has_refs_anchor(body: str) -> bool:
-    if REFS_HTML_MARKER in body:
+    if LEGACY_REFS_MARKER in body:
         return True
-    if LEGACY_REFS_MARKER in body or REFS_SECTION_HEADER in body:
+    if any(h in body for h in LEGACY_REFS_HEADERS):
         return True
-    return any(h in body for h in LEGACY_REFS_HEADERS)
+    if REFS_HTML_COMMENT_PREFIX in body:
+        return True
+    if REFS_MD_ANCHOR in body:
+        return True
+    return REFS_SECTION_HEADER in body
 
 
 def undirected_pair_key(a: str, b: str) -> tuple[str, str]:

--- a/.github/workflows/security-scan-linear-sync.yml
+++ b/.github/workflows/security-scan-linear-sync.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       docker_tag:
-        description: "Image tag in the container registry to pull/scan. Default is `head` (DataHub’s published branch image tag; see `MAIN_BRANCH_TAG` in docker helpers)."
+        description: "Container image tag to pull and scan. Default is `head`."
         required: false
         type: string
         default: head
@@ -20,7 +20,7 @@ on:
           - javaImages
           - actionsImages
       variant_scope:
-        description: "Variant scope for registry image refs. `primary` = base tag only, `all` = all suffixes per `registry.repos` entry, else suffixes come from `registry.variant_scope_suffixes` in the profile (or default `-<variant_scope>`). Only registry pulls; no local Gradle build."
+        description: "Tag variants to scan: base only (`primary`), all profile suffixes (`all`), or `slim` / `locked`."
         required: true
         type: choice
         default: all
@@ -38,12 +38,12 @@ on:
           - CRITICAL,HIGH
           - CRITICAL,HIGH,MEDIUM
       scan_with_trivy:
-        description: "Run Trivy in parallel across image repositories from the profile (one workflow job per repo; tag variants of the same repo share that runner). Feed JSON into Linear sync (merged with Grype by CVE per image)."
+        description: "Run Trivy"
         required: true
         type: boolean
         default: true
       scan_with_grype:
-        description: "Run Grype in parallel across image repositories from the profile (one workflow job per repo; tag variants share that runner). Feed JSON into Linear sync (merged with Trivy by CVE per image)."
+        description: "Run Grype"
         required: true
         type: boolean
         default: true
@@ -454,7 +454,7 @@ jobs:
           REPO_GROUP: ${{ matrix.group }}
         run: |
           set -euo pipefail
-          mkdir -p scan-reports/trivy scan-reports-raw/trivy
+          mkdir -p scan-reports/trivy
           PTR_PREFIX="${TRIVY_ECR_PTR_PREFIX:-public-ecr-aws}"
           GHCR_PT="${TRIVY_GHCR_ECR_PTR_PREFIX:-ghcr}"
           PUB_DB="public.ecr.aws/aquasecurity/trivy-db:2"
@@ -497,18 +497,16 @@ jobs:
               --skip-db-update \
               --skip-java-db-update \
               --format json \
-              --output "scan-reports-raw/trivy/trivy-tmp.json" \
+              --output "scan-reports/trivy/trivy-tmp.json" \
               "${img}"; then
               fail_count=$((fail_count + 1))
               continue
             fi
             img_key="$(echo "${img}" | sed -E 's#[^A-Za-z0-9._-]+#_#g')"
-            out_raw="scan-reports-raw/trivy/trivy-${img_key}.json"
             out="scan-reports/trivy/trivy-${img_key}.json"
-            cp "scan-reports-raw/trivy/trivy-tmp.json" "${out_raw}"
-            cp "${out_raw}" "${out}"
+            cp "scan-reports/trivy/trivy-tmp.json" "${out}"
           done
-          rm -f scan-reports-raw/trivy/trivy-tmp.json
+          rm -f scan-reports/trivy/trivy-tmp.json
           ls -la scan-reports/trivy/
           if [[ "${fail_count}" -gt 0 ]]; then
             echo "::error::Trivy failed for ${fail_count} image(s) in group ${REPO_GROUP}"
@@ -521,15 +519,6 @@ jobs:
         with:
           name: security-scan-trivy--${{ steps.trivy-art.outputs.slug }}
           path: scan-reports/trivy
-          if-no-files-found: warn
-          retention-days: ${{ inputs.scan_artifact_retention_days }}
-
-      - name: Upload Trivy raw reports by image
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: security-scan-trivy-raw--${{ steps.trivy-art.outputs.slug }}
-          path: scan-reports-raw/trivy
           if-no-files-found: warn
           retention-days: ${{ inputs.scan_artifact_retention_days }}
 
@@ -551,9 +540,9 @@ jobs:
 
       - name: Install Grype
         id: grype-install
-        uses: anchore/scan-action/download-grype@v7.4.0
+        uses: anchore/scan-action/download-grype@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2
         with:
-          grype-version: ${{ vars.GRYPE_CLI_VERSION || 'v0.86.1' }}
+          grype-version: ${{ vars.GRYPE_CLI_VERSION || 'v0.111.1' }}
 
       - name: Artifact name slug
         id: grype-art
@@ -609,21 +598,20 @@ jobs:
             exit 1
           fi
 
+      - name: Package Grype merged + raw (single artifact)
+        if: always()
+        run: |
+          set -euo pipefail
+          mkdir -p grype-artifact/scan-reports grype-artifact/scan-reports-raw
+          if [[ -d scan-reports/grype ]]; then cp -a scan-reports/grype grype-artifact/scan-reports/; fi
+          if [[ -d scan-reports-raw/grype ]]; then cp -a scan-reports-raw/grype grype-artifact/scan-reports-raw/; fi
+
       - name: Upload Grype reports
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: security-scan-grype--${{ steps.grype-art.outputs.slug }}
-          path: scan-reports/grype
-          if-no-files-found: warn
-          retention-days: ${{ inputs.scan_artifact_retention_days }}
-
-      - name: Upload Grype raw reports by image
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: security-scan-grype-raw--${{ steps.grype-art.outputs.slug }}
-          path: scan-reports-raw/grype
+          path: grype-artifact
           if-no-files-found: warn
           retention-days: ${{ inputs.scan_artifact_retention_days }}
 
@@ -659,7 +647,7 @@ jobs:
       - name: Ensure report directories
         run: |
           set -euo pipefail
-          mkdir -p scan-reports/trivy scan-reports/grype scan-reports-raw/trivy scan-reports-raw/grype
+          mkdir -p scan-reports/trivy scan-reports/grype scan-reports-raw/grype
 
       - name: Download Trivy report artifacts (per-image matrix)
         if: inputs.scan_with_trivy
@@ -669,29 +657,13 @@ jobs:
           merge-multiple: true
           path: scan-reports/trivy
 
-      - name: Download Grype report artifacts (per-image matrix)
+      - name: Download Grype report artifacts (merged + raw, per matrix)
         if: inputs.scan_with_grype
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: security-scan-grype--*
           merge-multiple: true
-          path: scan-reports/grype
-
-      - name: Download Trivy raw report artifacts (per-image matrix)
-        if: inputs.scan_with_trivy
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          pattern: security-scan-trivy-raw--*
-          merge-multiple: true
-          path: scan-reports-raw/trivy
-
-      - name: Download Grype raw report artifacts (per-image matrix)
-        if: inputs.scan_with_grype
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          pattern: security-scan-grype-raw--*
-          merge-multiple: true
-          path: scan-reports-raw/grype
+          path: .
 
       - name: Sync to Linear
         env:
@@ -733,7 +705,7 @@ jobs:
           fi
           raw_files=()
           if [[ "${SCAN_WITH_TRIVY}" == "true" ]]; then
-            for f in scan-reports-raw/trivy/*.json; do
+            for f in scan-reports/trivy/*.json; do
               [[ -f "${f}" ]] && raw_files+=("${f}")
             done
           fi
@@ -742,12 +714,17 @@ jobs:
               [[ -f "${f}" ]] && raw_files+=("${f}")
             done
           fi
-          [[ ${#files[@]} -gt 0 ]] || { echo "::error::No scan JSON reports (check enabled scanners and image list)"; exit 1; }
-          cmd=(python3 .github/scripts/security_scan_linear_sync.py --scanner trivy_grype)
-          if [[ ${#raw_files[@]} -gt 0 ]]; then
-            cmd+=(--raw-report-paths "${raw_files[@]}")
+          if [[ ${#files[@]} -eq 0 ]]; then
+            echo "::notice::No merged scan report JSONs (e.g. all matrix scanner jobs failed or produced no files). Skipping Linear sync."
+            exit 0
           fi
+          cmd=(python3 .github/scripts/security_scan_linear_sync.py --scanner trivy_grype)
           cmd+=("${files[@]}")
+          if [[ ${#raw_files[@]} -gt 0 ]]; then
+            for f in "${raw_files[@]}"; do
+              cmd+=(--raw-report-paths "$f")
+            done
+          fi
           "${cmd[@]}"
 
       - name: Fail on scanner errors


### PR DESCRIPTION
- Use argparse append for --raw-report-paths and pass merged report paths before raw paths so they are not consumed as raw arguments.
- Skip Linear sync with a notice when no merged JSON exists; rely on the existing fail step for scanner job failures.
- Pin anchore/scan-action/download-grype to commit SHA (v7.4.0) and set default Grype CLI to v0.111.1.

Made-with: Cursor

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
