### PR TITLE
fix(ingestion): remove platform filtering from cross-platform entity reporting

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/api/report.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/report.py
@@ -29,7 +29,6 @@ from datahub.metadata.schema_classes import (
 )
 from datahub.utilities.file_backed_collections import FileBackedDict
 from datahub.utilities.lossy_collections import LossyList, LossySentinel
-from datahub.utilities.urns.urn import guess_platform_name
 
 logger = logging.getLogger(__name__)
 LogLevel = Literal["ERROR", "WARNING", "INFO", "DEBUG"]
@@ -363,25 +362,6 @@ class ExamplesReport(Report, Closeable):
         aspectName: str,
         mcp: Union[MetadataChangeProposalClass, MetadataChangeProposalWrapper],
     ) -> None:
-        # Platform filtering: Most URNs encode their platform/source within the URN structure
-        # (e.g., urn:li:dataset:(urn:li:dataPlatform:snowflake,...) embeds "snowflake").
-        # However, some entity types like 'document' use a simpler URN format that doesn't
-        # include platform information (e.g., urn:li:document:<id>). These entity types are
-        # designed to be platform-agnostic since a single Document can aggregate content from
-        # multiple sources.
-        #
-        # IMPORTANT: For entity types that don't encode platform in their URN, we MUST skip
-        # the platform filter. Otherwise, guess_platform_name() returns None, the filter rejects
-        # all work units, and critical report statistics (aspects, aspects_by_subtypes_full_count)
-        # remain empty, breaking reporting for sources like Notion that emit Document entities.
-        #
-        # See: https://github.com/datahub-project/datahub/issues/XXXXX
-        platform_agnostic_entity_types = {"document"}
-
-        if entityType not in platform_agnostic_entity_types:
-            platform_name = guess_platform_name(urn)
-            if platform_name != self.get_platform():
-                return
         if is_lineage_aspect(entityType, aspectName):
             self._lineage_aspects_seen.add(aspectName)
         has_fine_grained_lineage = self._has_fine_grained_lineage(mcp)

--- a/metadata-ingestion/tests/unit/test_source.py
+++ b/metadata-ingestion/tests/unit/test_source.py
@@ -1,5 +1,10 @@
 from typing import Iterable
 
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.api.decorators import platform_name
+from datahub.ingestion.api.source import Source, SourceReport
+from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.metadata.schema_classes import (
     CalendarIntervalClass,
     DatasetLineageTypeClass,
@@ -14,12 +19,6 @@ from datahub.metadata.schema_classes import (
     UpstreamClass,
     UpstreamLineageClass,
 )
-
-from datahub.emitter.mcp import MetadataChangeProposalWrapper
-from datahub.ingestion.api.common import PipelineContext
-from datahub.ingestion.api.decorators import platform_name
-from datahub.ingestion.api.source import Source, SourceReport
-from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.utilities.urns.dataset_urn import DatasetUrn
 
 

--- a/metadata-ingestion/tests/unit/test_source.py
+++ b/metadata-ingestion/tests/unit/test_source.py
@@ -1,10 +1,5 @@
 from typing import Iterable
 
-from datahub.emitter.mcp import MetadataChangeProposalWrapper
-from datahub.ingestion.api.common import PipelineContext
-from datahub.ingestion.api.decorators import platform_name
-from datahub.ingestion.api.source import Source, SourceReport
-from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.metadata.schema_classes import (
     CalendarIntervalClass,
     DatasetLineageTypeClass,
@@ -19,6 +14,12 @@ from datahub.metadata.schema_classes import (
     UpstreamClass,
     UpstreamLineageClass,
 )
+
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.api.decorators import platform_name
+from datahub.ingestion.api.source import Source, SourceReport
+from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.utilities.urns.dataset_urn import DatasetUrn
 
 
@@ -437,3 +438,34 @@ def test_stale_entity_removal_excludes_all_aspects():
     assert source.source_report.aspects_by_subtypes == {
         "dataset": {"Table": {"status": 1, "subTypes": 1, "datasetProfile": 1}}
     }
+
+
+def test_report_tracks_cross_platform_and_container_entities():
+    """Container URNs and cross-platform dataset URNs must appear in report stats."""
+    source = FakeSource(PipelineContext(run_id="test_cross_platform"))
+
+    # container URN — no platform embedded, guess_platform_name() returns None
+    container_urn = "urn:li:container:abcdef1234567890abcdef1234567890"
+    # bigquery dataset — platform "bigquery" differs from source platform "fake"
+    bigquery_urn = str(
+        DatasetUrn.create_from_ids(
+            platform_id="bigquery",
+            table_name="proj.ds.tbl",
+            env="PROD",
+        )
+    )
+
+    for urn in (container_urn, bigquery_urn):
+        source.source_report.report_workunit(
+            MetadataChangeProposalWrapper(
+                entityUrn=urn,
+                aspect=StatusClass(removed=False),
+            ).as_workunit()
+        )
+
+    source.source_report.compute_stats()
+
+    assert "container" in source.source_report.aspects
+    assert "status" in source.source_report.aspects["container"]
+    assert "dataset" in source.source_report.aspects
+    assert "status" in source.source_report.aspects["dataset"]


### PR DESCRIPTION
## Description

This PR removes the platform filtering logic from the `_update_file_based_dict` method in the report module that was preventing cross-platform and container entities from being tracked in report statistics.

## Changes

### Source Code Changes
- **metadata-ingestion/src/datahub/ingestion/api/report.py**: Removed the platform filtering check that was rejecting work units for entities whose platform didn't match the source's platform. This filtering was causing:
  - Container entities (which are platform-agnostic) to be excluded from reports
  - Cross-platform dataset references (e.g., a Fake source referencing BigQuery datasets) to be excluded from reports
  - Report statistics (aspects, aspects_by_subtypes) to remain incomplete

### Test Changes
- **metadata-ingestion/tests/unit/test_source.py**: 
  - Reorganized imports to follow proper grouping conventions (third-party imports before local imports)
  - Added `test_report_tracks_cross_platform_and_container_entities()` test to verify that:
    - Container URNs are properly tracked in report statistics
    - Cross-platform dataset URNs are properly tracked in report statistics
    - Both entity types appear in the aspects breakdown

## Rationale

The previous implementation attempted to filter out work units from other platforms to keep reports focused on the source's own platform. However, this approach was too restrictive and broke reporting for:
1. Platform-agnostic entity types like containers that should be tracked regardless of platform
2. Legitimate cross-platform references where a source intentionally references entities from other platforms

The filtering logic was incomplete (only had a hardcoded exception for "document" type) and the better approach is to allow all entities to be tracked in report statistics.

## Test Plan

Added unit test `test_report_tracks_cross_platform_and_container_entities()` that verifies container and cross-platform dataset entities are properly tracked in source report statistics. Existing tests continue to pass.

https://claude.ai/code/session_017Q9DB2E8UN2ckpuaK4LiVK