### PR TITLE
docs(dataplex): update Dataplex prerequisites and IAM role requirements

### DIFF
--- a/metadata-ingestion/docs/sources/dataplex/dataplex_pre.md
+++ b/metadata-ingestion/docs/sources/dataplex/dataplex_pre.md
@@ -18,6 +18,7 @@ Enable the following APIs on all target projects:
 
 - **Dataplex API** (`dataplex.googleapis.com`) — see [Enable Knowledge Catalog](https://docs.cloud.google.com/dataplex/docs/enable-api)
 - **Data Lineage API** (`datalineage.googleapis.com`) — required for lineage extraction (`include_lineage: true`), see [Enable Data Lineage API](https://docs.cloud.google.com/dataplex/docs/use-lineage#enable-apis)
+- **Cloud Resource Manager API** (`cloudresourcemanager.googleapis.com`) — required for term-asset associations (`include_glossary_term_associations: true`)
 
 Some asset types require additional setup. For example, Cloud SQL instances must be connected to Dataplex to enable automatic metadata harvesting (schemas, tables, and views):
 
@@ -79,12 +80,12 @@ For service account authentication, follow these instructions:
 
 Grant the following roles to the service account on all target projects.
 
-| Feature                                                              | Required Role                                                                                                                                            |
-| -------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Universal Catalog Entries API (core ingestion)                       | [`roles/dataplex.catalogViewer`](https://cloud.google.com/dataplex/docs/iam-roles#dataplex.catalogViewer)                                                |
-| Lineage extraction (`include_lineage: true`)                         | [`roles/datalineage.viewer`](https://cloud.google.com/dataplex/docs/iam-roles#datalineage.viewer)                                                        |
-| Business Glossary ingestion (`include_glossaries: true`)             | [`roles/dataplex.catalogViewer`](https://cloud.google.com/dataplex/docs/iam-roles#dataplex.catalogViewer)                                                |
-| Term-asset associations (`include_glossary_term_associations: true`) | [`roles/resourcemanager.projectViewer`](https://cloud.google.com/resource-manager/docs/access-control-proj) — required for resolving GCP project numbers |
+| Feature                                                              | Required Role                                                                                                                                                                                    |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Universal Catalog Entries API (core ingestion)                       | [`roles/dataplex.catalogViewer`](https://cloud.google.com/dataplex/docs/iam-roles#dataplex.catalogViewer)                                                                                        |
+| Lineage extraction (`include_lineage: true`)                         | [`roles/datalineage.viewer`](https://cloud.google.com/dataplex/docs/iam-roles#datalineage.viewer)                                                                                                |
+| Business Glossary ingestion (`include_glossaries: true`)             | [`roles/dataplex.catalogViewer`](https://cloud.google.com/dataplex/docs/iam-roles#dataplex.catalogViewer)                                                                                        |
+| Term-asset associations (`include_glossary_term_associations: true`) | [`roles/resourcemanager.folderViewer`](https://cloud.google.com/resource-manager/docs/access-control-proj) — provides `resourcemanager.projects.get`, required for resolving GCP project numbers |
 
 :::tip "Lineage requires the role on multiple projects"
 


### PR DESCRIPTION
## Description

Updates the Dataplex source documentation to clarify API and IAM role requirements for term-asset associations functionality.

### Changes

- Added **Cloud Resource Manager API** (`cloudresourcemanager.googleapis.com`) to the list of required APIs when using `include_glossary_term_associations: true`
- Updated the IAM role requirement for term-asset associations from `roles/resourcemanager.projectViewer` to `roles/resourcemanager.folderViewer`, which provides the necessary `resourcemanager.projects.get` permission for resolving GCP project numbers
- Reformatted the IAM roles table for improved readability

### Motivation

These documentation updates ensure users have accurate information about the APIs and permissions required to successfully configure and use the Dataplex source connector, particularly for the glossary term-asset associations feature.

### Test Plan

N/A - Documentation only change

https://claude.ai/code/session_018831CNLKuLDU5oS4mE4UGL