### PR TITLE
fix(graph): avoid logging GraphQL query contents in execute_graphql

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/graph/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/client.py
@@ -1289,13 +1289,15 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
         body: Dict = {
             "query": query,
         }
+        variable_keys: Optional[List[str]] = None
         if variables:
             body["variables"] = variables
+            variable_keys = list(variables.keys())
         if operation_name:
             body["operationName"] = operation_name
 
         logger.debug(
-            f"Executing {operation_name or ''} graphql query: {query} with variables: {json.dumps(variables)}"
+            f"Executing {operation_name or ''} graphql query: {query} with variables: {len(variable_keys) if variable_keys is not None else 0}"
         )
         result = self._post_generic(url, body)
         if result.get("errors"):


### PR DESCRIPTION
This change removes clear-text GraphQL query logging from execute_graphql in metadata-ingestion/src/datahub/ingestion/graph/client.py.

Previously, the debug log included the full query string. In some cases, GraphQL queries can contain inline sensitive values, which means secrets could be written to logs in clear text. This reduces the risk of leaking sensitive information through application logs while preserving useful debugging metadata. 

This is a low-risk security hardening change that prevents accidental secret exposure in logs.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_

-->
