### PR TITLE
perf(actions): optimize FilterTransformer with two-pass filtering for simple fields

### DIFF
--- a/datahub-actions/src/datahub_actions/plugin/transform/filter/filter_transformer.py
+++ b/datahub-actions/src/datahub_actions/plugin/transform/filter/filter_transformer.py
@@ -16,6 +16,7 @@ import json
 import logging
 from typing import Any, Dict, List, Optional, Union
 
+from avrogen.dict_wrapper import DictWrapper
 from pydantic import Field
 
 from datahub.configuration import ConfigModel
@@ -80,8 +81,7 @@ class FilterTransformer(Transformer):
 
         # Match Event Body - full filter on all configured fields
         if self.config.event is not None:
-            # Use to_obj() instead of json.loads(as_json()) to avoid JSON serialization round-trip
-            body_as_dict = env_event.event.to_obj()
+            body_as_dict = self._event_to_dict(env_event.event)
             for key, val in self.config.event.items():
                 if not self._matches(val, body_as_dict.get(key)):
                     return None
@@ -97,6 +97,42 @@ class FilterTransformer(Transformer):
             if not self._matches(expected_val, actual_val):
                 return False
         return True
+
+    def _event_to_dict(self, event: Any) -> Dict[str, Any]:
+        """
+        Convert event to dictionary representation.
+
+        Uses to_obj() if available (via DictWrapper inheritance) to avoid the JSON
+        serialization round-trip that happens with json.loads(as_json()). The round-trip
+        means: dict -> json.dumps() -> JSON string -> json.loads() -> dict, which involves
+        expensive serialization/deserialization. Calling to_obj() directly returns the dict
+        without the intermediate JSON string step.
+
+        Falls back to json.loads(as_json()) for Event implementations that don't inherit
+        from DictWrapper (though all current implementations do).
+
+        TODO: This runtime check could be removed by adding to_obj() as an abstract
+        method to the Event base class (which currently only defines as_json/from_json).
+
+        All current Event implementations inherit from avrogen-generated classes that
+        provide to_obj() via DictWrapper:
+        - MetadataChangeLogEvent (from MetadataChangeLogClass -> DictWrapper)
+        - EntityChangeEvent (from EntityChangeEventClass -> DictWrapper)
+        - RelationshipChangeEvent (from RelationshipChangeEventClass -> DictWrapper)
+        Making to_obj() part of the Event interface would eliminate this runtime check.
+
+        Args:
+            event: The event object to convert
+
+        Returns:
+            Dictionary representation of the event
+        """
+        if isinstance(event, DictWrapper):
+            # Optimized path - direct dict conversion without JSON serialization
+            return event.to_obj()
+        else:
+            # Fallback for Event implementations that don't inherit from DictWrapper
+            return json.loads(event.as_json())
 
     def _matches(self, match_val: Any, match_val_to: Any) -> bool:
         if isinstance(match_val, dict):

--- a/datahub-actions/src/datahub_actions/plugin/transform/filter/filter_transformer.py
+++ b/datahub-actions/src/datahub_actions/plugin/transform/filter/filter_transformer.py
@@ -34,11 +34,35 @@ class FilterTransformerConfig(ConfigModel):
 class FilterTransformer(Transformer):
     def __init__(self, config: FilterTransformerConfig):
         self.config: FilterTransformerConfig = config
+        # Extract simple top-level fields for fast path optimization
+        self._simple_field_checks = self._extract_simple_fields()
 
     @classmethod
     def create(cls, config_dict: dict, ctx: PipelineContext) -> "Transformer":
         config = FilterTransformerConfig.model_validate(config_dict)
         return cls(config)
+
+    def _extract_simple_fields(self) -> Dict[str, Any]:
+        """
+        Extract simple top-level string fields for fast rejection path.
+
+        These fields (entityType, entityUrn, aspectName, changeType) are:
+        - Always simple strings in MCL events
+        - Most commonly used in filters
+        - Can be checked via direct attribute access without dict conversion
+
+        This optimization avoids expensive as_json() + json.loads() conversion
+        for events that fail these basic checks.
+        """
+        if self.config.event is None:
+            return {}
+
+        # Only these 4 fields - guaranteed to be simple strings in MCL
+        SIMPLE_FIELDS = {"entityType", "entityUrn", "aspectName", "changeType"}
+
+        return {
+            key: val for key, val in self.config.event.items() if key in SIMPLE_FIELDS
+        }
 
     def transform(self, env_event: EventEnvelope) -> Optional[EventEnvelope]:
         logger.debug(f"Preparing to filter event {env_event}")
