### PR TITLE
fix(ingestV2): secret deletion always removes last secret instead of …

### DIFF
--- a/datahub-web-react/src/app/ingestV2/secret/SecretsList.tsx
+++ b/datahub-web-react/src/app/ingestV2/secret/SecretsList.tsx
@@ -108,7 +108,7 @@ export const SecretsList = ({ showCreateModal: isCreatingSecret, setShowCreateMo
     const start = (page - 1) * pageSize;
 
     const [editSecret, setEditSecret] = useState<SecretBuilderState | undefined>(undefined);
-    const [showConfirmDelete, setShowConfirmDelete] = useState<boolean>(false);
+    const [deletingSecretUrn, setDeletingSecretUrn] = useState<string | null>(null);
 
     const [deleteSecretMutation] = useDeleteSecretMutation();
     const [createSecretMutation] = useCreateSecretMutation();
@@ -141,7 +141,7 @@ export const SecretsList = ({ showCreateModal: isCreatingSecret, setShowCreateMo
                     message.error({ content: `Failed to remove secret: \n ${e.message || ''}`, duration: 3 });
                 }
             });
-        setShowConfirmDelete(false);
+        setDeletingSecretUrn(null);
         refetch();
     };
 
@@ -233,7 +233,7 @@ export const SecretsList = ({ showCreateModal: isCreatingSecret, setShowCreateMo
     };
 
     const handleDeleteClose = () => {
-        setShowConfirmDelete(false);
+        setDeletingSecretUrn(null);
     };
 
     const onEditSecret = (urnData: any) => {
@@ -289,30 +289,21 @@ export const SecretsList = ({ showCreateModal: isCreatingSecret, setShowCreateMo
             title: '',
             key: 'actions',
             render: (record: TableDataType) => (
-                <>
-                    <ButtonsContainer>
-                        <button type="button" onClick={() => onEditSecret(record)} aria-label="Edit secret">
-                            <Icon icon={PencilSimpleLine} />
-                        </button>
-                        <button
-                            type="button"
-                            className="delete-action"
-                            onClick={() => setShowConfirmDelete(true)}
-                            aria-label="Delete secret"
-                            data-test-id="delete-secret-action"
-                            data-icon="delete"
-                        >
-                            <Icon icon={Trash} color="red" />
-                        </button>
-                    </ButtonsContainer>
-                    <ConfirmationModal
-                        isOpen={showConfirmDelete}
-                        modalTitle="Confirm Secret Removal"
-                        modalText="Are you sure you want to remove this secret? Sources that use it may no longer work as expected."
-                        handleConfirm={() => deleteSecret(record.urn)}
-                        handleClose={handleDeleteClose}
-                    />
-                </>
+                <ButtonsContainer>
+                    <button type="button" onClick={() => onEditSecret(record)} aria-label="Edit secret">
+                        <Icon icon={PencilSimpleLine} />
+                    </button>
+                    <button
+                        type="button"
+                        className="delete-action"
+                        onClick={() => setDeletingSecretUrn(record.urn)}
+                        aria-label="Delete secret"
+                        data-test-id="delete-secret-action"
+                        data-icon="delete"
+                    >
+                        <Icon icon={Trash} color="red" />
+                    </button>
+                </ButtonsContainer>
             ),
             width: '100px',
         },
@@ -370,6 +361,13 @@ export const SecretsList = ({ showCreateModal: isCreatingSecret, setShowCreateMo
                 onUpdate={onUpdate}
                 onSubmit={onSubmit}
                 onCancel={onCancel}
+            />
+            <ConfirmationModal
+                isOpen={deletingSecretUrn !== null}
+                modalTitle="Confirm Secret Removal"
+                modalText="Are you sure you want to remove this secret? Sources that use it may no longer work as expected."
+                handleConfirm={() => deletingSecretUrn && deleteSecret(deletingSecretUrn)}
+                handleClose={handleDeleteClose}
             />
         </>
     );


### PR DESCRIPTION
…selected

ConfirmationModal was rendered inside the per-row table column renderer, sharing a single boolean `showConfirmDelete` state. When any delete button was clicked all rows' modals opened simultaneously, and confirming always triggered the last row's handleConfirm closure, deleting the wrong secret. Fix tracks the pending-deletion URN in `deletingSecretUrn: string | null` and renders a single ConfirmationModal at the component root.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
