### PR TITLE
feat(ingest/sigma): emit FineGrainedLineage on Data Model elements

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/autogenerated/connector_registry/datahub.json
+++ b/metadata-ingestion/src/datahub/ingestion/autogenerated/connector_registry/datahub.json
@@ -3550,6 +3550,12 @@
           "supported": true
         },
         {
+          "capability": "LINEAGE_FINE",
+          "description": "Enabled by default.",
+          "subtype_modifier": null,
+          "supported": true
+        },
+        {
           "capability": "DESCRIPTIONS",
           "description": "Enabled by default",
           "subtype_modifier": null,

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
@@ -267,6 +267,9 @@ class SigmaSourceReport(StaleEntityRemovalSourceReport):
     data_model_element_fgl_cross_dm_deferred: int = 0
     # resolved URN not in /lineage upstreams; drop to avoid orphan FGL.
     data_model_element_fgl_dropped_orphan_upstream: int = 0
+    # ref.column not found in the upstream element's winner column set; drop to
+    # avoid a schemaField URN that has no corresponding fieldPath in SchemaMetadata.
+    data_model_element_fgl_dropped_unknown_upstream_column: int = 0
     # Formula-bearing columns dropped by fieldPath dedup (duplicate column.name
     # within one element); their FGL was not emitted.
     data_model_element_fgl_dropped_dedup_loser: int = 0

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
@@ -249,8 +249,16 @@ class SigmaSourceReport(StaleEntityRemovalSourceReport):
     # DM element column-level lineage (FGL) counters.
     # How many FGL entries were emitted across all elements.
     data_model_element_fgl_emitted: int = 0
+    # Refs where multiple sibling candidates passed the /lineage filter;
+    # sorted-first URN was chosen (matches T2 PR1's collision precedent).
+    data_model_element_fgl_collision_pick_first: int = 0
     # Refs whose source element is outside this DM; deferred to cross-DM resolution.
     data_model_element_fgl_cross_dm_deferred: int = 0
+    # Refs where element-name matches the element's own warehouse-table name
+    # (e.g., element "data.csv" with formula "[data.csv/col]"). These are
+    # warehouse-passthrough passthroughs, not intra-DM self-edges; the actual
+    # upstream is the warehouse inode — out of RESOLVE-A scope.
+    data_model_element_fgl_warehouse_passthrough_deferred: int = 0
     # Refs whose source element is in this DM but not listed as an upstream by
     # /lineage; dropped to avoid orphan FGL the UI silently rejects.
     data_model_element_fgl_dropped_orphan_upstream: int = 0

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
@@ -246,6 +246,24 @@ class SigmaSourceReport(StaleEntityRemovalSourceReport):
     # ``SchemaMetadata`` with duplicate ``fieldPath`` values.
     data_model_element_columns_duplicate_fieldpath_dropped: int = 0
 
+    # T1.RESOLVE-A — DM element formula-driven FGL.
+    # Totals.
+    data_model_element_columns_with_formula: int = 0
+    data_model_element_fgl_emitted: int = 0
+    # Success path: intra-DM [ElementName/col] ref resolved to an upstream URN
+    # that /lineage also claims (safe to emit as FGL).
+    data_model_element_fgl_intra_resolved: int = 0
+    # Skip paths: ref present but not cross-Dataset lineage.
+    data_model_element_fgl_sibling_skipped: int = 0  # bare [col] intra-element ref
+    data_model_element_fgl_param_skipped: int = 0  # [P_*] parameter ref
+    # Drop paths: ref would be FGL but is suppressed for correctness.
+    # cross-DM ref ([OtherDM/col]) -- RESOLVE-B will handle these.
+    data_model_element_fgl_cross_dm_unresolved: int = 0
+    # resolved URN not in /lineage upstreams; drop to avoid orphan FGL.
+    data_model_element_fgl_dropped_orphan_upstream: int = 0
+    # column is the dedup loser (duplicate fieldPath); no FGL emitted.
+    data_model_element_fgl_dropped_dedup_loser: int = 0
+
     # Entries dropped as duplicates by the pagination-level natural-key
     # dedup in ``_paginated_entries`` / lineage raw dedup. Normally 0;
     # non-zero indicates an echoed pagination cursor or server-side

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
@@ -249,6 +249,8 @@ class SigmaSourceReport(StaleEntityRemovalSourceReport):
     # DM element column-level lineage (FGL) counters.
     # Totals.
     data_model_element_columns_with_formula: int = 0
+    # Roll-up of all success paths; equals fgl_intra_resolved today and will
+    # diverge when cross-DM resolution (RESOLVE-B) adds a second success path.
     data_model_element_fgl_emitted: int = 0
     # Success path: intra-DM [ElementName/col] ref resolved to an upstream URN
     # that /lineage also claims (safe to emit as FGL).
@@ -257,11 +259,12 @@ class SigmaSourceReport(StaleEntityRemovalSourceReport):
     data_model_element_fgl_sibling_skipped: int = 0  # bare [col] intra-element ref
     data_model_element_fgl_param_skipped: int = 0  # [P_*] parameter ref
     # Drop paths: ref would be FGL but is suppressed for correctness.
-    # cross-DM ref ([OtherDM/col]) -- handled by a separate ingestion pass.
-    data_model_element_fgl_cross_dm_unresolved: int = 0
+    # cross-DM ref ([OtherDM/col]) -- deferred to a follow-up ingestion pass.
+    data_model_element_fgl_cross_dm_deferred: int = 0
     # resolved URN not in /lineage upstreams; drop to avoid orphan FGL.
     data_model_element_fgl_dropped_orphan_upstream: int = 0
-    # column is the dedup loser (duplicate fieldPath); no FGL emitted.
+    # Formula-bearing columns dropped by fieldPath dedup (duplicate column.name
+    # within one element); their FGL was not emitted.
     data_model_element_fgl_dropped_dedup_loser: int = 0
 
     # Entries dropped as duplicates by the pagination-level natural-key

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
@@ -246,7 +246,7 @@ class SigmaSourceReport(StaleEntityRemovalSourceReport):
     # ``SchemaMetadata`` with duplicate ``fieldPath`` values.
     data_model_element_columns_duplicate_fieldpath_dropped: int = 0
 
-    # T1.RESOLVE-A — DM element formula-driven FGL.
+    # DM element column-level lineage (FGL) counters.
     # Totals.
     data_model_element_columns_with_formula: int = 0
     data_model_element_fgl_emitted: int = 0
@@ -257,7 +257,7 @@ class SigmaSourceReport(StaleEntityRemovalSourceReport):
     data_model_element_fgl_sibling_skipped: int = 0  # bare [col] intra-element ref
     data_model_element_fgl_param_skipped: int = 0  # [P_*] parameter ref
     # Drop paths: ref would be FGL but is suppressed for correctness.
-    # cross-DM ref ([OtherDM/col]) -- RESOLVE-B will handle these.
+    # cross-DM ref ([OtherDM/col]) -- handled by a separate ingestion pass.
     data_model_element_fgl_cross_dm_unresolved: int = 0
     # resolved URN not in /lineage upstreams; drop to avoid orphan FGL.
     data_model_element_fgl_dropped_orphan_upstream: int = 0

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
@@ -247,32 +247,16 @@ class SigmaSourceReport(StaleEntityRemovalSourceReport):
     data_model_element_columns_duplicate_fieldpath_dropped: int = 0
 
     # DM element column-level lineage (FGL) counters.
-    # Totals.
-    # NOTE: columns_with_formula is counted only for elements that have at
-    # least one entity-level upstream from /lineage; elements with zero
-    # resolved /lineage upstreams are excluded because no FGL can be emitted
-    # for them regardless of their formula content.
-    data_model_element_columns_with_formula: int = 0
-    # Roll-up of all success paths; equals fgl_intra_resolved today and will
-    # diverge when cross-DM resolution (RESOLVE-B) adds a second success path.
+    # How many FGL entries were emitted across all elements.
     data_model_element_fgl_emitted: int = 0
-    # Success path: intra-DM [ElementName/col] ref resolved to an upstream URN
-    # that /lineage also claims (safe to emit as FGL).
-    data_model_element_fgl_intra_resolved: int = 0
-    # Skip paths: ref present but not cross-Dataset lineage.
-    data_model_element_fgl_sibling_skipped: int = 0  # bare [col] intra-element ref
-    data_model_element_fgl_param_skipped: int = 0  # [P_*] parameter ref
-    # Drop paths: ref would be FGL but is suppressed for correctness.
-    # cross-DM ref ([OtherDM/col]) -- deferred to a follow-up ingestion pass.
+    # Refs whose source element is outside this DM; deferred to cross-DM resolution.
     data_model_element_fgl_cross_dm_deferred: int = 0
-    # resolved URN not in /lineage upstreams; drop to avoid orphan FGL.
+    # Refs whose source element is in this DM but not listed as an upstream by
+    # /lineage; dropped to avoid orphan FGL the UI silently rejects.
     data_model_element_fgl_dropped_orphan_upstream: int = 0
-    # ref.column not found in the upstream element's winner column set; drop to
-    # avoid a schemaField URN that has no corresponding fieldPath in SchemaMetadata.
+    # Refs whose column name has no matching fieldPath in the upstream element's
+    # schema; dropped to avoid a dangling schemaField URN.
     data_model_element_fgl_dropped_unknown_upstream_column: int = 0
-    # Formula-bearing columns dropped by fieldPath dedup (duplicate column.name
-    # within one element); their FGL was not emitted.
-    data_model_element_fgl_dropped_dedup_loser: int = 0
 
     # Entries dropped as duplicates by the pagination-level natural-key
     # dedup in ``_paginated_entries`` / lineage raw dedup. Normally 0;

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
@@ -248,6 +248,10 @@ class SigmaSourceReport(StaleEntityRemovalSourceReport):
 
     # DM element column-level lineage (FGL) counters.
     # Totals.
+    # NOTE: columns_with_formula is counted only for elements that have at
+    # least one entity-level upstream from /lineage; elements with zero
+    # resolved /lineage upstreams are excluded because no FGL can be emitted
+    # for them regardless of their formula content.
     data_model_element_columns_with_formula: int = 0
     # Roll-up of all success paths; equals fgl_intra_resolved today and will
     # diverge when cross-DM resolution (RESOLVE-B) adds a second success path.

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -798,11 +798,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         element edges as well as external warehouse edges, so the intersection
         correctly filters phantom formula refs.
         """
-        by_name, displaced = _dedup_dm_element_columns(element.columns)
-        for _winner, loser in displaced:
-            if loser.formula:
-                # Formula-bearing column displaced by fieldPath dedup; FGL not emitted.
-                self.reporter.data_model_element_fgl_dropped_dedup_loser += 1
+        by_name, _ = _dedup_dm_element_columns(element.columns)
 
         # Build a per-upstream-element column map keyed by Dataset URN (not
         # element name) so duplicate-named DM elements with different schemas
@@ -831,17 +827,13 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         for column in sorted(by_name.values(), key=lambda c: c.name):
             if not column.formula:
                 continue
-            self.reporter.data_model_element_columns_with_formula += 1
             downstream_field = builder.make_schema_field_urn(
                 element_dataset_urn, column.name
             )
             for ref in extract_bracket_refs(column.formula):
-                if ref.is_parameter:
-                    self.reporter.data_model_element_fgl_param_skipped += 1
-                    continue
-                if ref.column is None:
-                    # Bare [col] — intra-element transform, not cross-Dataset lineage.
-                    self.reporter.data_model_element_fgl_sibling_skipped += 1
+                if ref.is_parameter or ref.column is None:
+                    # [P_*] parameter refs and bare [col] intra-element refs
+                    # are not cross-Dataset lineage; skip.
                     continue
                 candidate_urns = element_name_to_dataset_urns.get(
                     ref.source.lower(), []
@@ -897,7 +889,6 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                     if pair in emitted_pairs:
                         continue
                     emitted_pairs.add(pair)
-                    self.reporter.data_model_element_fgl_intra_resolved += 1
                     fgls.append(
                         FineGrainedLineageClass(
                             downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
@@ -907,8 +898,6 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                             confidenceScore=1.0,
                         )
                     )
-        # fgl_emitted equals fgl_intra_resolved today; the split is intentional
-        # so RESOLVE-B can add a second success path without changing the roll-up.
         self.reporter.data_model_element_fgl_emitted += len(fgls)
         fgls.sort(
             key=lambda fgl: (

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -782,11 +782,10 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         Bare [col] refs are intra-element transforms (lineage within one Dataset,
         not across Datasets) and are skipped for FGL.
 
-        element.name → URN lookup is case-sensitive (byte-for-byte match against
-        the element's display name).  extract_bracket_refs preserves the bracket
-        body verbatim, so the source string mirrors whatever the formula author
-        typed.  Sigma's formula bar autocompletes canonical names, making
-        case-divergence rare in practice, but it is a known limitation.
+        element_name_to_dataset_urns is keyed with lowercased names (matching the
+        cross-DM name_map convention), and ref.source is lowercased before lookup,
+        so a formula like [Random Data Model/col] resolves to an element named
+        "random data model" without a spurious cross_dm_deferred miss.
 
         Intra-DM FGL is conditioned on entity_level_upstream_urns, which is
         populated from Sigma's /lineage API.  The /lineage API reports intra-DM
@@ -814,7 +813,9 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                     # Bare [col] — intra-element transform, not cross-Dataset lineage.
                     self.reporter.data_model_element_fgl_sibling_skipped += 1
                     continue
-                candidate_urns = element_name_to_dataset_urns.get(ref.source, [])
+                candidate_urns = element_name_to_dataset_urns.get(
+                    ref.source.lower(), []
+                )
                 surviving_urns = sorted(
                     u for u in candidate_urns if u in entity_level_upstream_urns
                 )
@@ -841,6 +842,10 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                 downstream_field = builder.make_schema_field_urn(
                     element_dataset_urn, column.name
                 )
+                # When surviving_urns > 1 (duplicate element names in the DM
+                # both appearing in /lineage), one FGL entry is emitted per
+                # upstream.  fgl_emitted therefore counts FGL entries, not
+                # unique downstream fields; treat it as an entry count.
                 for upstream_urn in surviving_urns:
                     self.reporter.data_model_element_fgl_intra_resolved += 1
                     fgls.append(
@@ -856,6 +861,8 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                             confidenceScore=1.0,
                         )
                     )
+        # fgl_emitted equals fgl_intra_resolved today; the split is intentional
+        # so RESOLVE-B can add a second success path without changing the roll-up.
         self.reporter.data_model_element_fgl_emitted += len(fgls)
         fgls.sort(
             key=lambda fgl: (
@@ -1190,12 +1197,15 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         if data_model.workspaceId:
             self.reporter.workspaces.increment_data_models_count(data_model.workspaceId)
 
+        # Keys are lowercased so formula refs — which users type and Sigma
+        # autocompletes from canonical names — match even when case differs.
+        # This mirrors the lowercasing in the cross-DM name_map (dm_element_urn_by_name).
         element_name_to_dataset_urns: Dict[str, List[str]] = {}
         for element in data_model.elements:
             if element.name:
-                element_name_to_dataset_urns.setdefault(element.name, []).append(
-                    elementId_to_dataset_urn[element.elementId]
-                )
+                element_name_to_dataset_urns.setdefault(
+                    element.name.lower(), []
+                ).append(elementId_to_dataset_urn[element.elementId])
 
         yield from self._gen_data_model_element_workunits(
             data_model,

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -193,6 +193,7 @@ CrossDmOutcome = Literal[
 )
 @capability(SourceCapability.DESCRIPTIONS, "Enabled by default")
 @capability(SourceCapability.LINEAGE_COARSE, "Enabled by default.")
+@capability(SourceCapability.LINEAGE_FINE, "Enabled by default.")
 @capability(SourceCapability.PLATFORM_INSTANCE, "Enabled by default")
 @capability(SourceCapability.SCHEMA_METADATA, "Enabled by default")
 @capability(SourceCapability.TAGS, "Enabled by default")
@@ -778,33 +779,56 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         """Build FineGrainedLineage entries for intra-DM [ElementName/col] refs.
 
         Uses _dedup_dm_element_columns for the winner set so the fieldPaths
-        referenced in FGL are guaranteed to match those in SchemaMetadata.
-        Bare [col] refs are intra-element transforms (lineage within one Dataset,
-        not across Datasets) and are skipped for FGL.
+        referenced in FGL match those in SchemaMetadata.  Bare [col] refs are
+        intra-element transforms (lineage within one Dataset, not across Datasets)
+        and are skipped.
 
-        element_name_to_dataset_urns is keyed with lowercased names (matching the
-        cross-DM name_map convention), and ref.source is lowercased before lookup,
-        so a formula like [Random Data Model/col] resolves to an element named
-        "random data model" without a spurious cross_dm_deferred miss.
+        element_name_to_dataset_urns is keyed with lowercased names, and
+        ref.source is lowercased before lookup so [Random Data Model/col] resolves
+        to an element named "random data model" without a spurious
+        cross_dm_deferred miss.
+
+        ref.column is validated and case-normalised against the upstream element's
+        winner column set (built from data_model.elements).  A ref whose column
+        name has no match in the upstream element's schema is dropped to avoid a
+        schemaField URN that points at a non-existent fieldPath.
 
         Intra-DM FGL is conditioned on entity_level_upstream_urns, which is
         populated from Sigma's /lineage API.  The /lineage API reports intra-DM
-        element edges (element A → element B when A's formula references B) as
-        well as external warehouse edges, so the intersection correctly filters
-        phantom formula refs that Sigma's own resolver would ignore.
+        element edges as well as external warehouse edges, so the intersection
+        correctly filters phantom formula refs.
         """
         by_name, displaced = _dedup_dm_element_columns(element.columns)
         for _winner, loser in displaced:
             if loser.formula:
-                # Formula-bearing columns dropped by fieldPath dedup; their FGL
-                # was not emitted because the fieldPath isn't in SchemaMetadata.
+                # Formula-bearing column displaced by fieldPath dedup; FGL not emitted.
                 self.reporter.data_model_element_fgl_dropped_dedup_loser += 1
 
+        # Build a per-upstream-element column map: lowercased element name →
+        # { lowercased col name → canonical col name }.  Used to validate and
+        # normalise ref.column so the emitted schemaField URN matches the
+        # fieldPath actually present in the upstream element's SchemaMetadata.
+        upstream_col_map: Dict[str, Dict[str, str]] = {}
+        for dm_el in data_model.elements:
+            if not dm_el.name:
+                continue
+            el_by_name, _ = _dedup_dm_element_columns(dm_el.columns)
+            upstream_col_map[dm_el.name.lower()] = {
+                col_name.lower(): col_name for col_name in el_by_name
+            }
+
         fgls: List[FineGrainedLineageClass] = []
+        # Track emitted (downstream, upstream) schemaField pairs to deduplicate
+        # multiple occurrences of the same bracket ref in one formula
+        # (e.g. If([A/x] = 0, [A/x], [A/x] / 2) → one FGL, not three).
+        emitted_pairs: Set[Tuple[str, str]] = set()
         for column in sorted(by_name.values(), key=lambda c: c.name):
             if not column.formula:
                 continue
             self.reporter.data_model_element_columns_with_formula += 1
+            downstream_field = builder.make_schema_field_urn(
+                element_dataset_urn, column.name
+            )
             for ref in extract_bracket_refs(column.formula):
                 if ref.is_parameter:
                     self.reporter.data_model_element_fgl_param_skipped += 1
@@ -828,6 +852,22 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                         # Source not in this DM — cross-DM ref handled separately.
                         self.reporter.data_model_element_fgl_cross_dm_deferred += 1
                     continue
+                # Validate and normalise ref.column against the upstream element's
+                # actual column winners.  Using the canonical name avoids a dangling
+                # schemaField URN when the formula author used different capitalisation.
+                source_cols = upstream_col_map.get(ref.source.lower(), {})
+                canonical_col = source_cols.get(ref.column.lower())
+                if canonical_col is None:
+                    self.reporter.data_model_element_fgl_dropped_unknown_upstream_column += 1
+                    logger.debug(
+                        "DM %s element %s: ref %r column %r not found in upstream "
+                        "element's schema winners; dropping FGL entry",
+                        data_model.dataModelId,
+                        element.elementId,
+                        ref.raw,
+                        ref.column,
+                    )
+                    continue
                 if len(surviving_urns) > 1:
                     logger.debug(
                         "DM %s element %s: ref %r resolves to %d URNs after "
@@ -839,25 +879,23 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                         len(surviving_urns),
                         surviving_urns,
                     )
-                downstream_field = builder.make_schema_field_urn(
-                    element_dataset_urn, column.name
-                )
-                # When surviving_urns > 1 (duplicate element names in the DM
-                # both appearing in /lineage), one FGL entry is emitted per
-                # upstream.  fgl_emitted therefore counts FGL entries, not
-                # unique downstream fields; treat it as an entry count.
+                # When surviving_urns > 1, one FGL entry is emitted per upstream;
+                # fgl_emitted therefore counts entries, not unique downstream fields.
                 for upstream_urn in surviving_urns:
+                    upstream_field = builder.make_schema_field_urn(
+                        upstream_urn, canonical_col
+                    )
+                    pair = (downstream_field, upstream_field)
+                    if pair in emitted_pairs:
+                        continue
+                    emitted_pairs.add(pair)
                     self.reporter.data_model_element_fgl_intra_resolved += 1
                     fgls.append(
                         FineGrainedLineageClass(
                             downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
                             downstreams=[downstream_field],
                             upstreamType=FineGrainedLineageUpstreamTypeClass.FIELD_SET,
-                            upstreams=[
-                                builder.make_schema_field_urn(upstream_urn, ref.column)
-                            ],
-                            # confidenceScore=1.0 is the default; set explicitly to
-                            # signal this is structural (formula-derived), not statistical.
+                            upstreams=[upstream_field],
                             confidenceScore=1.0,
                         )
                     )

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -862,14 +862,16 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                 # policy and Sigma's server-side coalescing.
                 if len(surviving_urns) > 1:
                     self.reporter.data_model_element_fgl_collision_pick_first += 1
-                    logger.debug(
-                        "DM %s element %s: ref %r — %d URNs passed /lineage filter "
-                        "(duplicate element names); picking sorted-first: %s",
-                        data_model.dataModelId,
-                        element.elementId,
-                        ref.raw,
-                        len(surviving_urns),
-                        surviving_urns[0],
+                    self.reporter.warning(
+                        title="Ambiguous DM element name in formula ref",
+                        message=(
+                            f"Formula ref {ref.raw!r} in element {element.elementId} "
+                            f"resolves to {len(surviving_urns)} elements with the same "
+                            f"display name — picking the lexicographically-first URN "
+                            f"({surviving_urns[0]!r}). Rename duplicate elements in "
+                            f"Data Model {data_model.dataModelId} to remove ambiguity."
+                        ),
+                        context=f"ref={ref.raw!r}, candidates={surviving_urns}",
                     )
                 chosen_upstream_urn = surviving_urns[0]
 

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -597,7 +597,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         data_model: SigmaDataModel,
         element_dataset_urn: str,
         elementId_to_dataset_urn: Dict[str, str],
-        element_name_to_dataset_urns: Dict[str, List[str]],
+        element_name_to_eids: Dict[str, List[str]],
     ) -> Optional[UpstreamLineage]:
         # Success counters bump once per unique URN; diamond source_ids
         # resolving to the same URN should not inflate the signal.
@@ -697,7 +697,8 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         fine_grained = self._build_dm_element_fine_grained_lineages(
             element=element,
             element_dataset_urn=element_dataset_urn,
-            element_name_to_dataset_urns=element_name_to_dataset_urns,
+            element_name_to_eids=element_name_to_eids,
+            elementId_to_dataset_urn=elementId_to_dataset_urn,
             entity_level_upstream_urns=set(upstream_urns),
             data_model=data_model,
         )
@@ -772,52 +773,34 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         *,
         element: SigmaDataModelElement,
         element_dataset_urn: str,
-        element_name_to_dataset_urns: Dict[str, List[str]],
+        element_name_to_eids: Dict[str, List[str]],
+        elementId_to_dataset_urn: Dict[str, str],
         entity_level_upstream_urns: Set[str],
         data_model: SigmaDataModel,
     ) -> List[FineGrainedLineageClass]:
         """Build FineGrainedLineage entries for intra-DM [ElementName/col] refs.
 
-        Uses _dedup_dm_element_columns for the winner set so the fieldPaths
-        referenced in FGL match those in SchemaMetadata.  Bare [col] refs are
-        intra-element transforms (lineage within one Dataset, not across Datasets)
-        and are skipped.
+        element_name_to_eids maps lowercased element name → list of elementIds.
+        Self-references are stripped before resolution: when a DM element is named
+        after its warehouse source (e.g., element "data.csv" with formula
+        "[data.csv/col]"), the formula ref matches the element's own name and must
+        be filtered out to avoid self-referential FGL.  These are counted under
+        fgl_warehouse_passthrough_deferred and left for warehouse-external resolution.
 
-        element_name_to_dataset_urns is keyed with lowercased names, and
-        ref.source is lowercased before lookup so [Random Data Model/col] resolves
-        to an element named "random data model" without a spurious
-        cross_dm_deferred miss.
-
-        ref.column is validated and case-normalised against the upstream element's
-        winner column set (built from data_model.elements).  A ref whose column
-        name has no match in the upstream element's schema is dropped to avoid a
-        schemaField URN that points at a non-existent fieldPath.
-
-        Intra-DM FGL is conditioned on entity_level_upstream_urns, which is
-        populated from Sigma's /lineage API.  The /lineage API reports intra-DM
-        element edges as well as external warehouse edges, so the intersection
-        correctly filters phantom formula refs.
+        When multiple sibling elements share a name and both pass the /lineage filter,
+        the lexicographically-first URN is chosen (matching T2 PR1's collision policy
+        and Sigma's server-side coalescing behaviour).
         """
         by_name, _ = _dedup_dm_element_columns(element.columns)
 
-        # Build a per-upstream-element column map keyed by Dataset URN (not
-        # element name) so duplicate-named DM elements with different schemas
-        # are handled correctly.  The i-th element of each name group in
-        # element_name_to_dataset_urns corresponds to the i-th occurrence of
-        # that name in data_model.elements (both built in the same iteration
-        # order in _gen_data_model_workunit).
+        # Build URN → winner-column map directly from elementId_to_dataset_urn,
+        # which gives an unambiguous elementId→URN mapping for every DM element.
         urn_to_cols: Dict[str, Dict[str, str]] = {}
-        name_index: Dict[str, int] = {}
         for dm_el in data_model.elements:
-            if not dm_el.name:
-                continue
-            name_lower = dm_el.name.lower()
-            idx = name_index.get(name_lower, 0)
-            name_index[name_lower] = idx + 1
-            urns = element_name_to_dataset_urns.get(name_lower, [])
-            if idx < len(urns):
+            el_urn = elementId_to_dataset_urn.get(dm_el.elementId)
+            if el_urn:
                 el_by_name, _ = _dedup_dm_element_columns(dm_el.columns)
-                urn_to_cols[urns[idx]] = {c.lower(): c for c in el_by_name}
+                urn_to_cols[el_urn] = {c.lower(): c for c in el_by_name}
 
         fgls: List[FineGrainedLineageClass] = []
         # Track emitted (downstream, upstream) schemaField pairs to deduplicate
@@ -835,69 +818,94 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                     # [P_*] parameter refs and bare [col] intra-element refs
                     # are not cross-Dataset lineage; skip.
                     continue
-                candidate_urns = element_name_to_dataset_urns.get(
-                    ref.source.lower(), []
-                )
-                surviving_urns = sorted(
-                    u for u in candidate_urns if u in entity_level_upstream_urns
-                )
-                if not surviving_urns:
-                    if candidate_urns:
-                        # Element is in this DM but /lineage doesn't claim it as
-                        # upstream. Drop to avoid orphan FGL the UI silently rejects.
-                        self.reporter.data_model_element_fgl_dropped_orphan_upstream += 1
+
+                candidate_eids = element_name_to_eids.get(ref.source.lower(), [])
+
+                # Strip self-references: element-name == warehouse-table name is a
+                # common Sigma authoring pattern.  The formula ref resolves to the
+                # element itself, which is not a valid FGL upstream (the real upstream
+                # is the warehouse inode reported by /lineage).
+                candidate_eids_after_self_strip = [
+                    eid for eid in candidate_eids if eid != element.elementId
+                ]
+
+                if not candidate_eids_after_self_strip:
+                    if candidate_eids:
+                        # All candidates were self-references; actual upstream is a
+                        # warehouse table — out of RESOLVE-A scope.
+                        self.reporter.data_model_element_fgl_warehouse_passthrough_deferred += 1
                     else:
                         # Source not in this DM — cross-DM ref handled separately.
                         self.reporter.data_model_element_fgl_cross_dm_deferred += 1
                     continue
+
+                # Map surviving elementIds to Dataset URNs and filter against
+                # /lineage's reported entity-level upstreams.
+                candidate_urns = sorted(
+                    elementId_to_dataset_urn[eid]
+                    for eid in candidate_eids_after_self_strip
+                    if eid in elementId_to_dataset_urn
+                )
+                surviving_urns = sorted(
+                    u for u in candidate_urns if u in entity_level_upstream_urns
+                )
+
+                if not surviving_urns:
+                    # Intra-DM candidate(s) exist but none appear in /lineage.
+                    # Rare on tenants where /lineage correctly reports intra-DM edges;
+                    # keep counter for observability on future tenants.
+                    self.reporter.data_model_element_fgl_dropped_orphan_upstream += 1
+                    continue
+
+                # Collision handling: multiple siblings passed /lineage filter.
+                # Pick sorted-first to match T2 PR1's _resolve_external_upstream
+                # policy and Sigma's server-side coalescing.
                 if len(surviving_urns) > 1:
+                    self.reporter.data_model_element_fgl_collision_pick_first += 1
                     logger.debug(
-                        "DM %s element %s: ref %r resolves to %d URNs after "
-                        "/lineage filter (duplicate element names in DM); "
-                        "emitting FGL to all surviving candidates: %s",
+                        "DM %s element %s: ref %r — %d URNs passed /lineage filter "
+                        "(duplicate element names); picking sorted-first: %s",
                         data_model.dataModelId,
                         element.elementId,
                         ref.raw,
                         len(surviving_urns),
-                        surviving_urns,
+                        surviving_urns[0],
                     )
-                # When surviving_urns > 1, one FGL entry is emitted per upstream.
-                # Column validation is per-URN so duplicate-named elements with
-                # different schemas each validate against their own column set.
-                for upstream_urn in surviving_urns:
-                    # Validate and normalise ref.column against this specific upstream
-                    # element's schema winners.  Keying by URN (not element name)
-                    # correctly handles duplicate-named elements with different schemas.
-                    source_cols = urn_to_cols.get(upstream_urn, {})
-                    canonical_col = source_cols.get(ref.column.lower())
-                    if canonical_col is None:
-                        self.reporter.data_model_element_fgl_dropped_unknown_upstream_column += 1
-                        logger.debug(
-                            "DM %s element %s: ref %r column %r not found in upstream "
-                            "element %s schema winners; dropping FGL entry",
-                            data_model.dataModelId,
-                            element.elementId,
-                            ref.raw,
-                            ref.column,
-                            upstream_urn,
-                        )
-                        continue
-                    upstream_field = builder.make_schema_field_urn(
-                        upstream_urn, canonical_col
+                chosen_upstream_urn = surviving_urns[0]
+
+                # Validate and normalise ref.column against the chosen upstream
+                # element's schema winners to avoid a dangling schemaField URN.
+                source_cols = urn_to_cols.get(chosen_upstream_urn, {})
+                canonical_col = source_cols.get(ref.column.lower())
+                if canonical_col is None:
+                    self.reporter.data_model_element_fgl_dropped_unknown_upstream_column += 1
+                    logger.debug(
+                        "DM %s element %s: ref %r column %r not found in upstream "
+                        "element %s schema winners; dropping FGL entry",
+                        data_model.dataModelId,
+                        element.elementId,
+                        ref.raw,
+                        ref.column,
+                        chosen_upstream_urn,
                     )
-                    pair = (downstream_field, upstream_field)
-                    if pair in emitted_pairs:
-                        continue
-                    emitted_pairs.add(pair)
-                    fgls.append(
-                        FineGrainedLineageClass(
-                            downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
-                            downstreams=[downstream_field],
-                            upstreamType=FineGrainedLineageUpstreamTypeClass.FIELD_SET,
-                            upstreams=[upstream_field],
-                            confidenceScore=1.0,
-                        )
+                    continue
+
+                upstream_field = builder.make_schema_field_urn(
+                    chosen_upstream_urn, canonical_col
+                )
+                pair = (downstream_field, upstream_field)
+                if pair in emitted_pairs:
+                    continue
+                emitted_pairs.add(pair)
+                fgls.append(
+                    FineGrainedLineageClass(
+                        downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
+                        downstreams=[downstream_field],
+                        upstreamType=FineGrainedLineageUpstreamTypeClass.FIELD_SET,
+                        upstreams=[upstream_field],
+                        confidenceScore=1.0,
                     )
+                )
         self.reporter.data_model_element_fgl_emitted += len(fgls)
         fgls.sort(
             key=lambda fgl: (
@@ -913,7 +921,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         data_model_key: DataModelKey,
         data_model_container_urn: str,
         elementId_to_dataset_urn: Dict[str, str],
-        element_name_to_dataset_urns: Dict[str, List[str]],
+        element_name_to_eids: Dict[str, List[str]],
         owner_username: Optional[str] = None,
     ) -> Iterable[MetadataWorkUnit]:
         dm_url_id = data_model.get_url_id()
@@ -1029,7 +1037,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                 data_model,
                 element_dataset_urn,
                 elementId_to_dataset_urn,
-                element_name_to_dataset_urns,
+                element_name_to_eids,
             )
             if upstream_lineage is not None:
                 yield MetadataChangeProposalWrapper(
@@ -1234,20 +1242,21 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
 
         # Keys are lowercased so formula refs — which users type and Sigma
         # autocompletes from canonical names — match even when case differs.
-        # This mirrors the lowercasing in the cross-DM name_map (dm_element_urn_by_name).
-        element_name_to_dataset_urns: Dict[str, List[str]] = {}
+        # Values are elementIds (not URNs) so the FGL builder can strip self-references
+        # by elementId before mapping to URNs via elementId_to_dataset_urn.
+        element_name_to_eids: Dict[str, List[str]] = {}
         for element in data_model.elements:
             if element.name:
-                element_name_to_dataset_urns.setdefault(
-                    element.name.lower(), []
-                ).append(elementId_to_dataset_urn[element.elementId])
+                element_name_to_eids.setdefault(element.name.lower(), []).append(
+                    element.elementId
+                )
 
         yield from self._gen_data_model_element_workunits(
             data_model,
             data_model_key,
             data_model_container_urn,
             elementId_to_dataset_urn,
-            element_name_to_dataset_urns,
+            element_name_to_eids,
             owner_username=owner_username,
         )
 

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -125,14 +125,47 @@ def _dm_column_ranks_above(
     field Sigma surfaces in the UI). Tie-break: lexicographically smaller
     columnId so the choice is stable across runs even if /columns ordering
     shifts.
-
-    Used by both _gen_data_model_element_schema_metadata (to build SchemaMetadata)
-    and _build_dm_element_fine_grained_lineages (to mirror the same dedup so FGL
-    only references fieldPaths that actually appear in the schema).
     """
     if bool(candidate.formula) != bool(incumbent.formula):
         return bool(candidate.formula)
     return candidate.columnId < incumbent.columnId
+
+
+def _dedup_dm_element_columns(
+    columns: List[SigmaDataModelColumn],
+) -> Tuple[
+    Dict[str, SigmaDataModelColumn],
+    List[Tuple[SigmaDataModelColumn, SigmaDataModelColumn]],
+]:
+    """Return (winners_by_name, displaced_pairs) for an element's column list.
+
+    ``winners_by_name`` maps each unique column name to the winning column
+    when duplicates exist (per _dm_column_ranks_above).  ``displaced_pairs``
+    is a list of (winner, loser) tuples — each caller uses this to update its
+    own counters and logs.
+
+    Called by both _gen_data_model_element_schema_metadata and
+    _build_dm_element_fine_grained_lineages so the two sites share a single
+    source of truth for which fieldPaths are "live".  Any future change to the
+    tie-break logic only needs to be made here.
+    """
+    by_name: Dict[str, SigmaDataModelColumn] = {}
+    displaced: List[Tuple[SigmaDataModelColumn, SigmaDataModelColumn]] = []
+    for column in columns:
+        if not column.name:
+            continue
+        existing = by_name.get(column.name)
+        if existing is None:
+            by_name[column.name] = column
+            continue
+        winner, loser = (
+            (column, existing)
+            if _dm_column_ranks_above(column, existing)
+            else (existing, column)
+        )
+        by_name[column.name] = winner
+        displaced.append((winner, loser))
+    return by_name, displaced
 
 
 CrossDmOutcome = Literal[
@@ -561,6 +594,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         self,
         element: SigmaDataModelElement,
         data_model: SigmaDataModel,
+        element_dataset_urn: str,
         elementId_to_dataset_urn: Dict[str, str],
         element_name_to_dataset_urns: Dict[str, List[str]],
     ) -> Optional[UpstreamLineage]:
@@ -661,7 +695,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             return None
         fine_grained = self._build_dm_element_fine_grained_lineages(
             element=element,
-            element_dataset_urn=elementId_to_dataset_urn[element.elementId],
+            element_dataset_urn=element_dataset_urn,
             element_name_to_dataset_urns=element_name_to_dataset_urns,
             entity_level_upstream_urns=set(upstream_urns),
             data_model=data_model,
@@ -680,33 +714,13 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         # Dedup by ``fieldPath`` within the element: Sigma can return two
         # columns with the same name (e.g. a calculated field shadowing a
         # native column), and GMS rejects / non-deterministically dedupes
-        # duplicate ``fieldPath``s.
-        #
-        # Tie-break is deterministic across runs:
-        # 1. Prefer the row with a non-empty ``formula`` -- that's the
-        #    user-authored calculated field and the one Sigma surfaces
-        #    in the UI when both exist with the same name.
-        # 2. Fall back to the row with the lexicographically smallest
-        #    ``columnId`` so the choice is stable even without
-        #    ``/columns`` ordering guarantees.
-        # Dropped ``columnId``s are emitted to debug logs so operators
-        # can reconcile against Sigma.
-        by_name: Dict[str, SigmaDataModelColumn] = {}
+        # duplicate ``fieldPath``s. Tie-break logic lives in _dedup_dm_element_columns
+        # so it stays in sync with the FGL builder's winner set.
+        by_name, displaced = _dedup_dm_element_columns(element.columns)
         dropped_column_ids_by_name: Dict[str, List[str]] = {}
-        for column in element.columns:
-            if not column.name:
-                continue
-            existing = by_name.get(column.name)
-            if existing is None:
-                by_name[column.name] = column
-                continue
+        for winner, loser in displaced:
             self.reporter.data_model_element_columns_duplicate_fieldpath_dropped += 1
-            if _dm_column_ranks_above(column, existing):
-                winner, loser = column, existing
-            else:
-                winner, loser = existing, column
-            by_name[column.name] = winner
-            dropped_column_ids_by_name.setdefault(column.name, []).append(
+            dropped_column_ids_by_name.setdefault(winner.name, []).append(
                 loser.columnId
             )
         if dropped_column_ids_by_name:
@@ -763,32 +777,28 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
     ) -> List[FineGrainedLineageClass]:
         """Build FineGrainedLineage entries for intra-DM [ElementName/col] refs.
 
-        Mirrors the dedup pass from _gen_data_model_element_schema_metadata (via
-        _dm_column_ranks_above) so FGL is only emitted for winner columns —
-        fieldPaths present in SchemaMetadata. Bare [col] refs are intra-element
-        transforms (lineage within one Dataset, not across Datasets) and are
-        skipped for FGL.
+        Uses _dedup_dm_element_columns for the winner set so the fieldPaths
+        referenced in FGL are guaranteed to match those in SchemaMetadata.
+        Bare [col] refs are intra-element transforms (lineage within one Dataset,
+        not across Datasets) and are skipped for FGL.
 
-        element.name values are used as-is (byte-for-byte) as dictionary keys;
-        extract_bracket_refs produces source strings verbatim from the bracket
-        body, so no case-folding or whitespace normalization is applied on either
-        side.
+        element.name → URN lookup is case-sensitive (byte-for-byte match against
+        the element's display name).  extract_bracket_refs preserves the bracket
+        body verbatim, so the source string mirrors whatever the formula author
+        typed.  Sigma's formula bar autocompletes canonical names, making
+        case-divergence rare in practice, but it is a known limitation.
+
+        Intra-DM FGL is conditioned on entity_level_upstream_urns, which is
+        populated from Sigma's /lineage API.  The /lineage API reports intra-DM
+        element edges (element A → element B when A's formula references B) as
+        well as external warehouse edges, so the intersection correctly filters
+        phantom formula refs that Sigma's own resolver would ignore.
         """
-        by_name: Dict[str, SigmaDataModelColumn] = {}
-        for column in element.columns:
-            if not column.name:
-                continue
-            existing = by_name.get(column.name)
-            if existing is None:
-                by_name[column.name] = column
-                continue
-            winner, loser = (
-                (column, existing)
-                if _dm_column_ranks_above(column, existing)
-                else (existing, column)
-            )
-            by_name[column.name] = winner
+        by_name, displaced = _dedup_dm_element_columns(element.columns)
+        for _winner, loser in displaced:
             if loser.formula:
+                # Formula-bearing columns dropped by fieldPath dedup; their FGL
+                # was not emitted because the fieldPath isn't in SchemaMetadata.
                 self.reporter.data_model_element_fgl_dropped_dedup_loser += 1
 
         fgls: List[FineGrainedLineageClass] = []
@@ -815,7 +825,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                         self.reporter.data_model_element_fgl_dropped_orphan_upstream += 1
                     else:
                         # Source not in this DM — cross-DM ref handled separately.
-                        self.reporter.data_model_element_fgl_cross_dm_unresolved += 1
+                        self.reporter.data_model_element_fgl_cross_dm_deferred += 1
                     continue
                 if len(surviving_urns) > 1:
                     logger.debug(
@@ -975,6 +985,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             upstream_lineage = self._gen_data_model_element_upstream_lineage(
                 element,
                 data_model,
+                element_dataset_urn,
                 elementId_to_dataset_urn,
                 element_name_to_dataset_urns,
             )

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -54,6 +54,7 @@ from datahub.ingestion.source.sigma.data_classes import (
     Workspace,
     WorkspaceKey,
 )
+from datahub.ingestion.source.sigma.formula_parser import extract_bracket_refs
 from datahub.ingestion.source.sigma.sigma_api import SigmaAPI
 from datahub.ingestion.source.state.stale_entity_removal_handler import (
     StaleEntityRemovalHandler,
@@ -69,6 +70,9 @@ from datahub.metadata.com.linkedin.pegasus2avro.common import (
 from datahub.metadata.com.linkedin.pegasus2avro.dataset import (
     DatasetLineageType,
     DatasetProperties,
+    FineGrainedLineageClass,
+    FineGrainedLineageDownstreamTypeClass,
+    FineGrainedLineageUpstreamTypeClass,
     Upstream,
     UpstreamLineage,
 )
@@ -538,6 +542,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         element: SigmaDataModelElement,
         data_model: SigmaDataModel,
         elementId_to_dataset_urn: Dict[str, str],
+        element_name_to_dataset_urns: Dict[str, List[str]],
     ) -> Optional[UpstreamLineage]:
         # Success counters bump once per unique URN; diamond source_ids
         # resolving to the same URN should not inflate the signal.
@@ -629,16 +634,24 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                             upstream_urn,
                         )
 
-        if not upstream_urns:
-            return None
         # Sort for deterministic emission order: Sigma's /lineage API does
         # not document ordering, and Upstream entries have no semantic order.
         upstream_urns.sort()
+        fine_grained = self._build_dm_element_fine_grained_lineages(
+            element=element,
+            element_dataset_urn=elementId_to_dataset_urn[element.elementId],
+            element_name_to_dataset_urns=element_name_to_dataset_urns,
+            entity_level_upstream_urns=set(upstream_urns),
+            data_model=data_model,
+        )
+        if not upstream_urns and not fine_grained:
+            return None
         return UpstreamLineage(
             upstreams=[
                 Upstream(dataset=urn, type=DatasetLineageType.TRANSFORMED)
                 for urn in upstream_urns
-            ]
+            ],
+            fineGrainedLineages=fine_grained or None,
         )
 
     def _gen_data_model_element_schema_metadata(
@@ -729,12 +742,104 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             entityUrn=element_dataset_urn, aspect=schema_metadata
         ).as_workunit()
 
+    def _build_dm_element_fine_grained_lineages(
+        self,
+        *,
+        element: SigmaDataModelElement,
+        element_dataset_urn: str,
+        element_name_to_dataset_urns: Dict[str, List[str]],
+        entity_level_upstream_urns: Set[str],
+        data_model: SigmaDataModel,
+    ) -> List[FineGrainedLineageClass]:
+        """Build FineGrainedLineage entries for intra-DM [ElementName/col] refs.
+
+        Mirrors the dedup pass from _gen_data_model_element_schema_metadata so
+        FGL is only emitted for winner columns (fieldPaths present in SchemaMetadata).
+        """
+
+        def _ranks_above(
+            candidate: SigmaDataModelColumn, incumbent: SigmaDataModelColumn
+        ) -> bool:
+            if bool(candidate.formula) != bool(incumbent.formula):
+                return bool(candidate.formula)
+            return candidate.columnId < incumbent.columnId
+
+        by_name: Dict[str, SigmaDataModelColumn] = {}
+        drop_count = 0
+        for column in element.columns:
+            if not column.name:
+                continue
+            existing = by_name.get(column.name)
+            if existing is None:
+                by_name[column.name] = column
+                continue
+            winner, loser = (
+                (column, existing)
+                if _ranks_above(column, existing)
+                else (existing, column)
+            )
+            by_name[column.name] = winner
+            if loser.formula:
+                drop_count += 1
+        self.reporter.data_model_element_fgl_dropped_dedup_loser += drop_count
+
+        fgls: List[FineGrainedLineageClass] = []
+        for column in sorted(by_name.values(), key=lambda c: c.name):
+            if not column.formula:
+                continue
+            self.reporter.data_model_element_columns_with_formula += 1
+            for ref in extract_bracket_refs(column.formula):
+                if ref.is_parameter:
+                    self.reporter.data_model_element_fgl_param_skipped += 1
+                    continue
+                if ref.column is None:
+                    # Bare [col] sibling ref — intra-element transform, not cross-Dataset.
+                    self.reporter.data_model_element_fgl_sibling_skipped += 1
+                    continue
+                candidate_urns = element_name_to_dataset_urns.get(ref.source, [])
+                surviving_urns = sorted(
+                    u for u in candidate_urns if u in entity_level_upstream_urns
+                )
+                if not surviving_urns:
+                    if candidate_urns:
+                        # Element is in this DM but /lineage doesn't claim it as upstream.
+                        # Drop to avoid orphan FGL the UI silently rejects.
+                        self.reporter.data_model_element_fgl_dropped_orphan_upstream += 1
+                    else:
+                        # Source not in this DM — cross-DM ref; RESOLVE-B will handle it.
+                        self.reporter.data_model_element_fgl_cross_dm_unresolved += 1
+                    continue
+                downstream_field = builder.make_schema_field_urn(
+                    element_dataset_urn, column.name
+                )
+                for upstream_urn in surviving_urns:
+                    self.reporter.data_model_element_fgl_intra_resolved += 1
+                    fgls.append(
+                        FineGrainedLineageClass(
+                            downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
+                            downstreams=[downstream_field],
+                            upstreamType=FineGrainedLineageUpstreamTypeClass.FIELD_SET,
+                            upstreams=[
+                                builder.make_schema_field_urn(upstream_urn, ref.column)
+                            ],
+                        )
+                    )
+        self.reporter.data_model_element_fgl_emitted += len(fgls)
+        fgls.sort(
+            key=lambda fgl: (
+                (fgl.downstreams or [""])[0],
+                (fgl.upstreams or [""])[0],
+            )
+        )
+        return fgls
+
     def _gen_data_model_element_workunits(
         self,
         data_model: SigmaDataModel,
         data_model_key: DataModelKey,
         data_model_container_urn: str,
         elementId_to_dataset_urn: Dict[str, str],
+        element_name_to_dataset_urns: Dict[str, List[str]],
         owner_username: Optional[str] = None,
     ) -> Iterable[MetadataWorkUnit]:
         dm_url_id = data_model.get_url_id()
@@ -846,7 +951,10 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             ).as_workunit()
 
             upstream_lineage = self._gen_data_model_element_upstream_lineage(
-                element, data_model, elementId_to_dataset_urn
+                element,
+                data_model,
+                elementId_to_dataset_urn,
+                element_name_to_dataset_urns,
             )
             if upstream_lineage is not None:
                 yield MetadataChangeProposalWrapper(
@@ -1049,11 +1157,19 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         if data_model.workspaceId:
             self.reporter.workspaces.increment_data_models_count(data_model.workspaceId)
 
+        element_name_to_dataset_urns: Dict[str, List[str]] = {}
+        for element in data_model.elements:
+            if element.name:
+                element_name_to_dataset_urns.setdefault(element.name, []).append(
+                    elementId_to_dataset_urn[element.elementId]
+                )
+
         yield from self._gen_data_model_element_workunits(
             data_model,
             data_model_key,
             data_model_container_urn,
             elementId_to_dataset_urn,
+            element_name_to_dataset_urns,
             owner_username=owner_username,
         )
 

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -115,6 +115,26 @@ logger = logging.getLogger(__name__)
 # column field (or we add SQL-based inference), swap this out here.
 SIGMA_DM_UNKNOWN_COLUMN_NATIVE_TYPE = "unknown"
 
+
+def _dm_column_ranks_above(
+    candidate: SigmaDataModelColumn, incumbent: SigmaDataModelColumn
+) -> bool:
+    """Tie-breaking order for duplicate-fieldPath columns within a DM element.
+
+    Prefers the row with a non-empty formula (the user-authored calculated
+    field Sigma surfaces in the UI). Tie-break: lexicographically smaller
+    columnId so the choice is stable across runs even if /columns ordering
+    shifts.
+
+    Used by both _gen_data_model_element_schema_metadata (to build SchemaMetadata)
+    and _build_dm_element_fine_grained_lineages (to mirror the same dedup so FGL
+    only references fieldPaths that actually appear in the schema).
+    """
+    if bool(candidate.formula) != bool(incumbent.formula):
+        return bool(candidate.formula)
+    return candidate.columnId < incumbent.columnId
+
+
 CrossDmOutcome = Literal[
     "strict",
     "ambiguous",
@@ -637,6 +657,8 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         # Sort for deterministic emission order: Sigma's /lineage API does
         # not document ordering, and Upstream entries have no semantic order.
         upstream_urns.sort()
+        if not upstream_urns:
+            return None
         fine_grained = self._build_dm_element_fine_grained_lineages(
             element=element,
             element_dataset_urn=elementId_to_dataset_urn[element.elementId],
@@ -644,8 +666,6 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             entity_level_upstream_urns=set(upstream_urns),
             data_model=data_model,
         )
-        if not upstream_urns and not fine_grained:
-            return None
         return UpstreamLineage(
             upstreams=[
                 Upstream(dataset=urn, type=DatasetLineageType.TRANSFORMED)
@@ -671,16 +691,6 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         #    ``/columns`` ordering guarantees.
         # Dropped ``columnId``s are emitted to debug logs so operators
         # can reconcile against Sigma.
-        def _ranks_above(
-            candidate: SigmaDataModelColumn, incumbent: SigmaDataModelColumn
-        ) -> bool:
-            # Prefer row with formula set (user-authored calc field).
-            # Tie-break: smaller columnId wins so the choice is stable
-            # across runs even if ``/columns`` ordering shifts.
-            if bool(candidate.formula) != bool(incumbent.formula):
-                return bool(candidate.formula)
-            return candidate.columnId < incumbent.columnId
-
         by_name: Dict[str, SigmaDataModelColumn] = {}
         dropped_column_ids_by_name: Dict[str, List[str]] = {}
         for column in element.columns:
@@ -691,7 +701,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                 by_name[column.name] = column
                 continue
             self.reporter.data_model_element_columns_duplicate_fieldpath_dropped += 1
-            if _ranks_above(column, existing):
+            if _dm_column_ranks_above(column, existing):
                 winner, loser = column, existing
             else:
                 winner, loser = existing, column
@@ -753,19 +763,18 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
     ) -> List[FineGrainedLineageClass]:
         """Build FineGrainedLineage entries for intra-DM [ElementName/col] refs.
 
-        Mirrors the dedup pass from _gen_data_model_element_schema_metadata so
-        FGL is only emitted for winner columns (fieldPaths present in SchemaMetadata).
+        Mirrors the dedup pass from _gen_data_model_element_schema_metadata (via
+        _dm_column_ranks_above) so FGL is only emitted for winner columns —
+        fieldPaths present in SchemaMetadata. Bare [col] refs are intra-element
+        transforms (lineage within one Dataset, not across Datasets) and are
+        skipped for FGL.
+
+        element.name values are used as-is (byte-for-byte) as dictionary keys;
+        extract_bracket_refs produces source strings verbatim from the bracket
+        body, so no case-folding or whitespace normalization is applied on either
+        side.
         """
-
-        def _ranks_above(
-            candidate: SigmaDataModelColumn, incumbent: SigmaDataModelColumn
-        ) -> bool:
-            if bool(candidate.formula) != bool(incumbent.formula):
-                return bool(candidate.formula)
-            return candidate.columnId < incumbent.columnId
-
         by_name: Dict[str, SigmaDataModelColumn] = {}
-        drop_count = 0
         for column in element.columns:
             if not column.name:
                 continue
@@ -775,13 +784,12 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                 continue
             winner, loser = (
                 (column, existing)
-                if _ranks_above(column, existing)
+                if _dm_column_ranks_above(column, existing)
                 else (existing, column)
             )
             by_name[column.name] = winner
             if loser.formula:
-                drop_count += 1
-        self.reporter.data_model_element_fgl_dropped_dedup_loser += drop_count
+                self.reporter.data_model_element_fgl_dropped_dedup_loser += 1
 
         fgls: List[FineGrainedLineageClass] = []
         for column in sorted(by_name.values(), key=lambda c: c.name):
@@ -793,7 +801,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                     self.reporter.data_model_element_fgl_param_skipped += 1
                     continue
                 if ref.column is None:
-                    # Bare [col] sibling ref — intra-element transform, not cross-Dataset.
+                    # Bare [col] — intra-element transform, not cross-Dataset lineage.
                     self.reporter.data_model_element_fgl_sibling_skipped += 1
                     continue
                 candidate_urns = element_name_to_dataset_urns.get(ref.source, [])
@@ -802,13 +810,24 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                 )
                 if not surviving_urns:
                     if candidate_urns:
-                        # Element is in this DM but /lineage doesn't claim it as upstream.
-                        # Drop to avoid orphan FGL the UI silently rejects.
+                        # Element is in this DM but /lineage doesn't claim it as
+                        # upstream. Drop to avoid orphan FGL the UI silently rejects.
                         self.reporter.data_model_element_fgl_dropped_orphan_upstream += 1
                     else:
-                        # Source not in this DM — cross-DM ref; RESOLVE-B will handle it.
+                        # Source not in this DM — cross-DM ref handled separately.
                         self.reporter.data_model_element_fgl_cross_dm_unresolved += 1
                     continue
+                if len(surviving_urns) > 1:
+                    logger.debug(
+                        "DM %s element %s: ref %r resolves to %d URNs after "
+                        "/lineage filter (duplicate element names in DM); "
+                        "emitting FGL to all surviving candidates: %s",
+                        data_model.dataModelId,
+                        element.elementId,
+                        ref.raw,
+                        len(surviving_urns),
+                        surviving_urns,
+                    )
                 downstream_field = builder.make_schema_field_urn(
                     element_dataset_urn, column.name
                 )
@@ -822,6 +841,9 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                             upstreams=[
                                 builder.make_schema_field_urn(upstream_urn, ref.column)
                             ],
+                            # confidenceScore=1.0 is the default; set explicitly to
+                            # signal this is structural (formula-derived), not statistical.
+                            confidenceScore=1.0,
                         )
                     )
         self.reporter.data_model_element_fgl_emitted += len(fgls)

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -804,18 +804,24 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                 # Formula-bearing column displaced by fieldPath dedup; FGL not emitted.
                 self.reporter.data_model_element_fgl_dropped_dedup_loser += 1
 
-        # Build a per-upstream-element column map: lowercased element name →
-        # { lowercased col name → canonical col name }.  Used to validate and
-        # normalise ref.column so the emitted schemaField URN matches the
-        # fieldPath actually present in the upstream element's SchemaMetadata.
-        upstream_col_map: Dict[str, Dict[str, str]] = {}
+        # Build a per-upstream-element column map keyed by Dataset URN (not
+        # element name) so duplicate-named DM elements with different schemas
+        # are handled correctly.  The i-th element of each name group in
+        # element_name_to_dataset_urns corresponds to the i-th occurrence of
+        # that name in data_model.elements (both built in the same iteration
+        # order in _gen_data_model_workunit).
+        urn_to_cols: Dict[str, Dict[str, str]] = {}
+        name_index: Dict[str, int] = {}
         for dm_el in data_model.elements:
             if not dm_el.name:
                 continue
-            el_by_name, _ = _dedup_dm_element_columns(dm_el.columns)
-            upstream_col_map[dm_el.name.lower()] = {
-                col_name.lower(): col_name for col_name in el_by_name
-            }
+            name_lower = dm_el.name.lower()
+            idx = name_index.get(name_lower, 0)
+            name_index[name_lower] = idx + 1
+            urns = element_name_to_dataset_urns.get(name_lower, [])
+            if idx < len(urns):
+                el_by_name, _ = _dedup_dm_element_columns(dm_el.columns)
+                urn_to_cols[urns[idx]] = {c.lower(): c for c in el_by_name}
 
         fgls: List[FineGrainedLineageClass] = []
         # Track emitted (downstream, upstream) schemaField pairs to deduplicate
@@ -852,22 +858,6 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                         # Source not in this DM — cross-DM ref handled separately.
                         self.reporter.data_model_element_fgl_cross_dm_deferred += 1
                     continue
-                # Validate and normalise ref.column against the upstream element's
-                # actual column winners.  Using the canonical name avoids a dangling
-                # schemaField URN when the formula author used different capitalisation.
-                source_cols = upstream_col_map.get(ref.source.lower(), {})
-                canonical_col = source_cols.get(ref.column.lower())
-                if canonical_col is None:
-                    self.reporter.data_model_element_fgl_dropped_unknown_upstream_column += 1
-                    logger.debug(
-                        "DM %s element %s: ref %r column %r not found in upstream "
-                        "element's schema winners; dropping FGL entry",
-                        data_model.dataModelId,
-                        element.elementId,
-                        ref.raw,
-                        ref.column,
-                    )
-                    continue
                 if len(surviving_urns) > 1:
                     logger.debug(
                         "DM %s element %s: ref %r resolves to %d URNs after "
@@ -879,9 +869,27 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                         len(surviving_urns),
                         surviving_urns,
                     )
-                # When surviving_urns > 1, one FGL entry is emitted per upstream;
-                # fgl_emitted therefore counts entries, not unique downstream fields.
+                # When surviving_urns > 1, one FGL entry is emitted per upstream.
+                # Column validation is per-URN so duplicate-named elements with
+                # different schemas each validate against their own column set.
                 for upstream_urn in surviving_urns:
+                    # Validate and normalise ref.column against this specific upstream
+                    # element's schema winners.  Keying by URN (not element name)
+                    # correctly handles duplicate-named elements with different schemas.
+                    source_cols = urn_to_cols.get(upstream_urn, {})
+                    canonical_col = source_cols.get(ref.column.lower())
+                    if canonical_col is None:
+                        self.reporter.data_model_element_fgl_dropped_unknown_upstream_column += 1
+                        logger.debug(
+                            "DM %s element %s: ref %r column %r not found in upstream "
+                            "element %s schema winners; dropping FGL entry",
+                            data_model.dataModelId,
+                            element.elementId,
+                            ref.raw,
+                            ref.column,
+                            upstream_urn,
+                        )
+                        continue
                     upstream_field = builder.make_schema_field_urn(
                         upstream_urn, canonical_col
                     )

--- a/metadata-ingestion/tests/integration/sigma/golden_test_sigma_ingest_data_models.json
+++ b/metadata-ingestion/tests/integration/sigma/golden_test_sigma_ingest_data_models.json
@@ -1113,11 +1113,24 @@
                     "dataset": "urn:li:dataset:(urn:li:dataPlatform:sigma,147a4d09-a686-4eea-b183-9b82aa0f7beb.0ui59vLc38,PROD)",
                     "type": "TRANSFORMED"
                 }
+            ],
+            "fineGrainedLineages": [
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:sigma,147a4d09-a686-4eea-b183-9b82aa0f7beb.0ui59vLc38,PROD),team1)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:sigma,147a4d09-a686-4eea-b183-9b82aa0f7beb.4plNusNz75,PROD),team1)"
+                    ],
+                    "confidenceScore": 1.0
+                }
             ]
         }
     },
     "systemMetadata": {
-        "lastObserved": 1776827045128,
+        "lastObserved": 1777502569919,
         "runId": "sigma-test",
         "lastRunId": "no-run-id-provided"
     }

