### PR TITLE
fix(ingestion/teradata): clear class-level caches on close to prevent OOM

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/teradata.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/teradata.py
@@ -1991,18 +1991,21 @@ ORDER by DataBaseName, TableName;
                 self._pooled_engine.dispose()
                 self._pooled_engine = None
 
-        # Clear class-level caches so memory is released between recipe runs in the
-        # same process. Without this, sequential recipes accumulate all TeradataTable
-        # objects (including view request_text) and creator metadata indefinitely.
-        with self._tables_cache_lock:
-            self._tables_cache.clear()
-            self._table_creator_cache.clear()
+        try:
+            # Clear class-level caches so memory is released between recipe runs in the
+            # same process. Without this, sequential recipes accumulate all TeradataTable
+            # objects (including view request_text) and creator metadata indefinitely.
+            with self._tables_cache_lock:
+                self._tables_cache.clear()
+                self._table_creator_cache.clear()
 
-        # Clear module-level LRU caches for the same reason — schema column/PK/FK
-        # data is per-connection and must not carry over to the next recipe run.
-        get_schema_columns.cache_clear()
-        get_schema_pk_constraints.cache_clear()
-        get_schema_foreign_keys.cache_clear()
+            # Clear module-level LRU caches for the same reason — schema column/PK/FK
+            # data is per-connection and must not carry over to the next recipe run.
+            get_schema_columns.cache_clear()
+            get_schema_pk_constraints.cache_clear()
+            get_schema_foreign_keys.cache_clear()
+        except Exception as e:
+            logger.warning(f"Failed to clear caches during close: {e}")
 
         # Report failed views summary
         super().close()

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/teradata.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/teradata.py
@@ -1991,5 +1991,18 @@ ORDER by DataBaseName, TableName;
                 self._pooled_engine.dispose()
                 self._pooled_engine = None
 
+        # Clear class-level caches so memory is released between recipe runs in the
+        # same process. Without this, sequential recipes accumulate all TeradataTable
+        # objects (including view request_text) and creator metadata indefinitely.
+        with self._tables_cache_lock:
+            self._tables_cache.clear()
+            self._table_creator_cache.clear()
+
+        # Clear module-level LRU caches for the same reason — schema column/PK/FK
+        # data is per-connection and must not carry over to the next recipe run.
+        get_schema_columns.cache_clear()
+        get_schema_pk_constraints.cache_clear()
+        get_schema_foreign_keys.cache_clear()
+
         # Report failed views summary
         super().close()

--- a/metadata-ingestion/tests/unit/test_teradata_source.py
+++ b/metadata-ingestion/tests/unit/test_teradata_source.py
@@ -476,6 +476,21 @@ class TestTeradataSource:
             # Replace the aggregator with our mock after creation
             source.aggregator = mock_aggregator
 
+            # Pre-populate class-level caches to verify they are cleared on close
+            source._tables_cache["db1"] = [
+                TeradataTable(
+                    database="db1",
+                    name="t1",
+                    description=None,
+                    object_type="Table",
+                    create_timestamp=datetime(2024, 1, 1),
+                    last_alter_name=None,
+                    last_alter_timestamp=None,
+                    request_text=None,
+                )
+            ]
+            source._table_creator_cache[("db1", "t1")] = "owner"
+
             with patch(
                 "datahub.ingestion.source.sql.two_tier_sql_source.TwoTierSQLAlchemySource.close"
             ) as mock_super_close:
@@ -483,6 +498,16 @@ class TestTeradataSource:
 
                 mock_aggregator.close.assert_called_once()
                 mock_super_close.assert_called_once()
+
+                # Class-level caches must be emptied so memory is released between
+                # sequential recipe runs in the same process (OOM fix for #7602).
+                assert len(source._tables_cache) == 0
+                assert len(source._table_creator_cache) == 0
+
+                # Module-level LRU caches must also be cleared between recipe runs.
+                assert get_schema_columns.cache_info().currsize == 0
+                assert get_schema_pk_constraints.cache_info().currsize == 0
+                assert get_schema_foreign_keys.cache_info().currsize == 0
 
     def test_make_lineage_queries_with_time_defaults(self):
         """Test that _make_lineage_queries works with automatic time defaults."""


### PR DESCRIPTION
## Summary

- `TeradataSource.close()` now clears `_tables_cache` and `_table_creator_cache` (class-level, shared across all instances in the same process) so memory is fully released between sequential recipe runs
- `close()` also calls `.cache_clear()` on the three module-level `@lru_cache` functions (`get_schema_columns`, `get_schema_pk_constraints`, `get_schema_foreign_keys`) for the same reason
- Extended `test_close_cleanup` to assert both caches are empty and all LRU caches are cleared after `close()` is called

## Root cause

When running multiple Teradata recipes in the same process (e.g. 10 recipes against ~500k datasets via the Python SDK), class-level caches accumulated `TeradataTable` objects — including full view `request_text` — across every recipe run because `close()` only disposed the SQLAlchemy engine and never cleared these caches. Combined with module-level LRU caches that held per-schema column/PK/FK metadata indefinitely, memory grew monotonically until the Kubernetes pod was OOM-killed.

Fixes Zendesk ticket #7602 (JPMC: Teradata ingestion pod OOM with 10 recipes / 500k datasets).

## Test plan

- [ ] `test_close_cleanup` now pre-populates both class-level caches and asserts they are empty post-`close()`, and asserts all three LRU `cache_info().currsize == 0`
- [ ] All 122 Teradata unit tests pass (`test_teradata_source.py`, `test_teradata_performance.py`, `test_teradata_integration.py`)
- [ ] Pre-commit hooks (lint) pass

## Checklist

- [x] PR conforms to Contributing Guidelines
- [x] Tests added/updated
- [ ] Docs added/updated (N/A — internal fix)
- [ ] Breaking changes documented (N/A)