### PR TITLE
debug(oracle): Add logging to investigate default_schema in view lineage

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/oracle.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/oracle.py
@@ -1402,14 +1402,25 @@ class OracleSource(SQLAlchemySource):
                 yield inspector
 
     def get_db_schema(self, dataset_identifier: str) -> Tuple[Optional[str], str]:
+        logger.info(
+            f"Oracle get_db_schema called: dataset_identifier='{dataset_identifier}', "
+            f"add_database_name_to_urn={self.config.add_database_name_to_urn}"
+        )
+
         try:
             # dataset_identifier is either "db.schema.table" or "schema.table"
             # depending on add_database_name_to_urn. parts[-3], parts[-2], parts[-1]
             # are db, schema, table respectively.
             parts = dataset_identifier.split(".")
+            logger.info(f"Oracle get_db_schema: parts={parts}, len={len(parts)}")
+
             if self.config.add_database_name_to_urn:
                 if len(parts) >= 3:
-                    return parts[-3], parts[-2]  # db, schema
+                    result = (parts[-3], parts[-2])  # db, schema
+                    logger.info(
+                        f"Oracle get_db_schema: returning (3+ parts with db): {result}"
+                    )
+                    return result
                 elif len(parts) >= 2:
                     # Identifier is missing the db component — fall back to config.
                     # Using str(None) here would produce "None.schema.table" URNs.
@@ -1421,16 +1432,26 @@ class OracleSource(SQLAlchemySource):
                         else None
                     )
                     db_name = self.config.database or urn_db or None
-                    return db_name, parts[-2]  # db (or None), schema
+                    result = (db_name, parts[-2])  # db (or None), schema
+                    logger.info(
+                        f"Oracle get_db_schema: returning (2 parts with db): {result}"
+                    )
+                    return result
             else:
                 if len(parts) >= 2:
-                    return None, parts[-2]  # schema only; no db in URNs
+                    result = (None, parts[-2])  # schema only; no db in URNs
+                    logger.info(
+                        f"Oracle get_db_schema: returning (2 parts no db): {result}"
+                    )
+                    return result
         except Exception as e:
+            logger.info(f"Oracle get_db_schema: Exception caught: {e}")
             logger.warning(
                 f"Error extracting schema from identifier {dataset_identifier}: {e}"
             )
 
         # Reached only on a malformed identifier (e.g. no dots) or an exception above.
+        logger.info("Oracle get_db_schema: falling back to super().get_db_schema()")
         return super().get_db_schema(dataset_identifier)
 
     @property

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
@@ -1190,6 +1190,11 @@ class SQLAlchemySource(StatefulIngestionSourceBase, TestableSource):
 
         Override this method in subclasses to customize how view lineage is registered.
         """
+        logger.info(
+            f"Adding view to aggregator: view_urn={view_urn}, "
+            f"default_db={default_db}, default_schema={default_schema}, "
+            f"definition_preview={view_definition[:100] if view_definition else 'None'}..."
+        )
         self.aggregator.add_view_definition(
             view_urn=view_urn,
             view_definition=view_definition,
@@ -1246,7 +1251,11 @@ class SQLAlchemySource(StatefulIngestionSourceBase, TestableSource):
                 default_db, default_schema = self.get_view_default_db_schema(
                     inspector, dataset_name
                 )
+                logger.info(
+                    f"View lineage setup for '{dataset_name}': default_db={default_db}, default_schema={default_schema}"
+                )
             except Exception as e:
+                logger.info(f"View lineage setup FAILED for '{dataset_name}': {e}")
                 self.report.warning(
                     "Failed to get default db and schema names for view",
                     context=dataset_name,


### PR DESCRIPTION
## Purpose

Add debug logging to investigate why unqualified table names in Oracle view definitions are not being resolved correctly when determining lineage.

## Problem Description

When an Oracle view references a table without specifying the schema (e.g., `FROM table_a` instead of `FROM schema_x.table_a`), the lineage is not being created correctly. The table URN should be `oracle,schema_x.table_a,PROD` but it appears to be looking for just `oracle,table_a,PROD`.

The `default_schema` mechanism exists and should handle this, but we need to understand where in the flow it's failing.

## Changes

Added info-level logging to track the entire flow:

### 1. Oracle.get_db_schema()
- Logs when called with dataset_identifier
- Shows how the identifier is parsed
- Displays the returned default_db and default_schema values

### 2. SQLCommonSource view processing
- Logs the default_db/default_schema values determined for each view
- Catches and logs any exceptions during determination

### 3. SQLCommonSource._add_view_to_aggregator()
- Confirms the values being passed to the SQL aggregator
- Shows view definition preview

## Expected Output

When processing a view like `schema_x.view_y`, you should see:

```
Oracle get_db_schema called: dataset_identifier='schema_x.view_y', add_database_name_to_urn=False
Oracle get_db_schema: parts=['schema_x', 'view_y'], len=2
Oracle get_db_schema: returning (2 parts no db): (None, 'schema_x')
View lineage setup for 'schema_x.view_y': default_db=None, default_schema=schema_x
Adding view to aggregator: view_urn=urn:li:dataset:(urn:li:dataPlatform:oracle,schema_x.view_y,PROD), default_db=None, default_schema=schema_x, definition_preview=SELECT col1, col2 FROM table_a...
```

## Testing

This is debug-only logging with no functional changes. To test:

1. Enable info-level logging for DataHub ingestion
2. Run Oracle ingestion with views that have unqualified table references
3. Check logs for the new log lines
4. Verify whether default_schema is being determined correctly

## Related Issues

- User report: View lineage not working for unqualified table names in Oracle
- Suspected: default_schema returning None or incorrect value

## Next Steps

Based on the log output, we'll identify:
1. Whether get_db_schema() is being called for views
2. What dataset_identifier value is being used
3. What default_schema value is extracted
4. Whether it's correctly passed to sqlglot_lineage

---

**Note**: This is a **draft PR for debugging purposes only**. It will not be merged as-is. Once we identify the root cause from the logs, we'll create a proper fix PR.