--- a/metadata-ingestion/tests/unit/sigma/test_dm_element_fgl.py
+++ b/metadata-ingestion/tests/unit/sigma/test_dm_element_fgl.py
@@ -71,7 +71,8 @@ def _build(
     element: SigmaDataModelElement,
     *,
     element_dataset_urn: str | None = None,
-    element_name_to_dataset_urns: Dict[str, List[str]] | None = None,
+    element_name_to_eids: Dict[str, List[str]] | None = None,
+    elementId_to_dataset_urn: Dict[str, str] | None = None,
     entity_level_upstream_urns: Set[str] | None = None,
     upstream_elements: List[SigmaDataModelElement] | None = None,
 ) -> list:
@@ -79,7 +80,8 @@ def _build(
     return source._build_dm_element_fine_grained_lineages(
         element=element,
         element_dataset_urn=element_dataset_urn or _urn(element.elementId),
-        element_name_to_dataset_urns=element_name_to_dataset_urns or {},
+        element_name_to_eids=element_name_to_eids or {},
+        elementId_to_dataset_urn=elementId_to_dataset_urn or {},
         entity_level_upstream_urns=entity_level_upstream_urns or set(),
         data_model=_data_model(all_elements),
     )
@@ -95,7 +97,8 @@ def test_trivial_passthrough_resolves() -> None:
         source,
         element,
         element_dataset_urn=downstream_urn,
-        element_name_to_dataset_urns={"a": [upstream_urn]},
+        element_name_to_eids={"a": ["a"]},
+        elementId_to_dataset_urn={"a": upstream_urn},
         entity_level_upstream_urns={upstream_urn},
         upstream_elements=[_upstream_element("a", "A", ["x"])],
     )
