### PR TITLE
fix(ingestion): MCPObserver failures must not fail ingest

### DIFF
--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/batch/AspectsBatch.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/batch/AspectsBatch.java
@@ -25,6 +25,8 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A batch of aspects in the context of either an MCP or MCL write path to a data store. The item is
@@ -32,6 +34,8 @@ import org.apache.commons.lang3.StringUtils;
  * SystemMetadata} and record/message created time
  */
 public interface AspectsBatch {
+  Logger log = LoggerFactory.getLogger(AspectsBatch.class);
+
   Collection<? extends BatchItem> getItems();
 
   Collection<? extends BatchItem> getInitialItems();
@@ -181,11 +185,10 @@ public interface AspectsBatch {
         // Belt-and-suspenders. observer.apply() is final + try/catch, but this guarantees that an
         // exception during dispatch (registry lookup, plugin construction, etc.) cannot fail the
         // ingest batch.
-        org.slf4j.LoggerFactory.getLogger(AspectsBatch.class)
-            .warn(
-                "MCPObserver dispatch failed for {}; ingest continuing.",
-                observer == null ? "null" : observer.getClass().getName(),
-                t);
+        log.warn(
+            "MCPObserver dispatch failed for {}; ingest continuing.",
+            observer == null ? "null" : observer.getClass().getName(),
+            t);
       }
     }
   }

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/batch/AspectsBatch.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/batch/AspectsBatch.java
@@ -181,10 +181,11 @@ public interface AspectsBatch {
         retrieverContext.getAspectRetriever().getEntityRegistry().getAllMCPObservers()) {
       try {
         observer.apply(items, retrieverContext);
+      } catch (VirtualMachineError e) {
+        throw e;
       } catch (Throwable t) {
-        // Belt-and-suspenders. observer.apply() is final + try/catch, but this guarantees that an
-        // exception during dispatch (registry lookup, plugin construction, etc.) cannot fail the
-        // ingest batch.
+        // Belt-and-suspenders around the per-observer apply call. observer.apply() is final and
+        // already catches; this loop guarantees one bad observer cannot stop dispatch to the rest.
         log.warn(
             "MCPObserver dispatch failed for {}; ingest continuing.",
             observer == null ? "null" : observer.getClass().getName(),

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/batch/AspectsBatch.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/batch/AspectsBatch.java
@@ -6,6 +6,7 @@ import com.datahub.authorization.AuthorizationSession;
 import com.linkedin.metadata.aspect.ReadItem;
 import com.linkedin.metadata.aspect.RetrieverContext;
 import com.linkedin.metadata.aspect.SystemAspect;
+import com.linkedin.metadata.aspect.plugins.hooks.MCPObserver;
 import com.linkedin.metadata.aspect.plugins.hooks.MutationHook;
 import com.linkedin.metadata.aspect.plugins.validation.ValidationExceptionCollection;
 import com.linkedin.mxe.SystemMetadata;
@@ -172,11 +173,21 @@ public interface AspectsBatch {
 
   static void applyMCPObservers(
       Collection<? extends BatchItem> items, @Nonnull RetrieverContext retrieverContext) {
-    retrieverContext
-        .getAspectRetriever()
-        .getEntityRegistry()
-        .getAllMCPObservers()
-        .forEach(observer -> observer.apply(items, retrieverContext));
+    for (MCPObserver observer :
+        retrieverContext.getAspectRetriever().getEntityRegistry().getAllMCPObservers()) {
+      try {
+        observer.apply(items, retrieverContext);
+      } catch (Throwable t) {
+        // Belt-and-suspenders. observer.apply() is final + try/catch, but this guarantees that an
+        // exception during dispatch (registry lookup, plugin construction, etc.) cannot fail the
+        // ingest batch.
+        org.slf4j.LoggerFactory.getLogger(AspectsBatch.class)
+            .warn(
+                "MCPObserver dispatch failed for {}; ingest continuing.",
+                observer == null ? "null" : observer.getClass().getName(),
+                t);
+      }
+    }
   }
 
   default Stream<MCLItem> applyMCLSideEffects(Collection<MCLItem> items) {

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/plugins/hooks/MCPObserver.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/plugins/hooks/MCPObserver.java
@@ -6,26 +6,39 @@ import com.linkedin.metadata.aspect.plugins.PluginSpec;
 import java.util.Collection;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Observe MCPs before the database transaction without producing additional MCPs or MCLs. Intended
  * for external actions like metrics collection that need pre-commit visibility.
  */
+@Slf4j
 public abstract class MCPObserver extends PluginSpec {
 
   /**
    * Filters items through {@code shouldApply()} and delegates to {@link #observeMCPs}.
    *
-   * @param items incoming batch items
-   * @param retrieverContext accessors for aspect and graph data
+   * <p>Observers are pre-transaction, side-effect-only (metrics/logs/external actions). They must
+   * never fail the ingest path. We catch and log any throwable here so a buggy observer (or a
+   * cast/NPE against a malformed item in the batch) cannot crash GMS ingestion. The full stack is
+   * logged at WARN so it surfaces even when ERROR-level logging is filtered downstream.
    */
   public final void apply(
       Collection<? extends BatchItem> items, @Nonnull RetrieverContext retrieverContext) {
-    observeMCPs(
-        items.stream()
-            .filter(item -> shouldApply(item.getChangeType(), item.getUrn(), item.getAspectName()))
-            .collect(Collectors.toList()),
-        retrieverContext);
+    try {
+      observeMCPs(
+          items.stream()
+              .filter(
+                  item -> shouldApply(item.getChangeType(), item.getUrn(), item.getAspectName()))
+              .collect(Collectors.toList()),
+          retrieverContext);
+    } catch (Throwable t) {
+      log.warn(
+          "MCPObserver {} failed; ingest continuing. batch_size={}",
+          getClass().getSimpleName(),
+          items == null ? -1 : items.size(),
+          t);
+    }
   }
 
   /**

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/plugins/hooks/MCPObserver.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/plugins/hooks/MCPObserver.java
@@ -32,10 +32,13 @@ public abstract class MCPObserver extends PluginSpec {
                   item -> shouldApply(item.getChangeType(), item.getUrn(), item.getAspectName()))
               .collect(Collectors.toList()),
           retrieverContext);
+    } catch (VirtualMachineError e) {
+      // Never swallow JVM-fatal errors (OOM, StackOverflow, InternalError, UnknownError).
+      throw e;
     } catch (Throwable t) {
       log.warn(
           "MCPObserver {} failed; ingest continuing. batch_size={}",
-          getClass().getSimpleName(),
+          getClass().getName(),
           items == null ? -1 : items.size(),
           t);
     }

--- a/entity-registry/src/test/java/com/linkedin/metadata/aspect/plugins/hooks/MCPObserverResilienceTest.java
+++ b/entity-registry/src/test/java/com/linkedin/metadata/aspect/plugins/hooks/MCPObserverResilienceTest.java
@@ -1,0 +1,69 @@
+package com.linkedin.metadata.aspect.plugins.hooks;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.fail;
+
+import com.linkedin.metadata.aspect.AspectRetriever;
+import com.linkedin.metadata.aspect.RetrieverContext;
+import com.linkedin.metadata.aspect.batch.AspectsBatch;
+import com.linkedin.metadata.aspect.batch.BatchItem;
+import com.linkedin.metadata.aspect.plugins.config.AspectPluginConfig;
+import com.linkedin.metadata.models.registry.EntityRegistry;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nonnull;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import org.testng.annotations.Test;
+
+public class MCPObserverResilienceTest {
+
+  @Test
+  public void throwingObserverDoesNotFailDispatch() {
+    ThrowingMCPObserver throwing = new ThrowingMCPObserver();
+    throwing.setConfig(
+        AspectPluginConfig.builder()
+            .className(ThrowingMCPObserver.class.getName())
+            .enabled(true)
+            .supportedOperations(List.of("UPSERT"))
+            .supportedEntityAspectNames(
+                List.of(
+                    AspectPluginConfig.EntityAspectName.builder()
+                        .entityName("*")
+                        .aspectName("*")
+                        .build()))
+            .build());
+
+    EntityRegistry registry = mock(EntityRegistry.class);
+    when(registry.getAllMCPObservers()).thenReturn(List.of(throwing));
+
+    AspectRetriever retriever = mock(AspectRetriever.class);
+    when(retriever.getEntityRegistry()).thenReturn(registry);
+
+    RetrieverContext rc = mock(RetrieverContext.class);
+    when(rc.getAspectRetriever()).thenReturn(retriever);
+
+    try {
+      AspectsBatch.applyMCPObservers(Collections.<BatchItem>emptyList(), rc);
+    } catch (Throwable t) {
+      fail("applyMCPObservers must not propagate observer errors", t);
+    }
+  }
+
+  @Getter
+  @Setter
+  @Accessors(chain = true)
+  public static class ThrowingMCPObserver extends MCPObserver {
+
+    private AspectPluginConfig config;
+
+    @Override
+    protected void observeMCPs(
+        Collection<? extends BatchItem> items, @Nonnull RetrieverContext retrieverContext) {
+      throw new ClassCastException("null");
+    }
+  }
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
@@ -1683,11 +1683,14 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
     if (!async) {
       try {
         aspectsBatch.applyMCPObservers(aspectsBatch.getItems());
+      } catch (VirtualMachineError e) {
+        throw e;
       } catch (Throwable t) {
-        // MCP observers are pre-transaction, side-effect only (metrics/logs). They must not fail
-        // the ingest path. Any leak here is a bug in an observer or its dispatch and should be
-        // fixed upstream, but we never want it to crash a customer ingest.
-        log.warn("MCP observer dispatch failed; ingest continuing", t);
+        // Outermost guard around the observer call site. Inner layers in MCPObserver.apply and
+        // AspectsBatch.applyMCPObservers already isolate per-observer failures; anything that
+        // leaks here is a non-observer bug (batch wiring, retriever context) — log it as such
+        // rather than as an observer failure so it doesn't get triaged to the wrong owner.
+        log.warn("MCP observer call site failed; ingest continuing", t);
       }
     }
     Stream<IngestResult> timeseriesIngestResults =

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
@@ -1681,7 +1681,14 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
     // Apply MCP observers (pre-transaction metrics collection, external actions).
     // Only on sync path — async MCPs come back via MCE consumer with async=false.
     if (!async) {
-      aspectsBatch.applyMCPObservers(aspectsBatch.getItems());
+      try {
+        aspectsBatch.applyMCPObservers(aspectsBatch.getItems());
+      } catch (Throwable t) {
+        // MCP observers are pre-transaction, side-effect only (metrics/logs). They must not fail
+        // the ingest path. Any leak here is a bug in an observer or its dispatch and should be
+        // fixed upstream, but we never want it to crash a customer ingest.
+        log.warn("MCP observer dispatch failed; ingest continuing", t);
+      }
     }
     Stream<IngestResult> timeseriesIngestResults =
         ingestTimeseriesProposal(opContext, aspectsBatch, async);

--- a/metadata-io/src/main/java/com/linkedin/metadata/ingestion/IngestionMetricsEmitter.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/ingestion/IngestionMetricsEmitter.java
@@ -95,7 +95,12 @@ public class IngestionMetricsEmitter extends MCPObserver {
         }
         recordMetrics(result, item.getUrn());
       } catch (Exception e) {
-        log.error("Failed to process ingestion metrics for item: {}", e.getMessage(), e);
+        log.warn(
+            "Failed to process ingestion metrics. urn={} aspect={} changeType={}",
+            item.getUrn(),
+            item.getAspectName(),
+            item.getChangeType(),
+            e);
       }
     }
   }
@@ -207,7 +212,7 @@ public class IngestionMetricsEmitter extends MCPObserver {
           report);
 
     } catch (Exception e) {
-      log.error("Error recording metrics for {}: {}", executionRequestUrn, e.getMessage(), e);
+      log.warn("Error recording metrics for {}", executionRequestUrn, e);
     }
   }
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/ingestion/IngestionMetricsEmitter.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/ingestion/IngestionMetricsEmitter.java
@@ -95,12 +95,7 @@ public class IngestionMetricsEmitter extends MCPObserver {
         }
         recordMetrics(result, item.getUrn());
       } catch (Exception e) {
-        log.warn(
-            "Failed to process ingestion metrics. urn={} aspect={} changeType={}",
-            item != null ? item.getUrn() : null,
-            item != null ? item.getAspectName() : null,
-            item != null ? item.getChangeType() : null,
-            e);
+        log.error("Failed to process ingestion metrics for item: {}", e.getMessage(), e);
       }
     }
   }
@@ -212,7 +207,7 @@ public class IngestionMetricsEmitter extends MCPObserver {
           report);
 
     } catch (Exception e) {
-      log.warn("Error recording metrics for {}", executionRequestUrn, e);
+      log.error("Error recording metrics for {}: {}", executionRequestUrn, e.getMessage(), e);
     }
   }
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/ingestion/IngestionMetricsEmitter.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/ingestion/IngestionMetricsEmitter.java
@@ -97,9 +97,9 @@ public class IngestionMetricsEmitter extends MCPObserver {
       } catch (Exception e) {
         log.warn(
             "Failed to process ingestion metrics. urn={} aspect={} changeType={}",
-            item.getUrn(),
-            item.getAspectName(),
-            item.getChangeType(),
+            item != null ? item.getUrn() : null,
+            item != null ? item.getAspectName() : null,
+            item != null ? item.getChangeType() : null,
             e);
       }
     }


### PR DESCRIPTION
Three defensive layers, innermost to outermost:

MCPObserver.apply() — catch any Throwable from the shouldApply() filter or observeMCPs() implementation; log at WARN with batch size.
AspectsBatch.applyMCPObservers() dispatch loop — per-observer catch so one bad observer doesn't kill healthy ones.
EntityServiceImpl.ingestProposal() call site — outermost guard for anything that leaks through.
All logs at WARN — ERROR-level visibility is broken on the affected branch.

IngestionMetricsEmitter catch blocks also changed from ERROR to WARN and now log urn/aspect/changeType instead of e.getMessage() (which was literally "null", giving nothing to grep on).

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
