### PR TITLE
feat(cli): Add capability to pass recipe + secrets via stdin

### DIFF
--- a/metadata-ingestion/src/datahub/configuration/config_loader.py
+++ b/metadata-ingestion/src/datahub/configuration/config_loader.py
@@ -202,13 +202,32 @@ def load_config_file(
     allow_remote: bool = True,  # TODO: Change the default to False.
     resolve_env_vars: bool = True,  # TODO: Change the default to False.
     process_directives: bool = False,
+    extra_env_vars: Optional[Dict[str, str]] = None,
 ) -> dict:
     config_mech: ConfigurationMechanism
     if allow_stdin and config_file == "-":
-        # If we're reading from stdin, we assume that the input is a YAML file.
-        # Note that YAML is a superset of JSON, so this will also read JSON files.
+        # Reading from stdin. Supports two formats:
+        # 1. Plain YAML/JSON recipe (backward compatible)
+        # 2. JSON envelope: {"__recipe_yaml__": "...", "__secrets__": {...}}
+        #    Secrets are merged into the env resolver without touching os.environ.
         config_mech = YamlConfigurationMechanism()
-        raw_config_file = sys.stdin.read()
+        raw_stdin = sys.stdin.read()
+
+        try:
+            import json as _json
+
+            envelope = _json.loads(raw_stdin)
+            if isinstance(envelope, dict) and "__recipe_yaml__" in envelope:
+                raw_config_file = envelope["__recipe_yaml__"]
+                stdin_secrets = envelope.get("__secrets__", {})
+                if stdin_secrets:
+                    extra_env_vars = {**(extra_env_vars or {}), **stdin_secrets}
+            else:
+                # Plain JSON (which is valid YAML) — treat as recipe
+                raw_config_file = raw_stdin
+        except (ValueError, _json.JSONDecodeError):
+            # Not JSON — treat as plain YAML
+            raw_config_file = raw_stdin
     else:
         config_file_path = pathlib.Path(config_file)
         if config_file_path.suffix in {".yaml", ".yml"}:
@@ -256,7 +275,10 @@ def load_config_file(
 
     config = raw_config.copy()
     if resolve_env_vars:
-        config = EnvResolver(environ=os.environ).resolve(config)
+        environ: Environ = os.environ
+        if extra_env_vars:
+            environ = {**os.environ, **extra_env_vars}
+        config = EnvResolver(environ=environ).resolve(config)
     if process_directives:
         config = _process_directives(config)
 

--- a/metadata-ingestion/tests/unit/config/test_config_loader.py
+++ b/metadata-ingestion/tests/unit/config/test_config_loader.py
@@ -1,3 +1,5 @@
+import io
+import json
 import os
 import pathlib
 import textwrap
@@ -195,6 +197,140 @@ def test_load_error(pytestconfig, filename, env, error_type):
 
     with mock.patch.dict(os.environ, env), pytest.raises(error_type):
         _ = load_config_file(filepath)
+
+
+class TestStdinEnvelopeWithSecrets:
+    """Tests for the stdin envelope format: {"__recipe_yaml__": ..., "__secrets__": ...}."""
+
+    def test_envelope_secrets_resolve_variables(self) -> None:
+        """Secrets from stdin envelope should resolve ${VAR} in the recipe."""
+        recipe_yaml = "source:\n  type: test\n  config:\n    password: ${DB_PASS}\n    host: localhost\n"
+        envelope_json = json.dumps(
+            {
+                "__recipe_yaml__": recipe_yaml,
+                "__secrets__": {"DB_PASS": "my_secret_password"},
+            }
+        )
+
+        with mock.patch("sys.stdin", io.StringIO(envelope_json)):
+            config = load_config_file("-", allow_stdin=True, resolve_env_vars=True)
+
+        assert config["source"]["config"]["password"] == "my_secret_password"
+        assert config["source"]["config"]["host"] == "localhost"
+
+    def test_envelope_secrets_do_not_touch_os_environ(self) -> None:
+        """Secrets from the envelope must NOT be written to os.environ."""
+        recipe_yaml = "source:\n  type: test\n  config:\n    token: ${SECRET_TOKEN}\n"
+        envelope_json = json.dumps(
+            {
+                "__recipe_yaml__": recipe_yaml,
+                "__secrets__": {"SECRET_TOKEN": "tok_abc123"},
+            }
+        )
+
+        # Ensure not in env before
+        assert "SECRET_TOKEN" not in os.environ
+
+        with mock.patch("sys.stdin", io.StringIO(envelope_json)):
+            config = load_config_file("-", allow_stdin=True, resolve_env_vars=True)
+
+        assert config["source"]["config"]["token"] == "tok_abc123"
+        # Must NOT leak to os.environ
+        assert "SECRET_TOKEN" not in os.environ
+
+    def test_envelope_secrets_override_env_vars(self) -> None:
+        """Secrets from the envelope should take priority over os.environ."""
+        recipe_yaml = "source:\n  type: test\n  config:\n    key: ${MY_KEY}\n"
+        envelope_json = json.dumps(
+            {
+                "__recipe_yaml__": recipe_yaml,
+                "__secrets__": {"MY_KEY": "from_envelope"},
+            }
+        )
+
+        with (
+            mock.patch.dict(os.environ, {"MY_KEY": "from_env"}),
+            mock.patch("sys.stdin", io.StringIO(envelope_json)),
+        ):
+            config = load_config_file("-", allow_stdin=True, resolve_env_vars=True)
+
+        # Envelope secrets take priority
+        assert config["source"]["config"]["key"] == "from_envelope"
+
+    def test_envelope_falls_back_to_env_for_unresolved(self) -> None:
+        """Variables not in __secrets__ should still resolve from os.environ."""
+        recipe_yaml = "source:\n  type: test\n  config:\n    a: ${FROM_SECRETS}\n    b: ${FROM_ENV}\n"
+        envelope_json = json.dumps(
+            {
+                "__recipe_yaml__": recipe_yaml,
+                "__secrets__": {"FROM_SECRETS": "secret_val"},
+            }
+        )
+
+        with (
+            mock.patch.dict(os.environ, {"FROM_ENV": "env_val"}),
+            mock.patch("sys.stdin", io.StringIO(envelope_json)),
+        ):
+            config = load_config_file("-", allow_stdin=True, resolve_env_vars=True)
+
+        assert config["source"]["config"]["a"] == "secret_val"
+        assert config["source"]["config"]["b"] == "env_val"
+
+    def test_plain_yaml_stdin_still_works(self) -> None:
+        """Plain YAML on stdin (no envelope) should work as before."""
+        plain_yaml = "source:\n  type: test\n  config:\n    host: localhost\n"
+
+        with mock.patch("sys.stdin", io.StringIO(plain_yaml)):
+            config = load_config_file("-", allow_stdin=True, resolve_env_vars=True)
+
+        assert config["source"]["config"]["host"] == "localhost"
+
+    def test_plain_json_stdin_still_works(self) -> None:
+        """Plain JSON on stdin (no __recipe_yaml__ key) should work as a recipe."""
+        plain_json = json.dumps(
+            {"source": {"type": "test", "config": {"host": "localhost"}}}
+        )
+
+        with mock.patch("sys.stdin", io.StringIO(plain_json)):
+            config = load_config_file("-", allow_stdin=True, resolve_env_vars=True)
+
+        assert config["source"]["config"]["host"] == "localhost"
+
+    def test_envelope_with_empty_secrets(self) -> None:
+        """Envelope with empty __secrets__ dict should work (no extra resolution)."""
+        recipe_yaml = "source:\n  type: test\n  config:\n    host: localhost\n"
+        envelope_json = json.dumps(
+            {
+                "__recipe_yaml__": recipe_yaml,
+                "__secrets__": {},
+            }
+        )
+
+        with mock.patch("sys.stdin", io.StringIO(envelope_json)):
+            config = load_config_file("-", allow_stdin=True, resolve_env_vars=True)
+
+        assert config["source"]["config"]["host"] == "localhost"
+
+    def test_extra_env_vars_parameter_merges_with_envelope_secrets(self) -> None:
+        """extra_env_vars parameter should merge with envelope __secrets__."""
+        recipe_yaml = "source:\n  type: test\n  config:\n    a: ${FROM_PARAM}\n    b: ${FROM_ENVELOPE}\n"
+        envelope_json = json.dumps(
+            {
+                "__recipe_yaml__": recipe_yaml,
+                "__secrets__": {"FROM_ENVELOPE": "envelope_val"},
+            }
+        )
+
+        with mock.patch("sys.stdin", io.StringIO(envelope_json)):
+            config = load_config_file(
+                "-",
+                allow_stdin=True,
+                resolve_env_vars=True,
+                extra_env_vars={"FROM_PARAM": "param_val"},
+            )
+
+        assert config["source"]["config"]["a"] == "param_val"
+        assert config["source"]["config"]["b"] == "envelope_val"
 
 
 def test_write_file_directive(pytestconfig):


### PR DESCRIPTION
Backward compatible capability to pass recipe + secrets via stdin, to avoid using environmental variables for that.