@@ -118,7 +121,8 @@ def test_multi_ref_formula_emits_one_lineage_per_ref() -> None:
         source,
         element,
         element_dataset_urn=downstream_urn,
-        element_name_to_dataset_urns={"a": [upstream_urn]},
+        element_name_to_eids={"a": ["a"]},
+        elementId_to_dataset_urn={"a": upstream_urn},
         entity_level_upstream_urns={upstream_urn},
         upstream_elements=[_upstream_element("a", "A", ["p", "q"])],
     )
@@ -157,13 +161,22 @@ def test_cross_dm_ref_is_counted_unresolved() -> None:
     assert source.reporter.data_model_element_fgl_cross_dm_deferred == 1
 
 
-def test_orphan_upstream_is_dropped() -> None:
+def test_orphan_upstream_genuinely_dropped_when_lineage_api_gap_exists() -> None:
+    # Element IS in this DM (found in element_name_to_eids) but /lineage does
+    # not report it as an upstream (entity_level_upstream_urns is empty).
+    # This is the rare case where /lineage genuinely omits an intra-DM edge.
     source = _source()
     upstream_urn = _urn("a")
     element = _element("b", "B", [_column("b-x", "x", "[A/x]")])
 
     assert (
-        _build(source, element, element_name_to_dataset_urns={"a": [upstream_urn]})
+        _build(
+            source,
+            element,
+            element_name_to_eids={"a": ["a"]},
+            elementId_to_dataset_urn={"a": upstream_urn},
+            # entity_level_upstream_urns empty → /lineage API gap
+        )
         == []
     )
     assert source.reporter.data_model_element_fgl_dropped_orphan_upstream == 1
