### PR TITLE
feat(ingest/fivetran): support Managed Data Lake destination with Glue catalog

### DIFF
--- a/metadata-ingestion/docs/sources/fivetran/fivetran_pre.md
+++ b/metadata-ingestion/docs/sources/fivetran/fivetran_pre.md
@@ -46,6 +46,21 @@ The connector emits the destination dataset URN against the AWS Glue platform: `
 
 Snowflake auto-uppercases unquoted identifiers, but catalog-linked databases retain the original case-preserving identifiers from the underlying catalog (Glue/Iceberg). Recipes targeting Managed Data Lake default `preserve_case: true` so the log query reads from `"fivetran_metadata_<suffix>"` rather than `"FIVETRAN_METADATA_<SUFFIX>"`. The same flag is available on `snowflake_destination_config` for any Snowflake-CLD setup.
 
+##### Matching the Glue source connector's `platform_instance`
+
+Emitted destination URNs use the Glue platform. If you also ingest the same AWS Glue catalog with DataHub's [Glue source connector](https://docs.datahub.com/docs/generated/ingestion/sources/glue), both connectors must agree on `platform_instance` for the URNs to refer to the same datasets and for lineage to render end-to-end.
+
+Use the existing `destination_to_platform_instance` mapping (keyed by the Fivetran destination ID, visible in the Fivetran UI under **Destinations → Overview**) to set the Glue-side `platform_instance` and `env`:
+
+```yaml
+destination_to_platform_instance:
+  my_fivetran_destination_id:
+    platform_instance: "glue_us_west" # must match what the Glue source recipe uses
+    env: PROD
+```
+
+If you don't run a Glue source connector, the Fivetran-emitted Glue URNs simply stand alone — no `platform_instance` is required, but downstream entities you wire up later must use the same convention.
+
 ##### Example recipe
 
 ```yaml
@@ -68,6 +83,12 @@ source:
 
         # Glue catalog settings
         glue_database_prefix: "fivetran_" # Fivetran default
