### PR TITLE
fix(search): route bulk writes by docId across remaining write DAOs

### DIFF
--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/schemafield/MigrateSchemaFieldDocIdsStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/schemafield/MigrateSchemaFieldDocIdsStep.java
@@ -268,6 +268,7 @@ public class MigrateSchemaFieldDocIdsStep implements UpgradeStep {
   }
 
   private void deleteDocumentIds(Set<String> documentIds) {
-    documentIds.forEach(docId -> elasticsearchClient.addBulk(new DeleteRequest(indexName, docId)));
+    documentIds.forEach(
+        docId -> elasticsearchClient.addBulk(docId, new DeleteRequest(indexName, docId)));
   }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/ESGraphWriteDAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/ESGraphWriteDAO.java
@@ -51,7 +51,11 @@ public class ESGraphWriteDAO {
             .docAsUpsert(true)
             .doc(document, XContentType.JSON)
             .retryOnConflict(numRetries);
-    bulkProcessor.add(updateRequest);
+    // Route by docId (hash of source + relationshipType + destination + lifecycleOwner)
+    // so remove+add pairs on the same edge land on the same bulk processor thread.
+    // Otherwise same-docId writes race on OpenSearch's seqNo and retryOnConflict
+    // cannot converge — the losing write is silently dropped.
+    bulkProcessor.add(docId, updateRequest);
   }
 
   /**
@@ -66,7 +70,8 @@ public class ESGraphWriteDAO {
     }
     final DeleteRequest deleteRequest =
         new DeleteRequest(indexConvention.getIndexName(INDEX_NAME)).id(docId);
-    bulkProcessor.add(deleteRequest);
+    // Route by docId — see upsertDocument above.
+    bulkProcessor.add(docId, deleteRequest);
   }
 
   @Nullable

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/client/shim/impl/AbstractBulkProcessorShim.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/client/shim/impl/AbstractBulkProcessorShim.java
@@ -1,20 +1,18 @@
 package com.linkedin.metadata.search.elasticsearch.client.shim.impl;
 
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
 import org.opensearch.action.DocWriteRequest;
 
 /**
  * Abstract base class that provides common bulk processor functionality for search client shims.
- * This class handles the common patterns of managing multiple bulk processors with round-robin
- * distribution and URN-based consistent hashing.
+ * This class handles the common patterns of managing multiple bulk processors with URN-based
+ * consistent hashing.
  */
 @Slf4j
 public abstract class AbstractBulkProcessorShim<T> {
 
   protected int threadCount = 1;
-  protected AtomicInteger roundRobinCounter;
   protected T[] bulkProcessors;
 
   /**
@@ -23,7 +21,6 @@ public abstract class AbstractBulkProcessorShim<T> {
    */
   protected void initBulkProcessors(int threadCount, Supplier<T> processorSupplier) {
     this.threadCount = threadCount;
-    this.roundRobinCounter = new AtomicInteger(0);
 
     @SuppressWarnings("unchecked")
     T[] processors = (T[]) new Object[threadCount];
@@ -31,15 +28,6 @@ public abstract class AbstractBulkProcessorShim<T> {
       processors[i] = processorSupplier.get();
     }
     this.bulkProcessors = processors;
-  }
-
-  /**
-   * Add a write request using round-robin distribution across processors. Subclasses must implement
-   * the actual processor-specific add logic.
-   */
-  public void addBulk(DocWriteRequest<?> writeRequest) {
-    int index = roundRobinCounter.getAndIncrement() % threadCount;
-    addToProcessor(bulkProcessors[index], writeRequest);
   }
 
   /**

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/update/ESBulkProcessor.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/update/ESBulkProcessor.java
@@ -94,17 +94,6 @@ public class ESBulkProcessor implements Closeable {
     this.metricUtils = metricUtils;
   }
 
-  public ESBulkProcessor add(DocWriteRequest<?> request) {
-    if (metricUtils != null) metricUtils.increment(this.getClass(), ES_WRITES_METRIC, 1);
-    searchClient.addBulk(request);
-    log.debug(
-        "Added request id: {}, operation type: {}, index: {}",
-        request.id(),
-        request.opType(),
-        request.index());
-    return this;
-  }
-
   /**
    * Add a request with URN-based routing for entity document consistency. This method routes all
    * operations for the same URN to the same BulkProcessor to ensure consistent ordering and avoid

--- a/metadata-io/src/main/java/com/linkedin/metadata/systemmetadata/ESSystemMetadataDAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/systemmetadata/ESSystemMetadataDAO.java
@@ -79,7 +79,10 @@ public class ESSystemMetadataDAO {
             .docAsUpsert(true)
             .doc(document, XContentType.JSON)
             .retryOnConflict(numRetries);
-    bulkProcessor.add(updateRequest);
+    // Route by docId (Base64(SHA-256(urn + "--" + aspect))) so concurrent writes for
+    // the same (urn, aspect) — e.g. setDocStatus during soft-delete racing with a
+    // normal aspect insert — serialize on one bulk thread and retryOnConflict works.
+    bulkProcessor.add(docId, updateRequest);
   }
 
   public DeleteResponse deleteByDocId(@Nonnull final String docId) {

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeseries/elastic/ElasticSearchTimeseriesAspectService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeseries/elastic/ElasticSearchTimeseriesAspectService.java
@@ -320,7 +320,10 @@ public class ElasticSearchTimeseriesAspectService
             .docAsUpsert(true)
             .doc(document.toString(), XContentType.JSON)
             .retryOnConflict(numRetries);
-    bulkProcessor.add(updateRequest);
+    // Route by docId — see ESGraphWriteDAO#upsertDocument. Defensive here (timeseries
+    // docIds are per-messageId and rarely collide), but consistent with the rest of
+    // the bulk-write paths.
+    bulkProcessor.add(docId, updateRequest);
   }
 
   @Override

--- a/metadata-io/src/test/java/com/linkedin/metadata/elasticsearch/update/ESBulkProcessorTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/elasticsearch/update/ESBulkProcessorTest.java
@@ -102,7 +102,7 @@ public class ESBulkProcessorTest {
     ESBulkProcessor processor = ESBulkProcessor.builder(mockSearchClient, mockMetricUtils).build();
 
     IndexRequest indexRequest = new IndexRequest("test-index").id("1");
-    processor.add(indexRequest);
+    processor.add("1", indexRequest);
 
     verify(mockMetricUtils, times(1))
         .increment(eq(processor.getClass()), eq("num_elasticSearch_writes"), eq(1d));
@@ -114,7 +114,7 @@ public class ESBulkProcessorTest {
 
     IndexRequest indexRequest = new IndexRequest("test-index").id("1");
     // Should not throw exception even with null metrics
-    processor.add(indexRequest);
+    processor.add("1", indexRequest);
   }
 
   @Test
@@ -347,9 +347,9 @@ public class ESBulkProcessorTest {
     ESBulkProcessor processor = ESBulkProcessor.builder(mockSearchClient, mockMetricUtils).build();
 
     // Add various types of requests
-    processor.add(new IndexRequest("index1").id("1"));
-    processor.add(new UpdateRequest("index1", "2"));
-    processor.add(new DeleteRequest("index1", "3"));
+    processor.add("1", new IndexRequest("index1").id("1"));
+    processor.add("2", new UpdateRequest("index1", "2"));
+    processor.add("3", new DeleteRequest("index1", "3"));
 
     verify(mockMetricUtils, times(3))
         .increment(eq(processor.getClass()), eq("num_elasticSearch_writes"), eq(1d));

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/elastic/ESGraphWriteDAOTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/elastic/ESGraphWriteDAOTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 
@@ -20,6 +21,7 @@ import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
 import io.datahubproject.test.search.SearchTestUtils;
 import java.util.Optional;
+import org.mockito.ArgumentCaptor;
 import org.opensearch.action.delete.DeleteRequest;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.index.query.QueryBuilders;
@@ -81,10 +83,10 @@ public class ESGraphWriteDAOTest {
 
     if (canWrite) {
       // When writable, bulkProcessor.add should be called
-      verify(mockBulkProcessor, times(1)).add(any(UpdateRequest.class));
+      verify(mockBulkProcessor, times(1)).add(any(String.class), any(UpdateRequest.class));
     } else {
       // When not writable, bulkProcessor.add should not be called
-      verify(mockBulkProcessor, never()).add(any(UpdateRequest.class));
+      verify(mockBulkProcessor, never()).add(any(String.class), any(UpdateRequest.class));
     }
   }
 
@@ -100,11 +102,35 @@ public class ESGraphWriteDAOTest {
 
     if (canWrite) {
       // When writable, bulkProcessor.add should be called with DeleteRequest
-      verify(mockBulkProcessor, times(1)).add(any(DeleteRequest.class));
+      verify(mockBulkProcessor, times(1)).add(any(String.class), any(DeleteRequest.class));
     } else {
       // When not writable, bulkProcessor.add should not be called
-      verify(mockBulkProcessor, never()).add(any(DeleteRequest.class));
+      verify(mockBulkProcessor, never()).add(any(String.class), any(DeleteRequest.class));
     }
+  }
+
+  @Test
+  public void testUpsertDocumentRoutesByDocId() {
+    String docId = "edge-doc-abc";
+    String document =
+        "{\"source\":{\"urn\":\"urn:li:dataset:a\"},\"destination\":{\"urn\":\"urn:li:dataset:b\"}}";
+
+    testDao.upsertDocument(docId, document);
+
+    ArgumentCaptor<UpdateRequest> captor = ArgumentCaptor.forClass(UpdateRequest.class);
+    verify(mockBulkProcessor).add(eq(docId), captor.capture());
+    assertEquals(captor.getValue().id(), docId);
+  }
+
+  @Test
+  public void testDeleteDocumentRoutesByDocId() {
+    String docId = "edge-doc-xyz";
+
+    testDao.deleteDocument(docId);
+
+    ArgumentCaptor<DeleteRequest> captor = ArgumentCaptor.forClass(DeleteRequest.class);
+    verify(mockBulkProcessor).add(eq(docId), captor.capture());
+    assertEquals(captor.getValue().id(), docId);
   }
 
   @Test(dataProvider = "writabilityConfig")
@@ -184,7 +210,7 @@ public class ESGraphWriteDAOTest {
 
     // Upsert should work when writable
     testDao.upsertDocument(docId1, document1);
-    verify(mockBulkProcessor, times(1)).add(any(UpdateRequest.class));
+    verify(mockBulkProcessor, times(1)).add(any(String.class), any(UpdateRequest.class));
 
     testDao.setWritable(false);
 
@@ -194,7 +220,7 @@ public class ESGraphWriteDAOTest {
     testDao.upsertDocument(docId2, document2);
 
     // Should still only have 1 call from before
-    verify(mockBulkProcessor, times(1)).add(any(UpdateRequest.class));
+    verify(mockBulkProcessor, times(1)).add(any(String.class), any(UpdateRequest.class));
 
     testDao.setWritable(true);
 
@@ -203,7 +229,7 @@ public class ESGraphWriteDAOTest {
 
     // Upsert should work again
     testDao.upsertDocument(docId3, document3);
-    verify(mockBulkProcessor, times(2)).add(any(UpdateRequest.class));
+    verify(mockBulkProcessor, times(2)).add(any(String.class), any(UpdateRequest.class));
   }
 
   @Test
@@ -211,10 +237,10 @@ public class ESGraphWriteDAOTest {
     testDao.setWritable(false);
 
     testDao.upsertDocument("doc1", "{\"test\": \"data\"}");
-    verify(mockBulkProcessor, never()).add(any(UpdateRequest.class));
+    verify(mockBulkProcessor, never()).add(any(String.class), any(UpdateRequest.class));
 
     testDao.deleteDocument("doc2");
-    verify(mockBulkProcessor, never()).add(any(DeleteRequest.class));
+    verify(mockBulkProcessor, never()).add(any(String.class), any(DeleteRequest.class));
 
     GraphFilters mockFilters = mock(GraphFilters.class);
     BulkByScrollResponse deleteResult = testDao.deleteByQuery(opContext, mockFilters);
@@ -276,8 +302,8 @@ public class ESGraphWriteDAOTest {
     testDao.upsertDocument("doc2", "{\"seq\": 2}");
     testDao.deleteDocument("doc3");
 
-    verify(mockBulkProcessor, times(2)).add(any(UpdateRequest.class));
-    verify(mockBulkProcessor, times(1)).add(any(DeleteRequest.class));
+    verify(mockBulkProcessor, times(2)).add(any(String.class), any(UpdateRequest.class));
+    verify(mockBulkProcessor, times(1)).add(any(String.class), any(DeleteRequest.class));
 
     testDao.setWritable(false);
 
@@ -285,14 +311,14 @@ public class ESGraphWriteDAOTest {
     testDao.deleteDocument("doc5");
 
     // Counts should not increase
-    verify(mockBulkProcessor, times(2)).add(any(UpdateRequest.class));
-    verify(mockBulkProcessor, times(1)).add(any(DeleteRequest.class));
+    verify(mockBulkProcessor, times(2)).add(any(String.class), any(UpdateRequest.class));
+    verify(mockBulkProcessor, times(1)).add(any(String.class), any(DeleteRequest.class));
 
     testDao.setWritable(true);
 
     // Operations should work again
     testDao.upsertDocument("doc6", "{\"seq\": 6}");
-    verify(mockBulkProcessor, times(3)).add(any(UpdateRequest.class));
+    verify(mockBulkProcessor, times(3)).add(any(String.class), any(UpdateRequest.class));
   }
 
   @Test
@@ -305,7 +331,7 @@ public class ESGraphWriteDAOTest {
     testDao.upsertDocument(docId, document);
 
     // Verify the UpdateRequest was created with correct parameters
-    verify(mockBulkProcessor, times(1)).add(any(UpdateRequest.class));
+    verify(mockBulkProcessor, times(1)).add(any(String.class), any(UpdateRequest.class));
   }
 
   @Test
@@ -317,7 +343,7 @@ public class ESGraphWriteDAOTest {
     testDao.deleteDocument(docId);
 
     // Verify the DeleteRequest was created with correct parameters
-    verify(mockBulkProcessor, times(1)).add(any(DeleteRequest.class));
+    verify(mockBulkProcessor, times(1)).add(any(String.class), any(DeleteRequest.class));
   }
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/SearchClientShimElasticsearchIntegrationTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/SearchClientShimElasticsearchIntegrationTest.java
@@ -717,18 +717,19 @@ public class SearchClientShimElasticsearchIntegrationTest extends AbstractTestNG
 
     // Add bulk requests
     for (int i = 0; i < 5; i++) {
+      String docId = "bulk-doc-" + i;
       IndexRequest indexRequest =
-          new IndexRequest(TEST_INDEX).id("bulk-doc-" + i).source("bulk_field", "bulk_value_" + i);
-      searchClientShim.addBulk(indexRequest);
+          new IndexRequest(TEST_INDEX).id(docId).source("bulk_field", "bulk_value_" + i);
+      searchClientShim.addBulk(docId, indexRequest);
     }
 
     // Add an update request
     UpdateRequest updateRequest = new UpdateRequest(TEST_INDEX, "bulk-doc-0").doc("updated", true);
-    searchClientShim.addBulk(updateRequest);
+    searchClientShim.addBulk("bulk-doc-0", updateRequest);
 
     // Add a delete request
     DeleteRequest deleteRequest = new DeleteRequest(TEST_INDEX, "bulk-doc-1");
-    searchClientShim.addBulk(deleteRequest);
+    searchClientShim.addBulk("bulk-doc-1", deleteRequest);
 
     // Flush and close bulk processor
     searchClientShim.flushBulkProcessor();

--- a/metadata-io/src/test/java/com/linkedin/metadata/systemmetadata/ESSystemMetadataDAOTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/systemmetadata/ESSystemMetadataDAOTest.java
@@ -1,0 +1,56 @@
+package com.linkedin.metadata.systemmetadata;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import com.linkedin.metadata.config.SystemMetadataServiceConfig;
+import com.linkedin.metadata.search.elasticsearch.update.ESBulkProcessor;
+import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
+import com.linkedin.metadata.utils.elasticsearch.IndexConventionImpl;
+import com.linkedin.metadata.utils.elasticsearch.SearchClientShim;
+import io.datahubproject.test.search.SearchTestUtils;
+import org.mockito.ArgumentCaptor;
+import org.opensearch.action.update.UpdateRequest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class ESSystemMetadataDAOTest {
+
+  private static final IndexConvention TEST_INDEX_CONVENTION =
+      IndexConventionImpl.noPrefix("md5", SearchTestUtils.DEFAULT_ENTITY_INDEX_CONFIGURATION);
+
+  private ESBulkProcessor mockBulkProcessor;
+  private ESSystemMetadataDAO dao;
+
+  @BeforeMethod
+  public void setUp() {
+    SearchClientShim<?> mockClient = mock(SearchClientShim.class);
+    mockBulkProcessor = mock(ESBulkProcessor.class);
+    SystemMetadataServiceConfig config = mock(SystemMetadataServiceConfig.class);
+    dao = new ESSystemMetadataDAO(mockClient, TEST_INDEX_CONVENTION, mockBulkProcessor, 0, config);
+  }
+
+  @Test
+  public void testUpsertDocumentRoutesByDocId() {
+    String docId = "sysmeta-doc-abc";
+    String document = "{\"urn\":\"urn:li:dataset:foo\",\"aspect\":\"ownership\",\"removed\":false}";
+
+    dao.upsertDocument(docId, document);
+
+    ArgumentCaptor<UpdateRequest> captor = ArgumentCaptor.forClass(UpdateRequest.class);
+    verify(mockBulkProcessor).add(eq(docId), captor.capture());
+    UpdateRequest captured = captor.getValue();
+    assertNotNull(captured);
+    assertEquals(captured.id(), docId);
+  }
+
+  @Test
+  public void testUpsertDocumentUsesRoutingOverload() {
+    dao.upsertDocument("doc-1", "{}");
+    verify(mockBulkProcessor).add(any(String.class), any(UpdateRequest.class));
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/timeseries/search/TimeseriesAspectServiceUnitTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/timeseries/search/TimeseriesAspectServiceUnitTest.java
@@ -52,7 +52,9 @@ import java.util.function.Supplier;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
 import org.apache.lucene.search.TotalHits;
+import org.mockito.ArgumentCaptor;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.client.Request;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
@@ -931,5 +933,24 @@ public class TimeseriesAspectServiceUnitTest {
     Assert.assertTrue(result.containsKey(expectedUrn2));
     Assert.assertEquals(result.get(expectedUrn1).get(aspectName), sourceMap1);
     Assert.assertEquals(result.get(expectedUrn2).get(aspectName), sourceMap2);
+  }
+
+  @Test
+  public void testUpsertDocumentRoutesByDocId() {
+    String entityName = "dataset";
+    String aspectName = "datasetProfile";
+    String docId = "ts-doc-abc";
+    ObjectNode document = JsonNodeFactory.instance.objectNode();
+    document.put("urn", "urn:li:dataset:foo");
+    document.put("timestampMillis", 1_700_000_000_000L);
+
+    when(indexConvention.getTimeseriesAspectIndexName(entityName, aspectName))
+        .thenReturn("dataset_datasetprofileaspect_v1");
+
+    _timeseriesAspectService.upsertDocument(opContext, entityName, aspectName, docId, document);
+
+    ArgumentCaptor<UpdateRequest> captor = ArgumentCaptor.forClass(UpdateRequest.class);
+    verify(bulkProcessor).add(eq(docId), captor.capture());
+    Assert.assertEquals(captor.getValue().id(), docId);
   }
 }

--- a/metadata-io/src/test/java/io/datahubproject/test/fixtures/search/FixtureReader.java
+++ b/metadata-io/src/test/java/io/datahubproject/test/fixtures/search/FixtureReader.java
@@ -56,7 +56,13 @@ public class FixtureReader {
                                   .id(doc.urn)
                                   .source(line.getBytes(), XContentType.JSON);
 
-                          bulkProcessor.add(request);
+                          // Some fixtures (e.g. graph edge docs in graph_service_v1) have
+                          // no top-level `urn` field. Fall back to the line's hash so each
+                          // unique fixture line still spreads evenly across bulk-processor
+                          // threads (using a constant fallback would hotspot one thread).
+                          String routingKey =
+                              doc.urn != null ? doc.urn : String.valueOf(line.hashCode());
+                          bulkProcessor.add(routingKey, request);
                         } catch (JsonProcessingException e) {
                           throw new RuntimeException(e);
                         }

--- a/metadata-io/src/test/java/io/datahubproject/test/search/FaultInjectingSearchClientShim.java
+++ b/metadata-io/src/test/java/io/datahubproject/test/search/FaultInjectingSearchClientShim.java
@@ -419,11 +419,6 @@ public class FaultInjectingSearchClientShim implements SearchClientShim<Object> 
   }
 
   @Override
-  public void addBulk(DocWriteRequest<?> writeRequest) {
-    delegate.addBulk(writeRequest);
-  }
-
-  @Override
   public void addBulk(String urn, DocWriteRequest<?> writeRequest) {
     delegate.addBulk(urn, writeRequest);
   }

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/elasticsearch/ElasticsearchConnector.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/elasticsearch/ElasticsearchConnector.java
@@ -26,12 +26,15 @@ public class ElasticsearchConnector {
   */
   public void feedElasticEvent(@Nonnull ElasticEvent event) {
     if (event.getActionType().equals(ChangeType.DELETE)) {
-      _bulkProcessor.add(createDeleteRequest(event));
+      // Route by event.getId() (the OpenSearch doc id) — same rationale as
+      // ESWriteDAO / ESGraphWriteDAO. Protects against future callers that emit
+      // UPDATE/DELETE for the same docId in a bulk window.
+      _bulkProcessor.add(event.getId(), createDeleteRequest(event));
     } else if (event.getActionType().equals(ChangeType.CREATE)
         || event.getActionType().equals(ChangeType.CREATE_ENTITY)) {
-      _bulkProcessor.add(createIndexRequest(event));
+      _bulkProcessor.add(event.getId(), createIndexRequest(event));
     } else if (event.getActionType().equals(ChangeType.UPDATE)) {
-      _bulkProcessor.add(createUpsertRequest(event));
+      _bulkProcessor.add(event.getId(), createUpsertRequest(event));
     }
   }
 

--- a/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/elasticsearch/ElasticsearchConnectorTest.java
+++ b/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/elasticsearch/ElasticsearchConnectorTest.java
@@ -1,0 +1,81 @@
+package com.linkedin.metadata.kafka.elasticsearch;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.linkedin.events.metadata.ChangeType;
+import com.linkedin.metadata.search.elasticsearch.update.ESBulkProcessor;
+import org.opensearch.action.delete.DeleteRequest;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.update.UpdateRequest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class ElasticsearchConnectorTest {
+
+  private ESBulkProcessor mockBulkProcessor;
+  private ElasticsearchConnector connector;
+
+  @BeforeMethod
+  public void setUp() {
+    mockBulkProcessor = mock(ESBulkProcessor.class);
+    connector = new ElasticsearchConnector(mockBulkProcessor, 3);
+  }
+
+  private static JsonElasticEvent makeEvent(String id, ChangeType changeType, String document) {
+    JsonElasticEvent event = new JsonElasticEvent(document);
+    event.setId(id);
+    event.setIndex("test_index");
+    event.setActionType(changeType);
+    return event;
+  }
+
+  @Test
+  public void testCreateRoutesByEventId() {
+    JsonElasticEvent event = makeEvent("create-id-1", ChangeType.CREATE, "{\"field\":\"value\"}");
+
+    connector.feedElasticEvent(event);
+
+    verify(mockBulkProcessor).add(eq("create-id-1"), any(IndexRequest.class));
+  }
+
+  @Test
+  public void testCreateEntityRoutesByEventId() {
+    JsonElasticEvent event =
+        makeEvent("create-entity-id", ChangeType.CREATE_ENTITY, "{\"field\":\"value\"}");
+
+    connector.feedElasticEvent(event);
+
+    verify(mockBulkProcessor).add(eq("create-entity-id"), any(IndexRequest.class));
+  }
+
+  @Test
+  public void testUpdateRoutesByEventId() {
+    JsonElasticEvent event = makeEvent("update-id-2", ChangeType.UPDATE, "{\"field\":\"value\"}");
+
+    connector.feedElasticEvent(event);
+
+    verify(mockBulkProcessor).add(eq("update-id-2"), any(UpdateRequest.class));
+  }
+
+  @Test
+  public void testDeleteRoutesByEventId() {
+    JsonElasticEvent event = makeEvent("delete-id-3", ChangeType.DELETE, "{}");
+
+    connector.feedElasticEvent(event);
+
+    verify(mockBulkProcessor).add(eq("delete-id-3"), any(DeleteRequest.class));
+  }
+
+  @Test
+  public void testUnhandledChangeTypeDoesNotWrite() {
+    JsonElasticEvent event = makeEvent("noop-id", ChangeType.RESTATE, "{}");
+
+    connector.feedElasticEvent(event);
+
+    verifyNoInteractions(mockBulkProcessor);
+  }
+}

--- a/metadata-utils/src/main/java/com/linkedin/metadata/utils/elasticsearch/SearchClientShim.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/utils/elasticsearch/SearchClientShim.java
@@ -335,8 +335,6 @@ public interface SearchClientShim<T> extends Closeable {
       int numRetries,
       int threadCount);
 
-  void addBulk(DocWriteRequest<?> writeRequest);
-
   void addBulk(String urn, DocWriteRequest<?> writeRequest);
 
   void flushBulkProcessor();


### PR DESCRIPTION
## Summary

Follow-up to #17150. Three other ES write DAOs in `metadata-io` and the MAE-consumer's `ElasticsearchConnector` had the same non-routing `bulkProcessor.add(request)` pattern that #17150 fixed for `ESWriteDAO`. Same bug class (same-docId writes racing across round-robin bulk-processor threads, OCC loss / ordering inversion, silently dropped writes). Same one-line-per-site fix (routing overload `add(routingKey, request)`). Same test pattern (Mockito assertion on the routing overload).

## Root cause (recap)

`ESBulkProcessor` exposes both overloads at `ESBulkProcessor.java:97` (non-routing, round-robin across N workers) and `:117` (URN-aware routing, hash-to-thread). #17150 wired `ESWriteDAO` through the routing overload; this PR does the same for the remaining four call sites.

For `ESGraphWriteDAO` specifically, the intra-MCL trigger is a change to `via` on an otherwise-unchanged edge: `Edge.@EqualsAndHashCode` includes `via` but `Edge.toDocId()` does not, so a via-URN change produces `removeEdge` + `addEdge` on the same docId within one `EdgeDiff`. The two halves of the diff land on different bulk-processor threads; OpenSearch applies them in wire-arrival order; if delete arrives after upsert, the delete wins and the edge is silently gone from `graph_service_v1`.

For `ESSystemMetadataDAO`, the trigger is `setDocStatus` (soft-delete) iterating every `(urn, aspect)` row concurrently with another `insert(..., urn, aspect)` on the same tuple.

For `ElasticsearchConnector`, only the `CREATE` branch is exercised today (by `DataHubUsageEventsProcessor`, which engineers unique event ids — safe). The `UPDATE` / `DELETE` branches are latent and get fixed defensively.

## Fix

| File | Lines | Routing key |
|---|---|---|
| `ESGraphWriteDAO.java` | 54 (upsert), 69 (delete) | `docId` (method-local) |
| `ESSystemMetadataDAO.java` | 82 (upsert) | `docId` (first method param) |
| `ElasticSearchTimeseriesAspectService.java` | 323 (upsert) | `docId` (fourth method param) |
| `ElasticsearchConnector.java` (mae-consumer) | 29, 32, 34 | `event.getId()` (Lombok `@Data` getter — fast field access) |

Each swap is `bulkProcessor.add(request)` → `bulkProcessor.add(routingKey, request)` with a short why-comment. Zero signature changes, zero new dependencies.

The non-routing overload had no production callers after this fix, so it is **removed everywhere it was declared**:
- `ESBulkProcessor.add(DocWriteRequest)`
- `SearchClientShim.addBulk(DocWriteRequest)`
- `AbstractBulkProcessorShim.addBulk(DocWriteRequest)` (round-robin) and the now-dead `roundRobinCounter` field.
- `FaultInjectingSearchClientShim` test override.

The remaining test/migration callers (`FixtureReader`, `MigrateSchemaFieldDocIdsStep`, `SearchClientShimElasticsearchIntegrationTest`, `ESBulkProcessorTest`) are migrated to the routing overload using the doc URN/id they already have in scope. The only way to write to the bulk processor is now the URN-routed path.

### Performance

The routing overload swaps `AtomicInteger.getAndIncrement() % threadCount` for `Math.abs(urn.hashCode()) % threadCount`. `String.hashCode()` caches after first call. The routing key itself is always a cheap local — `docId` is a method parameter for three sites and `event.getId()` is a Lombok-generated field accessor. Net perf: nil, marginally positive (skips the atomic op).

## Reproduction (graph via-URN race)

Emitted 200 `upstreamLineage` MCPs for `race.downstream → race.upstream` flipping `query` between `race-q1` and `race-q2` on a local `quickstartDebug` instance (`threadCount=2`, the default).

**Before fix:** `GET graph_service_v1/_search` for the edge returned `"total": {"value": 0}` — the edge was completely missing. `BulkListener` logged `"Successfully fed bulk request"` for all 10 bulk flushes with zero `version_conflict_engine_exception` — a fully-silent ordering race (delete arrived last on the shard after upserts, net state: no doc).

**After fix** (verified locally): exactly one edge doc with the final `via = race-q2`, no version_conflict, no `BulkListener` anomaly.

Both I/O dispatcher threads (3 and 4) participated in flushing, confirming the round-robin fan-out is the failure vector.

## Test plan

- [x] `./gradlew :metadata-io:test --tests "com.linkedin.metadata.graph.elastic.ESGraphWriteDAOTest"` — GREEN
- [x] `./gradlew :metadata-io:test --tests "com.linkedin.metadata.systemmetadata.ESSystemMetadataDAOTest"` — GREEN (new test file)
- [x] `./gradlew :metadata-io:test --tests "com.linkedin.metadata.timeseries.search.TimeseriesAspectServiceUnitTest"` — GREEN
- [x] `./gradlew :metadata-io:test --tests "com.linkedin.metadata.elasticsearch.update.ESBulkProcessorTest"` — GREEN
- [x] `./gradlew :metadata-jobs:mae-consumer:test --tests "com.linkedin.metadata.kafka.elasticsearch.ElasticsearchConnectorTest"` — GREEN (new test file)
- [x] `./gradlew spotlessApply` clean (no manual formatting needed beyond what spotless applied)
- [x] Live repro on `quickstartDebug`: edge doc correct after fix

## Scope notes — not in this PR

- **`BulkListener` per-item WARN on `response.hasFailures()`**: the observability gap that made this bug class invisible in logs (we observed it firsthand — 0 log signals, yet the edge was missing). Separate follow-up PR.
- **Cascade-id propagation across the bulk-processor thread boundary**: MDC does not cross into `BulkListener.afterBulk`'s worker thread. Separate follow-up if/when cross-layer correlation becomes a priority.