@@ -47,13 +71,32 @@ class FilterTransformer(Transformer):
         if not self._matches(self.config.event_type, env_event.event_type):
             return None
 
-        # Match Event Body.
+        # Fast rejection path - check simple fields directly on typed object
+        # This avoids as_json() + json.loads() conversion for events that fail basic checks
+        if self._simple_field_checks:
+            if not self._check_simple_fields_fast(env_event.event):
+                logger.debug("Event rejected by fast path filter")
+                return None  # Early rejection - no dict conversion needed
+
+        # Match Event Body - full filter on all configured fields
         if self.config.event is not None:
-            body_as_json_dict = json.loads(env_event.event.as_json())
+            # Use to_obj() instead of json.loads(as_json()) to avoid JSON serialization round-trip
+            body_as_dict = env_event.event.to_obj()
             for key, val in self.config.event.items():
-                if not self._matches(val, body_as_json_dict.get(key)):
+                if not self._matches(val, body_as_dict.get(key)):
                     return None
         return env_event
+
+    def _check_simple_fields_fast(self, event: Any) -> bool:
+        """
+        Fast rejection check on simple string fields.
+        Direct attribute access, no dict conversion needed.
+        """
+        for key, expected_val in self._simple_field_checks.items():
+            actual_val = getattr(event, key, None)
+            if not self._matches(expected_val, actual_val):
+                return False
+        return True
 
     def _matches(self, match_val: Any, match_val_to: Any) -> bool:
         if isinstance(match_val, dict):

--- a/datahub-actions/tests/unit/plugin/transform/filter/test_filter_transformer.py
+++ b/datahub-actions/tests/unit/plugin/transform/filter/test_filter_transformer.py
@@ -184,3 +184,189 @@ def test_no_match_when_list_filter_on_dict_obj():
         EventEnvelope(event_type=ENTITY_CHANGE_EVENT_V1_TYPE, event=test_event, meta={})
     )
     assert result is None
