### PR TITLE
fix(ingest/glue): filter table-level resource links when ignore_resource_links is true

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
@@ -1166,10 +1166,20 @@ class GlueSource(StatefulIngestionSourceBase):
             paginator_response = paginator.paginate(DatabaseName=database_name)
 
         for table in paginator_response.search("TableList"):
-            # if resource links are detected, re-use database names from the current catalog
-            # otherwise, external names are picked up instead of aliased ones when creating full table names later
-            # This will cause an incoherent situation when creating full table names later
-            # Note: use an explicit source_config check but it is useless actually (filtering has already been done)
+            # Lake Formation can share individual tables across accounts as table-level
+            # resource links (table has a TargetTable pointing at the shared table).
+            # Database-level filtering in get_all_databases() does not catch these,
+            # since they live inside non-resource-link databases.
+            if self.source_config.ignore_resource_links and "TargetTable" in table:
+                logger.debug(
+                    f"Skipping resource link table {database_name}.{table.get('Name')} "
+                    f"(TargetTable: {table.get('TargetTable')})"
+                )
+                continue
+
+            # When ingesting resource-link databases (ignore_resource_links=False),
+            # rewrite DatabaseName to the local alias so downstream URN construction
+            # uses the catalog-local name instead of the target catalog's name.
             if (
                 not self.source_config.ignore_resource_links
                 and "TargetDatabase" in database

--- a/metadata-ingestion/tests/unit/glue/test_glue_source.py
+++ b/metadata-ingestion/tests/unit/glue/test_glue_source.py
@@ -46,6 +46,7 @@ from tests.unit.glue.test_glue_source_stubs import (
     get_databases_response,
     get_databases_response_for_lineage,
     get_databases_response_profiling,
+    get_databases_response_with_mixed_database,
     get_databases_response_with_resource_link,
     get_dataflow_graph_response_1,
     get_dataflow_graph_response_2,
@@ -64,9 +65,13 @@ from tests.unit.glue.test_glue_source_stubs import (
     get_tables_lineage_response_1,
     get_tables_response_1,
     get_tables_response_2,
+    get_tables_response_for_mixed_database,
     get_tables_response_for_target_database,
     get_tables_response_profiling_1,
+    mixed_database,
+    normal_table_in_mixed_database,
     resource_link_database,
+    resource_link_table_in_mixed_database,
     tables_1,
     tables_2,
     tables_profiling_1,
@@ -317,6 +322,55 @@ def test_ignore_resource_links(ignore_resource_links, all_databases_and_tables_r
         )
 
         assert source.get_all_databases_and_tables() == all_databases_and_tables_result
+
+
+@pytest.mark.parametrize(
+    "ignore_resource_links, expected_tables",
+    [
+        # When ignore_resource_links is True, the table-level resource link
+        # (TargetTable) is dropped and only the normal table is yielded.
+        (True, [normal_table_in_mixed_database]),
+        # When ignore_resource_links is False, both tables are yielded.
+        (
+            False,
+            [normal_table_in_mixed_database, resource_link_table_in_mixed_database],
+        ),
+    ],
+)
+def test_ignore_resource_links_filters_table_level_links(
+    ignore_resource_links, expected_tables
+):
+    """Regression test for CUS-8715.
+
+    Lake Formation supports table-granularity sharing where a regular database
+    contains tables that are resource links (i.e. tables with a TargetTable
+    field). Database-level filtering does not catch these, so the table-level
+    filter must drop them when ignore_resource_links is enabled.
+    """
+    source = GlueSource(
+        ctx=PipelineContext(run_id="glue-source-test"),
+        config=GlueSourceConfig(
+            aws_region="eu-west-1",
+            ignore_resource_links=ignore_resource_links,
+        ),
+    )
+
+    with Stubber(source.glue_client) as glue_stubber:
+        glue_stubber.add_response(
+            "get_databases",
+            get_databases_response_with_mixed_database,
+            {},
+        )
+        glue_stubber.add_response(
+            "get_tables",
+            get_tables_response_for_mixed_database,
+            {"DatabaseName": "mixed-database"},
+        )
+
+        databases, tables = source.get_all_databases_and_tables()
+
+    assert databases == [mixed_database]
+    assert tables == expected_tables
 
 
 def test_platform_must_be_valid():

--- a/metadata-ingestion/tests/unit/glue/test_glue_source_stubs.py
+++ b/metadata-ingestion/tests/unit/glue/test_glue_source_stubs.py
@@ -49,6 +49,61 @@ target_database_tables = [
 ]
 get_tables_response_for_target_database = {"TableList": target_database_tables}
 
+# A regular (non-resource-link) database that contains a mix of normal tables and
+# table-level resource links. Lake Formation can share individual tables across
+# accounts at table granularity, so the database itself has no TargetDatabase but
+# some tables expose a TargetTable pointer.
+mixed_database = {
+    "Name": "mixed-database",
+    "CreateTime": datetime.datetime(2021, 6, 9, 14, 14, 19),
+    "CreateTableDefaultPermissions": [],
+    "CatalogId": "123412341234",
+}
+
+normal_table_in_mixed_database = {
+    "Name": "normal-table",
+    "DatabaseName": "mixed-database",
+    "CreateTime": datetime.datetime(2021, 6, 9, 14, 14, 19),
+    "UpdateTime": datetime.datetime(
+        2021, 6, 9, 14, 14, 19, tzinfo=datetime.timezone.utc
+    ),
+    "Retention": 0,
+    "StorageDescriptor": {
+        "Columns": [{"Name": "id", "Type": "bigint", "Comment": ""}],
+        "Location": "s3://test-db-123412341234/normal-table",
+        "InputFormat": "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat",
+        "OutputFormat": "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat",
+        "Compressed": False,
+        "NumberOfBuckets": 0,
+        "SerdeInfo": {
+            "Parameters": {"serialization.format": "1"},
+            "SerializationLibrary": "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe",
+        },
+        "SortColumns": [],
+        "StoredAsSubDirectories": False,
+    },
+    "TableType": "EXTERNAL_TABLE",
+    "Parameters": {"classification": "parquet"},
+    "CatalogId": "123412341234",
+}
+
+resource_link_table_in_mixed_database = {
+    "Name": "shared-transactions",
+    "DatabaseName": "mixed-database",
+    "CreateTime": datetime.datetime(2021, 6, 9, 14, 14, 19),
+    "TargetTable": {
+        "CatalogId": "432143214321",
+        "DatabaseName": "test-database",
+        "Name": "transactions",
+    },
+    "CatalogId": "123412341234",
+}
+
+get_databases_response_with_mixed_database = {"DatabaseList": [mixed_database]}
+get_tables_response_for_mixed_database = {
+    "TableList": [normal_table_in_mixed_database, resource_link_table_in_mixed_database]
+}
+
 get_databases_response = {
     "DatabaseList": [
         {


### PR DESCRIPTION
## Summary

The Glue connector previously only filtered **database-level** resource links (via JMESPath `DatabaseList[?!TargetDatabase]` in `get_all_databases`). Lake Formation can also share individual tables across accounts as **table-level** resource links — the table object exposes a `TargetTable` pointer, but the parent database is a normal (non-resource-link) database. Those tables were ingested regardless of `ignore_resource_links: true`.

This PR adds an explicit Python-level filter in `get_tables_from_database` that skips tables with a `TargetTable` field when the flag is enabled, and clarifies a misleading code comment that implied table-level filtering was already covered.

- Drop tables with `TargetTable` when `ignore_resource_links: true`
- Reword the "filtering has already been done" comment that only described database-level filtering
- Add regression test covering a regular database with a mix of normal tables and table-level resource links

## Issue

Linear: [CUS-8715](https://linear.app/acryl-data/issue/CUS-8715/resource-links-not-fully-excluded-and-missing-browse-paths-in-glue)

## Test plan

- [x] New unit test `test_ignore_resource_links_filters_table_level_links` passes (parametrized over both flag values)
- [x] Existing `test_ignore_resource_links` (database-level case) still passes
- [x] Full `tests/unit/glue/test_glue_source.py` passes — 60/60
- [x] `./gradlew :metadata-ingestion:lintFix` clean

## Checklist

- [x] PR conforms to [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (PR title format)
- [x] Links to related issue
- [x] Tests added
- [ ] Docs — n/a (existing `ignore_resource_links` config behavior, just expanded coverage)
- [ ] Breaking change — n/a (filter is additive and only active when the opt-in flag is set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)