### PR TITLE
docs: link assertion alerts and embed Slack rich-alert example

### DIFF
--- a/docs/api/tutorials/subscriptions.md
+++ b/docs/api/tutorials/subscriptions.md
@@ -13,6 +13,10 @@ import TabItem from '@theme/TabItem';
 
 Subscriptions are a way to receive notifications when entity changes occur (e.g. deprecations, schema changes, ownership changes, etc.) or when assertions change state (pass, fail, or error). Subscriptions can be created at the dataset level (affecting any changes on the dataset, as well as all assertions on the dataset) or at the assertion level (affecting only specific assertions).
 
+:::tip
+For more on how assertion alerts are delivered (Slack DMs, channel notifications, incident alerts, EventBridge), see [Assertions › Alerts](../../managed-datahub/observe/assertions.md#alerts).
+:::
+
 ### Goal Of This Guide
 
 This guide specifically covers how to use the [DataHub Cloud Python SDK](https://pypi.org/project/acryl-datahub-cloud/) for managing Subscriptions:
@@ -80,6 +84,8 @@ The following change types are available for subscriptions:
 - `ASSERTION_PASSED` - When an assertion run passes
 - `ASSERTION_FAILED` - When an assertion run fails
 - `ASSERTION_ERROR` - When an assertion run encounters an error
+
+See [Assertions › Alerts](../../managed-datahub/observe/assertions.md#alerts) for details on how these events are delivered as alerts.
 
 #### Incident Status Changes
 

--- a/docs/managed-datahub/observe/assertions.md
+++ b/docs/managed-datahub/observe/assertions.md
@@ -78,6 +78,10 @@ If you opt for a 3rd party tool, it will be your responsibility to ensure the as
 
 Beyond the ability to see the results of the assertion checks (and history of the results) both on the physical asset’s page in the DataHub UI and as the result of DataHub API calls, you can also get notified via [Slack messages](/docs/managed-datahub/slack/saas-slack-setup.md) (DMs or to a team channel) based on your [subscription](https://youtu.be/VNNZpkjHG_I?t=79) to an assertion run event, or when an [incident](../../incidents/incidents.md) is raised or resolved. In the future, we’ll also provide the ability to subscribe directly to contracts.
 
+<p align="center">
+  <img width="60%" src="https://raw.githubusercontent.com/datahub-project/static-assets/main/imgs/observe/assertions/slack-assertions-rich-alert.png"/>
+</p>
+
 With DataHub Cloud Observe, you can react to the Assertion Run Event by listening to API events via [AWS EventBridge](/docs/managed-datahub/operator-guide/setting-up-events-api-on-aws-eventbridge.md) (the availability and simplicity of setup of each solution dependent on your current DataHub Cloud setup – chat with your DataHub Cloud representative to learn more).
 
 ## Sifting through the noise & Data Health Reporting


### PR DESCRIPTION
## Summary

- Add a `:::tip` and a "See:" reference in `docs/api/tutorials/subscriptions.md` pointing readers to the **Assertions › Alerts** section for details on how assertion alerts are delivered.
- Embed a Slack rich-alert example image (Volume Assertion failure with downstream impact) under the **Alerts** section in `docs/managed-datahub/observe/assertions.md`.

The image is hosted in [`datahub-project/static-assets`](https://github.com/datahub-project/static-assets) at `imgs/observe/assertions/slack-assertions-rich-alert.png`.

## Test plan

- [ ] Render docs locally (`scripts/dev/datahub-dev.sh docs`) and verify:
  - [ ] Subscriptions tutorial shows the tip + cross-link, and the link resolves to the Alerts section in the assertions doc
  - [ ] Assertions Alerts section displays the Slack screenshot at a reasonable size

🤖 Generated with [Claude Code](https://claude.com/claude-code)