@@ -171,8 +184,6 @@ def test_orphan_upstream_is_dropped() -> None:
 
 def test_element_name_collision_is_filtered_by_entity_level_upstreams() -> None:
     source = _source()
-    # winner_urn and loser_urn are listed in element order so urn_to_cols can
-    # correctly pair each URN with its element's schema.
     winner_urn = _urn("rdm-1")
     loser_urn = _urn("rdm-2")
     downstream_urn = _urn("b")
@@ -188,7 +199,8 @@ def test_element_name_collision_is_filtered_by_entity_level_upstreams() -> None:
         element,
         element_dataset_urn=downstream_urn,
         # URN order matches upstream_elements order (rdm-1 first, rdm-2 second).
-        element_name_to_dataset_urns={"random data model": [winner_urn, loser_urn]},
+        element_name_to_eids={"random data model": ["rdm-1", "rdm-2"]},
+        elementId_to_dataset_urn={"rdm-1": winner_urn, "rdm-2": loser_urn},
         entity_level_upstream_urns={winner_urn},
         upstream_elements=[
             _upstream_element("rdm-1", "random data model", ["c"]),
@@ -198,62 +210,6 @@ def test_element_name_collision_is_filtered_by_entity_level_upstreams() -> None:
 
     assert len(lineages) == 1
     assert lineages[0].upstreams == [builder.make_schema_field_urn(winner_urn, "c")]
-
-
-def test_duplicate_element_names_different_schemas_validates_correct_element() -> None:
-    # Two elements share the name "orders" but have different schemas.
-    # The surviving upstream (orders-a) has "amount"; the non-surviving (orders-b)
-    # has "revenue".  urn_to_cols must pair each URN with its own element's schema
-    # so the wrong column set isn't used for validation.
-    source = _source()
-    orders_a_urn = _urn("orders-a")
-    orders_b_urn = _urn("orders-b")
-    downstream_urn = _urn("b")
-    element = _element("b", "B", [_column("b-x", "x", "[orders/amount]")])
-
-    lineages = _build(
-        source,
-        element,
-        element_dataset_urn=downstream_urn,
-        element_name_to_dataset_urns={"orders": [orders_a_urn, orders_b_urn]},
-        entity_level_upstream_urns={orders_a_urn},
-        upstream_elements=[
-            _upstream_element("orders-a", "orders", ["amount"]),
-            _upstream_element("orders-b", "orders", ["revenue"]),
-        ],
-    )
-
-    assert len(lineages) == 1
-    assert lineages[0].upstreams == [
-        builder.make_schema_field_urn(orders_a_urn, "amount")
-    ]
-    assert source.reporter.data_model_element_fgl_emitted == 1
-
-
-def test_duplicate_element_names_surviving_element_lacks_column() -> None:
-    # The surviving upstream element does NOT have the referenced column.
-    # FGL must be dropped to avoid a dangling schemaField URN, even though
-    # the non-surviving element does have that column.
-    source = _source()
-    orders_a_urn = _urn("orders-a")
-    orders_b_urn = _urn("orders-b")
-    downstream_urn = _urn("b")
-    element = _element("b", "B", [_column("b-x", "x", "[orders/revenue]")])
-
-    lineages = _build(
-        source,
-        element,
-        element_dataset_urn=downstream_urn,
-        element_name_to_dataset_urns={"orders": [orders_a_urn, orders_b_urn]},
-        entity_level_upstream_urns={orders_a_urn},
-        upstream_elements=[
-            _upstream_element("orders-a", "orders", ["amount"]),
-            _upstream_element("orders-b", "orders", ["revenue"]),
-        ],
-    )
-
-    assert lineages == []
-    assert source.reporter.data_model_element_fgl_dropped_unknown_upstream_column == 1
 
 
 def test_dedup_loser_formula_is_dropped() -> None:
@@ -273,7 +229,8 @@ def test_dedup_loser_formula_is_dropped() -> None:
         source,
         element,
         element_dataset_urn=downstream_urn,
-        element_name_to_dataset_urns={"a": [upstream_urn]},
+        element_name_to_eids={"a": ["a"]},
+        elementId_to_dataset_urn={"a": upstream_urn},
         entity_level_upstream_urns={upstream_urn},
         upstream_elements=[_upstream_element("a", "A", ["winner"])],
     )