+
+
+class TestEventWithSimpleFields(Event, DictWrapper):
+    """Test event that simulates MCL structure with simple top-level fields."""
+
+    def __init__(
+        self,
+        entity_type: str,
+        entity_urn: str,
+        aspect_name: str,
+        change_type: str,
+        nested_field: Any = None,
+    ):
+        super().__init__()
+        self._inner_dict["entityType"] = entity_type
+        self._inner_dict["entityUrn"] = entity_urn
+        self._inner_dict["aspectName"] = aspect_name
+        self._inner_dict["changeType"] = change_type
+        if nested_field is not None:
+            self._inner_dict["aspect"] = nested_field
+
+    @property
+    def entityType(self) -> str:
+        return self._inner_dict["entityType"]
+
+    @property
+    def entityUrn(self) -> str:
+        return self._inner_dict["entityUrn"]
+
+    @property
+    def aspectName(self) -> str:
+        return self._inner_dict["aspectName"]
+
+    @property
+    def changeType(self) -> str:
+        return self._inner_dict["changeType"]
+
+    @classmethod
+    def from_obj(cls, obj: dict, tuples: bool = False) -> "TestEventWithSimpleFields":
+        return cls(
+            obj["entityType"],
+            obj["entityUrn"],
+            obj["aspectName"],
+            obj["changeType"],
+            obj.get("aspect"),
+        )
+
+    def to_obj(self, tuples: bool = False) -> dict:
+        return self._inner_dict
+
+    @classmethod
+    def from_json(cls, json_str: str) -> "TestEventWithSimpleFields":
+        json_obj = json.loads(json_str)
+        return TestEventWithSimpleFields.from_obj(json_obj)
+
+    def as_json(self) -> str:
+        return json.dumps(self.to_obj())
+
+
+def test_fast_path_rejects_on_entity_type_mismatch():
+    """Test that fast path correctly rejects based on entityType without dict conversion."""
+    filter_transformer_config = FilterTransformerConfig.model_validate(
+        {
+            "event_type": "MetadataChangeLogEvent_v1",
+            "event": {
+                "entityType": "dataHubExecutionRequest",
+                "aspectName": "dataHubExecutionRequestInput",
+            },
+        }
+    )
+    filter_transformer = FilterTransformer(filter_transformer_config)
+
+    # Event with different entityType should be rejected by fast path
+    test_event = TestEventWithSimpleFields(
+        entity_type="dataset",  # Doesn't match filter
+        entity_urn="urn:li:dataset:(urn:li:dataPlatform:kafka,test,PROD)",
+        aspect_name="dataHubExecutionRequestInput",
+        change_type="UPSERT",
+    )
+
+    result = filter_transformer.transform(
+        EventEnvelope(
+            event_type=METADATA_CHANGE_LOG_EVENT_V1_TYPE, event=test_event, meta={}
+        )
+    )
+
+    assert result is None
+
+
+def test_fast_path_rejects_on_aspect_name_mismatch():
+    """Test that fast path correctly rejects based on aspectName."""
+    filter_transformer_config = FilterTransformerConfig.model_validate(
+        {
+            "event_type": "MetadataChangeLogEvent_v1",
+            "event": {
+                "entityType": "dataHubExecutionRequest",
+                "aspectName": [
+                    "dataHubExecutionRequestInput",
+                    "dataHubExecutionRequestSignal",
+                ],
+            },
+        }
+    )
+    filter_transformer = FilterTransformer(filter_transformer_config)
+
+    # Event with different aspectName should be rejected by fast path
+    test_event = TestEventWithSimpleFields(
+        entity_type="dataHubExecutionRequest",
+        entity_urn="urn:li:dataHubExecutionRequest:test",
+        aspect_name="someOtherAspect",  # Doesn't match filter
+        change_type="UPSERT",
+    )
+
+    result = filter_transformer.transform(
+        EventEnvelope(
+            event_type=METADATA_CHANGE_LOG_EVENT_V1_TYPE, event=test_event, meta={}
+        )
+    )
+
+    assert result is None
+
+
+def test_fast_path_passes_then_full_filter_applies():
+    """Test that fast path passes simple checks, then full filter checks nested fields."""
+    filter_transformer_config = FilterTransformerConfig.model_validate(
+        {
+            "event_type": "MetadataChangeLogEvent_v1",
+            "event": {
+                "entityType": "dataHubExecutionRequest",
+                "aspectName": "dataHubExecutionRequestInput",
+                "changeType": "UPSERT",
+                "aspect": {"value": {"executorId": "default"}},  # Nested field
+            },
+        }
+    )
+    filter_transformer = FilterTransformer(filter_transformer_config)
+
+    # Event passes fast path but fails on nested field
+    test_event = TestEventWithSimpleFields(
+        entity_type="dataHubExecutionRequest",
+        entity_urn="urn:li:dataHubExecutionRequest:test",
+        aspect_name="dataHubExecutionRequestInput",
+        change_type="UPSERT",
+        nested_field={"value": {"executorId": "other"}},  # Doesn't match nested filter
+    )
+
+    result = filter_transformer.transform(
+        EventEnvelope(
+            event_type=METADATA_CHANGE_LOG_EVENT_V1_TYPE, event=test_event, meta={}
+        )
+    )
+
+    assert result is None
+
+
+def test_fast_path_and_full_filter_both_pass():
+    """Test that event passes both fast path and full filter."""
+    filter_transformer_config = FilterTransformerConfig.model_validate(
+        {
+            "event_type": "MetadataChangeLogEvent_v1",
+            "event": {
+                "entityType": "dataHubExecutionRequest",
+                "aspectName": "dataHubExecutionRequestInput",
+                "changeType": "UPSERT",
+                "aspect": {"value": {"executorId": "default"}},
+            },
+        }
+    )
+    filter_transformer = FilterTransformer(filter_transformer_config)
+
+    # Event passes both fast path and full filter
+    test_event = TestEventWithSimpleFields(
+        entity_type="dataHubExecutionRequest",
+        entity_urn="urn:li:dataHubExecutionRequest:test",
+        aspect_name="dataHubExecutionRequestInput",
+        change_type="UPSERT",
+        nested_field={"value": {"executorId": "default"}},  # Matches nested filter
+    )
+
+    result = filter_transformer.transform(
+        EventEnvelope(
+            event_type=METADATA_CHANGE_LOG_EVENT_V1_TYPE, event=test_event, meta={}
+        )
+    )
+
+    assert result is not None

--- a/datahub-actions/tests/unit/plugin/transform/filter/test_filter_transformer.py
+++ b/datahub-actions/tests/unit/plugin/transform/filter/test_filter_transformer.py
@@ -370,3 +370,70 @@ def test_fast_path_and_full_filter_both_pass():
     )
 
     assert result is not None
