### PR TITLE
refactor(ingest/looker): inject Looker creds via custom ApiSettings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,6 +248,7 @@ Forgetting step 2 means the release note is published but never appears in the s
   - **Data Structures**: Prefer dataclasses/pydantic for internal data, return dataclasses over tuples
   - **Code Quality**: Avoid global state, use named arguments, don't re-export in `__init__.py`, refactor repetitive code
   - **Error Handling**: Robust error handling with layers of protection for known failure points
+  - **Security**: Never pass credentials to third-party SDKs via `os.environ`. Use the SDK's programmatic injection mechanism (a settings object, client constructor argument, or credential provider). Writing secrets to the process environment exposes them via `/proc/<pid>/environ` and to any code in the same process. See [`looker_lib_wrapper.py`](metadata-ingestion/src/datahub/ingestion/source/looker/looker_lib_wrapper.py) (`_DataHubLookerApiSettings`) for the canonical pattern.
 - **TypeScript**: Use Prettier formatting, strict types (no `any`), React Testing Library
 
 ### Frontend Theming (Colors)

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_lib_wrapper.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_lib_wrapper.py
@@ -87,14 +87,16 @@ class _DataHubLookerApiSettings(looker_api_settings.ApiSettings):
 
     The default ApiSettings reads credentials from a ``looker.ini`` file or
     ``LOOKERSDK_*`` env vars. We override ``read_config`` so secrets never touch