@@ -293,7 +250,8 @@ def test_output_order_is_stable_for_shuffled_columns() -> None:
         _column("b-y", "y", "[C/c]"),
         _column("b-x", "x", "Sum([A/q], [A/p])"),
     ]
-    name_map: Dict[str, List[str]] = {"a": [upstream_a], "c": [upstream_c]}
+    name_eids: Dict[str, List[str]] = {"a": ["a"], "c": ["c"]}
+    eid_to_urn: Dict[str, str] = {"a": upstream_a, "c": upstream_c}
     upstream_urns: Set[str] = {upstream_a, upstream_c}
     upstream_els = [
         _upstream_element("a", "A", ["p", "q"]),
@@ -304,7 +262,8 @@ def test_output_order_is_stable_for_shuffled_columns() -> None:
         _source(),
         _element("b", "B", columns),
         element_dataset_urn=downstream_urn,
-        element_name_to_dataset_urns=name_map,
+        element_name_to_eids=name_eids,
+        elementId_to_dataset_urn=eid_to_urn,
         entity_level_upstream_urns=upstream_urns,
         upstream_elements=upstream_els,
     )
@@ -312,7 +271,8 @@ def test_output_order_is_stable_for_shuffled_columns() -> None:
         _source(),
         _element("b", "B", list(reversed(columns))),
         element_dataset_urn=downstream_urn,
