### PR TITLE
fix(swagger): allow caching to speed up swagger doc load time

### DIFF
--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -871,8 +871,6 @@ server:
     context-path: ${DATAHUB_GMS_BASE_PATH:/}
 
 springdoc:
-  cache:
-    disabled: false
   swagger-ui:
     path: ${path-mappings.${datahub.basePath:}:${datahub.basePath:}}/openapi/swagger-ui
     disable-swagger-default-url: true


### PR DESCRIPTION
Previously we had this setting in to allow for dynamic updating of entity endpoints at runtime, we've generally moved away from the implementation approach that warranted this setting so removing this should make swagger page loads much faster. 