-    the process environment (CWE-526).
+    the process environment.
     """
 
     def __init__(self, client_id: str, client_secret: str, base_url: str) -> None:
         self._client_id = client_id
         self._client_secret = client_secret
         self._base_url = base_url
-        # filename="" skips the looker.ini lookup; env_prefix=None disables env overrides.
+        # Our read_config() override is the actual guard against env/file lookup.
+        # filename="" and env_prefix=None just keep the parent __init__'s helpers
+        # (which it would otherwise call) from touching the filesystem or environment.
         super().__init__(
             filename="",
             section=None,

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_lib_wrapper.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_lib_wrapper.py
@@ -1,7 +1,6 @@
 # Looker SDK is imported here and higher level wrapper functions/classes are provided to interact with Looker Server
 import json
 import logging
-import os
 from enum import Enum
 from functools import lru_cache
 from typing import Dict, List, MutableMapping, Optional, Sequence, Set, Union, cast
@@ -9,7 +8,9 @@ from typing import Dict, List, MutableMapping, Optional, Sequence, Set, Union, c
 import looker_sdk
 import looker_sdk.rtl.requests_transport as looker_requests_transport
 from looker_sdk.error import SDKError
+from looker_sdk.rtl import api_settings as looker_api_settings
 from looker_sdk.rtl.transport import TransportOptions
+from looker_sdk.sdk import constants as looker_constants
 from looker_sdk.sdk.api40.models import (
     Dashboard,
     DashboardBase,
@@ -81,17 +82,45 @@ class LookerAPIStats(BaseModel):
     generate_sql_query_calls: int = 0
 
 
+class _DataHubLookerApiSettings(looker_api_settings.ApiSettings):
+    """Inject Looker credentials from memory instead of env vars or looker.ini.
+
+    The default ApiSettings reads credentials from a ``looker.ini`` file or
+    ``LOOKERSDK_*`` env vars. We override ``read_config`` so secrets never touch
+    the process environment (CWE-526).
+    """
+
+    def __init__(self, client_id: str, client_secret: str, base_url: str) -> None:
+        self._client_id = client_id
+        self._client_secret = client_secret
+        self._base_url = base_url
+        # filename="" skips the looker.ini lookup; env_prefix=None disables env overrides.
+        super().__init__(
+            filename="",
+            section=None,
+            sdk_version=looker_constants.sdk_version,
+            env_prefix=None,
+        )
+
+    def read_config(self) -> looker_api_settings.SettingsConfig:
+        return looker_api_settings.SettingsConfig(
+            client_id=self._client_id,
+            client_secret=self._client_secret,
+            base_url=self._base_url,
+        )
+
+
 class LookerAPI:
     """A holder class for a Looker client"""
 
     def __init__(self, config: LookerAPIConfig) -> None:
         self.config = config
-        # The Looker SDK wants these as environment variables
-        os.environ["LOOKERSDK_CLIENT_ID"] = config.client_id
-        os.environ["LOOKERSDK_CLIENT_SECRET"] = config.client_secret.get_secret_value()
-        os.environ["LOOKERSDK_BASE_URL"] = config.base_url
-
-        self.client = looker_sdk.init40()
+        settings = _DataHubLookerApiSettings(
+            client_id=config.client_id,
+            client_secret=config.client_secret.get_secret_value(),
+            base_url=config.base_url,
+        )
+        self.client = looker_sdk.init40(config_settings=settings)
 
         # Somewhat hacky mechanism for enabling retries on the Looker SDK.
         # Unfortunately, it doesn't expose a cleaner way to do this.

--- a/metadata-ingestion/tests/unit/looker/test_looker_lib_wrapper.py
+++ b/metadata-ingestion/tests/unit/looker/test_looker_lib_wrapper.py
@@ -1,0 +1,82 @@
+from unittest import mock
+
+import pytest
+
+from datahub.ingestion.source.looker.looker_lib_wrapper import (
+    LookerAPI,
+    LookerAPIConfig,
+    _DataHubLookerApiSettings,
+)
+
+_LOOKERSDK_ENV_VARS = (
+    "LOOKERSDK_CLIENT_ID",
+    "LOOKERSDK_CLIENT_SECRET",
+    "LOOKERSDK_BASE_URL",
+)
+
+
+@pytest.fixture
+def clean_lookersdk_env(monkeypatch):
+    for var in _LOOKERSDK_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+def _make_config() -> LookerAPIConfig:
+    return LookerAPIConfig(
+        base_url="https://looker.example.com",
+        client_id="test-client-id",
+        client_secret="test-client-secret",
+    )
+
+
+def test_credentials_not_written_to_environ(clean_lookersdk_env):
+    """LookerAPI must not leak credentials into os.environ (CWE-526)."""
+    import os
+
+    with mock.patch("looker_sdk.init40") as mock_init40:
+        mock_init40.return_value = mock.MagicMock()
+        LookerAPI(config=_make_config())
+
+    for var in _LOOKERSDK_ENV_VARS:
+        assert var not in os.environ, (
+            f"{var} should not be set in os.environ after LookerAPI init"
+        )
+
+
+def test_init40_called_with_in_memory_config_settings(clean_lookersdk_env):
+    """init40 must receive a config_settings instance carrying the credentials."""
+    config = _make_config()
+    with mock.patch("looker_sdk.init40") as mock_init40:
+        mock_init40.return_value = mock.MagicMock()
+        LookerAPI(config=config)
+
+    mock_init40.assert_called_once()
+    _, kwargs = mock_init40.call_args
+    settings = kwargs["config_settings"]
+
+    assert isinstance(settings, _DataHubLookerApiSettings)
+    assert settings.base_url == config.base_url
+
+    data = settings.read_config()
+    assert data["client_id"] == config.client_id
+    assert data["client_secret"] == config.client_secret.get_secret_value()
+    assert data["base_url"] == config.base_url
+
+
+def test_settings_read_config_ignores_lookersdk_env_vars(monkeypatch):
+    """read_config must return in-memory creds even if LOOKERSDK_* env vars are set."""
+    monkeypatch.setenv("LOOKERSDK_CLIENT_ID", "should-be-ignored")
+    monkeypatch.setenv("LOOKERSDK_CLIENT_SECRET", "should-be-ignored")
+    monkeypatch.setenv("LOOKERSDK_BASE_URL", "https://should-be-ignored.example.com")
+
+    settings = _DataHubLookerApiSettings(
+        client_id="real-id",
+        client_secret="real-secret",
+        base_url="https://real.example.com",
+    )
+
+    data = settings.read_config()
+    assert data["client_id"] == "real-id"
+    assert data["client_secret"] == "real-secret"
+    assert data["base_url"] == "https://real.example.com"
+    assert settings.base_url == "https://real.example.com"

--- a/metadata-ingestion/tests/unit/looker/test_looker_lib_wrapper.py
+++ b/metadata-ingestion/tests/unit/looker/test_looker_lib_wrapper.py
@@ -1,3 +1,4 @@
+import os
 from unittest import mock
 
 import pytest
@@ -30,9 +31,7 @@ def _make_config() -> LookerAPIConfig:
 
 
 def test_credentials_not_written_to_environ(clean_lookersdk_env):
-    """LookerAPI must not leak credentials into os.environ (CWE-526)."""
-    import os
-
+    """LookerAPI must not leak credentials into os.environ."""
     with mock.patch("looker_sdk.init40") as mock_init40:
         mock_init40.return_value = mock.MagicMock()
         LookerAPI(config=_make_config())
@@ -43,7 +42,7 @@ def test_credentials_not_written_to_environ(clean_lookersdk_env):
         )
 
 
-def test_init40_called_with_in_memory_config_settings(clean_lookersdk_env):
+def test_init40_called_with_in_memory_config_settings():
     """init40 must receive a config_settings instance carrying the credentials."""
     config = _make_config()
     with mock.patch("looker_sdk.init40") as mock_init40:


### PR DESCRIPTION
## Summary

The Looker source no longer writes `client_id`, `client_secret`, and `base_url` to `os.environ`. Instead, it constructs a custom `ApiSettings` subclass that returns credentials from in-memory state and passes it to `looker_sdk.init40(config_settings=...)`. Credentials never touch the process environment.

## Motivation

The previous implementation set `LOOKERSDK_CLIENT_ID`, `LOOKERSDK_CLIENT_SECRET`, and `LOOKERSDK_BASE_URL` in `os.environ` immediately before `looker_sdk.init40()`:

```python
os.environ[\"LOOKERSDK_CLIENT_ID\"] = config.client_id
os.environ[\"LOOKERSDK_CLIENT_SECRET\"] = config.client_secret.get_secret_value()
os.environ[\"LOOKERSDK_BASE_URL\"] = config.base_url
self.client = looker_sdk.init40()
```

This is problematic for two reasons:

1. **Security** — `LOOKERSDK_CLIENT_SECRET` is stored in plaintext in the process environment, accessible via `/proc/<pid>/environ` on Linux and to any code running in the same process.
2. **Unnecessary** — the Looker SDK provides a supported mechanism for programmatic credential injection via `init40(config_settings=...)`. The SDK's own README recommends this over env vars for production use.

A previous attempt (release `v0.3.17`) tried to clear the env vars _after_ init, but that doesn't work: `auth_session._login()` is lazy — it calls `self.settings.read_config()` on the first authenticated request, well after any cleanup would run, and the secret is still observable in the meantime.

## Changes Overview

**Refactoring:**
- New private class `_DataHubLookerApiSettings` (subclass of `looker_sdk.rtl.api_settings.ApiSettings`) that overrides `read_config()` to return credentials from instance state.
- `LookerAPI.__init__` now constructs this settings object and passes it via `looker_sdk.init40(config_settings=settings)`. The three `os.environ[...] = ...` writes and the now-unused `import os` are removed.

No changes to `LookerAPIConfig`, `transport_options`, retry logic, or any other source files. The configuration schema is unchanged.

## Architecture / Design Notes

The Looker SDK forces this approach. `ApiSettings` deliberately does **not** store `client_id` / `client_secret` as instance attributes — they only live inside the dict returned by `read_config()`, which `auth_session._login` calls lazily on every login. So:

- Setting `settings.client_id = ...` would be ignored.
- Setting then clearing `LOOKERSDK_*` env vars doesn't work because login is lazy.
- Subclassing and overriding `read_config()` is the SDK's documented extension point.

## Testing

**New unit tests** (`metadata-ingestion/tests/unit/looker/test_looker_lib_wrapper.py`):
- `test_credentials_not_written_to_environ` — asserts no `LOOKERSDK_*` keys appear in `os.environ` after `LookerAPI` construction.
- `test_init40_called_with_in_memory_config_settings` — asserts `looker_sdk.init40` receives a `_DataHubLookerApiSettings` whose `read_config()` returns the supplied credentials.
- `test_settings_read_config_ignores_lookersdk_env_vars` — asserts `read_config()` returns the in-memory creds even when `LOOKERSDK_*` env vars are set on the process.

**Existing tests:** all 74 looker/lookml unit tests pass. The looker integration tests that mock `looker_sdk.init40` are unaffected; the one that constructs a real `LookerAPI` (`test_independent_soft_deleted_looks`) passes.

**Live verification:** ran both `looker` and `lookml` ingestion against a real Looker instance.

Both runs successfully authenticated, proving the new `read_config()` path works end-to-end (login flow could not have completed otherwise).

**Lint:** `./gradlew :metadata-ingestion:lint` clean (ruff + ruff format + mypy on 2,285 files).

## Impact Assessment

- **Affected components:** `metadata-ingestion` Looker / LookML connectors only.
- **Breaking changes:** None. `LookerAPIConfig` schema, recipe format, and external behavior are unchanged. Anyone relying on the side effect of `LOOKERSDK_*` env vars being set after a Looker ingest run will find them missing — this is a private SDK detail and was not a documented contract.
- **Performance impact:** None.
- **Risk level:** Low. Tightly scoped (one source file, ~36 added / 7 removed lines), validated by both unit tests and a live ingestion run. No config or schema migration.

## Deployment Notes

None required.