-        element_name_to_dataset_urns=name_map,
+        element_name_to_eids=name_eids,
+        elementId_to_dataset_urn=eid_to_urn,
         entity_level_upstream_urns=upstream_urns,
         upstream_elements=upstream_els,
     )
@@ -343,9 +303,6 @@ def test_quoted_bracket_literal_does_not_emit_fgl() -> None:
 
 
 def test_case_insensitive_element_name_lookup() -> None:
-    # Formula uses "Orders" (mixed case); element is named "orders" (lowercase).
-    # element_name_to_dataset_urns is keyed lowercase, and ref.source is lowercased
-    # before lookup — so the ref must resolve despite the mismatch.
     source = _source()
     upstream_urn = _urn("orders")
     downstream_urn = _urn("b")
@@ -355,7 +312,8 @@ def test_case_insensitive_element_name_lookup() -> None:
         source,
         element,
         element_dataset_urn=downstream_urn,
-        element_name_to_dataset_urns={"orders": [upstream_urn]},
+        element_name_to_eids={"orders": ["orders-el"]},
+        elementId_to_dataset_urn={"orders-el": upstream_urn},
         entity_level_upstream_urns={upstream_urn},
         upstream_elements=[_upstream_element("orders-el", "orders", ["revenue"])],
     )
@@ -367,8 +325,6 @@ def test_case_insensitive_element_name_lookup() -> None:
 
 
 def test_duplicate_refs_in_formula_are_deduplicated() -> None:
-    # If([A/x] = 0, [A/x], [A/x] / 2) has three textual occurrences of [A/x].
-    # Only one FGL entry should be emitted, not three.
     source = _source()
     upstream_urn = _urn("a")
     downstream_urn = _urn("b")
@@ -380,19 +336,17 @@ def test_duplicate_refs_in_formula_are_deduplicated() -> None:
         source,
         element,
         element_dataset_urn=downstream_urn,
-        element_name_to_dataset_urns={"a": [upstream_urn]},
+        element_name_to_eids={"a": ["a"]},
+        elementId_to_dataset_urn={"a": upstream_urn},
         entity_level_upstream_urns={upstream_urn},
         upstream_elements=[_upstream_element("a", "A", ["x"])],
     )
 
     assert len(lineages) == 1
     assert source.reporter.data_model_element_fgl_emitted == 1
-    assert source.reporter.data_model_element_fgl_emitted == 1
 
 
 def test_unknown_upstream_column_is_dropped() -> None:
-    # Formula references [A/nonexistent] but upstream element A only has column "x".
-    # FGL must be dropped to avoid a dangling schemaField URN.
     source = _source()
     upstream_urn = _urn("a")
     downstream_urn = _urn("b")
@@ -402,10 +356,134 @@ def test_unknown_upstream_column_is_dropped() -> None:
         source,
         element,
         element_dataset_urn=downstream_urn,
-        element_name_to_dataset_urns={"a": [upstream_urn]},
+        element_name_to_eids={"a": ["a"]},
+        elementId_to_dataset_urn={"a": upstream_urn},
         entity_level_upstream_urns={upstream_urn},
         upstream_elements=[_upstream_element("a", "A", ["x"])],
     )
 
     assert lineages == []
     assert source.reporter.data_model_element_fgl_dropped_unknown_upstream_column == 1