+    assert result.event == test_event
+
+
+class NonDictWrapperEvent(Event):
+    """Event implementation that does NOT inherit from DictWrapper.
+
+    This simulates a hypothetical Event implementation that only implements
+    the Event interface (as_json/from_json) but not to_obj(). Used to test
+    the fallback path in FilterTransformer._event_to_dict().
+    """
+
+    def __init__(self, field1: Any, field2: Any):
+        self.field1 = field1
+        self.field2 = field2
+
+    @classmethod
+    def from_json(cls, json_str: str) -> "NonDictWrapperEvent":
+        obj = json.loads(json_str)
+        return cls(obj["field1"], obj["field2"])
+
+    def as_json(self) -> str:
+        """Only implements as_json() - no to_obj() method."""
+        return json.dumps({"field1": self.field1, "field2": self.field2})
+
+
+def test_fallback_path_for_non_dictwrapper_event():
+    """Test that FilterTransformer works with Events that don't inherit from DictWrapper.
+
+    This verifies the fallback path in _event_to_dict() which uses json.loads(as_json())
+    when to_obj() is not available via DictWrapper inheritance.
+    """
+    filter_transformer_config = FilterTransformerConfig.model_validate(
+        {
+            "event_type": "EntityChangeEvent_v1",
+            "event": {"field1": "test", "field2": 123},
+        }
+    )
+    filter_transformer = FilterTransformer(filter_transformer_config)
+
+    # This event only has as_json(), not to_obj()
+    test_event = NonDictWrapperEvent("test", 123)
+
+    result = filter_transformer.transform(
+        EventEnvelope(event_type=ENTITY_CHANGE_EVENT_V1_TYPE, event=test_event, meta={})
+    )
+
+    # Should match using the fallback path and return the same event
+    assert result is not None
+    assert result.event == test_event
+
+
+def test_fallback_path_rejects_non_match():
+    """Test that fallback path correctly rejects events that don't match filter."""
+    filter_transformer_config = FilterTransformerConfig.model_validate(
+        {"event_type": "EntityChangeEvent_v1", "event": {"field1": "expected"}}
+    )
+    filter_transformer = FilterTransformer(filter_transformer_config)
+
+    # This event only has as_json(), not to_obj()
+    test_event = NonDictWrapperEvent("different", 123)
+
+    result = filter_transformer.transform(
+        EventEnvelope(event_type=ENTITY_CHANGE_EVENT_V1_TYPE, event=test_event, meta={})
+    )
+
+    # Should reject using the fallback path
+    assert result is None


### PR DESCRIPTION
## Summary

Optimize FilterTransformer in datahub-actions with a two-pass filtering approach and type-safe event-to-dict conversion.

**Two-pass filtering:**
1. **Fast path**: Check simple top-level fields (entityType, entityUrn, aspectName, changeType) via direct attribute access
2. **Full filter**: Convert to dict and check all configured fields (only if fast path passes)

**Type-safe dict conversion:**
- Runtime check: Use `to_obj()` if event inherits from DictWrapper (all current implementations do)
- Fallback: Use `json.loads(as_json())` for hypothetical Event implementations without DictWrapper
- Avoids JSON serialization round-trip (dict → json.dumps() → JSON string → json.loads() → dict)
- Comprehensive TODO documents how to eliminate runtime check by adding `to_obj()` to Event interface

## Changes

- Add `_event_to_dict()` with `isinstance(DictWrapper)` runtime check
- Extract simple field checks in `__init__` via `_extract_simple_fields()`
- Fast rejection via `_check_simple_fields_fast()` using direct attribute access
- Add 2 tests for non-DictWrapper fallback path (match + reject cases)
- All 15 tests pass (13 original + 2 new)

## Performance Benefits

- **Events rejected by fast path**: Avoid dict conversion entirely
- **Events passing fast path**: Eliminate JSON serialization overhead

## Backward Compatibility

Fully backward compatible - works with any Event implementation (DictWrapper-based or not). Optimizes for the common case while maintaining type safety.

## Example Action Config

```
source:
  type: "kafka"
  config:
    connection:
      bootstrap: "localhost:9092"
      schema_registry_url: "http://localhost:8081"

action:
  type: "executor"
  config:
    executor_id: "default"

filter:
  event_type: MetadataChangeLogEvent_v1
  event:
    entityType: dataHubExecutionRequest
    aspectName: dataHubExecutionRequestInput
```

In this config, most MCL events could be rejected based on `entityType` and `aspectName`. The optimization avoids full round-trip json serialization for these rejected events.

