### PR TITLE
fix(ci): fix Linear sync raw report argv for security_scan_linear_sync

### DIFF
--- a/.github/workflows/security-scan-linear-sync.yml
+++ b/.github/workflows/security-scan-linear-sync.yml
@@ -724,8 +724,11 @@ jobs:
           fi
           cmd=(python3 .github/scripts/security_scan_linear_sync.py --scanner trivy_grype)
           cmd+=("${files[@]}")
+          # --raw-report-paths uses action=append in the script: repeat the flag once per file.
           if [[ ${#raw_files[@]} -gt 0 ]]; then
-            cmd+=(--raw-report-paths "${raw_files[@]}")
+            for f in "${raw_files[@]}"; do
+              cmd+=(--raw-report-paths "$f")
+            done
           fi
           "${cmd[@]}"
 

--- a/.github/workflows/security-scan-linear-sync.yml
+++ b/.github/workflows/security-scan-linear-sync.yml
@@ -713,11 +713,6 @@ jobs:
             done
           fi
           raw_files=()
-          if [[ "${SCAN_WITH_TRIVY}" == "true" ]]; then
-            for f in scan-reports/trivy/*.json; do
-              [[ -f "${f}" ]] && raw_files+=("${f}")
-            done
-          fi
           if [[ "${SCAN_WITH_GRYPE}" == "true" ]]; then
             for f in scan-reports-raw/grype/*.json; do
               [[ -f "${f}" ]] && raw_files+=("${f}")
@@ -730,9 +725,7 @@ jobs:
           cmd=(python3 .github/scripts/security_scan_linear_sync.py --scanner trivy_grype)
           cmd+=("${files[@]}")
           if [[ ${#raw_files[@]} -gt 0 ]]; then
-            for f in "${raw_files[@]}"; do
-              cmd+=(--raw-report-paths "$f")
-            done
+            cmd+=(--raw-report-paths "${raw_files[@]}")
           fi
           "${cmd[@]}"
 


### PR DESCRIPTION
Pass all Grype raw JSON paths in a single --raw-report-paths batch. Repeating --raw-report-paths made only the last file effective. Remove the Trivy raw loop: those files duplicate merged reports already passed as report_paths.

Made-with: Cursor

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