+
+
+def test_duplicate_element_names_different_schemas_validates_correct_element() -> None:
+    source = _source()
+    orders_a_urn = _urn("orders-a")
+    orders_b_urn = _urn("orders-b")
+    downstream_urn = _urn("b")
+    element = _element("b", "B", [_column("b-x", "x", "[orders/amount]")])
+
+    lineages = _build(
+        source,
+        element,
+        element_dataset_urn=downstream_urn,
+        element_name_to_eids={"orders": ["orders-a", "orders-b"]},
+        elementId_to_dataset_urn={"orders-a": orders_a_urn, "orders-b": orders_b_urn},
+        entity_level_upstream_urns={orders_a_urn},
+        upstream_elements=[
+            _upstream_element("orders-a", "orders", ["amount"]),
+            _upstream_element("orders-b", "orders", ["revenue"]),
+        ],
+    )
+
+    assert len(lineages) == 1
+    assert lineages[0].upstreams == [
+        builder.make_schema_field_urn(orders_a_urn, "amount")
+    ]
+    assert source.reporter.data_model_element_fgl_emitted == 1
+
+
+def test_duplicate_element_names_surviving_element_lacks_column() -> None:
+    source = _source()
+    orders_a_urn = _urn("orders-a")
+    orders_b_urn = _urn("orders-b")
+    downstream_urn = _urn("b")
+    element = _element("b", "B", [_column("b-x", "x", "[orders/revenue]")])
+
+    lineages = _build(
+        source,
+        element,
+        element_dataset_urn=downstream_urn,
+        element_name_to_eids={"orders": ["orders-a", "orders-b"]},
+        elementId_to_dataset_urn={"orders-a": orders_a_urn, "orders-b": orders_b_urn},
+        entity_level_upstream_urns={orders_a_urn},
+        upstream_elements=[
+            _upstream_element("orders-a", "orders", ["amount"]),
+            _upstream_element("orders-b", "orders", ["revenue"]),
+        ],
+    )
+
+    assert lineages == []
+    assert source.reporter.data_model_element_fgl_dropped_unknown_upstream_column == 1
+
+
+def test_self_reference_is_warehouse_passthrough_deferred() -> None:
+    """Element named X with formula [X/col] is a warehouse-passthrough, not intra-DM.
+
+    The element's name matches the underlying warehouse table name (a common Sigma
+    authoring pattern).  The resolver must detect the self-reference and increment
+    fgl_warehouse_passthrough_deferred rather than emitting self-referential FGL.
+    """
+    source = _source()
+    self_urn = _urn("data.csv")
+    warehouse_urn = _urn("snowflake-inode")
+    element = _element(
+        "elem-data-csv",
+        "data.csv",
+        [_column("c1", "city", "[data.csv/city]")],
+    )
+
+    lineages = _build(
+        source,
+        element,
+        element_dataset_urn=self_urn,
+        element_name_to_eids={"data.csv": ["elem-data-csv"]},
+        elementId_to_dataset_urn={"elem-data-csv": self_urn},
+        # /lineage reports the warehouse inode as upstream, not the element itself
+        entity_level_upstream_urns={warehouse_urn},
+        upstream_elements=[_upstream_element("elem-data-csv", "data.csv", ["city"])],
+    )
+
+    assert lineages == []
+    assert source.reporter.data_model_element_fgl_warehouse_passthrough_deferred == 1
+    assert source.reporter.data_model_element_fgl_emitted == 0
+    assert source.reporter.data_model_element_fgl_dropped_orphan_upstream == 0
+    assert source.reporter.data_model_element_fgl_cross_dm_deferred == 0
+
+
+def test_name_collision_picks_first_sorted_urn() -> None:
+    """Two siblings share a name and both pass the /lineage filter.
+
+    The resolver picks sorted(surviving_urns)[0], matching T2 PR1's collision
+    precedent and Sigma's server-side coalescing.  fgl_collision_pick_first
+    is incremented once per ref that triggers this path.
+    """
+    source = _source()
+    # URN for "elem-aaa" sorts before URN for "elem-zzz" lexicographically
+    urn_aaa = _urn("aaa")
+    urn_zzz = _urn("zzz")
+    downstream_urn = _urn("b")
+    element = _element(
+        "b",
+        "B",
+        [_column("b-x", "x", "[shared name/team1]")],
+    )
+
+    lineages = _build(
+        source,
+        element,
+        element_dataset_urn=downstream_urn,
+        element_name_to_eids={"shared name": ["elem-aaa", "elem-zzz"]},
+        elementId_to_dataset_urn={"elem-aaa": urn_aaa, "elem-zzz": urn_zzz},
+        entity_level_upstream_urns={urn_aaa, urn_zzz},
+        upstream_elements=[
+            _upstream_element("elem-aaa", "shared name", ["team1"]),
+            _upstream_element("elem-zzz", "shared name", ["team1"]),
+        ],
+    )
+
+    assert len(lineages) == 1
+    # sorted([urn_aaa, urn_zzz])[0] == urn_aaa since "aaa" < "zzz"
+    assert lineages[0].upstreams == [builder.make_schema_field_urn(urn_aaa, "team1")]
+    assert source.reporter.data_model_element_fgl_collision_pick_first == 1
+    assert source.reporter.data_model_element_fgl_emitted == 1