+
+    # Match the Glue source connector's platform_instance so URNs align.
+    destination_to_platform_instance:
+      my_fivetran_destination_id:
+        platform_instance: "glue_us_west"
+        env: PROD
 ```
 
 ##### Lineage scope

--- a/metadata-ingestion/docs/sources/fivetran/fivetran_pre.md
+++ b/metadata-ingestion/docs/sources/fivetran/fivetran_pre.md
@@ -17,7 +17,7 @@ This source extracts the following:
 
 1. Set up and complete initial sync of the [Fivetran Platform Connector](https://fivetran.com/docs/logs/fivetran-platform/setup-guide)
 2. Enable automatic schema updates (default) to avoid sync inconsistencies
-3. Configure the destination platform (Snowflake, BigQuery, or Databricks) in your recipe
+3. Configure the destination platform (Snowflake, BigQuery, Databricks, or Managed Data Lake) in your recipe
 
 ### Prerequisites
 
@@ -30,6 +30,49 @@ To use the Fivetran REST API integration, you need:
 - **Read access** to connection details (`GET /v1/connections/{connection_id}`)
 - The API key must be associated with a user or service account that has access to the connectors you want to ingest
 - The API key inherits permissions from the user or service account it's associated with
+
+#### Fivetran Managed Data Lake Service (AWS Glue + Snowflake catalog-linked database)
+
+The [Fivetran Managed Data Lake Service](https://fivetran.com/docs/destinations/managed-data-lake-service) replicates data to S3 as Iceberg tables and registers them in AWS Glue. The Fivetran Platform Connector log lands in the same Glue data lake, and Snowflake exposes the lake to analysts through a [catalog-linked database (CLD)](https://docs.snowflake.com/en/sql-reference/sql/create-database-catalog-linked) — a read-only Snowflake database whose schemas and tables are virtual surfaces over Glue objects.
+
+To ingest a Fivetran Managed Data Lake destination:
+
+1. Set `destination_platform: managed_data_lake` and supply `managed_data_lake_destination_config`.
+2. Provide the Snowflake connection details that point at the catalog-linked database surfacing the Fivetran Platform Connector log.
+
+The connector emits the destination dataset URN against the AWS Glue platform: `urn:li:dataset:(urn:li:dataPlatform:glue, <glue_database_prefix><schema>.<table>, <env>)`. The Glue database name follows the Fivetran convention `<glue_database_prefix><connector_schema>` (default prefix `fivetran_`).
+
+##### `preserve_case` and catalog-linked databases
+
+Snowflake auto-uppercases unquoted identifiers, but catalog-linked databases retain the original case-preserving identifiers from the underlying catalog (Glue/Iceberg). Recipes targeting Managed Data Lake default `preserve_case: true` so the log query reads from `"fivetran_metadata_<suffix>"` rather than `"FIVETRAN_METADATA_<SUFFIX>"`. The same flag is available on `snowflake_destination_config` for any Snowflake-CLD setup.
+
+##### Example recipe
+
+```yaml
+source:
+  type: fivetran
+  config:
+    fivetran_log_config:
+      destination_platform: managed_data_lake
+      managed_data_lake_destination_config:
+        # Snowflake CLD coordinates
+        account_id: "abc48144"
+        warehouse: "COMPUTE_WH"
+        database: "lh_source_fivetran_usw2"
+        log_schema: "fivetran_metadata_<suffix>"
+
+        # Credentials
+        username: "${SNOWFLAKE_USER}"
+        password: "${SNOWFLAKE_PASS}"
+        role: "fivetran_log_reader"
+
+        # Glue catalog settings
+        glue_database_prefix: "fivetran_" # Fivetran default
+```
+
+##### Lineage scope
+
+The destination URN points at the Glue table, not at the Snowflake CLD table that analysts query. The rendered lineage shows `<source> → <Glue Iceberg table>`; the corresponding Snowflake CLD table is ingested by the Snowflake source as a separate node.
 
 #### Fivetran REST API Configuration
 

--- a/metadata-ingestion/docs/sources/fivetran/fivetran_recipe.yml
+++ b/metadata-ingestion/docs/sources/fivetran/fivetran_recipe.yml
@@ -36,7 +36,28 @@ source:
         # Coordinates
         catalog: "fivetran_catalog"
         log_schema: "fivetran_log"
-     
+
+      # Optional - If destination platform is 'managed_data_lake', provide the
+      # Fivetran Managed Data Lake Service configuration. The Fivetran Platform
+      # Connector log is read through the Snowflake catalog-linked database that
+      # surfaces the data lake; emitted URNs target the underlying AWS Glue
+      # catalog.
+      # managed_data_lake_destination_config:
+      #   # Snowflake CLD coordinates (case-preserving)
+      #   account_id: "abc48144"
+      #   warehouse: "COMPUTE_WH"
+      #   database: "lh_source_fivetran_usw2"
+      #   log_schema: "fivetran_metadata_<suffix>"
+      #
+      #   # Credentials
+      #   username: "${SNOWFLAKE_USER}"
+      #   password: "${SNOWFLAKE_PASS}"
+      #   role: "snowflake_role"
+      #
+      #   # Glue catalog settings
+      #   glue_database_prefix: "fivetran_"  # default
+      #   # preserve_case: true              # default for MDL
+
     # Optional - filter for certain connector names instead of ingesting everything.
     # connector_patterns:
     #   allow:

--- a/metadata-ingestion/docs/sources/fivetran/fivetran_recipe.yml
+++ b/metadata-ingestion/docs/sources/fivetran/fivetran_recipe.yml
@@ -81,7 +81,10 @@ source:
     #     env: DEV
 
     # Optional -- This mapping is optional and only required to configure platform-instance for destination.
-    # A mapping of Fivetran destination id to data platform instance
+    # A mapping of Fivetran destination id to data platform instance.
+    # For `managed_data_lake` destinations, set this to match the platform_instance
+    # used by your AWS Glue source recipe so that emitted Glue URNs align with the
+    # ones the Glue source connector emits and lineage renders end-to-end.
     # destination_to_platform_instance:
     #   destination_id:
     #     platform_instance: cloud_instance

--- a/metadata-ingestion/src/datahub/ingestion/source/fivetran/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fivetran/config.py
@@ -94,6 +94,17 @@ DISABLE_COL_LINEAGE_FOR_CONNECTOR_TYPES = [Constant.GOOGLE_SHEETS_CONNECTOR_TYPE
 class SnowflakeDestinationConfig(SnowflakeConnectionConfig):
     database: str = Field(description="The fivetran connector log database.")
     log_schema: str = Field(description="The fivetran connector log schema.")
+    preserve_case: bool = Field(
+        default=False,
+        description=(
+            "Preserve the case of database and schema identifiers when querying "
+            "the Fivetran log. Set this to True when the log lives in a Snowflake "
+            "catalog-linked database (CLD) — e.g., when the Fivetran Managed Data "
+            "Lake Service surfaces logs through Snowflake — where Snowflake's "
+            "default identifier uppercasing breaks lookup against case-preserving "
+            "Glue/Iceberg-backed schemas."
+        ),
+    )
 
 
 class BigQueryDestinationConfig(BigQueryConnectionConfig):
@@ -112,6 +123,57 @@ class DatabricksDestinationConfig(UnityCatalogConnectionConfig):
         return warehouse_id
 
 
+class ManagedDataLakeDestinationConfig(SnowflakeConnectionConfig):
+    """Configuration for the Fivetran Managed Data Lake Service.
+
+    The Fivetran Platform Connector log is read through a Snowflake
+    catalog-linked database (CLD), so this config inherits Snowflake
+    connection details. The data tables themselves live in the
+    cloud-native catalog (AWS Glue) and emitted URNs target that catalog
+    rather than Snowflake.
+    """
+
+    database: str = Field(
+        description=(
+            "The Snowflake catalog-linked database that surfaces the "
+            "Fivetran Platform Connector logs (e.g., `LH_SOURCE_FIVETRAN_USW2`)."
+        )
+    )
+    log_schema: str = Field(
+        description=(
+            "The schema within the catalog-linked database that holds the "
+            "Fivetran log tables (e.g., `fivetran_metadata_<suffix>`)."
+        )
+    )
+    preserve_case: bool = Field(
+        default=True,
+        description=(
+            "Preserve the case of database and schema identifiers when "
+            "querying the Fivetran log. Defaults to True for Managed Data "
+            "Lake recipes because catalog-linked databases are case-preserving."
+        ),
+    )
+    catalog_type: Literal["glue", "iceberg_rest", "unity", "biglake", "onelake"] = (
+        Field(
+            default="glue",
+            description=(
+                "The cloud-native catalog backing the Fivetran Managed Data Lake "
+                "destination. Currently `glue` is implemented; other values are "
+                "accepted for forward compatibility but ingestion will raise "
+                "`NotImplementedError` until those branches are wired up."
+            ),
+        )
+    )
+    glue_database_prefix: str = Field(
+        default="fivetran_",
+        description=(
+            "Prefix Fivetran applies when auto-creating Glue databases. "
+            "Glue database name is `<glue_database_prefix><connector_schema>`. "
+            "Only consulted when `catalog_type='glue'`."
+        ),
+    )
+
+
 class FivetranAPIConfig(ConfigModel):
     api_key: TransparentSecretStr = Field(description="Fivetran API key")
     api_secret: TransparentSecretStr = Field(description="Fivetran API secret")
@@ -124,11 +186,16 @@ class FivetranAPIConfig(ConfigModel):
 
 
 class FivetranLogConfig(ConfigModel):
-    destination_platform: Literal["snowflake", "bigquery", "databricks"] = (
-        pydantic.Field(
-            default="snowflake",
-            description="The destination platform where fivetran connector log tables are dumped.",
-        )
+    destination_platform: Literal[
+        "snowflake", "bigquery", "databricks", "managed_data_lake"
+    ] = pydantic.Field(
+        default="snowflake",
+        description=(
+            "The destination platform where fivetran connector log tables are dumped. "
+            "`managed_data_lake` covers the Fivetran Managed Data Lake Service when "
+            "logs are surfaced through a Snowflake catalog-linked database; "
+            "emitted URNs target the underlying AWS Glue catalog."
+        ),
     )
     snowflake_destination_config: Optional[SnowflakeDestinationConfig] = pydantic.Field(
         default=None,
@@ -142,6 +209,16 @@ class FivetranLogConfig(ConfigModel):
         pydantic.Field(
             default=None,
             description="If destination platform is 'databricks', provide databricks configuration.",
+        )
+    )
+    managed_data_lake_destination_config: Optional[ManagedDataLakeDestinationConfig] = (
+        pydantic.Field(
+            default=None,
+            description=(
+                "If destination platform is 'managed_data_lake', provide the Fivetran "
+                "Managed Data Lake Service configuration (Snowflake CLD connection + "
+                "Glue catalog settings)."
+            ),
         )
     )
     _rename_destination_config = pydantic_renamed_field(
@@ -182,6 +259,12 @@ class FivetranLogConfig(ConfigModel):
             if self.databricks_destination_config is None:
                 raise ValueError(
                     "If destination platform is 'databricks', user must provide databricks destination configuration in the recipe."
+                )
+        elif self.destination_platform == "managed_data_lake":
+            if self.managed_data_lake_destination_config is None:
+                raise ValueError(
+                    "If destination platform is 'managed_data_lake', user must provide "
+                    "managed_data_lake destination configuration in the recipe."
                 )
         else:
             raise ValueError(

--- a/metadata-ingestion/src/datahub/ingestion/source/fivetran/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fivetran/config.py
@@ -158,9 +158,9 @@ class ManagedDataLakeDestinationConfig(SnowflakeConnectionConfig):
             default="glue",
             description=(
                 "The cloud-native catalog backing the Fivetran Managed Data Lake "
-                "destination. Currently `glue` is implemented; other values are "
-                "accepted for forward compatibility but ingestion will raise "
-                "`NotImplementedError` until those branches are wired up."
+                "destination. Currently only `glue` is implemented; other values "
+                "are accepted by the type but rejected at config-load time until "
+                "those branches are wired up."
             ),
         )
     )
@@ -172,6 +172,20 @@ class ManagedDataLakeDestinationConfig(SnowflakeConnectionConfig):
             "Only consulted when `catalog_type='glue'`."
         ),
     )
+
+    @field_validator("catalog_type", mode="after")
+    @classmethod
+    def validate_catalog_type(cls, value: str) -> str:
+        # The Literal is forward-compatible (new catalogs can be added without a
+        # config-shape migration), but the URN-construction branches don't exist
+        # yet. Reject at recipe load time so users see the failure before any
+        # ingestion work runs, not partway through a connector loop.
+        if value != "glue":
+            raise ValueError(
+                f"`catalog_type='{value}'` is not implemented yet; "
+                "only `catalog_type='glue'` is currently supported."
+            )
+        return value
 
 
 class FivetranAPIConfig(ConfigModel):

--- a/metadata-ingestion/src/datahub/ingestion/source/fivetran/fivetran.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fivetran/fivetran.py
@@ -269,33 +269,54 @@ class FivetranSource(StatefulIngestionSourceBase):
         (default `fivetran_`).
         """
         if destination_details.platform == "managed_data_lake":
-            assert mdl_cfg is not None, (
-                "managed_data_lake_destination_config required when "
-                "destination_platform is 'managed_data_lake' (validated upstream)."
-            )
-            if mdl_cfg.catalog_type == "glue":
-                # destination_table is "<schema>.<table>" — keep the schema part
-                # so we can derive the Glue database name. include_schema_in_urn
-                # is intentionally ignored here because the schema component is
-                # load-bearing (it determines the Glue DB), not just naming.
-                schema, _, table = destination_table.partition(".")
-                glue_db = f"{mdl_cfg.glue_database_prefix}{schema}"
-                return DatasetUrn.create_from_ids(
-                    platform_id="glue",
-                    table_name=f"{glue_db}.{table}",
-                    env=destination_details.env,
-                    platform_instance=destination_details.platform_instance,
+            if mdl_cfg is None:
+                raise ValueError(
+                    "managed_data_lake_destination_config is required when "
+                    "destination_platform is 'managed_data_lake'."
                 )
-            raise NotImplementedError(
-                f"managed_data_lake catalog_type={mdl_cfg.catalog_type!r} "
-                "is not implemented yet."
+            # The config validator on `catalog_type` rejects unimplemented
+            # catalog types at recipe-load time, so by the time we're here the
+            # value is guaranteed to be `glue`. The Literal still accepts other
+            # values for forward compatibility.
+            if mdl_cfg.catalog_type != "glue":
+                raise NotImplementedError(
+                    f"managed_data_lake catalog_type={mdl_cfg.catalog_type!r} "
+                    "is not implemented yet."
+                )
+            # destination_table is "<schema>.<table>" — keep the schema part
+            # so we can derive the Glue database name. include_schema_in_urn
+            # is intentionally ignored here because the schema component is
+            # load-bearing (it determines the Glue DB), not just naming.
+            if "." not in destination_table:
+                raise ValueError(
+                    "Expected destination_table in '<schema>.<table>' form to "
+                    "derive the Glue database name; got "
+                    f"{destination_table!r} (no '.' separator). The Glue "
+                    "database is `<glue_database_prefix><schema>` so the "
+                    "schema component is required."
+                )
+            schema, _, table = destination_table.partition(".")
+            glue_db = f"{mdl_cfg.glue_database_prefix}{schema}"
+            return DatasetUrn.create_from_ids(
+                platform_id="glue",
+                table_name=f"{glue_db}.{table}",
+                env=destination_details.env,
+                platform_instance=destination_details.platform_instance,
             )
 
         # Existing relational-warehouse path. Platform and database are
         # populated upstream in `_extend_lineage` (defaulting to the log
         # config's destination_platform / fivetran_log_database).
-        assert destination_details.platform is not None
-        assert destination_details.database is not None
+        if destination_details.platform is None:
+            raise ValueError(
+                "destination_details.platform must be set before constructing "
+                "the destination URN."
+            )
+        if destination_details.database is None:
+            raise ValueError(
+                "destination_details.database must be set before constructing "
+                "the destination URN."
+            )
         table_name = (
             destination_table
             if destination_details.include_schema_in_urn

--- a/metadata-ingestion/src/datahub/ingestion/source/fivetran/fivetran.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fivetran/fivetran.py
@@ -29,6 +29,7 @@ from datahub.ingestion.source.fivetran.config import (
     Constant,
     FivetranSourceConfig,
     FivetranSourceReport,
+    ManagedDataLakeDestinationConfig,
     PlatformDetail,
 )
 from datahub.ingestion.source.fivetran.data_classes import Connector, Job
@@ -193,16 +194,8 @@ class FivetranSource(StatefulIngestionSourceBase):
             if input_dataset_urn:
                 input_dataset_urn_list.append(input_dataset_urn)
 
-            destination_table = (
-                lineage.destination_table
-                if destination_details.include_schema_in_urn
-                else lineage.destination_table.split(".", 1)[1]
-            )
-            output_dataset_urn = DatasetUrn.create_from_ids(
-                platform_id=destination_details.platform,
-                table_name=f"{destination_details.database.lower()}.{destination_table}",
-                env=destination_details.env,
-                platform_instance=destination_details.platform_instance,
+            output_dataset_urn = self._build_destination_urn(
+                lineage.destination_table, destination_details
             )
             output_dataset_urn_list.append(output_dataset_urn)
 
@@ -250,6 +243,69 @@ class FivetranSource(StatefulIngestionSourceBase):
                 for k, v in destination_details.model_dump().items()
                 if v is not None and not isinstance(v, bool)
             },
+        )
+
+    def _build_destination_urn(
+        self, destination_table: str, destination_details: PlatformDetail
+    ) -> DatasetUrn:
+        return self.build_destination_urn(
+            destination_table,
+            destination_details,
+            self.config.fivetran_log_config.managed_data_lake_destination_config,
+        )
+
+    @staticmethod
+    def build_destination_urn(
+        destination_table: str,
+        destination_details: PlatformDetail,
+        mdl_cfg: Optional[ManagedDataLakeDestinationConfig] = None,
+    ) -> DatasetUrn:
+        """Construct the destination dataset URN for one lineage edge.
+
+        For relational warehouses (snowflake/bigquery/databricks), emits a
+        three-part `<database>.<schema>.<table>` URN. For the Fivetran Managed
+        Data Lake destination, emits a Glue URN where the Glue database name
+        is derived from the connector schema with the configured prefix
+        (default `fivetran_`).
+        """
+        if destination_details.platform == "managed_data_lake":
+            assert mdl_cfg is not None, (
+                "managed_data_lake_destination_config required when "
+                "destination_platform is 'managed_data_lake' (validated upstream)."
+            )
+            if mdl_cfg.catalog_type == "glue":
+                # destination_table is "<schema>.<table>" — keep the schema part
+                # so we can derive the Glue database name. include_schema_in_urn
+                # is intentionally ignored here because the schema component is
+                # load-bearing (it determines the Glue DB), not just naming.
+                schema, _, table = destination_table.partition(".")
+                glue_db = f"{mdl_cfg.glue_database_prefix}{schema}"
+                return DatasetUrn.create_from_ids(
+                    platform_id="glue",
+                    table_name=f"{glue_db}.{table}",
+                    env=destination_details.env,
+                    platform_instance=destination_details.platform_instance,
+                )
+            raise NotImplementedError(
+                f"managed_data_lake catalog_type={mdl_cfg.catalog_type!r} "
+                "is not implemented yet."
+            )
+
+        # Existing relational-warehouse path. Platform and database are
+        # populated upstream in `_extend_lineage` (defaulting to the log
+        # config's destination_platform / fivetran_log_database).
+        assert destination_details.platform is not None
+        assert destination_details.database is not None
+        table_name = (
+            destination_table
+            if destination_details.include_schema_in_urn
+            else destination_table.split(".", 1)[1]
+        )
+        return DatasetUrn.create_from_ids(
+            platform_id=destination_details.platform,
+            table_name=f"{destination_details.database.lower()}.{table_name}",
+            env=destination_details.env,
+            platform_instance=destination_details.platform_instance,
         )
 
     def _generate_dataflow_from_connector(self, connector: Connector) -> DataFlow:

--- a/metadata-ingestion/src/datahub/ingestion/source/fivetran/fivetran_log_api.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fivetran/fivetran_log_api.py
@@ -2,10 +2,11 @@ import functools
 import json
 import logging
 from collections import defaultdict
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import sqlglot
 from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
 
 from datahub.configuration.common import AllowDenyPattern, ConfigurationError
 from datahub.ingestion.source.fivetran.config import (
@@ -13,6 +14,8 @@ from datahub.ingestion.source.fivetran.config import (
     Constant,
     FivetranLogConfig,
     FivetranSourceReport,
+    ManagedDataLakeDestinationConfig,
+    SnowflakeDestinationConfig,
 )
 from datahub.ingestion.source.fivetran.data_classes import (
     ColumnLineage,
@@ -40,55 +43,52 @@ class FivetranLogAPI:
 
     @staticmethod
     def _setup_snowflake_engine(
-        snowflake_config: Any,
-        database: str,
-        log_schema: str,
-        preserve_case: bool,
+        cfg: Union[SnowflakeDestinationConfig, ManagedDataLakeDestinationConfig],
         fivetran_log_query: FivetranLogQuery,
-    ) -> Tuple[Any, str]:
+    ) -> Engine:
         """Build a Snowflake SQLAlchemy engine and apply USE DATABASE / SET SCHEMA.
 
         Shared between the `snowflake` and `managed_data_lake` destination
         platforms — both read the Fivetran log through Snowflake. When
-        `preserve_case` is True, identifiers are passed through verbatim
+        `cfg.preserve_case` is True, identifiers are passed through verbatim
         (required for catalog-linked databases, where schema/table names
         retain their original lowercase casing).
         """
         engine = create_engine(
-            snowflake_config.get_sql_alchemy_url(),
-            **snowflake_config.get_options(),
+            cfg.get_sql_alchemy_url(),
+            **cfg.get_options(),
         )
 
         # Snowflake auto-uppercases unquoted identifiers. Conventional Snowflake
         # warehouses created via DataHub have always been queried with the
         # ".upper()" path below for backward compatibility. CLDs (and any
         # case-preserving Snowflake schema) need the verbatim path instead.
-        if preserve_case:
-            resolved_database = database
-            resolved_schema = log_schema
+        if cfg.preserve_case:
+            resolved_database = cfg.database
+            resolved_schema = cfg.log_schema
         else:
             resolved_database = (
-                database.upper()
-                if FivetranLogQuery._is_valid_unquoted_identifier(database)
-                else database
+                cfg.database.upper()
+                if FivetranLogQuery._is_valid_unquoted_identifier(cfg.database)
+                else cfg.database
             )
             resolved_schema = (
-                log_schema.upper()
-                if FivetranLogQuery._is_valid_unquoted_identifier(log_schema)
-                else log_schema
+                cfg.log_schema.upper()
+                if FivetranLogQuery._is_valid_unquoted_identifier(cfg.log_schema)
+                else cfg.log_schema
             )
 
         logger.info(
-            f"Using snowflake database: {resolved_database} (original: {database})"
+            f"Using snowflake database: {resolved_database} (original: {cfg.database})"
         )
         engine.execute(fivetran_log_query.use_database(resolved_database))
 
         logger.info(
-            f"Using snowflake schema: {resolved_schema} (original: {log_schema})"
+            f"Using snowflake schema: {resolved_schema} (original: {cfg.log_schema})"
         )
         fivetran_log_query.set_schema(resolved_schema)
 
-        return engine, database
+        return engine
 
     def _initialize_fivetran_variables(
         self,
@@ -106,13 +106,10 @@ class FivetranLogAPI:
                 self.fivetran_log_config.snowflake_destination_config
             )
             if snowflake_destination_config is not None:
-                engine, fivetran_log_database = self._setup_snowflake_engine(
-                    snowflake_destination_config,
-                    snowflake_destination_config.database,
-                    snowflake_destination_config.log_schema,
-                    snowflake_destination_config.preserve_case,
-                    fivetran_log_query,
+                engine = self._setup_snowflake_engine(
+                    snowflake_destination_config, fivetran_log_query
                 )
+                fivetran_log_database = snowflake_destination_config.database
         elif destination_platform == "managed_data_lake":
             mdl_destination_config = (
                 self.fivetran_log_config.managed_data_lake_destination_config
@@ -121,13 +118,10 @@ class FivetranLogAPI:
                 # The Fivetran Managed Data Lake log is read through a Snowflake
                 # catalog-linked database — same engine setup as the snowflake branch,
                 # with preserve_case defaulted to True for CLD compatibility.
-                engine, fivetran_log_database = self._setup_snowflake_engine(
-                    mdl_destination_config,
-                    mdl_destination_config.database,
-                    mdl_destination_config.log_schema,
-                    mdl_destination_config.preserve_case,
-                    fivetran_log_query,
+                engine = self._setup_snowflake_engine(
+                    mdl_destination_config, fivetran_log_query
                 )
+                fivetran_log_database = mdl_destination_config.database
         elif destination_platform == "bigquery":
             bigquery_destination_config = (
                 self.fivetran_log_config.bigquery_destination_config

--- a/metadata-ingestion/src/datahub/ingestion/source/fivetran/fivetran_log_api.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fivetran/fivetran_log_api.py
@@ -2,7 +2,7 @@ import functools
 import json
 import logging
 from collections import defaultdict
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import sqlglot
 from sqlalchemy import create_engine
@@ -192,7 +192,7 @@ class FivetranLogAPI:
     # log queries are authored in Snowflake dialect and need no transpilation.
     _SNOWFLAKE_NATIVE_PLATFORMS = frozenset({"snowflake", "managed_data_lake"})
 
-    def _query(self, query: str) -> List[Dict]:
+    def _query(self, query: str) -> List[Dict[str, Any]]:
         # Automatically transpile snowflake query syntax to the target dialect.
         if (
             self.fivetran_log_config.destination_platform
@@ -209,11 +209,14 @@ class FivetranLogAPI:
 
     def _get_column_lineage_metadata(
         self, connector_ids: List[str]
-    ) -> Dict[Tuple[str, str], List]:
+    ) -> Dict[Tuple[str, str], List[Dict[str, Any]]]:
         """
-        Returns dict of column lineage metadata with key as (<SOURCE_TABLE_ID>, <DESTINATION_TABLE_ID>)
+        Returns dict of column lineage metadata with key as (<SOURCE_TABLE_ID>, <DESTINATION_TABLE_ID>).
+        Values are raw query-result rows (each a `Dict[str, Any]` produced by `_query`).
         """
-        all_column_lineage: Dict[Tuple[str, str], List] = defaultdict(list)
+        all_column_lineage: Dict[Tuple[str, str], List[Dict[str, Any]]] = defaultdict(
+            list
+        )
 
         if not connector_ids:
             return dict(all_column_lineage)
@@ -231,11 +234,16 @@ class FivetranLogAPI:
             all_column_lineage[key].append(column_lineage)
         return dict(all_column_lineage)
 
-    def _get_table_lineage_metadata(self, connector_ids: List[str]) -> Dict[str, List]:
+    def _get_table_lineage_metadata(
+        self, connector_ids: List[str]
+    ) -> Dict[str, List[Dict[str, Any]]]:
         """
-        Returns dict of table lineage metadata with key as 'CONNECTOR_ID'
+        Returns dict of table lineage metadata with key as 'CONNECTOR_ID'.
+        Values are raw query-result rows (each a `Dict[str, Any]` produced by `_query`).
         """
-        connectors_table_lineage_metadata: Dict[str, List] = defaultdict(list)
+        connectors_table_lineage_metadata: Dict[str, List[Dict[str, Any]]] = (
+            defaultdict(list)
+        )
 
         if not connector_ids:
             return dict(connectors_table_lineage_metadata)

--- a/metadata-ingestion/src/datahub/ingestion/source/fivetran/fivetran_log_api.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fivetran/fivetran_log_api.py
@@ -2,7 +2,7 @@ import functools
 import json
 import logging
 from collections import defaultdict
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import sqlglot
 from sqlalchemy import create_engine
@@ -92,72 +92,92 @@ class FivetranLogAPI:
 
     def _initialize_fivetran_variables(
         self,
-    ) -> Tuple[Any, FivetranLogQuery, str]:
+    ) -> Tuple[Engine, FivetranLogQuery, str]:
         fivetran_log_query = FivetranLogQuery(
             max_jobs_per_connector=self.fivetran_log_config.max_jobs_per_connector,
             max_table_lineage_per_connector=self.fivetran_log_config.max_table_lineage_per_connector,
             max_column_lineage_per_connector=self.fivetran_log_config.max_column_lineage_per_connector,
         )
         destination_platform = self.fivetran_log_config.destination_platform
-        # For every destination, create sqlalchemy engine,
-        # set db_clause to generate select queries and set fivetran_log_database class variable
+
+        # Each branch fails fast with a ConfigurationError if its destination
+        # config block is missing. The model_validator on FivetranLogConfig
+        # already enforces this in the normal path, but the early-raise pattern
+        # protects programmatic callers (tests, model_construct) and prevents
+        # an UnboundLocalError on `engine` if the validator is bypassed.
         if destination_platform == "snowflake":
             snowflake_destination_config = (
                 self.fivetran_log_config.snowflake_destination_config
             )
-            if snowflake_destination_config is not None:
-                engine = self._setup_snowflake_engine(
-                    snowflake_destination_config, fivetran_log_query
+            if snowflake_destination_config is None:
+                raise ConfigurationError(
+                    "snowflake_destination_config is required when "
+                    "destination_platform is 'snowflake'."
                 )
-                fivetran_log_database = snowflake_destination_config.database
+            engine = self._setup_snowflake_engine(
+                snowflake_destination_config, fivetran_log_query
+            )
+            fivetran_log_database = snowflake_destination_config.database
         elif destination_platform == "managed_data_lake":
             mdl_destination_config = (
                 self.fivetran_log_config.managed_data_lake_destination_config
             )
-            if mdl_destination_config is not None:
-                # The Fivetran Managed Data Lake log is read through a Snowflake
-                # catalog-linked database — same engine setup as the snowflake branch,
-                # with preserve_case defaulted to True for CLD compatibility.
-                engine = self._setup_snowflake_engine(
-                    mdl_destination_config, fivetran_log_query
+            if mdl_destination_config is None:
+                raise ConfigurationError(
+                    "managed_data_lake_destination_config is required when "
+                    "destination_platform is 'managed_data_lake'."
                 )
-                fivetran_log_database = mdl_destination_config.database
+            # The Fivetran Managed Data Lake log is read through a Snowflake
+            # catalog-linked database — same engine setup as the snowflake branch,
+            # with preserve_case defaulted to True for CLD compatibility.
+            engine = self._setup_snowflake_engine(
+                mdl_destination_config, fivetran_log_query
+            )
+            fivetran_log_database = mdl_destination_config.database
         elif destination_platform == "bigquery":
             bigquery_destination_config = (
                 self.fivetran_log_config.bigquery_destination_config
             )
-            if bigquery_destination_config is not None:
-                engine = create_engine(
-                    bigquery_destination_config.get_sql_alchemy_url(),
+            if bigquery_destination_config is None:
+                raise ConfigurationError(
+                    "bigquery_destination_config is required when "
+                    "destination_platform is 'bigquery'."
                 )
-                fivetran_log_query.set_schema(bigquery_destination_config.dataset)
+            engine = create_engine(
+                bigquery_destination_config.get_sql_alchemy_url(),
+            )
+            fivetran_log_query.set_schema(bigquery_destination_config.dataset)
 
-                # The "database" should be the BigQuery project name.
-                result = engine.execute("SELECT @@project_id").fetchone()
-                if result is None:
-                    raise ValueError("Failed to retrieve BigQuery project ID")
-                fivetran_log_database = result[0]
+            # The "database" should be the BigQuery project name.
+            result = engine.execute("SELECT @@project_id").fetchone()
+            if result is None:
+                raise ValueError("Failed to retrieve BigQuery project ID")
+            fivetran_log_database = result[0]
         elif destination_platform == "databricks":
             databricks_destination_config = (
                 self.fivetran_log_config.databricks_destination_config
             )
-            if databricks_destination_config is not None:
-                # Pass connect_args (server_hostname, http_path, credentials_provider)
-                # so the databricks-sql-connector has valid authentication settings.
-                options = {
-                    **databricks_destination_config.get_options(),
-                    "connect_args": get_sql_connection_params(
-                        create_workspace_client(databricks_destination_config)
-                    ),
-                }
-                engine = create_engine(
-                    databricks_destination_config.get_sql_alchemy_url(
-                        databricks_destination_config.catalog
-                    ),
-                    **options,
+            if databricks_destination_config is None:
+                raise ConfigurationError(
+                    "databricks_destination_config is required when "
+                    "destination_platform is 'databricks'."
                 )
-                fivetran_log_query.set_schema(databricks_destination_config.log_schema)
-                fivetran_log_database = databricks_destination_config.catalog
+            # Pass connect_args (server_hostname, http_path, credentials_provider)
+            # so the databricks-sql-connector has valid authentication settings.
+            options = {
+                **databricks_destination_config.get_options(),
+                "connect_args": get_sql_connection_params(
+                    create_workspace_client(databricks_destination_config)
+                ),
+            }
+            engine = create_engine(
+                databricks_destination_config.get_sql_alchemy_url(
+                    databricks_destination_config.catalog
+                ),
+                **options,
+            )
+            fivetran_log_query.set_schema(databricks_destination_config.log_schema)
+            fivetran_log_database = databricks_destination_config.catalog
         else:
             raise ConfigurationError(
                 f"Destination platform '{destination_platform}' is not yet supported."
@@ -183,7 +203,9 @@ class FivetranLogAPI:
             )
         logger.info(f"Executing query: {query}")
         resp = self.engine.execute(query)
-        return [row for row in resp]
+        # Convert SQLAlchemy Row objects to plain dicts at the boundary so
+        # downstream consumers can treat results as dict-like uniformly.
+        return [dict(row) for row in resp]
 
     def _get_column_lineage_metadata(
         self, connector_ids: List[str]

--- a/metadata-ingestion/src/datahub/ingestion/source/fivetran/fivetran_log_api.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fivetran/fivetran_log_api.py
@@ -38,6 +38,58 @@ class FivetranLogAPI:
             self.fivetran_log_database,
         ) = self._initialize_fivetran_variables()
 
+    @staticmethod
+    def _setup_snowflake_engine(
+        snowflake_config: Any,
+        database: str,
+        log_schema: str,
+        preserve_case: bool,
+        fivetran_log_query: FivetranLogQuery,
+    ) -> Tuple[Any, str]:
+        """Build a Snowflake SQLAlchemy engine and apply USE DATABASE / SET SCHEMA.
+
+        Shared between the `snowflake` and `managed_data_lake` destination
+        platforms — both read the Fivetran log through Snowflake. When
+        `preserve_case` is True, identifiers are passed through verbatim
+        (required for catalog-linked databases, where schema/table names
+        retain their original lowercase casing).
+        """
+        engine = create_engine(
+            snowflake_config.get_sql_alchemy_url(),
+            **snowflake_config.get_options(),
+        )
+
+        # Snowflake auto-uppercases unquoted identifiers. Conventional Snowflake
+        # warehouses created via DataHub have always been queried with the
+        # ".upper()" path below for backward compatibility. CLDs (and any
+        # case-preserving Snowflake schema) need the verbatim path instead.
+        if preserve_case:
+            resolved_database = database
+            resolved_schema = log_schema
+        else:
+            resolved_database = (
+                database.upper()
+                if FivetranLogQuery._is_valid_unquoted_identifier(database)
+                else database
+            )
+            resolved_schema = (
+                log_schema.upper()
+                if FivetranLogQuery._is_valid_unquoted_identifier(log_schema)
+                else log_schema
+            )
+
+        logger.info(
+            f"Using snowflake database: {resolved_database} (original: {database})"
+        )
+        engine.execute(fivetran_log_query.use_database(resolved_database))
+
+        logger.info(
+            f"Using snowflake schema: {resolved_schema} (original: {log_schema})"
+        )
+        fivetran_log_query.set_schema(resolved_schema)
+
+        return engine, database
+
     def _initialize_fivetran_variables(
         self,
     ) -> Tuple[Any, FivetranLogQuery, str]:
@@ -54,45 +106,28 @@ class FivetranLogAPI:
                 self.fivetran_log_config.snowflake_destination_config
             )
             if snowflake_destination_config is not None:
-                engine = create_engine(
-                    snowflake_destination_config.get_sql_alchemy_url(),
-                    **snowflake_destination_config.get_options(),
+                engine, fivetran_log_database = self._setup_snowflake_engine(
+                    snowflake_destination_config,
+                    snowflake_destination_config.database,
+                    snowflake_destination_config.log_schema,
+                    snowflake_destination_config.preserve_case,
+                    fivetran_log_query,
                 )
-
-                """
-                Special Handling for Snowflake Backward Compatibility:
-                We have migrated to using quoted identifiers for database and schema names.
-                However, we need to support backward compatibility for existing databases and schemas that were created with unquoted identifiers.
-                When an unquoted identifier us used, we automatically convert it to uppercase + quoted identifier (this is Snowflake's behavior to resolve the identifier).
-                unquoted identifier -> uppercase + quoted identifier -> Snowflake resolves the identifier
-                """
-                snowflake_database = (
-                    snowflake_destination_config.database.upper()
-                    if FivetranLogQuery._is_valid_unquoted_identifier(
-                        snowflake_destination_config.database
-                    )
-                    else snowflake_destination_config.database
+        elif destination_platform == "managed_data_lake":
+            mdl_destination_config = (
+                self.fivetran_log_config.managed_data_lake_destination_config
+            )
+            if mdl_destination_config is not None:
+                # The Fivetran Managed Data Lake log is read through a Snowflake
+                # catalog-linked database — same engine setup as the snowflake branch,
+                # with preserve_case defaulted to True for CLD compatibility.
+                engine, fivetran_log_database = self._setup_snowflake_engine(
+                    mdl_destination_config,
+                    mdl_destination_config.database,
+                    mdl_destination_config.log_schema,
+                    mdl_destination_config.preserve_case,
+                    fivetran_log_query,
                 )
-                logger.info(
-                    f"Using snowflake database: {snowflake_database} (original: {snowflake_destination_config.database})"
-                )
-                engine.execute(fivetran_log_query.use_database(snowflake_database))
-
-                snowflake_schema = (
-                    snowflake_destination_config.log_schema.upper()
-                    if FivetranLogQuery._is_valid_unquoted_identifier(
-                        snowflake_destination_config.log_schema
-                    )
-                    else snowflake_destination_config.log_schema
-                )
-
-                logger.info(
-                    f"Using snowflake schema: {snowflake_schema} (original: {snowflake_destination_config.log_schema})"
-                )
-                fivetran_log_query.set_schema(
-                    snowflake_schema,
-                )
-                fivetran_log_database = snowflake_destination_config.database
         elif destination_platform == "bigquery":
             bigquery_destination_config = (
                 self.fivetran_log_config.bigquery_destination_config
@@ -139,9 +174,16 @@ class FivetranLogAPI:
             fivetran_log_database,
         )
 
+    # Destination platforms whose engine speaks native Snowflake SQL — the
+    # log queries are authored in Snowflake dialect and need no transpilation.
+    _SNOWFLAKE_NATIVE_PLATFORMS = frozenset({"snowflake", "managed_data_lake"})
+
     def _query(self, query: str) -> List[Dict]:
         # Automatically transpile snowflake query syntax to the target dialect.
-        if self.fivetran_log_config.destination_platform != "snowflake":
+        if (
+            self.fivetran_log_config.destination_platform
+            not in self._SNOWFLAKE_NATIVE_PLATFORMS
+        ):
             query = sqlglot.parse_one(query, dialect="snowflake").sql(
                 dialect=self.fivetran_log_config.destination_platform, pretty=True
             )

--- a/metadata-ingestion/tests/integration/fivetran/fivetran_managed_data_lake_golden.json
+++ b/metadata-ingestion/tests/integration/fivetran/fivetran_managed_data_lake_golden.json
@@ -1,0 +1,693 @@
+[
+{
+    "entityType": "dataFlow",
+    "entityUrn": "urn:li:dataFlow:(fivetran,calendar_elected,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:fivetran"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataFlow",
+    "entityUrn": "urn:li:dataFlow:(fivetran,calendar_elected,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataFlowInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "name": "postgres",
+            "env": "PROD"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(fivetran,calendar_elected,PROD),calendar_elected)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:fivetran"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(fivetran,calendar_elected,PROD),calendar_elected)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "connector_id": "calendar_elected",
+                "connector_type": "postgres",
+                "paused": "False",
+                "sync_frequency": "1440",
+                "destination_id": "interval_unconstitutional",
+                "source.platform": "postgres",
+                "source.env": "PROD",
+                "destination.platform": "managed_data_lake",
+                "destination.env": "PROD",
+                "destination.database": "lh_source_fivetran_usw2"
+            },
+            "name": "postgres",
+            "type": {
+                "string": "COMMAND"
+            },
+            "flowUrn": "urn:li:dataFlow:(fivetran,calendar_elected,PROD)",
+            "env": "PROD"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(fivetran,calendar_elected,PROD),calendar_elected)",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:abc.xyz@email.com",
+                    "type": "TECHNICAL_OWNER"
+                }
+            ],
+            "ownerTypes": {},
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(fivetran,calendar_elected,PROD),calendar_elected)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInputOutput",
+    "aspect": {
+        "json": {
+            "inputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:postgres,public.employee,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:postgres,public.company,PROD)"
+            ],
+            "outputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:glue,fivetran_postgres_public.employee,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:glue,fivetran_postgres_public.company,PROD)"
+            ],
+            "fineGrainedLineages": [
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,public.employee,PROD),id)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:glue,fivetran_postgres_public.employee,PROD),id)"
+                    ],
+                    "confidenceScore": 1.0
+                },
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,public.employee,PROD),name)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:glue,fivetran_postgres_public.employee,PROD),name)"
+                    ],
+                    "confidenceScore": 1.0
+                },
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,public.company,PROD),id)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:glue,fivetran_postgres_public.company,PROD),id)"
+                    ],
+                    "confidenceScore": 1.0
+                },
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,public.company,PROD),name)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:glue,fivetran_postgres_public.company,PROD),name)"
+                    ],
+                    "confidenceScore": 1.0
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(fivetran,calendar_elected,PROD),calendar_elected)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "calendar_elected",
+                    "urn": "urn:li:dataFlow:(fivetran,calendar_elected,PROD)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataProcessInstance",
+    "entityUrn": "urn:li:dataProcessInstance:ee88d32dbe3133a23a9023c097050190",
+    "changeType": "UPSERT",
+    "aspectName": "dataProcessInstanceProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "name": "4c9a03d6-eded-4422-a46a-163266e58243",
+            "type": "BATCH_SCHEDULED",
+            "created": {
+                "time": 1695184653000,
+                "actor": "urn:li:corpuser:datahub"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataProcessInstance",
+    "entityUrn": "urn:li:dataProcessInstance:ee88d32dbe3133a23a9023c097050190",
+    "changeType": "UPSERT",
+    "aspectName": "dataProcessInstanceRelationships",
+    "aspect": {
+        "json": {
+            "parentTemplate": "urn:li:dataJob:(urn:li:dataFlow:(fivetran,calendar_elected,PROD),calendar_elected)",
+            "upstreamInstances": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataProcessInstance",
+    "entityUrn": "urn:li:dataProcessInstance:ee88d32dbe3133a23a9023c097050190",
+    "changeType": "UPSERT",
+    "aspectName": "dataProcessInstanceInput",
+    "aspect": {
+        "json": {
+            "inputs": [
+                "urn:li:dataset:(urn:li:dataPlatform:postgres,public.employee,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:postgres,public.company,PROD)"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataProcessInstance",
+    "entityUrn": "urn:li:dataProcessInstance:ee88d32dbe3133a23a9023c097050190",
+    "changeType": "UPSERT",
+    "aspectName": "dataProcessInstanceOutput",
+    "aspect": {
+        "json": {
+            "outputs": [
+                "urn:li:dataset:(urn:li:dataPlatform:glue,fivetran_postgres_public.employee,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:glue,fivetran_postgres_public.company,PROD)"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataProcessInstance",
+    "entityUrn": "urn:li:dataProcessInstance:ee88d32dbe3133a23a9023c097050190",
+    "changeType": "UPSERT",
+    "aspectName": "dataProcessInstanceRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1695184653000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "status": "STARTED"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataProcessInstance",
+    "entityUrn": "urn:li:dataProcessInstance:ee88d32dbe3133a23a9023c097050190",
+    "changeType": "UPSERT",
+    "aspectName": "dataProcessInstanceRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1695184685000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResultType": "fivetran"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataFlow",
+    "entityUrn": "urn:li:dataFlow:(fivetran,my_confluent_cloud_connector_id,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:fivetran"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataFlow",
+    "entityUrn": "urn:li:dataFlow:(fivetran,my_confluent_cloud_connector_id,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataFlowInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "name": "confluent_cloud",
+            "env": "PROD"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(fivetran,my_confluent_cloud_connector_id,PROD),my_confluent_cloud_connector_id)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:fivetran"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(fivetran,my_confluent_cloud_connector_id,PROD),my_confluent_cloud_connector_id)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "connector_id": "my_confluent_cloud_connector_id",
+                "connector_type": "confluent_cloud",
+                "paused": "False",
+                "sync_frequency": "1440",
+                "destination_id": "my_confluent_cloud_connector_id",
+                "source.platform": "confluent_cloud",
+                "source.env": "PROD",
+                "destination.platform": "managed_data_lake",
+                "destination.env": "PROD",
+                "destination.database": "lh_source_fivetran_usw2"
+            },
+            "name": "confluent_cloud",
+            "type": {
+                "string": "COMMAND"
+            },
+            "flowUrn": "urn:li:dataFlow:(fivetran,my_confluent_cloud_connector_id,PROD)",
+            "env": "PROD"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(fivetran,my_confluent_cloud_connector_id,PROD),my_confluent_cloud_connector_id)",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:abc.xyz@email.com",
+                    "type": "TECHNICAL_OWNER"
+                }
+            ],
+            "ownerTypes": {},
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(fivetran,my_confluent_cloud_connector_id,PROD),my_confluent_cloud_connector_id)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInputOutput",
+    "aspect": {
+        "json": {
+            "inputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:confluent_cloud,confluent_cloud.my-source-topic,PROD)"
+            ],
+            "outputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:glue,fivetran_confluent_cloud.my-destination-topic,PROD)"
+            ],
+            "fineGrainedLineages": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(fivetran,my_confluent_cloud_connector_id,PROD),my_confluent_cloud_connector_id)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "my_confluent_cloud_connector_id",
+                    "urn": "urn:li:dataFlow:(fivetran,my_confluent_cloud_connector_id,PROD)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataProcessInstance",
+    "entityUrn": "urn:li:dataProcessInstance:08bddbc8007d76bfbbb8e231d1c65290",
+    "changeType": "UPSERT",
+    "aspectName": "dataProcessInstanceProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "name": "d9a03d6-eded-4422-a46a-163266e58244",
+            "type": "BATCH_SCHEDULED",
+            "created": {
+                "time": 1695184653000,
+                "actor": "urn:li:corpuser:datahub"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataProcessInstance",
+    "entityUrn": "urn:li:dataProcessInstance:08bddbc8007d76bfbbb8e231d1c65290",
+    "changeType": "UPSERT",
+    "aspectName": "dataProcessInstanceRelationships",
+    "aspect": {
+        "json": {
+            "parentTemplate": "urn:li:dataJob:(urn:li:dataFlow:(fivetran,my_confluent_cloud_connector_id,PROD),my_confluent_cloud_connector_id)",
+            "upstreamInstances": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataProcessInstance",
+    "entityUrn": "urn:li:dataProcessInstance:08bddbc8007d76bfbbb8e231d1c65290",
+    "changeType": "UPSERT",
+    "aspectName": "dataProcessInstanceInput",
+    "aspect": {
+        "json": {
+            "inputs": [
+                "urn:li:dataset:(urn:li:dataPlatform:confluent_cloud,confluent_cloud.my-source-topic,PROD)"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataProcessInstance",
+    "entityUrn": "urn:li:dataProcessInstance:08bddbc8007d76bfbbb8e231d1c65290",
+    "changeType": "UPSERT",
+    "aspectName": "dataProcessInstanceOutput",
+    "aspect": {
+        "json": {
+            "outputs": [
+                "urn:li:dataset:(urn:li:dataPlatform:glue,fivetran_confluent_cloud.my-destination-topic,PROD)"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataProcessInstance",
+    "entityUrn": "urn:li:dataProcessInstance:08bddbc8007d76bfbbb8e231d1c65290",
+    "changeType": "UPSERT",
+    "aspectName": "dataProcessInstanceRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1695184653000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "status": "STARTED"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataProcessInstance",
+    "entityUrn": "urn:li:dataProcessInstance:08bddbc8007d76bfbbb8e231d1c65290",
+    "changeType": "UPSERT",
+    "aspectName": "dataProcessInstanceRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1695184685000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResultType": "fivetran"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataFlow",
+    "entityUrn": "urn:li:dataFlow:(fivetran,calendar_elected,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataFlow",
+    "entityUrn": "urn:li:dataFlow:(fivetran,my_confluent_cloud_connector_id,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(fivetran,calendar_elected,PROD),calendar_elected)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(fivetran,my_confluent_cloud_connector_id,PROD),my_confluent_cloud_connector_id)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataProcessInstance",
+    "entityUrn": "urn:li:dataProcessInstance:08bddbc8007d76bfbbb8e231d1c65290",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataProcessInstance",
+    "entityUrn": "urn:li:dataProcessInstance:ee88d32dbe3133a23a9023c097050190",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+}
+]

--- a/metadata-ingestion/tests/integration/fivetran/fivetran_managed_data_lake_golden.json
+++ b/metadata-ingestion/tests/integration/fivetran/fivetran_managed_data_lake_golden.json
@@ -322,6 +322,252 @@
     }
 },
 {
+    "entityType": "dataProcessInstance",
+    "entityUrn": "urn:li:dataProcessInstance:be36f55c13ec4e313c7510770e50784a",
+    "changeType": "UPSERT",
+    "aspectName": "dataProcessInstanceProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "name": "f773d1e9-c791-48f4-894f-8cf9b3dfc834",
+            "type": "BATCH_SCHEDULED",
+            "created": {
+                "time": 1696336530000,
+                "actor": "urn:li:corpuser:datahub"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataProcessInstance",
+    "entityUrn": "urn:li:dataProcessInstance:be36f55c13ec4e313c7510770e50784a",
+    "changeType": "UPSERT",
+    "aspectName": "dataProcessInstanceRelationships",
+    "aspect": {
+        "json": {
+            "parentTemplate": "urn:li:dataJob:(urn:li:dataFlow:(fivetran,calendar_elected,PROD),calendar_elected)",
+            "upstreamInstances": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataProcessInstance",
+    "entityUrn": "urn:li:dataProcessInstance:be36f55c13ec4e313c7510770e50784a",
+    "changeType": "UPSERT",
+    "aspectName": "dataProcessInstanceInput",
+    "aspect": {
+        "json": {
+            "inputs": [
+                "urn:li:dataset:(urn:li:dataPlatform:postgres,public.employee,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:postgres,public.company,PROD)"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataProcessInstance",
+    "entityUrn": "urn:li:dataProcessInstance:be36f55c13ec4e313c7510770e50784a",
+    "changeType": "UPSERT",
+    "aspectName": "dataProcessInstanceOutput",
+    "aspect": {
+        "json": {
+            "outputs": [
+                "urn:li:dataset:(urn:li:dataPlatform:glue,fivetran_postgres_public.employee,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:glue,fivetran_postgres_public.company,PROD)"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataProcessInstance",
+    "entityUrn": "urn:li:dataProcessInstance:be36f55c13ec4e313c7510770e50784a",
+    "changeType": "UPSERT",
+    "aspectName": "dataProcessInstanceRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1696336530000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "status": "STARTED"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataProcessInstance",
+    "entityUrn": "urn:li:dataProcessInstance:be36f55c13ec4e313c7510770e50784a",
+    "changeType": "UPSERT",
+    "aspectName": "dataProcessInstanceRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1696336532000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "status": "COMPLETE",
+            "result": {
+                "type": "SKIPPED",
+                "nativeResultType": "fivetran"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataProcessInstance",
+    "entityUrn": "urn:li:dataProcessInstance:d8f100271d2dc3fa905717f82d083c8d",
+    "changeType": "UPSERT",
+    "aspectName": "dataProcessInstanceProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "name": "63c2fc85-600b-455f-9ba0-f576522465be",
+            "type": "BATCH_SCHEDULED",
+            "created": {
+                "time": 1696336555000,
+                "actor": "urn:li:corpuser:datahub"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataProcessInstance",
+    "entityUrn": "urn:li:dataProcessInstance:d8f100271d2dc3fa905717f82d083c8d",
+    "changeType": "UPSERT",
+    "aspectName": "dataProcessInstanceRelationships",
+    "aspect": {
+        "json": {
+            "parentTemplate": "urn:li:dataJob:(urn:li:dataFlow:(fivetran,calendar_elected,PROD),calendar_elected)",
+            "upstreamInstances": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataProcessInstance",
+    "entityUrn": "urn:li:dataProcessInstance:d8f100271d2dc3fa905717f82d083c8d",
+    "changeType": "UPSERT",
+    "aspectName": "dataProcessInstanceInput",
+    "aspect": {
+        "json": {
+            "inputs": [
+                "urn:li:dataset:(urn:li:dataPlatform:postgres,public.employee,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:postgres,public.company,PROD)"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataProcessInstance",
+    "entityUrn": "urn:li:dataProcessInstance:d8f100271d2dc3fa905717f82d083c8d",
+    "changeType": "UPSERT",
+    "aspectName": "dataProcessInstanceOutput",
+    "aspect": {
+        "json": {
+            "outputs": [
+                "urn:li:dataset:(urn:li:dataPlatform:glue,fivetran_postgres_public.employee,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:glue,fivetran_postgres_public.company,PROD)"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataProcessInstance",
+    "entityUrn": "urn:li:dataProcessInstance:d8f100271d2dc3fa905717f82d083c8d",
+    "changeType": "UPSERT",
+    "aspectName": "dataProcessInstanceRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1696336555000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "status": "STARTED"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataProcessInstance",
+    "entityUrn": "urn:li:dataProcessInstance:d8f100271d2dc3fa905717f82d083c8d",
+    "changeType": "UPSERT",
+    "aspectName": "dataProcessInstanceRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1696336590000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "status": "COMPLETE",
+            "result": {
+                "type": "FAILURE",
+                "nativeResultType": "fivetran"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
     "entityType": "dataFlow",
     "entityUrn": "urn:li:dataFlow:(fivetran,my_confluent_cloud_connector_id,PROD)",
     "changeType": "UPSERT",
@@ -661,6 +907,38 @@
 {
     "entityType": "dataProcessInstance",
     "entityUrn": "urn:li:dataProcessInstance:08bddbc8007d76bfbbb8e231d1c65290",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataProcessInstance",
+    "entityUrn": "urn:li:dataProcessInstance:be36f55c13ec4e313c7510770e50784a",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654614000000,
+        "runId": "fivetran-mdl-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataProcessInstance",
+    "entityUrn": "urn:li:dataProcessInstance:d8f100271d2dc3fa905717f82d083c8d",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {

--- a/metadata-ingestion/tests/integration/fivetran/test_fivetran.py
+++ b/metadata-ingestion/tests/integration/fivetran/test_fivetran.py
@@ -15,6 +15,7 @@ from datahub.ingestion.source.fivetran.config import (
     DatabricksDestinationConfig,
     FivetranLogConfig,
     FivetranSourceConfig,
+    ManagedDataLakeDestinationConfig,
     PlatformDetail,
     SnowflakeDestinationConfig,
 )
@@ -736,6 +737,220 @@ def test_fivetran_with_snowflake_dest_and_null_connector_user(pytestconfig, tmp_
         output_path=f"{output_file}",
         golden_path=f"{golden_file}",
     )
+
+
+def mdl_query_results(query, connector_query_results=default_connector_query_results):
+    """Mocked Fivetran-log query results for the Managed Data Lake destination.
+
+    Uses lowercase database/schema identifiers because the MDL config defaults
+    `preserve_case=True` — the catalog-linked database surfacing the log retains
+    the case of the underlying Glue/Iceberg schema. We rebuild the full query
+    set against the lowercase schema rather than delegating to
+    `default_query_results`, which is hard-coded to the legacy uppercase
+    Snowflake-warehouse path.
+    """
+    fivetran_log_query = FivetranLogQuery()
+    fivetran_log_query.set_schema("fivetran_metadata_test")
+
+    if query == fivetran_log_query.use_database("lh_source_fivetran_usw2"):
+        return []
+    if query == fivetran_log_query.get_connectors_query():
+        return connector_query_results
+    if query == fivetran_log_query.get_table_lineage_query(
+        connector_ids=["calendar_elected", "my_confluent_cloud_connector_id"]
+    ):
+        return [
+            {
+                "connection_id": "calendar_elected",
+                "source_table_id": "10040",
+                "source_table_name": "employee",
+                "source_schema_name": "public",
+                "destination_table_id": "7779",
+                "destination_table_name": "employee",
+                "destination_schema_name": "postgres_public",
+            },
+            {
+                "connection_id": "calendar_elected",
+                "source_table_id": "10041",
+                "source_table_name": "company",
+                "source_schema_name": "public",
+                "destination_table_id": "7780",
+                "destination_table_name": "company",
+                "destination_schema_name": "postgres_public",
+            },
+            {
+                "connection_id": "my_confluent_cloud_connector_id",
+                "source_table_id": "10042",
+                "source_table_name": "my-source-topic",
+                "source_schema_name": "confluent_cloud",
+                "destination_table_id": "7781",
+                "destination_table_name": "my-destination-topic",
+                "destination_schema_name": "confluent_cloud",
+            },
+        ]
+    if query == fivetran_log_query.get_column_lineage_query(
+        connector_ids=["calendar_elected", "my_confluent_cloud_connector_id"]
+    ):
+        return [
+            {
+                "source_table_id": "10040",
+                "destination_table_id": "7779",
+                "source_column_name": "id",
+                "destination_column_name": "id",
+            },
+            {
+                "source_table_id": "10040",
+                "destination_table_id": "7779",
+                "source_column_name": "name",
+                "destination_column_name": "name",
+            },
+            {
+                "source_table_id": "10041",
+                "destination_table_id": "7780",
+                "source_column_name": "id",
+                "destination_column_name": "id",
+            },
+            {
+                "source_table_id": "10041",
+                "destination_table_id": "7780",
+                "source_column_name": "name",
+                "destination_column_name": "name",
+            },
+        ]
+    if query == fivetran_log_query.get_users_query():
+        return [
+            {
+                "user_id": "reapply_phone",
+                "given_name": "Shubham",
+                "family_name": "Jagtap",
+                "email": "abc.xyz@email.com",
+            }
+        ]
+    if query == fivetran_log_query.get_sync_logs_query(
+        syncs_interval=7,
+        connector_ids=["calendar_elected", "my_confluent_cloud_connector_id"],
+    ):
+        return [
+            {
+                "connection_id": "calendar_elected",
+                "sync_id": "4c9a03d6-eded-4422-a46a-163266e58243",
+                "start_time": datetime.datetime(2023, 9, 20, 6, 37, 32, 606000),
+                "end_time": datetime.datetime(2023, 9, 20, 6, 38, 5, 56000),
+                "end_message_data": '"{\\"status\\":\\"SUCCESSFUL\\"}"',
+            },
+            {
+                "connection_id": "my_confluent_cloud_connector_id",
+                "sync_id": "d9a03d6-eded-4422-a46a-163266e58244",
+                "start_time": datetime.datetime(2023, 9, 20, 6, 37, 32, 606000),
+                "end_time": datetime.datetime(2023, 9, 20, 6, 38, 5, 56000),
+                "end_message_data": '"{\\"status\\":\\"SUCCESSFUL\\"}"',
+            },
+        ]
+    raise Exception(f"Unknown query {query}")
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+@pytest.mark.integration
+def test_fivetran_with_managed_data_lake_dest(pytestconfig, tmp_path):
+    """End-to-end test for the Fivetran Managed Data Lake destination.
+
+    Verifies that with a lowercase CLD database/schema and `preserve_case=True`:
+      1. The Snowflake-engine path emits queries against the verbatim lowercase
+         identifiers (no `.upper()`).
+      2. The destination URN is a Glue URN of shape
+         `urn:li:dataset:(glue, fivetran_<schema>.<table>, env)`, not a
+         Snowflake URN pointing at the CLD.
+    """
+    test_resources_dir = pytestconfig.rootpath / "tests/integration/fivetran"
+
+    output_file = tmp_path / "fivetran_test_events.json"
+    golden_file = test_resources_dir / "fivetran_managed_data_lake_golden.json"
+
+    with (
+        mock.patch(
+            "datahub.ingestion.source.fivetran.fivetran_log_api.create_engine"
+        ) as mock_create_engine,
+        mock.patch(
+            "datahub.ingestion.source.fivetran.fivetran_log_api.create_workspace_client"
+        ),
+    ):
+        connection_magic_mock = MagicMock()
+        connection_magic_mock.execute.side_effect = mdl_query_results
+        mock_create_engine.return_value = connection_magic_mock
+
+        pipeline = Pipeline.create(
+            {
+                "run_id": "fivetran-mdl-test",
+                "source": {
+                    "type": "fivetran",
+                    "config": {
+                        "fivetran_log_config": {
+                            "destination_platform": "managed_data_lake",
+                            "managed_data_lake_destination_config": {
+                                "account_id": "testid",
+                                "warehouse": "test_wh",
+                                "username": "test",
+                                "password": "test@123",
+                                "role": "testrole",
+                                # Lowercase database/schema — the case-preserving
+                                # CLD identifiers that the legacy `.upper()`
+                                # path would have failed against.
+                                "database": "lh_source_fivetran_usw2",
+                                "log_schema": "fivetran_metadata_test",
+                                # `preserve_case` defaults to True for MDL.
+                                "catalog_type": "glue",
+                                # Keep the default `glue_database_prefix="fivetran_"`.
+                            },
+                        },
+                        "connector_patterns": {
+                            "allow": ["postgres", "confluent_cloud"]
+                        },
+                        "destination_patterns": {
+                            "allow": [
+                                "interval_unconstitutional",
+                                "my_confluent_cloud_connector_id",
+                            ]
+                        },
+                    },
+                },
+                "sink": {
+                    "type": "file",
+                    "config": {"filename": f"{output_file}"},
+                },
+            }
+        )
+
+    pipeline.run()
+    pipeline.raise_from_status()
+
+    mce_helpers.check_golden_file(
+        pytestconfig,
+        output_path=f"{output_file}",
+        golden_path=f"{golden_file}",
+    )
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+def test_fivetran_managed_data_lake_destination_config():
+    """The MDL destination config must reuse the SnowflakeConnectionConfig
+    SQLAlchemy URL builder — the engine is Snowflake under the hood since
+    the CLD is what surfaces the log."""
+    mdl_dest = ManagedDataLakeDestinationConfig(
+        account_id="TESTID",
+        warehouse="TEST_WH",
+        username="test",
+        password="test@123",
+        role="TESTROLE",
+        database="LH_SOURCE_FIVETRAN_USW2",
+        log_schema="fivetran_metadata_test",
+    )
+    assert (
+        mdl_dest.get_sql_alchemy_url()
+        == "snowflake://test:test%40123@TESTID?application=acryl_datahub&authenticator=SNOWFLAKE&role=TESTROLE&warehouse=TEST_WH"
+    )
+    # MDL defaults to `preserve_case=True` — case-preserving CLDs are the norm.
+    assert mdl_dest.preserve_case is True
+    assert mdl_dest.catalog_type == "glue"
 
 
 @time_machine.travel(FROZEN_TIME, tick=False)

--- a/metadata-ingestion/tests/integration/fivetran/test_fivetran.py
+++ b/metadata-ingestion/tests/integration/fivetran/test_fivetran.py
@@ -1,5 +1,6 @@
 import datetime
 from functools import partial
+from typing import Callable, Dict, List
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -58,123 +59,140 @@ default_connector_query_results = [
 ]
 
 
-def default_query_results(
-    query, connector_query_results=default_connector_query_results
-):
-    fivetran_log_query = FivetranLogQuery()
-    # For Snowflake, valid unquoted identifiers are uppercased
-    # "test_database" -> "TEST_DATABASE", "test" -> "TEST"
-    fivetran_log_query.set_schema("TEST")
-    if query == fivetran_log_query.use_database("TEST_DATABASE"):
-        return []
-    if query == fivetran_log_query.get_connectors_query():
-        return connector_query_results
-    elif query == fivetran_log_query.get_table_lineage_query(
-        connector_ids=["calendar_elected", "my_confluent_cloud_connector_id"]
-    ):
-        return [
-            {
-                "connection_id": "calendar_elected",
-                "source_table_id": "10040",
-                "source_table_name": "employee",
-                "source_schema_name": "public",
-                "destination_table_id": "7779",
-                "destination_table_name": "employee",
-                "destination_schema_name": "postgres_public",
-            },
-            {
-                "connection_id": "calendar_elected",
-                "source_table_id": "10041",
-                "source_table_name": "company",
-                "source_schema_name": "public",
-                "destination_table_id": "7780",
-                "destination_table_name": "company",
-                "destination_schema_name": "postgres_public",
-            },
-            {
-                "connection_id": "my_confluent_cloud_connector_id",
-                "source_table_id": "10042",
-                "source_table_name": "my-source-topic",
-                "source_schema_name": "confluent_cloud",
-                "destination_table_id": "7781",
-                "destination_table_name": "my-destination-topic",
-                "destination_schema_name": "confluent_cloud",
-            },
-        ]
-    elif query == fivetran_log_query.get_column_lineage_query(
-        connector_ids=["calendar_elected", "my_confluent_cloud_connector_id"]
-    ):
-        return [
-            {
-                "source_table_id": "10040",
-                "destination_table_id": "7779",
-                "source_column_name": "id",
-                "destination_column_name": "id",
-            },
-            {
-                "source_table_id": "10040",
-                "destination_table_id": "7779",
-                "source_column_name": "name",
-                "destination_column_name": "name",
-            },
-            {
-                "source_table_id": "10041",
-                "destination_table_id": "7780",
-                "source_column_name": "id",
-                "destination_column_name": "id",
-            },
-            {
-                "source_table_id": "10041",
-                "destination_table_id": "7780",
-                "source_column_name": "name",
-                "destination_column_name": "name",
-            },
-        ]
-    elif query == fivetran_log_query.get_users_query():
-        return [
-            {
-                "user_id": "reapply_phone",
-                "given_name": "Shubham",
-                "family_name": "Jagtap",
-                "email": "abc.xyz@email.com",
-            }
-        ]
-    elif query == fivetran_log_query.get_sync_logs_query(
-        syncs_interval=7,
-        connector_ids=["calendar_elected", "my_confluent_cloud_connector_id"],
-    ):
-        return [
-            {
-                "connection_id": "calendar_elected",
-                "sync_id": "4c9a03d6-eded-4422-a46a-163266e58243",
-                "start_time": datetime.datetime(2023, 9, 20, 6, 37, 32, 606000),
-                "end_time": datetime.datetime(2023, 9, 20, 6, 38, 5, 56000),
-                "end_message_data": '"{\\"status\\":\\"SUCCESSFUL\\"}"',
-            },
-            {
-                "connection_id": "calendar_elected",
-                "sync_id": "f773d1e9-c791-48f4-894f-8cf9b3dfc834",
-                "start_time": datetime.datetime(2023, 10, 3, 14, 35, 30, 345000),
-                "end_time": datetime.datetime(2023, 10, 3, 14, 35, 31, 512000),
-                "end_message_data": '"{\\"reason\\":\\"Sync has been cancelled because of a user action in the dashboard.Standard Config updated.\\",\\"status\\":\\"CANCELED\\"}"',
-            },
-            {
-                "connection_id": "calendar_elected",
-                "sync_id": "63c2fc85-600b-455f-9ba0-f576522465be",
-                "start_time": datetime.datetime(2023, 10, 3, 14, 35, 55, 401000),
-                "end_time": datetime.datetime(2023, 10, 3, 14, 36, 29, 678000),
-                "end_message_data": '"{\\"reason\\":\\"java.lang.RuntimeException: FATAL: too many connections for role \\\\\\"hxwraqld\\\\\\"\\",\\"taskType\\":\\"reconnect\\",\\"status\\":\\"FAILURE_WITH_TASK\\"}"',
-            },
-            {
-                "connection_id": "my_confluent_cloud_connector_id",
-                "sync_id": "d9a03d6-eded-4422-a46a-163266e58244",
-                "start_time": datetime.datetime(2023, 9, 20, 6, 37, 32, 606000),
-                "end_time": datetime.datetime(2023, 9, 20, 6, 38, 5, 56000),
-                "end_message_data": '"{\\"status\\":\\"SUCCESSFUL\\"}"',
-            },
-        ]
-    # Unreachable code
-    raise Exception(f"Unknown query {query}")
+def _build_query_results_handler(database: str, schema: str) -> Callable[..., List]:
+    """Factory for the mocked Fivetran-log query handler.
+
+    Captures `database` and `schema` so the same mock query bodies work for
+    both the legacy Snowflake-warehouse path (uppercased identifiers) and the
+    Managed Data Lake / catalog-linked-database path (case-preserving
+    identifiers). The only difference between the two callers is the literal
+    identifiers; the lineage / column-lineage / users / sync-logs payloads
+    are shared.
+    """
+
+    def handler(
+        query: str,
+        connector_query_results: List[Dict] = default_connector_query_results,
+    ) -> List[Dict]:
+        fivetran_log_query = FivetranLogQuery()
+        fivetran_log_query.set_schema(schema)
+        if query == fivetran_log_query.use_database(database):
+            return []
+        if query == fivetran_log_query.get_connectors_query():
+            return connector_query_results
+        if query == fivetran_log_query.get_table_lineage_query(
+            connector_ids=["calendar_elected", "my_confluent_cloud_connector_id"]
+        ):
+            return [
+                {
+                    "connection_id": "calendar_elected",
+                    "source_table_id": "10040",
+                    "source_table_name": "employee",
+                    "source_schema_name": "public",
+                    "destination_table_id": "7779",
+                    "destination_table_name": "employee",
+                    "destination_schema_name": "postgres_public",
+                },
+                {
+                    "connection_id": "calendar_elected",
+                    "source_table_id": "10041",
+                    "source_table_name": "company",
+                    "source_schema_name": "public",
+                    "destination_table_id": "7780",
+                    "destination_table_name": "company",
+                    "destination_schema_name": "postgres_public",
+                },
+                {
+                    "connection_id": "my_confluent_cloud_connector_id",
+                    "source_table_id": "10042",
+                    "source_table_name": "my-source-topic",
+                    "source_schema_name": "confluent_cloud",
+                    "destination_table_id": "7781",
+                    "destination_table_name": "my-destination-topic",
+                    "destination_schema_name": "confluent_cloud",
+                },
+            ]
+        if query == fivetran_log_query.get_column_lineage_query(
+            connector_ids=["calendar_elected", "my_confluent_cloud_connector_id"]
+        ):
+            return [
+                {
+                    "source_table_id": "10040",
+                    "destination_table_id": "7779",
+                    "source_column_name": "id",
+                    "destination_column_name": "id",
+                },
+                {
+                    "source_table_id": "10040",
+                    "destination_table_id": "7779",
+                    "source_column_name": "name",
+                    "destination_column_name": "name",
+                },
+                {
+                    "source_table_id": "10041",
+                    "destination_table_id": "7780",
+                    "source_column_name": "id",
+                    "destination_column_name": "id",
+                },
+                {
+                    "source_table_id": "10041",
+                    "destination_table_id": "7780",
+                    "source_column_name": "name",
+                    "destination_column_name": "name",
+                },
+            ]
+        if query == fivetran_log_query.get_users_query():
+            return [
+                {
+                    "user_id": "reapply_phone",
+                    "given_name": "Shubham",
+                    "family_name": "Jagtap",
+                    "email": "abc.xyz@email.com",
+                }
+            ]
+        if query == fivetran_log_query.get_sync_logs_query(
+            syncs_interval=7,
+            connector_ids=["calendar_elected", "my_confluent_cloud_connector_id"],
+        ):
+            return [
+                {
+                    "connection_id": "calendar_elected",
+                    "sync_id": "4c9a03d6-eded-4422-a46a-163266e58243",
+                    "start_time": datetime.datetime(2023, 9, 20, 6, 37, 32, 606000),
+                    "end_time": datetime.datetime(2023, 9, 20, 6, 38, 5, 56000),
+                    "end_message_data": '"{\\"status\\":\\"SUCCESSFUL\\"}"',
+                },
+                {
+                    "connection_id": "calendar_elected",
+                    "sync_id": "f773d1e9-c791-48f4-894f-8cf9b3dfc834",
+                    "start_time": datetime.datetime(2023, 10, 3, 14, 35, 30, 345000),
+                    "end_time": datetime.datetime(2023, 10, 3, 14, 35, 31, 512000),
+                    "end_message_data": '"{\\"reason\\":\\"Sync has been cancelled because of a user action in the dashboard.Standard Config updated.\\",\\"status\\":\\"CANCELED\\"}"',
+                },
+                {
+                    "connection_id": "calendar_elected",
+                    "sync_id": "63c2fc85-600b-455f-9ba0-f576522465be",
+                    "start_time": datetime.datetime(2023, 10, 3, 14, 35, 55, 401000),
+                    "end_time": datetime.datetime(2023, 10, 3, 14, 36, 29, 678000),
+                    "end_message_data": '"{\\"reason\\":\\"java.lang.RuntimeException: FATAL: too many connections for role \\\\\\"hxwraqld\\\\\\"\\",\\"taskType\\":\\"reconnect\\",\\"status\\":\\"FAILURE_WITH_TASK\\"}"',
+                },
+                {
+                    "connection_id": "my_confluent_cloud_connector_id",
+                    "sync_id": "d9a03d6-eded-4422-a46a-163266e58244",
+                    "start_time": datetime.datetime(2023, 9, 20, 6, 37, 32, 606000),
+                    "end_time": datetime.datetime(2023, 9, 20, 6, 38, 5, 56000),
+                    "end_message_data": '"{\\"status\\":\\"SUCCESSFUL\\"}"',
+                },
+            ]
+        raise Exception(f"Unknown query {query}")
+
+    return handler
+
+
+# For Snowflake, valid unquoted identifiers are auto-uppercased by the
+# connector for backward compatibility:
+#   "test_database" -> "TEST_DATABASE", "test" -> "TEST"
+default_query_results = _build_query_results_handler("TEST_DATABASE", "TEST")
 
 
 # Test cases with different schema names that might cause issues
@@ -739,114 +757,13 @@ def test_fivetran_with_snowflake_dest_and_null_connector_user(pytestconfig, tmp_
     )
 
 
-def mdl_query_results(query, connector_query_results=default_connector_query_results):
-    """Mocked Fivetran-log query results for the Managed Data Lake destination.
-
-    Uses lowercase database/schema identifiers because the MDL config defaults
-    `preserve_case=True` — the catalog-linked database surfacing the log retains
-    the case of the underlying Glue/Iceberg schema. We rebuild the full query
-    set against the lowercase schema rather than delegating to
-    `default_query_results`, which is hard-coded to the legacy uppercase
-    Snowflake-warehouse path.
-    """
-    fivetran_log_query = FivetranLogQuery()
-    fivetran_log_query.set_schema("fivetran_metadata_test")
-
-    if query == fivetran_log_query.use_database("lh_source_fivetran_usw2"):
-        return []
-    if query == fivetran_log_query.get_connectors_query():
-        return connector_query_results
-    if query == fivetran_log_query.get_table_lineage_query(
-        connector_ids=["calendar_elected", "my_confluent_cloud_connector_id"]
-    ):
-        return [
-            {
-                "connection_id": "calendar_elected",
-                "source_table_id": "10040",
-                "source_table_name": "employee",
-                "source_schema_name": "public",
-                "destination_table_id": "7779",
-                "destination_table_name": "employee",
-                "destination_schema_name": "postgres_public",
-            },
-            {
-                "connection_id": "calendar_elected",
-                "source_table_id": "10041",
-                "source_table_name": "company",
-                "source_schema_name": "public",
-                "destination_table_id": "7780",
-                "destination_table_name": "company",
-                "destination_schema_name": "postgres_public",
-            },
-            {
-                "connection_id": "my_confluent_cloud_connector_id",
-                "source_table_id": "10042",
-                "source_table_name": "my-source-topic",
-                "source_schema_name": "confluent_cloud",
-                "destination_table_id": "7781",
-                "destination_table_name": "my-destination-topic",
-                "destination_schema_name": "confluent_cloud",
-            },
-        ]
-    if query == fivetran_log_query.get_column_lineage_query(
-        connector_ids=["calendar_elected", "my_confluent_cloud_connector_id"]
-    ):
-        return [
-            {
-                "source_table_id": "10040",
-                "destination_table_id": "7779",
-                "source_column_name": "id",
-                "destination_column_name": "id",
-            },
-            {
-                "source_table_id": "10040",
-                "destination_table_id": "7779",
-                "source_column_name": "name",
-                "destination_column_name": "name",
-            },
-            {
-                "source_table_id": "10041",
-                "destination_table_id": "7780",
-                "source_column_name": "id",
-                "destination_column_name": "id",
-            },
-            {
-                "source_table_id": "10041",
-                "destination_table_id": "7780",
-                "source_column_name": "name",
-                "destination_column_name": "name",
-            },
-        ]
-    if query == fivetran_log_query.get_users_query():
-        return [
-            {
-                "user_id": "reapply_phone",
-                "given_name": "Shubham",
-                "family_name": "Jagtap",
-                "email": "abc.xyz@email.com",
-            }
-        ]
-    if query == fivetran_log_query.get_sync_logs_query(
-        syncs_interval=7,
-        connector_ids=["calendar_elected", "my_confluent_cloud_connector_id"],
-    ):
-        return [
-            {
-                "connection_id": "calendar_elected",
-                "sync_id": "4c9a03d6-eded-4422-a46a-163266e58243",
-                "start_time": datetime.datetime(2023, 9, 20, 6, 37, 32, 606000),
-                "end_time": datetime.datetime(2023, 9, 20, 6, 38, 5, 56000),
-                "end_message_data": '"{\\"status\\":\\"SUCCESSFUL\\"}"',
-            },
-            {
-                "connection_id": "my_confluent_cloud_connector_id",
-                "sync_id": "d9a03d6-eded-4422-a46a-163266e58244",
-                "start_time": datetime.datetime(2023, 9, 20, 6, 37, 32, 606000),
-                "end_time": datetime.datetime(2023, 9, 20, 6, 38, 5, 56000),
-                "end_message_data": '"{\\"status\\":\\"SUCCESSFUL\\"}"',
-            },
-        ]
-    raise Exception(f"Unknown query {query}")
+# Lowercase identifiers — the Managed Data Lake config defaults
+# `preserve_case=True`, so the catalog-linked database surfacing the log
+# retains the case of the underlying Glue/Iceberg schema instead of being
+# auto-uppercased.
+mdl_query_results = _build_query_results_handler(
+    "lh_source_fivetran_usw2", "fivetran_metadata_test"
+)
 
 
 @time_machine.travel(FROZEN_TIME, tick=False)
@@ -922,6 +839,19 @@ def test_fivetran_with_managed_data_lake_dest(pytestconfig, tmp_path):
 
     pipeline.run()
     pipeline.raise_from_status()
+
+    # Belt-and-braces: the golden file is the primary regression guard, but a
+    # silent regression in `_build_destination_urn` (e.g., a config rename
+    # that flips destination_details.platform back to the relational branch)
+    # would just regenerate the golden and pass. Pin the contract that this
+    # test exists to enforce: at least one Glue URN with the `fivetran_`
+    # prefix must be emitted.
+    output_text = output_file.read_text()
+    assert "urn:li:dataPlatform:glue,fivetran_" in output_text, (
+        "Expected at least one `urn:li:dataPlatform:glue,fivetran_*` dataset "
+        "in the emitted MCEs — the Managed Data Lake destination must emit "
+        "Glue URNs, not Snowflake URNs pointing at the catalog-linked database."
+    )
 
     mce_helpers.check_golden_file(
         pytestconfig,

--- a/metadata-ingestion/tests/unit/fivetran/test_fivetran_managed_data_lake.py
+++ b/metadata-ingestion/tests/unit/fivetran/test_fivetran_managed_data_lake.py
@@ -1,0 +1,139 @@
+"""Unit tests for the Fivetran Managed Data Lake destination support.
+
+Covers AWS Glue catalog backing the Managed Data Lake with log access
+through a Snowflake catalog-linked database.
+"""
+
+from typing import Any
+
+import pytest
+
+from datahub.ingestion.source.fivetran.config import (
+    ManagedDataLakeDestinationConfig,
+    PlatformDetail,
+)
+from datahub.ingestion.source.fivetran.fivetran import FivetranSource
+
+
+def _mdl_config(**overrides: Any) -> ManagedDataLakeDestinationConfig:
+    """Build a minimal valid ManagedDataLakeDestinationConfig for testing."""
+    base: dict = dict(
+        account_id="abc12345.us-east-1",
+        username="datahub",
+        password="hunter2",
+        warehouse="DATAHUB_WH",
+        database="LH_SOURCE_FIVETRAN_USW2",
+        log_schema="fivetran_metadata_test",
+    )
+    base.update(overrides)
+    return ManagedDataLakeDestinationConfig(**base)
+
+
+class TestManagedDataLakeConfigValidation:
+    def test_glue_catalog_with_defaults_is_accepted(self):
+        cfg = _mdl_config()
+        assert cfg.catalog_type == "glue"
+        assert cfg.glue_database_prefix == "fivetran_"
+        # preserve_case defaults to True for MDL because CLDs are case-preserving.
+        assert cfg.preserve_case is True
+
+    @pytest.mark.parametrize(
+        "unimplemented_catalog_type",
+        ["iceberg_rest", "unity", "biglake", "onelake"],
+    )
+    def test_non_glue_catalog_raises_not_implemented_at_urn_time(
+        self, unimplemented_catalog_type
+    ):
+        # The Literal accepts the value (forward-compat for future catalog
+        # backends) but URN construction raises NotImplementedError until
+        # the branch is wired up.
+        details = PlatformDetail(platform="managed_data_lake", env="PROD")
+        with pytest.raises(NotImplementedError, match="not implemented yet"):
+            FivetranSource.build_destination_urn(
+                destination_table="orders.line_items",
+                destination_details=details,
+                mdl_cfg=_mdl_config(catalog_type=unimplemented_catalog_type),
+            )
+
+
+class TestManagedDataLakeUrnConstruction:
+    """`build_destination_urn` emits a Glue URN derived from the connector
+    schema rather than a Snowflake URN pointing at the CLD. These tests pin
+    the URN shape end-to-end."""
+
+    def test_glue_urn_uses_prefix_and_schema(self):
+        details = PlatformDetail(platform="managed_data_lake", env="PROD")
+        urn = FivetranSource.build_destination_urn(
+            destination_table="orders.line_items",
+            destination_details=details,
+            mdl_cfg=_mdl_config(),
+        )
+        assert (
+            str(urn)
+            == "urn:li:dataset:(urn:li:dataPlatform:glue,fivetran_orders.line_items,PROD)"
+        )
+
+    def test_glue_urn_honours_custom_prefix(self):
+        # `glue_database_prefix` is the configurable knob future-proofing
+        # against Fivetran renaming the auto-Glue-DB convention.
+        details = PlatformDetail(platform="managed_data_lake", env="PROD")
+        urn = FivetranSource.build_destination_urn(
+            destination_table="orders.line_items",
+            destination_details=details,
+            mdl_cfg=_mdl_config(glue_database_prefix="ft_"),
+        )
+        assert (
+            str(urn)
+            == "urn:li:dataset:(urn:li:dataPlatform:glue,ft_orders.line_items,PROD)"
+        )
+
+    def test_glue_urn_with_platform_instance(self):
+        details = PlatformDetail(
+            platform="managed_data_lake",
+            env="DEV",
+            platform_instance="lake_us_west",
+        )
+        urn = FivetranSource.build_destination_urn(
+            destination_table="events.page_views",
+            destination_details=details,
+            mdl_cfg=_mdl_config(),
+        )
+        assert (
+            str(urn)
+            == "urn:li:dataset:(urn:li:dataPlatform:glue,lake_us_west.fivetran_events.page_views,DEV)"
+        )
+
+    def test_relational_branch_unchanged_for_snowflake_destination(self):
+        # Regression guard: existing snowflake/bigquery/databricks recipes must
+        # produce the same three-part URN shape as before.
+        details = PlatformDetail(
+            platform="snowflake",
+            env="PROD",
+            database="prod_warehouse",
+        )
+        urn = FivetranSource.build_destination_urn(
+            destination_table="orders.line_items",
+            destination_details=details,
+            mdl_cfg=None,
+        )
+        assert (
+            str(urn)
+            == "urn:li:dataset:(urn:li:dataPlatform:snowflake,prod_warehouse.orders.line_items,PROD)"
+        )
+
+    def test_relational_branch_strips_schema_when_disabled(self):
+        details = PlatformDetail(
+            platform="snowflake",
+            env="PROD",
+            database="prod_warehouse",
+            include_schema_in_urn=False,
+        )
+        urn = FivetranSource.build_destination_urn(
+            destination_table="orders.line_items",
+            destination_details=details,
+            mdl_cfg=None,
+        )
+        assert (
+            str(urn)
+            == "urn:li:dataset:(urn:li:dataPlatform:snowflake,prod_warehouse.line_items,PROD)"
+        )

--- a/metadata-ingestion/tests/unit/fivetran/test_fivetran_managed_data_lake.py
+++ b/metadata-ingestion/tests/unit/fivetran/test_fivetran_managed_data_lake.py
@@ -41,19 +41,14 @@ class TestManagedDataLakeConfigValidation:
         "unimplemented_catalog_type",
         ["iceberg_rest", "unity", "biglake", "onelake"],
     )
-    def test_non_glue_catalog_raises_not_implemented_at_urn_time(
-        self, unimplemented_catalog_type
-    ):
-        # The Literal accepts the value (forward-compat for future catalog
-        # backends) but URN construction raises NotImplementedError until
-        # the branch is wired up.
-        details = PlatformDetail(platform="managed_data_lake", env="PROD")
-        with pytest.raises(NotImplementedError, match="not implemented yet"):
-            FivetranSource.build_destination_urn(
-                destination_table="orders.line_items",
-                destination_details=details,
-                mdl_cfg=_mdl_config(catalog_type=unimplemented_catalog_type),
-            )
+    def test_non_glue_catalog_rejected_at_config_load(self, unimplemented_catalog_type):
+        # The Literal accepts the value for forward compatibility, but the
+        # field validator rejects it at recipe-load time so the failure
+        # surfaces before any ingestion work runs (rather than mid-loop in
+        # URN construction). Match a stable substring rather than the full
+        # error wording.
+        with pytest.raises(ValueError, match="catalog_type"):
+            _mdl_config(catalog_type=unimplemented_catalog_type)
 
 
 class TestManagedDataLakeUrnConstruction:
@@ -86,6 +81,30 @@ class TestManagedDataLakeUrnConstruction:
             str(urn)
             == "urn:li:dataset:(urn:li:dataPlatform:glue,ft_orders.line_items,PROD)"
         )
+
+    def test_unqualified_destination_table_raises(self):
+        # If a table name reaches us without a "<schema>." prefix, the Glue
+        # database name can't be derived. Better to fail loudly than to emit
+        # a URN with an empty table component (e.g., `fivetran_orders.`).
+        details = PlatformDetail(platform="managed_data_lake", env="PROD")
+        with pytest.raises(ValueError, match="schema"):
+            FivetranSource.build_destination_urn(
+                destination_table="orders",  # no '.' separator
+                destination_details=details,
+                mdl_cfg=_mdl_config(),
+            )
+
+    def test_missing_mdl_cfg_raises(self):
+        # The instance-method wrapper passes the MDL config through, but the
+        # static method is reachable directly (e.g., from tests). Guard it
+        # with a runtime ValueError rather than a stripped-under-`-O` assert.
+        details = PlatformDetail(platform="managed_data_lake", env="PROD")
+        with pytest.raises(ValueError, match="managed_data_lake_destination_config"):
+            FivetranSource.build_destination_urn(
+                destination_table="orders.line_items",
+                destination_details=details,
+                mdl_cfg=None,
+            )
 
     def test_glue_urn_with_platform_instance(self):
         details = PlatformDetail(

--- a/metadata-ingestion/tests/unit/fivetran/test_fivetran_preserve_case.py
+++ b/metadata-ingestion/tests/unit/fivetran/test_fivetran_preserve_case.py
@@ -1,0 +1,110 @@
+"""Unit tests for preserve_case behaviour on the Snowflake-engine branch.
+
+The Snowflake destination uppercases unquoted database/schema identifiers
+for backward compatibility with recipes from before the quoted-identifier
+migration. Catalog-linked databases (CLDs), used by the Fivetran Managed
+Data Lake Service when surfacing logs through Snowflake, retain
+case-preserving lowercase identifiers — so the uppercasing path emits
+queries against schemas that don't exist. `preserve_case=True` skips the
+uppercasing.
+"""
+
+from typing import Tuple
+from unittest.mock import MagicMock
+
+import pytest
+
+from datahub.ingestion.source.fivetran.fivetran_log_api import FivetranLogAPI
+from datahub.ingestion.source.fivetran.fivetran_query import FivetranLogQuery
+
+
+def _build_snowflake_setup(
+    monkeypatch: pytest.MonkeyPatch, preserve_case: bool
+) -> Tuple[MagicMock, FivetranLogQuery, str]:
+    """Run the static `_setup_snowflake_engine` with mocked engine creation.
+
+    Returns the (engine, query) pair plus the executed-USE-DATABASE statement
+    so tests can assert on the resolved identifier casing.
+    """
+    fake_engine = MagicMock()
+
+    def fake_create_engine(*_args, **_kwargs):
+        return fake_engine
+
+    # Patch in the same module that holds the import.
+    monkeypatch.setattr(
+        "datahub.ingestion.source.fivetran.fivetran_log_api.create_engine",
+        fake_create_engine,
+    )
+
+    snowflake_config = MagicMock()
+    snowflake_config.get_sql_alchemy_url.return_value = "snowflake://stub"
+    snowflake_config.get_options.return_value = {}
+
+    query = FivetranLogQuery()
+    FivetranLogAPI._setup_snowflake_engine(
+        snowflake_config=snowflake_config,
+        database="lh_source_fivetran_usw2",
+        log_schema="fivetran_metadata_test",
+        preserve_case=preserve_case,
+        fivetran_log_query=query,
+    )
+    # Pull the USE DATABASE statement that hit the engine.
+    use_db_call = fake_engine.execute.call_args[0][0]
+    return fake_engine, query, use_db_call
+
+
+class TestPreserveCaseSnowflakeBranch:
+    def test_preserve_case_true_passes_lowercase_identifiers_verbatim(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The crucial assertion: when preserve_case is set, the lowercase CLD
+        # schema name reaches set_schema/use_database without being uppercased.
+        # Without this fix, Snowflake emits queries against an uppercased
+        # schema that doesn't exist in the catalog-linked database.
+        _, query, use_db_sql = _build_snowflake_setup(monkeypatch, preserve_case=True)
+
+        assert use_db_sql == 'use database "lh_source_fivetran_usw2"'
+        assert query.schema_clause == '"fivetran_metadata_test".'
+
+    def test_preserve_case_false_uppercases_unquoted_identifiers(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The legacy backward-compat path: unquoted identifiers (as Snowflake
+        # would resolve them at parse time) get uppercased before being
+        # quoted. This is what existing Snowflake-warehouse recipes rely on.
+        _, query, use_db_sql = _build_snowflake_setup(monkeypatch, preserve_case=False)
+
+        assert use_db_sql == 'use database "LH_SOURCE_FIVETRAN_USW2"'
+        assert query.schema_clause == '"FIVETRAN_METADATA_TEST".'
+
+    def test_preserve_case_false_keeps_pre_quoted_identifier_unchanged(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Pre-quoted identifiers (e.g., names with special chars) must not
+        # be uppercased even on the legacy path — the user has signalled
+        # they want exact control by quoting.
+        fake_engine = MagicMock()
+        monkeypatch.setattr(
+            "datahub.ingestion.source.fivetran.fivetran_log_api.create_engine",
+            lambda *_a, **_kw: fake_engine,
+        )
+
+        snowflake_config = MagicMock()
+        snowflake_config.get_sql_alchemy_url.return_value = "snowflake://stub"
+        snowflake_config.get_options.return_value = {}
+
+        query = FivetranLogQuery()
+        FivetranLogAPI._setup_snowflake_engine(
+            snowflake_config=snowflake_config,
+            database='"My Mixed-Case DB"',
+            log_schema='"My-Schema"',
+            preserve_case=False,
+            fivetran_log_query=query,
+        )
+
+        use_db_sql = fake_engine.execute.call_args[0][0]
+        # Already-quoted input takes the else branch (no .upper()); the inner
+        # quotes get doubled per Snowflake escaping rules.
+        assert '"My Mixed-Case DB"' in use_db_sql
+        assert '"My-Schema"' in query.schema_clause

--- a/metadata-ingestion/tests/unit/fivetran/test_fivetran_preserve_case.py
+++ b/metadata-ingestion/tests/unit/fivetran/test_fivetran_preserve_case.py
@@ -18,38 +18,39 @@ from datahub.ingestion.source.fivetran.fivetran_log_api import FivetranLogAPI
 from datahub.ingestion.source.fivetran.fivetran_query import FivetranLogQuery
 
 
+def _make_cfg(database: str, log_schema: str, preserve_case: bool) -> MagicMock:
+    """Build a stub config exposing the attrs `_setup_snowflake_engine` reads."""
+    cfg = MagicMock()
+    cfg.get_sql_alchemy_url.return_value = "snowflake://stub"
+    cfg.get_options.return_value = {}
+    cfg.database = database
+    cfg.log_schema = log_schema
+    cfg.preserve_case = preserve_case
+    return cfg
+
+
 def _build_snowflake_setup(
     monkeypatch: pytest.MonkeyPatch, preserve_case: bool
 ) -> Tuple[MagicMock, FivetranLogQuery, str]:
     """Run the static `_setup_snowflake_engine` with mocked engine creation.
 
-    Returns the (engine, query) pair plus the executed-USE-DATABASE statement
-    so tests can assert on the resolved identifier casing.
+    Returns the (engine, query, executed-USE-DATABASE statement) tuple so
+    tests can assert on the resolved identifier casing.
     """
     fake_engine = MagicMock()
-
-    def fake_create_engine(*_args, **_kwargs):
-        return fake_engine
-
-    # Patch in the same module that holds the import.
     monkeypatch.setattr(
         "datahub.ingestion.source.fivetran.fivetran_log_api.create_engine",
-        fake_create_engine,
+        lambda *_a, **_kw: fake_engine,
     )
 
-    snowflake_config = MagicMock()
-    snowflake_config.get_sql_alchemy_url.return_value = "snowflake://stub"
-    snowflake_config.get_options.return_value = {}
-
-    query = FivetranLogQuery()
-    FivetranLogAPI._setup_snowflake_engine(
-        snowflake_config=snowflake_config,
+    cfg = _make_cfg(
         database="lh_source_fivetran_usw2",
         log_schema="fivetran_metadata_test",
         preserve_case=preserve_case,
-        fivetran_log_query=query,
     )
-    # Pull the USE DATABASE statement that hit the engine.
+
+    query = FivetranLogQuery()
+    FivetranLogAPI._setup_snowflake_engine(cfg, query)
     use_db_call = fake_engine.execute.call_args[0][0]
     return fake_engine, query, use_db_call
 
@@ -83,28 +84,25 @@ class TestPreserveCaseSnowflakeBranch:
     ) -> None:
         # Pre-quoted identifiers (e.g., names with special chars) must not
         # be uppercased even on the legacy path — the user has signalled
-        # they want exact control by quoting.
+        # they want exact control by quoting. Pin the exact emitted SQL
+        # since the quote-doubling behaviour is the most fragile part.
         fake_engine = MagicMock()
         monkeypatch.setattr(
             "datahub.ingestion.source.fivetran.fivetran_log_api.create_engine",
             lambda *_a, **_kw: fake_engine,
         )
 
-        snowflake_config = MagicMock()
-        snowflake_config.get_sql_alchemy_url.return_value = "snowflake://stub"
-        snowflake_config.get_options.return_value = {}
-
-        query = FivetranLogQuery()
-        FivetranLogAPI._setup_snowflake_engine(
-            snowflake_config=snowflake_config,
+        cfg = _make_cfg(
             database='"My Mixed-Case DB"',
             log_schema='"My-Schema"',
             preserve_case=False,
-            fivetran_log_query=query,
         )
+        query = FivetranLogQuery()
+        FivetranLogAPI._setup_snowflake_engine(cfg, query)
 
         use_db_sql = fake_engine.execute.call_args[0][0]
-        # Already-quoted input takes the else branch (no .upper()); the inner
-        # quotes get doubled per Snowflake escaping rules.
-        assert '"My Mixed-Case DB"' in use_db_sql
-        assert '"My-Schema"' in query.schema_clause
+        # Pre-quoted input takes the else branch (no .upper()); the wrapping
+        # quotes are doubled per Snowflake escaping rules so the identifier
+        # round-trips correctly when re-quoted by `use_database`/`set_schema`.
+        assert use_db_sql == 'use database """My Mixed-Case DB"""'
+        assert query.schema_clause == '"""My-Schema""".'


### PR DESCRIPTION
## Summary

- Adds a new `managed_data_lake` value to `FivetranLogConfig.destination_platform` for the Fivetran Managed Data Lake Service. The Fivetran Platform Connector log is read through a Snowflake catalog-linked database (CLD); emitted destination URNs target the underlying AWS Glue catalog instead of Snowflake.
- Adds a `preserve_case` flag on `SnowflakeDestinationConfig` (default `false`, preserving existing behaviour) and on the new `ManagedDataLakeDestinationConfig` (default `true`). When enabled, identifiers are passed through verbatim instead of being uppercased — required for case-preserving CLDs surfacing Glue/Iceberg-backed schemas.
- `catalog_type` is a forward-compatible `Literal["glue", "iceberg_rest", "unity", "biglake", "onelake"]` defaulting to `"glue"`. Only the Glue branch is implemented today; non-glue values raise `NotImplementedError` at URN construction time.

## Implementation notes

- The shared Snowflake-engine setup is extracted into `FivetranLogAPI._setup_snowflake_engine` and reused by both the `snowflake` and `managed_data_lake` branches (the Managed Data Lake log lives in a Snowflake CLD).
- `_query` skips sqlglot transpilation for `managed_data_lake` since the underlying engine is Snowflake.
- The destination URN shape is `urn:li:dataset:(urn:li:dataPlatform:glue, <glue_database_prefix><schema>.<table>, <env>)`. The `glue_database_prefix` defaults to `fivetran_` to match Fivetran's auto-naming convention.

## Test plan

- [x] New unit tests in `tests/unit/fivetran/test_fivetran_managed_data_lake.py` for URN construction, config defaults, and `NotImplementedError` for non-glue catalog types.
- [x] New unit tests in `tests/unit/fivetran/test_fivetran_preserve_case.py` for the Snowflake-engine `preserve_case` branch (verbatim lowercase, legacy uppercasing, pre-quoted identifier handling).
- [x] New integration test in `tests/integration/fivetran/test_fivetran.py::test_fivetran_with_managed_data_lake_dest` with a golden file showing Glue URNs for postgres → glue and confluent_cloud → glue lineage edges plus column-level lineage.
- [x] Existing snowflake/bigquery/databricks integration goldens unchanged (regression guard).
- [x] `./gradlew :metadata-ingestion:lintFix` passes.
- [x] `./gradlew :metadata-ingestion:lint` (ruff + mypy) passes for fivetran code.