### PR TITLE
docs(remote-executor): document AWS and GCP Secret Manager usage

### DIFF
--- a/docs/managed-datahub/operator-guide/setting-up-remote-ingestion-executor.md
+++ b/docs/managed-datahub/operator-guide/setting-up-remote-ingestion-executor.md
@@ -394,6 +394,125 @@ New Ingestion Sources will automatically use your designated Default Pool if you
   <img width="90%"  src="https://github.com/datahub-project/static-assets/blob/main/imgs/remote-executor/view-ingestion-running.png?raw=true"/>
 </p>
 
+## Using Cloud Secret Managers
+
+You can configure the Remote Executor to resolve secrets directly from AWS Secrets Manager or GCP Secret Manager. This lets you manage credentials in your cloud provider instead of storing them inside DataHub. Secrets resolved this way are available to all executor workflows, including ingestion and assertions.
+
+Secrets are referenced using the standard `${SECRET_NAME}` syntax — no changes needed to existing configurations. The executor automatically prepends a configurable prefix (default: `datahub-`) when looking up secrets. For example, `${SNOWFLAKE_PASSWORD}` resolves to a secret named `datahub-SNOWFLAKE_PASSWORD` in your cloud provider. You can override this prefix using `DATAHUB_EXECUTOR_AWS_SM_PREFIX` (for AWS) or `DATAHUB_EXECUTOR_GCP_SM_PREFIX` (for GCP) — for example, setting it to `myapp-` would resolve `${SNOWFLAKE_PASSWORD}` to `myapp-SNOWFLAKE_PASSWORD` instead.
+
+### AWS Secrets Manager
+
+#### 1. Create your secrets
+
+Store each credential as a plain string value:
+
+```bash
+aws secretsmanager create-secret --region us-west-2 \
+  --name "datahub-SNOWFLAKE_PASSWORD" \
+  --secret-string "my-secret-value"
+```
+
+#### 2. Grant the executor IAM permissions
+
+The pod running the executor needs the following IAM permissions. Attach this policy to the pod's IAM role ([IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) on EKS, or [Task Role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html) on ECS):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:BatchGetSecretValue",
+        "secretsmanager:GetSecretValue"
+      ],
+      "Resource": "arn:aws:secretsmanager:<region>:<account-id>:secret:datahub-*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "secretsmanager:ListSecrets",
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+If you use a custom prefix, update the `Resource` pattern to match (e.g., `myapp-*` instead of `datahub-*`).
+
+#### 3. Enable on the executor
+
+Set these environment variables on the executor:
+
+| Variable                            | Required | Default    | Description                                  |
+| ----------------------------------- | -------- | ---------- | -------------------------------------------- |
+| `DATAHUB_EXECUTOR_AWS_SM_ENABLED`   | Yes      | `false`    | Set to `true` to enable                      |
+| `DATAHUB_EXECUTOR_AWS_SM_REGION`    | Yes      | —          | AWS region (e.g., `us-west-2`)               |
+| `DATAHUB_EXECUTOR_AWS_SM_PREFIX`    | No       | `datahub-` | Prefix prepended to secret names             |
+| `DATAHUB_EXECUTOR_SECRET_CACHE_TTL` | No       | `21600`    | Cache duration in seconds (default: 6 hours) |
+
+**Helm example:**
+
+```yaml
+extraEnvs:
+  - name: DATAHUB_EXECUTOR_AWS_SM_ENABLED
+    value: "true"
+  - name: DATAHUB_EXECUTOR_AWS_SM_REGION
+    value: "us-west-2"
+```
+
+For IRSA, annotate the service account:
+
+```yaml
+serviceAccount:
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::<account-id>:role/<executor-role>"
+```
+
+### GCP Secret Manager
+
+#### 1. Create your secrets
+
+```bash
+echo -n "my-secret-value" | gcloud secrets create "datahub-SNOWFLAKE_PASSWORD" \
+  --project="<project-id>" --data-file=-
+```
+
+#### 2. Grant the executor access to secrets
+
+Grant the **Secret Manager Secret Accessor** role (`roles/secretmanager.secretAccessor`) to the executor's GCP service account. On GKE, use [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) to bind a Kubernetes service account to a GCP service account.
+
+The following command grants access to all secrets with the `datahub-` prefix. Update the prefix if you configured a custom one:
+
+```bash
+gcloud projects add-iam-policy-binding "<project-id>" \
+  --member="serviceAccount:<sa>@<project-id>.iam.gserviceaccount.com" \
+  --role="roles/secretmanager.secretAccessor" \
+  --condition='expression=resource.name.startsWith("projects/<project-id>/secrets/datahub-"),title=DataHub executor secrets'
+```
+
+#### 3. Enable on the executor
+
+| Variable                             | Required | Default    | Description                                  |
+| ------------------------------------ | -------- | ---------- | -------------------------------------------- |
+| `DATAHUB_EXECUTOR_GCP_SM_ENABLED`    | Yes      | `false`    | Set to `true` to enable                      |
+| `DATAHUB_EXECUTOR_GCP_SM_PROJECT_ID` | Yes      | —          | GCP project ID                               |
+| `DATAHUB_EXECUTOR_GCP_SM_PREFIX`     | No       | `datahub-` | Prefix prepended to secret names             |
+| `DATAHUB_EXECUTOR_SECRET_CACHE_TTL`  | No       | `21600`    | Cache duration in seconds (default: 6 hours) |
+
+**Helm example:**
+
+```yaml
+extraEnvs:
+  - name: DATAHUB_EXECUTOR_GCP_SM_ENABLED
+    value: "true"
+  - name: DATAHUB_EXECUTOR_GCP_SM_PROJECT_ID
+    value: "my-gcp-project"
+
+serviceAccount:
+  annotations:
+    iam.gke.io/gcp-service-account: "<sa>@<project-id>.iam.gserviceaccount.com"
+```
+
 ## Advanced: Performance Settings and Task Weight-Based Queuing
 
 Executors use a weight-based queuing system to manage resource allocation efficiently:
@@ -440,9 +559,9 @@ The following environment variables can be configured to manage memory-intensive
 
 ### Frequently Asked Questions
 
-**Do AWS Secrets Manager secrets automatically update in the executor?**
+**Do cloud secret manager values automatically update in the executor?**
 
-No. Secrets are wired into the executor container at deployment time. The ECS Task needs to be restarted when secrets change.
+Yes, with a delay. Resolved secrets are cached in memory for 6 hours by default (configurable via `DATAHUB_EXECUTOR_SECRET_CACHE_TTL`). After you update a secret in AWS or GCP, the executor picks up the new value once the cache expires. To force an immediate refresh, restart the executor.
 
 **How can I verify successful deployment?**
 

--- a/docs/managed-datahub/operator-guide/setting-up-remote-ingestion-executor.md
+++ b/docs/managed-datahub/operator-guide/setting-up-remote-ingestion-executor.md
@@ -396,9 +396,44 @@ New Ingestion Sources will automatically use your designated Default Pool if you
 
 ## Using Cloud Secret Managers
 
-You can configure the Remote Executor to resolve secrets directly from AWS Secrets Manager or GCP Secret Manager. This lets you manage credentials in your cloud provider instead of storing them inside DataHub. Secrets resolved this way are available to all executor workflows, including ingestion and assertions.
+You can configure the Remote Executor to resolve secrets directly from AWS Secrets Manager or GCP Secret Manager at runtime. This lets you manage credentials in your cloud provider instead of storing them inside DataHub. Secrets resolved this way are available to all executor workflows, including ingestion and assertions.
+
+:::note
+This is different from the AWS Secrets Manager integration used by the [ECS CloudFormation deployment](#deploy-on-amazon-ecs), where secrets are wired into the executor container at deploy time via the `SECRET_NAME=SECRET_ARN` template parameter. That mechanism still works as before and requires the ECS task to be restarted whenever a secret value changes. The integration described in this section runs inside the executor itself, looks up secrets on demand, and applies to both ECS and Kubernetes deployments.
+:::
 
 Secrets are referenced using the standard `${SECRET_NAME}` syntax — no changes needed to existing configurations. The executor automatically prepends a configurable prefix (default: `datahub-`) when looking up secrets. For example, `${SNOWFLAKE_PASSWORD}` resolves to a secret named `datahub-SNOWFLAKE_PASSWORD` in your cloud provider. You can override this prefix using `DATAHUB_EXECUTOR_AWS_SM_PREFIX` (for AWS) or `DATAHUB_EXECUTOR_GCP_SM_PREFIX` (for GCP) — for example, setting it to `myapp-` would resolve `${SNOWFLAKE_PASSWORD}` to `myapp-SNOWFLAKE_PASSWORD` instead.
+
+### Naming Rules for Secrets and Prefixes
+
+The full secret name looked up in your cloud provider is `<prefix><variable-name>`. Each part has its own rules:
+
+**Variable name** (the `<variable-name>` part inside `${...}` in your recipe)
+
+The recipe parser extracts variables using the regex `\${(\w+)}`, where `\w` matches only `[A-Za-z0-9_]`. This means:
+
+- ✅ Allowed: ASCII letters, digits, and underscores (e.g., `${SNOWFLAKE_PASSWORD}`, `${db_user_1}`)
+- ❌ Not allowed: hyphens, dots, slashes, `@`, `+`, `=`, or any other special character
+
+**Use `UPPER_SNAKE_CASE` or `lower_snake_case`** for variable names.
+
+For full details on recipe variable syntax (including bash-style defaults), see [Secret Resolution in Recipes](../../secret-resolution.md).
+
+**Prefix** (`DATAHUB_EXECUTOR_AWS_SM_PREFIX` / `DATAHUB_EXECUTOR_GCP_SM_PREFIX`)
+
+The prefix must match `^[A-Za-z0-9_-]*$` — letters, digits, underscores, and hyphens. This is the intersection of AWS Secrets Manager and GCP Secret Manager naming rules and is enforced at startup; an invalid prefix causes the executor to fail with a configuration error. A non-empty prefix is recommended so the executor's IAM permissions can be scoped to a name pattern (see the IAM examples below).
+
+**Combined cloud secret name** (`<prefix><variable-name>`)
+
+**Examples**
+
+| Recipe reference        | Prefix     | Cloud secret name            | Result                    |
+| ----------------------- | ---------- | ---------------------------- | ------------------------- |
+| `${SNOWFLAKE_PASSWORD}` | `datahub-` | `datahub-SNOWFLAKE_PASSWORD` | ✅ Resolved               |
+| `${db_user_1}`          | `prod_`    | `prod_db_user_1`             | ✅ Resolved               |
+| `${SNOWFLAKE_PASSWORD}` | _(empty)_  | `SNOWFLAKE_PASSWORD`         | ✅ Resolved               |
+| `${snowflake-password}` | `datahub-` | _(never extracted)_          | ❌ Literal passed through |
+| `${snowflake.password}` | `datahub-` | _(never extracted)_          | ❌ Literal passed through |
 
 ### AWS Secrets Manager
 
@@ -559,9 +594,17 @@ The following environment variables can be configured to manage memory-intensive
 
 ### Frequently Asked Questions
 
-**Do cloud secret manager values automatically update in the executor?**
+**Do AWS Secrets Manager secrets wired in via CloudFormation automatically update in the executor?**
 
-Yes, with a delay. Resolved secrets are cached in memory for 6 hours by default (configurable via `DATAHUB_EXECUTOR_SECRET_CACHE_TTL`). After you update a secret in AWS or GCP, the executor picks up the new value once the cache expires. To force an immediate refresh, restart the executor.
+No. When using the [ECS CloudFormation deployment](#deploy-on-amazon-ecs), secrets passed via the `SECRET_NAME=SECRET_ARN` template parameter are wired into the executor container at deployment time. The ECS Task needs to be restarted when those secrets change.
+
+**Do values resolved by the runtime Cloud Secret Manager integration automatically update in the executor?**
+
+Yes, with a delay. When the executor uses the [runtime Cloud Secret Manager integration](#using-cloud-secret-managers) (AWS Secrets Manager or GCP Secret Manager), resolved values are cached in memory with a 6-hour TTL by default (configurable via `DATAHUB_EXECUTOR_SECRET_CACHE_TTL`). After you update a secret in AWS or GCP, the executor picks up the new value once the cache entry expires.
+
+Each executor workflow (ingestion, assertions, monitor training) uses its own secret manager instance, so caches are not shared between them. They all follow the same TTL behavior, but each instance expires independently from when it first cached a given value.
+
+To force an immediate refresh across all workflows, restart the executor.
 
 **How can I verify successful deployment?**
 


### PR DESCRIPTION
## Summary

- Adds a new **Using Cloud Secret Managers** section to the Remote Ingestion Executor operator guide, covering both AWS Secrets Manager and GCP Secret Manager.
- Documents the `${SECRET_NAME}` reference syntax, the configurable `datahub-` prefix, required env vars (`DATAHUB_EXECUTOR_AWS_SM_*`, `DATAHUB_EXECUTOR_GCP_SM_*`, `DATAHUB_EXECUTOR_SECRET_CACHE_TTL`), IAM/Workload Identity setup, and Helm snippets for each provider.
- Updates the FAQ entry on secret refresh: resolved values are cached in memory (default 6h, configurable) and pick up new values automatically once the cache expires — replacing the older "restart the ECS task" guidance.


## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Docs added/updated
- [x] Markdown formatted via `./gradlew :datahub-web-react:mdPrettierWrite`
- [ ] No code changes — tests not applicable
- [ ] No breaking changes

## Test plan

- [ ] Preview docs site locally with `scripts/dev/datahub-dev.sh docs` and verify the new section renders correctly under *Operator Guide → Setting Up Remote Ingestion Executor*
- [ ] Confirm the updated FAQ entry replaces the old AWS-only answer and reads correctly
- [ ] Confirm `markdown_format_check` CI job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)