--- a/metadata-ingestion/tests/unit/sigma/test_dm_element_fgl.py
+++ b/metadata-ingestion/tests/unit/sigma/test_dm_element_fgl.py
@@ -1,0 +1,413 @@
+import datetime as dt
+from typing import Dict, List, Set
+
+from datahub.emitter import mce_builder as builder
+from datahub.ingestion.source.sigma.config import SigmaSourceReport
+from datahub.ingestion.source.sigma.data_classes import (
+    SigmaDataModel,
+    SigmaDataModelColumn,
+    SigmaDataModelElement,
+)
+from datahub.ingestion.source.sigma.sigma import SigmaSource
+
+
+def _source() -> SigmaSource:
+    source = SigmaSource.__new__(SigmaSource)
+    source.reporter = SigmaSourceReport()
+    return source
+
+
+def _urn(name: str) -> str:
+    return f"urn:li:dataset:(urn:li:dataPlatform:sigma,{name},PROD)"
+
+
+def _column(column_id: str, name: str, formula: str | None) -> SigmaDataModelColumn:
+    return SigmaDataModelColumn(columnId=column_id, name=name, formula=formula)
+
+
+def _element(
+    element_id: str,
+    name: str,
+    columns: List[SigmaDataModelColumn],
+    source_ids: List[str] | None = None,
+) -> SigmaDataModelElement:
+    # The model_validator on SigmaDataModelElement discards non-dict columns
+    # (mimicking the /elements API which returns bare strings). Pass dicts so
+    # the validator keeps them and pydantic coerces them back to model objects.
+    return SigmaDataModelElement(
+        elementId=element_id,
+        name=name,
+        columns=[c.model_dump() for c in columns],
+        source_ids=source_ids or [],
+    )
+
+
+def _upstream_element(
+    element_id: str,
+    name: str,
+    col_names: List[str],
+) -> SigmaDataModelElement:
+    """Minimal upstream element with no-formula columns for canonical col lookup."""
+    return _element(
+        element_id,
+        name,
+        [_column(f"{element_id}-{c}", c, None) for c in col_names],
+    )
+
+
+def _data_model(elements: List[SigmaDataModelElement]) -> SigmaDataModel:
+    now = dt.datetime.now(dt.timezone.utc)
+    return SigmaDataModel(
+        dataModelId="dm-1",
+        name="DM",
+        createdAt=now,
+        updatedAt=now,
+        elements=elements,
+    )
+
+
+def _build(
+    source: SigmaSource,
+    element: SigmaDataModelElement,
+    *,
+    element_dataset_urn: str | None = None,
+    element_name_to_dataset_urns: Dict[str, List[str]] | None = None,
+    entity_level_upstream_urns: Set[str] | None = None,
+    upstream_elements: List[SigmaDataModelElement] | None = None,
+) -> list:
+    all_elements = [element] + (upstream_elements or [])
+    return source._build_dm_element_fine_grained_lineages(
+        element=element,
+        element_dataset_urn=element_dataset_urn or _urn(element.elementId),
+        element_name_to_dataset_urns=element_name_to_dataset_urns or {},
+        entity_level_upstream_urns=entity_level_upstream_urns or set(),
+        data_model=_data_model(all_elements),
+    )
+
+
+def test_trivial_passthrough_resolves() -> None:
+    source = _source()
+    upstream_urn = _urn("a")
+    downstream_urn = _urn("b")
+    element = _element("b", "B", [_column("b-x", "x", "[A/x]")])
+
+    lineages = _build(
+        source,
+        element,
+        element_dataset_urn=downstream_urn,
+        element_name_to_dataset_urns={"a": [upstream_urn]},
+        entity_level_upstream_urns={upstream_urn},
+        upstream_elements=[_upstream_element("a", "A", ["x"])],
+    )
+
+    assert len(lineages) == 1
+    assert lineages[0].upstreams == [builder.make_schema_field_urn(upstream_urn, "x")]
+    assert lineages[0].downstreams == [
+        builder.make_schema_field_urn(downstream_urn, "x")
+    ]
+    assert source.reporter.data_model_element_fgl_intra_resolved == 1
+    assert source.reporter.data_model_element_fgl_emitted == 1
+    assert source.reporter.data_model_element_columns_with_formula == 1
+
+
+def test_multi_ref_formula_emits_one_lineage_per_ref() -> None:
+    source = _source()
+    upstream_urn = _urn("a")
+    downstream_urn = _urn("b")
+    element = _element("b", "B", [_column("b-x", "x", "Sum([A/p], [A/q])")])
+
+    lineages = _build(
+        source,
+        element,
+        element_dataset_urn=downstream_urn,
+        element_name_to_dataset_urns={"a": [upstream_urn]},
+        entity_level_upstream_urns={upstream_urn},
+        upstream_elements=[_upstream_element("a", "A", ["p", "q"])],
+    )
+
+    assert [lineage.upstreams for lineage in lineages] == [
+        [builder.make_schema_field_urn(upstream_urn, "p")],
+        [builder.make_schema_field_urn(upstream_urn, "q")],
+    ]
+    assert [lineage.downstreams for lineage in lineages] == [
+        [builder.make_schema_field_urn(downstream_urn, "x")],
+        [builder.make_schema_field_urn(downstream_urn, "x")],
+    ]
+
+
+def test_bare_sibling_ref_is_skipped() -> None:
+    source = _source()
+    element = _element("b", "B", [_column("b-y", "y", "[B_other_col]")])
+
+    assert _build(source, element) == []
+    assert source.reporter.data_model_element_fgl_sibling_skipped == 1
+
+
+def test_parameter_ref_is_skipped() -> None:
+    source = _source()
+    element = _element("b", "B", [_column("b-z", "z", "[P_Date_Range]")])
+
+    assert _build(source, element) == []
+    assert source.reporter.data_model_element_fgl_param_skipped == 1
+
+
+def test_cross_dm_ref_is_counted_unresolved() -> None:
+    source = _source()
+    element = _element("b", "B", [_column("b-x", "x", "[OtherSource/y]")])
+
+    assert _build(source, element) == []
+    assert source.reporter.data_model_element_fgl_cross_dm_deferred == 1
+
+
+def test_orphan_upstream_is_dropped() -> None:
+    source = _source()
+    upstream_urn = _urn("a")
+    element = _element("b", "B", [_column("b-x", "x", "[A/x]")])
+
+    assert (
+        _build(source, element, element_name_to_dataset_urns={"a": [upstream_urn]})
+        == []
+    )
+    assert source.reporter.data_model_element_fgl_dropped_orphan_upstream == 1
+
+
+def test_element_name_collision_is_filtered_by_entity_level_upstreams() -> None:
+    source = _source()
+    # winner_urn and loser_urn are listed in element order so urn_to_cols can
+    # correctly pair each URN with its element's schema.
+    winner_urn = _urn("rdm-1")
+    loser_urn = _urn("rdm-2")
+    downstream_urn = _urn("b")
+    element = _element(
+        "b",
+        "B",
+        [_column("b-x", "x", "[random data model/c]")],
+        source_ids=["rdm-1"],
+    )
+
+    lineages = _build(
+        source,
+        element,
+        element_dataset_urn=downstream_urn,
+        # URN order matches upstream_elements order (rdm-1 first, rdm-2 second).
+        element_name_to_dataset_urns={"random data model": [winner_urn, loser_urn]},
+        entity_level_upstream_urns={winner_urn},
+        upstream_elements=[
+            _upstream_element("rdm-1", "random data model", ["c"]),
+            _upstream_element("rdm-2", "random data model", ["c"]),
+        ],
+    )
+
+    assert len(lineages) == 1
+    assert lineages[0].upstreams == [builder.make_schema_field_urn(winner_urn, "c")]
+
+
+def test_duplicate_element_names_different_schemas_validates_correct_element() -> None:
+    # Two elements share the name "orders" but have different schemas.
+    # The surviving upstream (orders-a) has "amount"; the non-surviving (orders-b)
+    # has "revenue".  urn_to_cols must pair each URN with its own element's schema
+    # so the wrong column set isn't used for validation.
+    source = _source()
+    orders_a_urn = _urn("orders-a")
+    orders_b_urn = _urn("orders-b")
+    downstream_urn = _urn("b")
+    element = _element("b", "B", [_column("b-x", "x", "[orders/amount]")])
+
+    lineages = _build(
+        source,
+        element,
+        element_dataset_urn=downstream_urn,
+        element_name_to_dataset_urns={"orders": [orders_a_urn, orders_b_urn]},
+        entity_level_upstream_urns={orders_a_urn},
+        upstream_elements=[
+            _upstream_element("orders-a", "orders", ["amount"]),
+            _upstream_element("orders-b", "orders", ["revenue"]),
+        ],
+    )
+
+    assert len(lineages) == 1
+    assert lineages[0].upstreams == [
+        builder.make_schema_field_urn(orders_a_urn, "amount")
+    ]
+    assert source.reporter.data_model_element_fgl_intra_resolved == 1
+
+
+def test_duplicate_element_names_surviving_element_lacks_column() -> None:
+    # The surviving upstream element does NOT have the referenced column.
+    # FGL must be dropped to avoid a dangling schemaField URN, even though
+    # the non-surviving element does have that column.
+    source = _source()
+    orders_a_urn = _urn("orders-a")
+    orders_b_urn = _urn("orders-b")
+    downstream_urn = _urn("b")
+    element = _element("b", "B", [_column("b-x", "x", "[orders/revenue]")])
+
+    lineages = _build(
+        source,
+        element,
+        element_dataset_urn=downstream_urn,
+        element_name_to_dataset_urns={"orders": [orders_a_urn, orders_b_urn]},
+        entity_level_upstream_urns={orders_a_urn},
+        upstream_elements=[
+            _upstream_element("orders-a", "orders", ["amount"]),
+            _upstream_element("orders-b", "orders", ["revenue"]),
+        ],
+    )
+
+    assert lineages == []
+    assert source.reporter.data_model_element_fgl_dropped_unknown_upstream_column == 1
+
+
+def test_dedup_loser_formula_is_dropped() -> None:
+    source = _source()
+    upstream_urn = _urn("a")
+    downstream_urn = _urn("b")
+    element = _element(
+        "b",
+        "B",
+        [
+            _column("col-1", "x", "[A/winner]"),
+            _column("col-2", "x", "[A/loser]"),
+        ],
+    )
+
+    lineages = _build(
+        source,
+        element,
+        element_dataset_urn=downstream_urn,
+        element_name_to_dataset_urns={"a": [upstream_urn]},
+        entity_level_upstream_urns={upstream_urn},
+        upstream_elements=[_upstream_element("a", "A", ["winner"])],
+    )
+
+    assert len(lineages) == 1
+    assert lineages[0].upstreams == [
+        builder.make_schema_field_urn(upstream_urn, "winner")
+    ]
+    assert source.reporter.data_model_element_fgl_dropped_dedup_loser == 1
+
+
+def test_output_order_is_stable_for_shuffled_columns() -> None:
+    upstream_a = _urn("a")
+    upstream_c = _urn("c")
+    downstream_urn = _urn("b")
+    columns = [
+        _column("b-y", "y", "[C/c]"),
+        _column("b-x", "x", "Sum([A/q], [A/p])"),
+    ]
+    name_map: Dict[str, List[str]] = {"a": [upstream_a], "c": [upstream_c]}
+    upstream_urns: Set[str] = {upstream_a, upstream_c}
+    upstream_els = [
+        _upstream_element("a", "A", ["p", "q"]),
+        _upstream_element("c", "C", ["c"]),
+    ]
+
+    first = _build(
+        _source(),
+        _element("b", "B", columns),
+        element_dataset_urn=downstream_urn,
+        element_name_to_dataset_urns=name_map,
+        entity_level_upstream_urns=upstream_urns,
+        upstream_elements=upstream_els,
+    )
+    second = _build(
+        _source(),
+        _element("b", "B", list(reversed(columns))),
+        element_dataset_urn=downstream_urn,
+        element_name_to_dataset_urns=name_map,
+        entity_level_upstream_urns=upstream_urns,
+        upstream_elements=upstream_els,
+    )
+
+    assert first == second
+    assert [(lineage.downstreams[0], lineage.upstreams[0]) for lineage in first] == [
+        (
+            builder.make_schema_field_urn(downstream_urn, "x"),
+            builder.make_schema_field_urn(upstream_a, "p"),
+        ),
+        (
+            builder.make_schema_field_urn(downstream_urn, "x"),
+            builder.make_schema_field_urn(upstream_a, "q"),
+        ),
+        (
+            builder.make_schema_field_urn(downstream_urn, "y"),
+            builder.make_schema_field_urn(upstream_c, "c"),
+        ),
+    ]
+
+
+def test_quoted_bracket_literal_does_not_emit_fgl() -> None:
+    source = _source()
+    element = _element("b", "B", [_column("b-x", "x", 'If([status]="[FAILED]", 1, 0)')])
+
+    assert _build(source, element) == []
+    assert source.reporter.data_model_element_fgl_sibling_skipped == 1
+
+
+def test_case_insensitive_element_name_lookup() -> None:
+    # Formula uses "Orders" (mixed case); element is named "orders" (lowercase).
+    # element_name_to_dataset_urns is keyed lowercase, and ref.source is lowercased
+    # before lookup — so the ref must resolve despite the mismatch.
+    source = _source()
+    upstream_urn = _urn("orders")
+    downstream_urn = _urn("b")
+    element = _element("b", "B", [_column("b-x", "x", "[Orders/revenue]")])
+
+    lineages = _build(
+        source,
+        element,
+        element_dataset_urn=downstream_urn,
+        element_name_to_dataset_urns={"orders": [upstream_urn]},
+        entity_level_upstream_urns={upstream_urn},
+        upstream_elements=[_upstream_element("orders-el", "orders", ["revenue"])],
+    )
+
+    assert len(lineages) == 1
+    assert lineages[0].upstreams == [
+        builder.make_schema_field_urn(upstream_urn, "revenue")
+    ]
+
+
+def test_duplicate_refs_in_formula_are_deduplicated() -> None:
+    # If([A/x] = 0, [A/x], [A/x] / 2) has three textual occurrences of [A/x].
+    # Only one FGL entry should be emitted, not three.
+    source = _source()
+    upstream_urn = _urn("a")
+    downstream_urn = _urn("b")
+    element = _element(
+        "b", "B", [_column("b-x", "x", "If([A/x] = 0, [A/x], [A/x] / 2)")]
+    )
+
+    lineages = _build(
+        source,
+        element,
+        element_dataset_urn=downstream_urn,
+        element_name_to_dataset_urns={"a": [upstream_urn]},
+        entity_level_upstream_urns={upstream_urn},
+        upstream_elements=[_upstream_element("a", "A", ["x"])],
+    )
+
+    assert len(lineages) == 1
+    assert source.reporter.data_model_element_fgl_intra_resolved == 1
+    assert source.reporter.data_model_element_fgl_emitted == 1
+
+
+def test_unknown_upstream_column_is_dropped() -> None:
+    # Formula references [A/nonexistent] but upstream element A only has column "x".
+    # FGL must be dropped to avoid a dangling schemaField URN.
+    source = _source()
+    upstream_urn = _urn("a")
+    downstream_urn = _urn("b")
+    element = _element("b", "B", [_column("b-x", "x", "[A/nonexistent]")])
+
+    lineages = _build(
+        source,
+        element,
+        element_dataset_urn=downstream_urn,
+        element_name_to_dataset_urns={"a": [upstream_urn]},
+        entity_level_upstream_urns={upstream_urn},
+        upstream_elements=[_upstream_element("a", "A", ["x"])],
+    )
+
+    assert lineages == []
+    assert source.reporter.data_model_element_fgl_dropped_unknown_upstream_column == 1

--- a/metadata-ingestion/tests/unit/sigma/test_dm_element_fgl.py
+++ b/metadata-ingestion/tests/unit/sigma/test_dm_element_fgl.py
@@ -105,9 +105,7 @@ def test_trivial_passthrough_resolves() -> None:
     assert lineages[0].downstreams == [
         builder.make_schema_field_urn(downstream_urn, "x")
     ]
-    assert source.reporter.data_model_element_fgl_intra_resolved == 1
     assert source.reporter.data_model_element_fgl_emitted == 1
-    assert source.reporter.data_model_element_columns_with_formula == 1
 
 
 def test_multi_ref_formula_emits_one_lineage_per_ref() -> None:
@@ -140,7 +138,7 @@ def test_bare_sibling_ref_is_skipped() -> None:
     element = _element("b", "B", [_column("b-y", "y", "[B_other_col]")])
 
     assert _build(source, element) == []
-    assert source.reporter.data_model_element_fgl_sibling_skipped == 1
+    assert source.reporter.data_model_element_fgl_emitted == 0
 
 
 def test_parameter_ref_is_skipped() -> None:
@@ -148,7 +146,7 @@ def test_parameter_ref_is_skipped() -> None:
     element = _element("b", "B", [_column("b-z", "z", "[P_Date_Range]")])
 
     assert _build(source, element) == []
-    assert source.reporter.data_model_element_fgl_param_skipped == 1
+    assert source.reporter.data_model_element_fgl_emitted == 0
 
 
 def test_cross_dm_ref_is_counted_unresolved() -> None:
@@ -229,7 +227,7 @@ def test_duplicate_element_names_different_schemas_validates_correct_element() -
     assert lineages[0].upstreams == [
         builder.make_schema_field_urn(orders_a_urn, "amount")
     ]
-    assert source.reporter.data_model_element_fgl_intra_resolved == 1
+    assert source.reporter.data_model_element_fgl_emitted == 1
 
 
 def test_duplicate_element_names_surviving_element_lacks_column() -> None:
@@ -284,7 +282,7 @@ def test_dedup_loser_formula_is_dropped() -> None:
     assert lineages[0].upstreams == [
         builder.make_schema_field_urn(upstream_urn, "winner")
     ]
-    assert source.reporter.data_model_element_fgl_dropped_dedup_loser == 1
+    assert source.reporter.data_model_element_fgl_emitted == 1
 
 
 def test_output_order_is_stable_for_shuffled_columns() -> None:
@@ -341,7 +339,7 @@ def test_quoted_bracket_literal_does_not_emit_fgl() -> None:
     element = _element("b", "B", [_column("b-x", "x", 'If([status]="[FAILED]", 1, 0)')])
 
     assert _build(source, element) == []
-    assert source.reporter.data_model_element_fgl_sibling_skipped == 1
+    assert source.reporter.data_model_element_fgl_emitted == 0
 
 
 def test_case_insensitive_element_name_lookup() -> None:
@@ -388,7 +386,7 @@ def test_duplicate_refs_in_formula_are_deduplicated() -> None:
     )
 
     assert len(lineages) == 1
-    assert source.reporter.data_model_element_fgl_intra_resolved == 1
+    assert source.reporter.data_model_element_fgl_emitted == 1
     assert source.reporter.data_model_element_fgl_emitted == 1
 
 


### PR DESCRIPTION
## What this fixes

Detect Sigma's "warehouse-passthrough" pattern, where a DM element's name matches
its underlying warehouse table name (e.g., element "data.csv" with formula
"[data.csv/col]"). Without this fix, the resolver tried to match these as intra-DM
siblings, hit the orphan filter (correctly, because /lineage reports the warehouse
inode as upstream, not the element itself), and dropped 92/114 (80%) of intra-DM
formula refs on the live PoC tenant. Counter taxonomy was misleading: these were
labeled "orphan upstream" but actually represented a different category entirely.

## What this does NOT fix

Warehouse-external column resolution (resolving `[warehouse_table/col]` to the
warehouse Dataset's column URN) is explicitly out of scope and stays deferred.
The 73 confirmed self-references are now correctly bucketed as
`fgl_warehouse_passthrough_deferred` so they can be picked up by a future
warehouse-external pass.
