### PR TITLE
feat(ingest/sigma): emit cross-DM FineGrainedLineage via global bridge index

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
@@ -272,14 +272,14 @@ class SigmaSourceReport(StaleEntityRemovalSourceReport):
     # How many FGL entries were emitted across all elements.
     data_model_element_fgl_emitted: int = 0
     # Refs where multiple sibling candidates passed the /lineage filter;
-    # sorted-first URN was chosen (matches T2 PR1's collision precedent).
+    # sorted-first URN was chosen (matches collision precedent).
     data_model_element_fgl_collision_pick_first: int = 0
     # Refs whose source element is outside this DM; deferred to cross-DM resolution.
     data_model_element_fgl_cross_dm_deferred: int = 0
     # Refs where element-name matches the element's own warehouse-table name
     # (e.g., element "data.csv" with formula "[data.csv/col]"). These are
     # warehouse-passthrough passthroughs, not intra-DM self-edges; the actual
-    # upstream is the warehouse inode — out of RESOLVE-A scope.
+    # upstream is the warehouse inode.
     data_model_element_fgl_warehouse_passthrough_deferred: int = 0
     # Refs whose source element is in this DM but not listed as an upstream by
     # /lineage; dropped to avoid orphan FGL the UI silently rejects.
@@ -287,8 +287,8 @@ class SigmaSourceReport(StaleEntityRemovalSourceReport):
     # Refs whose column name has no matching fieldPath in the upstream element's
     # schema; dropped to avoid a dangling schemaField URN.
     data_model_element_fgl_dropped_unknown_upstream_column: int = 0
-    # Cross-DM FGL counters (RESOLVE-B).
-    # Refs resolved via T2 PR2's global bridge index and emitted as cross-DM FGL.
+    # Cross-DM FGL counters.
+    # Refs resolved via global bridge index and emitted as cross-DM FGL.
     data_model_element_fgl_cross_dm_resolved: int = 0
     # Refs where multiple cross-DM candidates share a name; sorted-first URN chosen.
     data_model_element_fgl_cross_dm_collision_pick_first: int = 0

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
@@ -287,6 +287,13 @@ class SigmaSourceReport(StaleEntityRemovalSourceReport):
     # Refs whose column name has no matching fieldPath in the upstream element's
     # schema; dropped to avoid a dangling schemaField URN.
     data_model_element_fgl_dropped_unknown_upstream_column: int = 0
+    # Cross-DM FGL counters (RESOLVE-B).
+    # Refs resolved via T2 PR2's global bridge index and emitted as cross-DM FGL.
+    data_model_element_fgl_cross_dm_resolved: int = 0
+    # Refs where multiple cross-DM candidates share a name; sorted-first URN chosen.
+    data_model_element_fgl_cross_dm_collision_pick_first: int = 0
+    # Cross-DM refs whose column is absent from the resolved upstream element's schema.
+    data_model_element_fgl_cross_dm_dropped_unknown_upstream_column: int = 0
 
     # Entries dropped as duplicates by the pagination-level natural-key
     # dedup in ``_paginated_entries`` / lineage raw dedup. Normally 0;

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
@@ -269,7 +269,8 @@ class SigmaSourceReport(StaleEntityRemovalSourceReport):
     data_model_element_columns_duplicate_fieldpath_dropped: int = 0
 
     # DM element column-level lineage (FGL) counters.
-    # How many FGL entries were emitted across all elements.
+    # Throughout: "DM" / "dm" = data model.
+    # Intra-DM FGL only; total FGL = fgl_emitted + fgl_cross_dm_resolved.
     data_model_element_fgl_emitted: int = 0
     # Refs where multiple sibling candidates passed the /lineage filter;
     # sorted-first URN was chosen (matches collision precedent).
@@ -287,8 +288,10 @@ class SigmaSourceReport(StaleEntityRemovalSourceReport):
     # Refs whose column name has no matching fieldPath in the upstream element's
     # schema; dropped to avoid a dangling schemaField URN.
     data_model_element_fgl_dropped_unknown_upstream_column: int = 0
-    # Cross-DM FGL counters.
+    # Cross-DM FGL counters (DM = data model throughout).
     # Refs resolved via global bridge index and emitted as cross-DM FGL.
+    # Resolution uses entity-level upstreams as a soft collision tiebreaker,
+    # not a hard gate — a resolved entry does not imply entity-level confirmation.
     data_model_element_fgl_cross_dm_resolved: int = 0
     # Refs where multiple cross-DM candidates share a name; sorted-first URN chosen.
     data_model_element_fgl_cross_dm_collision_pick_first: int = 0

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/data_classes.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/data_classes.py
@@ -280,7 +280,7 @@ class SigmaDataModel(BaseModel):
     # Maps source DM dataModelId (UUID) → [element names consumed from that DM].
     # Used by cross-DM entity-level resolution to look up the correct source
     # element name without requiring the consuming element to share that name.
-    consumed_dm_element_names: Dict[str, List[str]] = {}
+    consumed_dm_element_names: Dict[str, List[str]] = Field(default_factory=dict)
 
     def get_url_id(self) -> str:
         """Return the DM's URL identifier: explicit ``urlId`` if set,

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/data_classes.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/data_classes.py
@@ -277,10 +277,10 @@ class SigmaDataModel(BaseModel):
     badge: Optional[str] = None
     elements: List[SigmaDataModelElement] = []
     # Populated from /lineage ``data-model`` type entries during assembly.
-    # Maps source DM dataModelId (UUID) → [element names consumed from that DM].
+    # Maps source DM dataModelId (UUID) → [element names from that source DM].
     # Used by cross-DM entity-level resolution to look up the correct source
     # element name without requiring the consuming element to share that name.
-    consumed_dm_element_names: Dict[str, List[str]] = Field(default_factory=dict)
+    source_dm_element_names: Dict[str, List[str]] = Field(default_factory=dict)
 
     def get_url_id(self) -> str:
         """Return the DM's URL identifier: explicit ``urlId`` if set,

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/data_classes.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/data_classes.py
@@ -276,6 +276,11 @@ class SigmaDataModel(BaseModel):
     path: Optional[str] = None
     badge: Optional[str] = None
     elements: List[SigmaDataModelElement] = []
+    # Populated from /lineage ``data-model`` type entries during assembly.
+    # Maps source DM dataModelId (UUID) → [element names consumed from that DM].
+    # Used by cross-DM entity-level resolution to look up the correct source
+    # element name without requiring the consuming element to share that name.
+    consumed_dm_element_names: Dict[str, List[str]] = {}
 
     def get_url_id(self) -> str:
         """Return the DM's URL identifier: explicit ``urlId`` if set,

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -574,7 +574,19 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                     if len(candidates) > 1:
                         return sorted(candidates)[0], "ambiguous"
                     return candidates[0], "strict"
-            # 0 or 2+ consumed names → fall through to consuming element name / fallback.
+            elif len(src_names) > 1:
+                # Multiple elements consumed from the same source DM; cannot
+                # determine which one maps to this consuming element without
+                # per-element scoping. Fall through to name-based / fallback.
+                logger.debug(
+                    "DM %s element %s: %d consumed names from source DM %s — "
+                    "cannot disambiguate via lineage entries alone; falling "
+                    "back to consuming-element-name lookup.",
+                    consuming_data_model.dataModelId,
+                    consuming_element.elementId,
+                    len(src_names),
+                    other_dm_id,
+                )
 
         candidates = name_map.get(consuming_element.name.lower())
         if not candidates:
@@ -873,6 +885,10 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                     # entity_level_upstream_urns is used as a collision tiebreaker
                     # (not a hard gate) because Sigma's /lineage API does not always
                     # surface cross-DM formula deps at the entity level.
+                    # Cross-DM source_ids use the shape <dm-url-id>/<suffix>;
+                    # intra-DM source_ids are bare elementIds (no "/").  So
+                    # source_dm_url_ids will never contain the consuming DM's
+                    # own url_id under normal Sigma API behaviour.
                     source_dm_url_ids = {
                         sid.partition("/")[0]
                         for sid in element.source_ids
@@ -892,25 +908,26 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                         self.reporter.data_model_element_fgl_cross_dm_deferred += 1
                         continue
                     if len(cross_dm_candidate_urns) > 1:
-                        # Prefer a candidate already confirmed as an entity-level
-                        # upstream: the entity-level resolver used /lineage data-model
-                        # entries to identify the correct source element, so a single
-                        # confirmed candidate is unambiguous and wins without collision.
+                        # Restrict to entity-level confirmed candidates whenever
+                        # any exist — even a subset of 2+ is better than
+                        # including unconfirmed URNs that sort earlier.
                         confirmed = [
                             u
                             for u in cross_dm_candidate_urns
                             if u in entity_level_upstream_urns
                         ]
-                        if len(confirmed) == 1:
+                        if confirmed:
                             cross_dm_candidate_urns = confirmed
-                        else:
-                            # 0 or 2+ confirmed — still ambiguous; pick sorted-first.
+                        if len(cross_dm_candidate_urns) > 1:
+                            # Still ambiguous after filtering; pick sorted-first.
                             self.reporter.data_model_element_fgl_cross_dm_collision_pick_first += 1
                     chosen_upstream_urn = cross_dm_candidate_urns[0]
+                    # dm_element_urn_to_cols is populated for every URN in
+                    # dm_element_urn_by_name (same loop in _prepopulate_dm_bridge_maps),
+                    # so this get() will only be None if a URN reaches this point
+                    # without going through prepopulation — defensively handled.
                     upstream_cols = self.dm_element_urn_to_cols.get(chosen_upstream_urn)
                     if upstream_cols is None:
-                        # Schema not cached for this upstream; defer rather than
-                        # emit an unvalidated dangling schemaField URN.
                         self.reporter.data_model_element_fgl_cross_dm_deferred += 1
                         continue
                     canonical_col = upstream_cols.get(ref.column.lower())

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -886,7 +886,20 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                         self.reporter.data_model_element_fgl_cross_dm_deferred += 1
                         continue
                     if len(cross_dm_candidate_urns) > 1:
-                        self.reporter.data_model_element_fgl_cross_dm_collision_pick_first += 1
+                        # Prefer a candidate already confirmed as an entity-level
+                        # upstream: the entity-level resolver used /lineage data-model
+                        # entries to identify the correct source element, so a single
+                        # confirmed candidate is unambiguous and wins without collision.
+                        confirmed = [
+                            u
+                            for u in cross_dm_candidate_urns
+                            if u in entity_level_upstream_urns
+                        ]
+                        if len(confirmed) == 1:
+                            cross_dm_candidate_urns = confirmed
+                        else:
+                            # 0 or 2+ confirmed — still ambiguous; pick sorted-first.
+                            self.reporter.data_model_element_fgl_cross_dm_collision_pick_first += 1
                     chosen_upstream_urn = cross_dm_candidate_urns[0]
                     upstream_cols = cross_dm_urn_to_cols.get(chosen_upstream_urn)
                     if upstream_cols is None:

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -244,11 +244,13 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         # DM urlId → DM dataModelId (UUID). Reverse of get_url_id(); used to
         # correlate ``data-model`` lineage entries (keyed by dataModelId) with
         # source_id prefixes (keyed by urlId) in cross-DM upstream resolution.
-        self.dm_url_id_to_dm_id: Dict[str, str] = {}
+        self.data_model_id_by_url_id: Dict[str, str] = {}
         # Global: element Dataset URN → {lowercased column name: canonical column name}.
         # Same dedup logic as the per-element urn_to_cols in the FGL builder so
         # cross-DM column validation uses the winner set rather than raw columns.
-        self.dm_element_urn_to_cols: Dict[str, Dict[str, str]] = {}
+        self.dm_element_urn_to_cols: Dict[
+            str, Dict[str, str]
+        ] = {}  # {lowercase_col: canonical_col}
         # Surface as a structured report warning so operators running
         # under ``--strict`` or CI dashboards that gate on report
         # warnings (rather than stdout logs) notice the misconfiguration.
@@ -562,9 +564,9 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         # Prefer source element names from /lineage ``data-model`` entries:
         # these directly name the element consumed from the source DM and
         # work even when the consuming element has a different display name.
-        other_dm_id = self.dm_url_id_to_dm_id.get(other_dm_url_id)
+        other_dm_id = self.data_model_id_by_url_id.get(other_dm_url_id)
         if other_dm_id:
-            src_names = consuming_data_model.consumed_dm_element_names.get(
+            src_names = consuming_data_model.source_dm_element_names.get(
                 other_dm_id, []
             )
             if len(src_names) == 1:
@@ -1190,8 +1192,10 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         self.dm_total_element_count_by_url_id[alias] = (
             self.dm_total_element_count_by_url_id.get(canonical_key, 0)
         )
-        if canonical_key in self.dm_url_id_to_dm_id:
-            self.dm_url_id_to_dm_id[alias] = self.dm_url_id_to_dm_id[canonical_key]
+        if canonical_key in self.data_model_id_by_url_id:
+            self.data_model_id_by_url_id[alias] = self.data_model_id_by_url_id[
+                canonical_key
+            ]
 
     def _prepopulate_dm_bridge_maps(
         self,
@@ -1264,7 +1268,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
 
         self.dm_container_urn_by_url_id[bridge_key] = data_model_container_urn
         self.dm_element_urn_by_name[bridge_key] = name_map
-        self.dm_url_id_to_dm_id[bridge_key] = data_model.dataModelId
+        self.data_model_id_by_url_id[bridge_key] = data_model.dataModelId
         # Total count (including blank-named elements) used by the
         # cross-DM single-element fallback to verify "DM has exactly one
         # element" before attributing an unmatched-name reference.

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -241,6 +241,15 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         # dataModelIds whose bridge key collided with an earlier DM. The
         # emit loop skips these to avoid unlinked orphan Containers.
         self.dm_collided_data_model_ids: Set[str] = set()
+        # Flat global index across all DMs: lowercased element name →
+        # [Dataset URNs].  Built incrementally in _prepopulate_dm_bridge_maps
+        # so cross-DM FGL resolution can look up any element name regardless
+        # of which DM owns it.
+        self.dm_global_element_urn_by_name: Dict[str, List[str]] = {}
+        # Global: element Dataset URN → {lowercased column name: canonical column name}.
+        # Same dedup logic as the per-element urn_to_cols in the FGL builder so
+        # cross-DM column validation uses the winner set rather than raw columns.
+        self.dm_element_urn_to_cols: Dict[str, Dict[str, str]] = {}
         # Surface as a structured report warning so operators running
         # under ``--strict`` or CI dashboards that gate on report
         # warnings (rather than stdout logs) notice the misconfiguration.
@@ -602,6 +611,8 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         element_dataset_urn: str,
         elementId_to_dataset_urn: Dict[str, str],
         element_name_to_eids: Dict[str, List[str]],
+        cross_dm_element_urn_by_name: Dict[str, List[str]],
+        cross_dm_urn_to_cols: Dict[str, Dict[str, str]],
     ) -> Optional[UpstreamLineage]:
         # Success counters bump once per unique URN; diamond source_ids
         # resolving to the same URN should not inflate the signal.
@@ -705,6 +716,8 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             elementId_to_dataset_urn=elementId_to_dataset_urn,
             entity_level_upstream_urns=set(upstream_urns),
             data_model=data_model,
+            cross_dm_element_urn_by_name=cross_dm_element_urn_by_name,
+            cross_dm_urn_to_cols=cross_dm_urn_to_cols,
         )
         return UpstreamLineage(
             upstreams=[
@@ -781,6 +794,8 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         elementId_to_dataset_urn: Dict[str, str],
         entity_level_upstream_urns: Set[str],
         data_model: SigmaDataModel,
+        cross_dm_element_urn_by_name: Dict[str, List[str]],
+        cross_dm_urn_to_cols: Dict[str, Dict[str, str]],
     ) -> List[FineGrainedLineageClass]:
         """Build FineGrainedLineage entries for intra-DM [ElementName/col] refs.
 
@@ -807,6 +822,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                 urn_to_cols[el_urn] = {c.lower(): c for c in el_by_name}
 
         fgls: List[FineGrainedLineageClass] = []
+        cross_dm_fgls: List[FineGrainedLineageClass] = []
         # Track emitted (downstream, upstream) schemaField pairs to deduplicate
         # multiple occurrences of the same bracket ref in one formula
         # (e.g. If([A/x] = 0, [A/x], [A/x] / 2) → one FGL, not three).
@@ -838,9 +854,48 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                         # All candidates were self-references; actual upstream is a
                         # warehouse table — out of RESOLVE-A scope.
                         self.reporter.data_model_element_fgl_warehouse_passthrough_deferred += 1
-                    else:
-                        # Source not in this DM — cross-DM ref handled separately.
+                        continue
+                    # Source not in this DM — consult the global cross-DM index.
+                    cross_dm_candidate_urns = sorted(
+                        cross_dm_element_urn_by_name.get(ref.source.lower(), [])
+                    )
+                    # Defensive strip: the current element's own URN should never
+                    # appear here (intra-DM lookup ran first), but cheap insurance.
+                    cross_dm_candidate_urns = [
+                        u for u in cross_dm_candidate_urns if u != element_dataset_urn
+                    ]
+                    if not cross_dm_candidate_urns:
                         self.reporter.data_model_element_fgl_cross_dm_deferred += 1
+                        continue
+                    if len(cross_dm_candidate_urns) > 1:
+                        self.reporter.data_model_element_fgl_cross_dm_collision_pick_first += 1
+                    chosen_upstream_urn = cross_dm_candidate_urns[0]
+                    upstream_cols = cross_dm_urn_to_cols.get(chosen_upstream_urn)
+                    if upstream_cols is None:
+                        # Schema not cached for this upstream; defer rather than
+                        # emit an unvalidated dangling schemaField URN.
+                        self.reporter.data_model_element_fgl_cross_dm_deferred += 1
+                        continue
+                    canonical_col = upstream_cols.get(ref.column.lower())
+                    if canonical_col is None:
+                        self.reporter.data_model_element_fgl_cross_dm_dropped_unknown_upstream_column += 1
+                        continue
+                    upstream_field = builder.make_schema_field_urn(
+                        chosen_upstream_urn, canonical_col
+                    )
+                    pair = (downstream_field, upstream_field)
+                    if pair not in emitted_pairs:
+                        emitted_pairs.add(pair)
+                        cross_dm_fgls.append(
+                            FineGrainedLineageClass(
+                                downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
+                                downstreams=[downstream_field],
+                                upstreamType=FineGrainedLineageUpstreamTypeClass.FIELD_SET,
+                                upstreams=[upstream_field],
+                                confidenceScore=1.0,
+                            )
+                        )
+                        self.reporter.data_model_element_fgl_cross_dm_resolved += 1
                     continue
 
                 # Map surviving elementIds to Dataset URNs and filter against
@@ -912,14 +967,17 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                         confidenceScore=1.0,
                     )
                 )
+        # fgl_emitted tracks intra-DM FGL only; cross-DM is tracked separately
+        # via fgl_cross_dm_resolved so operators can see both buckets independently.
         self.reporter.data_model_element_fgl_emitted += len(fgls)
-        fgls.sort(
+        all_fgls = fgls + cross_dm_fgls
+        all_fgls.sort(
             key=lambda fgl: (
                 (fgl.downstreams or [""])[0],
                 (fgl.upstreams or [""])[0],
             )
         )
-        return fgls
+        return all_fgls
 
     def _gen_data_model_element_workunits(
         self,
@@ -1044,6 +1102,8 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                 element_dataset_urn,
                 elementId_to_dataset_urn,
                 element_name_to_eids,
+                self.dm_global_element_urn_by_name,
+                self.dm_element_urn_to_cols,
             )
             if upstream_lineage is not None:
                 yield MetadataChangeProposalWrapper(
@@ -1136,12 +1196,20 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         for element in data_model.elements:
             element_dataset_urn = self._gen_data_model_element_urn(data_model, element)
             elementId_to_dataset_urn[element.elementId] = element_dataset_urn
+            # Build global column index for cross-DM FGL column validation.
+            el_by_name, _ = _dedup_dm_element_columns(element.columns)
+            self.dm_element_urn_to_cols[element_dataset_urn] = {
+                c.lower(): c for c in el_by_name
+            }
             # Blank-named elements are excluded from ``name_map`` so they
             # don't collapse into a single spuriously-ambiguous candidate.
             if element.name:
                 name_map.setdefault(element.name.lower(), []).append(
                     element_dataset_urn
                 )
+                self.dm_global_element_urn_by_name.setdefault(
+                    element.name.lower(), []
+                ).append(element_dataset_urn)
 
         self.dm_container_urn_by_url_id[bridge_key] = data_model_container_urn
         self.dm_element_urn_by_name[bridge_key] = name_map

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -245,11 +245,6 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         # correlate ``data-model`` lineage entries (keyed by dataModelId) with
         # source_id prefixes (keyed by urlId) in cross-DM upstream resolution.
         self.dm_url_id_to_dm_id: Dict[str, str] = {}
-        # Flat global index across all DMs: lowercased element name →
-        # [Dataset URNs].  Built incrementally in _prepopulate_dm_bridge_maps
-        # so cross-DM FGL resolution can look up any element name regardless
-        # of which DM owns it.
-        self.dm_global_element_urn_by_name: Dict[str, List[str]] = {}
         # Global: element Dataset URN → {lowercased column name: canonical column name}.
         # Same dedup logic as the per-element urn_to_cols in the FGL builder so
         # cross-DM column validation uses the winner set rather than raw columns.
@@ -569,14 +564,17 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         # work even when the consuming element has a different display name.
         other_dm_id = self.dm_url_id_to_dm_id.get(other_dm_url_id)
         if other_dm_id:
-            for src_name in consuming_data_model.consumed_dm_element_names.get(
+            src_names = consuming_data_model.consumed_dm_element_names.get(
                 other_dm_id, []
-            ):
-                candidates = name_map.get(src_name.lower())
+            )
+            if len(src_names) == 1:
+                # Exactly one element consumed from this source DM — unambiguous.
+                candidates = name_map.get(src_names[0].lower())
                 if candidates:
                     if len(candidates) > 1:
                         return sorted(candidates)[0], "ambiguous"
                     return candidates[0], "strict"
+            # 0 or 2+ consumed names → fall through to consuming element name / fallback.
 
         candidates = name_map.get(consuming_element.name.lower())
         if not candidates:
@@ -629,8 +627,6 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         element_dataset_urn: str,
         elementId_to_dataset_urn: Dict[str, str],
         element_name_to_eids: Dict[str, List[str]],
-        cross_dm_element_urn_by_name: Dict[str, List[str]],
-        cross_dm_urn_to_cols: Dict[str, Dict[str, str]],
     ) -> Optional[UpstreamLineage]:
         # Success counters bump once per unique URN; diamond source_ids
         # resolving to the same URN should not inflate the signal.
@@ -734,8 +730,6 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             elementId_to_dataset_urn=elementId_to_dataset_urn,
             entity_level_upstream_urns=set(upstream_urns),
             data_model=data_model,
-            cross_dm_element_urn_by_name=cross_dm_element_urn_by_name,
-            cross_dm_urn_to_cols=cross_dm_urn_to_cols,
         )
         return UpstreamLineage(
             upstreams=[
@@ -812,8 +806,6 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         elementId_to_dataset_urn: Dict[str, str],
         entity_level_upstream_urns: Set[str],
         data_model: SigmaDataModel,
-        cross_dm_element_urn_by_name: Dict[str, List[str]],
-        cross_dm_urn_to_cols: Dict[str, Dict[str, str]],
     ) -> List[FineGrainedLineageClass]:
         """Build FineGrainedLineage entries for intra-DM [ElementName/col] refs.
 
@@ -870,25 +862,32 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                 if not candidate_eids_after_self_strip:
                     if candidate_eids:
                         # All candidates were self-references; actual upstream is a
-                        # warehouse table — out of RESOLVE-A scope.
+                        # warehouse table.
                         self.reporter.data_model_element_fgl_warehouse_passthrough_deferred += 1
                         continue
-                    # Source not in this DM — consult the global cross-DM index.
-                    # The intra-DM orphan filter (entity_level_upstream_urns) is
-                    # intentionally not applied as a hard gate here. Sigma's /lineage
-                    # API only reports cross-DM formula dependencies at the entity
-                    # level when element names match, so a consuming element may have
-                    # no entity-level upstream for the referenced name even when the
-                    # formula ref is valid. entity_level_upstream_urns is used as a
-                    # collision tiebreaker but not as a required presence check.
+                    # Source not in this DM — search only the DMs this element's
+                    # source_ids explicitly reference. This prevents formula refs
+                    # like [Orders/id] from linking to any ingested element named
+                    # "Orders" regardless of whether Sigma reported a lineage
+                    # relationship to that DM.
+                    # entity_level_upstream_urns is used as a collision tiebreaker
+                    # (not a hard gate) because Sigma's /lineage API does not always
+                    # surface cross-DM formula deps at the entity level.
+                    source_dm_url_ids = {
+                        sid.partition("/")[0]
+                        for sid in element.source_ids
+                        if "/" in sid and not sid.startswith("inode-")
+                    }
                     cross_dm_candidate_urns = sorted(
-                        cross_dm_element_urn_by_name.get(ref.source.lower(), [])
+                        {
+                            urn
+                            for dm_url_id in source_dm_url_ids
+                            for urn in self.dm_element_urn_by_name.get(
+                                dm_url_id, {}
+                            ).get(ref.source.lower(), [])
+                            if urn != element_dataset_urn
+                        }
                     )
-                    # Defensive strip: the current element's own URN should never
-                    # appear here (intra-DM lookup ran first), but cheap insurance.
-                    cross_dm_candidate_urns = [
-                        u for u in cross_dm_candidate_urns if u != element_dataset_urn
-                    ]
                     if not cross_dm_candidate_urns:
                         self.reporter.data_model_element_fgl_cross_dm_deferred += 1
                         continue
@@ -908,7 +907,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                             # 0 or 2+ confirmed — still ambiguous; pick sorted-first.
                             self.reporter.data_model_element_fgl_cross_dm_collision_pick_first += 1
                     chosen_upstream_urn = cross_dm_candidate_urns[0]
-                    upstream_cols = cross_dm_urn_to_cols.get(chosen_upstream_urn)
+                    upstream_cols = self.dm_element_urn_to_cols.get(chosen_upstream_urn)
                     if upstream_cols is None:
                         # Schema not cached for this upstream; defer rather than
                         # emit an unvalidated dangling schemaField URN.
@@ -1140,8 +1139,6 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                 element_dataset_urn,
                 elementId_to_dataset_urn,
                 element_name_to_eids,
-                self.dm_global_element_urn_by_name,
-                self.dm_element_urn_to_cols,
             )
             if upstream_lineage is not None:
                 yield MetadataChangeProposalWrapper(
@@ -1247,11 +1244,6 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                 name_map.setdefault(element.name.lower(), []).append(
                     element_dataset_urn
                 )
-                existing = self.dm_global_element_urn_by_name.setdefault(
-                    element.name.lower(), []
-                )
-                if element_dataset_urn not in existing:
-                    existing.append(element_dataset_urn)
 
         self.dm_container_urn_by_url_id[bridge_key] = data_model_container_urn
         self.dm_element_urn_by_name[bridge_key] = name_map

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -241,6 +241,10 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         # dataModelIds whose bridge key collided with an earlier DM. The
         # emit loop skips these to avoid unlinked orphan Containers.
         self.dm_collided_data_model_ids: Set[str] = set()
+        # DM urlId → DM dataModelId (UUID). Reverse of get_url_id(); used to
+        # correlate ``data-model`` lineage entries (keyed by dataModelId) with
+        # source_id prefixes (keyed by urlId) in cross-DM upstream resolution.
+        self.dm_url_id_to_dm_id: Dict[str, str] = {}
         # Flat global index across all DMs: lowercased element name →
         # [Dataset URNs].  Built incrementally in _prepopulate_dm_bridge_maps
         # so cross-DM FGL resolution can look up any element name regardless
@@ -559,6 +563,20 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         if other_dm_url_id not in self.dm_container_urn_by_url_id:
             return None, "dm_unknown"
         name_map = self.dm_element_urn_by_name.get(other_dm_url_id, {})
+
+        # Prefer source element names from /lineage ``data-model`` entries:
+        # these directly name the element consumed from the source DM and
+        # work even when the consuming element has a different display name.
+        other_dm_id = self.dm_url_id_to_dm_id.get(other_dm_url_id)
+        if other_dm_id:
+            for src_name in consuming_data_model.consumed_dm_element_names.get(
+                other_dm_id, []
+            ):
+                candidates = name_map.get(src_name.lower())
+                if candidates:
+                    if len(candidates) > 1:
+                        return sorted(candidates)[0], "ambiguous"
+                    return candidates[0], "strict"
 
         candidates = name_map.get(consuming_element.name.lower())
         if not candidates:
@@ -1138,6 +1156,8 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         self.dm_total_element_count_by_url_id[alias] = (
             self.dm_total_element_count_by_url_id.get(canonical_key, 0)
         )
+        if canonical_key in self.dm_url_id_to_dm_id:
+            self.dm_url_id_to_dm_id[alias] = self.dm_url_id_to_dm_id[canonical_key]
 
     def _prepopulate_dm_bridge_maps(
         self,
@@ -1213,6 +1233,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
 
         self.dm_container_urn_by_url_id[bridge_key] = data_model_container_urn
         self.dm_element_urn_by_name[bridge_key] = name_map
+        self.dm_url_id_to_dm_id[bridge_key] = data_model.dataModelId
         # Total count (including blank-named elements) used by the
         # cross-DM single-element fallback to verify "DM has exactly one
         # element" before attributing an unmatched-name reference.

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -874,6 +874,13 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                         self.reporter.data_model_element_fgl_warehouse_passthrough_deferred += 1
                         continue
                     # Source not in this DM — consult the global cross-DM index.
+                    # The intra-DM orphan filter (entity_level_upstream_urns) is
+                    # intentionally not applied as a hard gate here. Sigma's /lineage
+                    # API only reports cross-DM formula dependencies at the entity
+                    # level when element names match, so a consuming element may have
+                    # no entity-level upstream for the referenced name even when the
+                    # formula ref is valid. entity_level_upstream_urns is used as a
+                    # collision tiebreaker but not as a required presence check.
                     cross_dm_candidate_urns = sorted(
                         cross_dm_element_urn_by_name.get(ref.source.lower(), [])
                     )
@@ -1240,9 +1247,11 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                 name_map.setdefault(element.name.lower(), []).append(
                     element_dataset_urn
                 )
-                self.dm_global_element_urn_by_name.setdefault(
+                existing = self.dm_global_element_urn_by_name.setdefault(
                     element.name.lower(), []
-                ).append(element_dataset_urn)
+                )
+                if element_dataset_urn not in existing:
+                    existing.append(element_dataset_urn)
 
         self.dm_container_urn_by_url_id[bridge_key] = data_model_container_urn
         self.dm_element_urn_by_name[bridge_key] = name_map

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
@@ -1045,6 +1045,9 @@ class SigmaAPI:
                 continue
             columns_by_element.setdefault(column.elementId, []).append(column)
 
+        # Reset before populating so repeated _assemble_data_model calls
+        # (e.g. during alias discovery) cannot accumulate stale entries.
+        data_model.consumed_dm_element_names = {}
         source_ids_by_element: Dict[str, List[str]] = {}
         for entry in lineage_entries:
             entry_type = entry.get(Constant.TYPE)
@@ -1061,12 +1064,17 @@ class SigmaAPI:
                 # ``_resolve_dm_element_cross_dm_upstream`` can look up the
                 # correct source element name without relying on the consuming
                 # element sharing that name.
-                src_dm_id = str(entry.get("dataModelId", ""))
-                src_name = str(entry.get("name", ""))
-                if src_dm_id and src_name:
+                src_dm_id = entry.get("dataModelId")
+                src_name = entry.get("name")
+                if (
+                    isinstance(src_dm_id, str)
+                    and src_dm_id
+                    and isinstance(src_name, str)
+                    and src_name.strip()
+                ):
                     data_model.consumed_dm_element_names.setdefault(
                         src_dm_id, []
-                    ).append(src_name)
+                    ).append(src_name.strip())
             # ``type: dataset`` / ``type: table`` entries are resolved
             # on the fly from their ``inode-<id>`` source_ids; no DM-side
             # stash is needed.

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
@@ -1047,7 +1047,7 @@ class SigmaAPI:
 
         # Reset before populating so repeated _assemble_data_model calls
         # (e.g. during alias discovery) cannot accumulate stale entries.
-        data_model.consumed_dm_element_names = {}
+        data_model.source_dm_element_names = {}
         source_ids_by_element: Dict[str, List[str]] = {}
         for entry in lineage_entries:
             entry_type = entry.get(Constant.TYPE)
@@ -1072,9 +1072,9 @@ class SigmaAPI:
                     and isinstance(src_name, str)
                     and src_name.strip()
                 ):
-                    data_model.consumed_dm_element_names.setdefault(
-                        src_dm_id, []
-                    ).append(src_name.strip())
+                    data_model.source_dm_element_names.setdefault(src_dm_id, []).append(
+                        src_name.strip()
+                    )
             # ``type: dataset`` / ``type: table`` entries are resolved
             # on the fly from their ``inode-<id>`` source_ids; no DM-side
             # stash is needed.

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
@@ -1055,6 +1055,18 @@ class SigmaAPI:
                     source_ids_by_element[element_id] = [
                         s for s in source_ids if isinstance(s, str)
                     ]
+            elif entry_type == "data-model":
+                # Each ``data-model`` entry names the specific element consumed
+                # from a source DM.  Stash by source dataModelId so
+                # ``_resolve_dm_element_cross_dm_upstream`` can look up the
+                # correct source element name without relying on the consuming
+                # element sharing that name.
+                src_dm_id = str(entry.get("dataModelId", ""))
+                src_name = str(entry.get("name", ""))
+                if src_dm_id and src_name:
+                    data_model.consumed_dm_element_names.setdefault(
+                        src_dm_id, []
+                    ).append(src_name)
             # ``type: dataset`` / ``type: table`` entries are resolved
             # on the fly from their ``inode-<id>`` source_ids; no DM-side
             # stash is needed.

--- a/metadata-ingestion/tests/integration/sigma/test_sigma.py
+++ b/metadata-ingestion/tests/integration/sigma/test_sigma.py
@@ -2901,6 +2901,292 @@ def test_sigma_ingest_data_models_cross_dm_upstream(
 
 
 @pytest.mark.integration
+def test_sigma_ingest_data_models_cross_dm_fgl(pytestconfig, tmp_path, requests_mock):
+    """Cross-DM FineGrainedLineage: formula refs resolved to schemaField URNs.
+
+    Consumer DM element has formula columns referencing a source DM element
+    by name.  The emitted UpstreamLineage aspect must contain fineGrainedLineages
+    with correct upstream/downstream schemaField URN pairs.
+    """
+    source_dm_id = "src-dm-0000-0000-0000-000000000001"
+    source_dm_url_id = "srcDmUrlId0001"
+    source_element_id = "srcElem01"
+    consumer_dm_id = "con-dm-0000-0000-0000-000000000002"
+    consumer_dm_url_id = "conDmUrlId0002"
+    consumer_element_id = "conElem01"
+    cross_dm_suffix = "xSuffix01"
+
+    workspace_json = {
+        "workspaceId": "ws-0001",
+        "name": "Test WS",
+        "createdBy": "u1",
+        "createdAt": "2026-01-01T00:00:00.000Z",
+        "updatedAt": "2026-01-01T00:00:00.000Z",
+    }
+    override_data: Dict[str, Dict[str, Any]] = {
+        "https://aws-api.sigmacomputing.com/v2/workspaces": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {"entries": [workspace_json], "total": 1, "nextPage": None},
+        },
+        "https://aws-api.sigmacomputing.com/v2/workspaces/ws-0001": {
+            "method": "GET",
+            "status_code": 200,
+            "json": workspace_json,
+        },
+        "https://aws-api.sigmacomputing.com/v2/members": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {"entries": [], "total": 0, "nextPage": None},
+        },
+        "https://aws-api.sigmacomputing.com/v2/files?typeFilters=dataset": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {"entries": [], "total": 0, "nextPage": None},
+        },
+        "https://aws-api.sigmacomputing.com/v2/workbooks": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {"entries": [], "total": 0, "nextPage": None},
+        },
+        "https://aws-api.sigmacomputing.com/v2/files?typeFilters=data-model": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "entries": [
+                    {
+                        "id": source_dm_id,
+                        "urlId": source_dm_url_id,
+                        "name": "Source DM",
+                        "type": "data-model",
+                        "parentId": "ws-0001",
+                        "permission": "edit",
+                        "path": "Test WS",
+                        "badge": None,
+                        "createdBy": "u1",
+                        "updatedBy": "u1",
+                        "createdAt": "2026-01-01T00:00:00.000Z",
+                        "updatedAt": "2026-01-01T00:00:00.000Z",
+                        "isArchived": False,
+                    },
+                    {
+                        "id": consumer_dm_id,
+                        "urlId": consumer_dm_url_id,
+                        "name": "Consumer DM",
+                        "type": "data-model",
+                        "parentId": "ws-0001",
+                        "permission": "edit",
+                        "path": "Test WS",
+                        "badge": None,
+                        "createdBy": "u1",
+                        "updatedBy": "u1",
+                        "createdAt": "2026-01-01T00:00:00.000Z",
+                        "updatedAt": "2026-01-01T00:00:00.000Z",
+                        "isArchived": False,
+                    },
+                ],
+                "total": 2,
+                "nextPage": None,
+            },
+        },
+        "https://aws-api.sigmacomputing.com/v2/dataModels": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "entries": [
+                    {
+                        "dataModelId": source_dm_id,
+                        "urlId": source_dm_url_id,
+                        "name": "Source DM",
+                        "createdBy": "u1",
+                        "createdAt": "2026-01-01T00:00:00.000Z",
+                        "updatedAt": "2026-01-01T00:00:00.000Z",
+                        "url": f"https://app.sigmacomputing.com/t/data-model/{source_dm_url_id}",
+                        "latestVersion": 1,
+                        "workspaceId": "ws-0001",
+                        "path": "Test WS",
+                    },
+                    {
+                        "dataModelId": consumer_dm_id,
+                        "urlId": consumer_dm_url_id,
+                        "name": "Consumer DM",
+                        "createdBy": "u1",
+                        "createdAt": "2026-01-01T00:00:00.000Z",
+                        "updatedAt": "2026-01-01T00:00:00.000Z",
+                        "url": f"https://app.sigmacomputing.com/t/data-model/{consumer_dm_url_id}",
+                        "latestVersion": 1,
+                        "workspaceId": "ws-0001",
+                        "path": "Test WS",
+                    },
+                ],
+                "total": 2,
+                "nextPage": None,
+            },
+        },
+        # Source DM: one element "Sales Data" with two columns.
+        f"https://aws-api.sigmacomputing.com/v2/dataModels/{source_dm_id}/elements": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "entries": [
+                    {
+                        "elementId": source_element_id,
+                        "name": "Sales Data",
+                        "type": "table",
+                        "vizualizationType": "levelTable",
+                        "columns": [],
+                    }
+                ],
+                "total": 1,
+                "nextPage": None,
+            },
+        },
+        f"https://aws-api.sigmacomputing.com/v2/dataModels/{source_dm_id}/columns": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "entries": [
+                    {
+                        "elementId": source_element_id,
+                        "columnId": f"{source_element_id}-revenue",
+                        "name": "revenue",
+                        "formula": "",
+                        "label": "revenue",
+                    },
+                    {
+                        "elementId": source_element_id,
+                        "columnId": f"{source_element_id}-region",
+                        "name": "region",
+                        "formula": "",
+                        "label": "region",
+                    },
+                ],
+                "total": 2,
+                "nextPage": None,
+            },
+        },
+        f"https://aws-api.sigmacomputing.com/v2/dataModels/{source_dm_id}/lineage": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {"entries": [], "total": 0, "nextPage": None},
+        },
+        # Consumer DM: one element "Summary" with formula columns referencing
+        # "Sales Data" from the source DM.
+        f"https://aws-api.sigmacomputing.com/v2/dataModels/{consumer_dm_id}/elements": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "entries": [
+                    {
+                        "elementId": consumer_element_id,
+                        "name": "Summary",
+                        "type": "table",
+                        "vizualizationType": "levelTable",
+                        "columns": [],
+                    }
+                ],
+                "total": 1,
+                "nextPage": None,
+            },
+        },
+        f"https://aws-api.sigmacomputing.com/v2/dataModels/{consumer_dm_id}/columns": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "entries": [
+                    {
+                        "elementId": consumer_element_id,
+                        "columnId": f"{consumer_element_id}-revenue",
+                        "name": "revenue",
+                        "formula": "[Sales Data/revenue]",
+                        "label": "revenue",
+                    },
+                    {
+                        "elementId": consumer_element_id,
+                        "columnId": f"{consumer_element_id}-region",
+                        "name": "region",
+                        "formula": "[Sales Data/region]",
+                        "label": "region",
+                    },
+                ],
+                "total": 2,
+                "nextPage": None,
+            },
+        },
+        f"https://aws-api.sigmacomputing.com/v2/dataModels/{consumer_dm_id}/lineage": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "entries": [
+                    {
+                        "type": "data-model",
+                        "dataModelId": source_dm_id,
+                        "name": "Sales Data",
+                        "connectionId": "conn-0001",
+                    },
+                    {
+                        "elementId": consumer_element_id,
+                        "type": "element",
+                        "sourceIds": [f"{source_dm_url_id}/{cross_dm_suffix}"],
+                        "dataSourceIds": [f"{source_dm_url_id}/{cross_dm_suffix}"],
+                    },
+                ],
+                "total": 2,
+                "nextPage": None,
+            },
+        },
+    }
+    register_mock_api(request_mock=requests_mock, override_data=override_data)
+
+    output_path = f"{tmp_path}/sigma_cross_dm_fgl_mces.json"
+    pipeline = Pipeline.create(
+        _minimal_sigma_pipeline_config(output_path, ingest_shared_entities=True)
+    )
+    pipeline.run()
+    pipeline.raise_from_status()
+
+    report = _sigma_report(pipeline)
+    assert report.data_model_element_cross_dm_upstreams_resolved == 1
+    assert report.data_model_element_fgl_cross_dm_resolved == 2
+    assert report.data_model_element_fgl_cross_dm_deferred == 0
+    assert report.data_model_element_fgl_cross_dm_collision_pick_first == 0
+
+    source_urn = f"urn:li:dataset:(urn:li:dataPlatform:sigma,{source_dm_id}.{source_element_id},PROD)"
+    consumer_urn = f"urn:li:dataset:(urn:li:dataPlatform:sigma,{consumer_dm_id}.{consumer_element_id},PROD)"
+
+    with open(output_path) as f:
+        mces = json.load(f)
+
+    fgl_mces = [
+        mce
+        for mce in mces
+        if mce.get("entityUrn") == consumer_urn
+        and mce.get("aspectName") == "upstreamLineage"
+    ]
+    assert len(fgl_mces) == 1, (
+        f"expected one upstreamLineage on consumer, got {len(fgl_mces)}"
+    )
+
+    aspect = fgl_mces[0].get("aspect", {}).get("json", fgl_mces[0].get("aspect", {}))
+    fgls = aspect.get("fineGrainedLineages", [])
+    assert len(fgls) == 2, f"expected 2 FGL entries, got {len(fgls)}"
+
+    emitted_pairs = {(fgl["downstreams"][0], fgl["upstreams"][0]) for fgl in fgls}
+    from datahub.emitter import mce_builder as builder
+
+    assert emitted_pairs == {
+        (
+            builder.make_schema_field_urn(consumer_urn, "revenue"),
+            builder.make_schema_field_urn(source_urn, "revenue"),
+        ),
+        (
+            builder.make_schema_field_urn(consumer_urn, "region"),
+            builder.make_schema_field_urn(source_urn, "region"),
+        ),
+    }
+
+
+@pytest.mark.integration
 def test_sigma_ingest_data_models_orphan_dm_discovery(
     pytestconfig, tmp_path, requests_mock
 ):

--- a/metadata-ingestion/tests/integration/sigma/test_sigma.py
+++ b/metadata-ingestion/tests/integration/sigma/test_sigma.py
@@ -4985,22 +4985,17 @@ def test_sigma_ingest_data_models_cross_dm_diamond_counter_not_inflated(
 
 
 @pytest.mark.integration
-def test_sigma_ingest_data_models_cross_dm_single_element_fallback_requires_total_count(
+def test_sigma_ingest_data_models_cross_dm_lineage_entry_resolves_despite_blank_sibling(
     pytestconfig, tmp_path, requests_mock
 ):
-    """Regression pin for M3: the single-element fallback must require the
-    producer DM to have exactly one element **total**, not just one *named*
-    element. Blank-named elements are excluded from
-    ``dm_element_urn_by_name`` (see ``_prepopulate_dm_bridge_maps``), so a
-    DM with 1 named + N blank-named elements would previously have
-    spuriously triggered the fallback and attributed a cross-DM edge to
-    the single named element even though Sigma could legitimately be
-    pointing at any of the anonymous ones.
+    """When a /lineage data-model entry explicitly names the source element,
+    resolution succeeds even when the producer DM has a blank-named sibling
+    element (which would block the single-element fallback).
 
     Construction: producer DM with 1 named element ("data.csv") and 1
-    blank-named element. Consumer element name "Test Data" does not match.
-    The fallback must refuse (name_unmatched_but_dm_known, not
-    single_element_fallback) because the producer has 2 elements.
+    blank-named element. Consumer lineage carries a ``data-model`` entry
+    naming "data.csv". Resolution uses the entry name directly — the
+    blank sibling is irrelevant — and emits the correct upstream edge.
     """
 
     override_data = _orphan_dm_mock_fixture()
@@ -5075,6 +5070,109 @@ def test_sigma_ingest_data_models_cross_dm_single_element_fallback_requires_tota
         f"data-model entry should resolve edge to named producer element "
         f"{producer_element_urn}; got {upstream_edges}"
     )
+
+
+@pytest.mark.integration
+def test_sigma_ingest_data_models_cross_dm_single_element_fallback_requires_total_count(
+    pytestconfig, tmp_path, requests_mock
+):
+    """Regression pin: the single-element fallback must require the producer DM
+    to have exactly one element total. When there is no /lineage data-model entry
+    and the consumer name does not match, a producer with 1 named + 1 blank-named
+    element must not trigger the fallback (total_elements == 2).
+    """
+    producer_dm_id = "766ea1d1-5ee0-4a9c-9b68-b8ba19a7f624"
+    producer_dm_url_id = "3BtEwqctAlmKlYTJIQ8QFC"
+    consumer_dm_id = "b584ddca-cfd6-4b72-97da-367fc0a5606d"
+    consumer_element_id = "1DYf5I08WO"
+
+    override_data = _orphan_dm_mock_fixture()
+
+    # Remove the data-model entry from consumer lineage so name-matching is
+    # the only resolution path available.
+    override_data[
+        f"https://aws-api.sigmacomputing.com/v2/dataModels/{consumer_dm_id}/lineage"
+    ] = {
+        "method": "GET",
+        "status_code": 200,
+        "json": {
+            "entries": [
+                {
+                    "elementId": consumer_element_id,
+                    "type": "element",
+                    "sourceIds": [f"{producer_dm_url_id}/vACRd1GzJS"],
+                    "dataSourceIds": [f"{producer_dm_url_id}/vACRd1GzJS"],
+                }
+            ],
+            "total": 1,
+            "nextPage": None,
+        },
+    }
+    # Producer has 1 named + 1 blank-named element → total_elements == 2.
+    override_data[
+        f"https://aws-api.sigmacomputing.com/v2/dataModels/{producer_dm_id}/elements"
+    ] = {
+        "method": "GET",
+        "status_code": 200,
+        "json": {
+            "entries": [
+                {
+                    "elementId": "wcUd3nEUAv",
+                    "name": "data.csv",
+                    "type": "table",
+                    "vizualizationType": "levelTable",
+                    "columns": [],
+                },
+                {
+                    "elementId": "anonBlank001",
+                    "name": "",
+                    "type": "table",
+                    "vizualizationType": None,
+                    "columns": [],
+                },
+            ],
+            "total": 2,
+            "nextPage": None,
+        },
+    }
+    register_mock_api(request_mock=requests_mock, override_data=override_data)
+
+    output_path = f"{tmp_path}/sigma_dm_fallback_total_count_mces.json"
+    pipeline = Pipeline.create(
+        _minimal_sigma_pipeline_config(output_path, ingest_shared_entities=True)
+    )
+    pipeline.run()
+    pipeline.raise_from_status()
+
+    report = _sigma_report(pipeline)
+    # No data-model entry and DM has 2 elements → fallback must not fire.
+    assert report.data_model_element_cross_dm_upstreams_single_element_fallback == 0
+    assert report.data_model_element_cross_dm_upstreams_name_unmatched_but_dm_known == 1
+    assert report.data_model_element_cross_dm_upstreams_resolved == 0
+
+    consumer_element_urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:sigma,"
+        f"{consumer_dm_id}.{consumer_element_id},PROD)"
+    )
+    producer_element_urn = (
+        f"urn:li:dataset:(urn:li:dataPlatform:sigma,{producer_dm_id}.wcUd3nEUAv,PROD)"
+    )
+    with open(output_path) as f:
+        mces = json.load(f)
+    for mce in mces:
+        if (
+            mce.get("entityUrn") == consumer_element_urn
+            and mce.get("aspectName") == "upstreamLineage"
+        ):
+            for up in (
+                mce.get("aspect", {})
+                .get("json", mce.get("aspect", {}))
+                .get("upstreams", [])
+            ):
+                assert up.get("dataset") != producer_element_urn, (
+                    "fallback must not fire when producer has blank-named siblings "
+                    "and no data-model lineage entry is present"
+                )
 
 
 @pytest.mark.integration

--- a/metadata-ingestion/tests/integration/sigma/test_sigma.py
+++ b/metadata-ingestion/tests/integration/sigma/test_sigma.py
@@ -3154,10 +3154,9 @@ def test_sigma_ingest_data_models_orphan_dm_discovery(
         f"{report.data_model_external_references_discovered}"
     )
     assert report.data_model_external_reference_unresolved == 0
-    assert report.data_model_element_cross_dm_upstreams_single_element_fallback == 1, (
-        f"expected 1 single-element fallback, got "
-        f"{report.data_model_element_cross_dm_upstreams_single_element_fallback}"
-    )
+    # Resolves via /lineage data-model entry name (not single-element fallback):
+    # the entry explicitly names the source element so name-matching is exact.
+    assert report.data_model_element_cross_dm_upstreams_single_element_fallback == 0
     assert report.data_model_element_cross_dm_upstreams_resolved == 1
     assert report.data_model_element_cross_dm_upstreams_dm_unknown == 0
 
@@ -5045,16 +5044,15 @@ def test_sigma_ingest_data_models_cross_dm_single_element_fallback_requires_tota
     pipeline.raise_from_status()
 
     report = _sigma_report(pipeline)
-    # Fallback must NOT fire — producer has 2 elements total.
-    assert report.data_model_element_cross_dm_upstreams_single_element_fallback == 0, (
-        f"single-element fallback must refuse when DM has >1 element total "
-        f"(even if only 1 is named); got "
-        f"{report.data_model_element_cross_dm_upstreams_single_element_fallback}"
-    )
-    # Degrades to name_unmatched_but_dm_known instead.
-    assert report.data_model_element_cross_dm_upstreams_name_unmatched_but_dm_known == 1
+    # Single-element fallback must NOT fire — superseded by /lineage data-model
+    # entry which explicitly names the source element regardless of total count.
+    assert report.data_model_element_cross_dm_upstreams_single_element_fallback == 0
+    assert report.data_model_element_cross_dm_upstreams_name_unmatched_but_dm_known == 0
+    # Resolves correctly via data-model entry name: the blank-named sibling is
+    # irrelevant because the lineage entry explicitly identifies "data.csv".
+    assert report.data_model_element_cross_dm_upstreams_resolved == 1
 
-    # And no upstream edge should point at the producer element.
+    # Upstream edge should point at the named producer element (not the blank one).
     consumer_element_urn = (
         "urn:li:dataset:(urn:li:dataPlatform:sigma,"
         "b584ddca-cfd6-4b72-97da-367fc0a5606d.1DYf5I08WO,PROD)"
@@ -5064,18 +5062,19 @@ def test_sigma_ingest_data_models_cross_dm_single_element_fallback_requires_tota
     )
     with open(output_path) as f:
         mces = json.load(f)
-    for mce in mces:
-        if (
-            mce.get("entityUrn") == consumer_element_urn
-            and mce.get("aspectName") == "upstreamLineage"
-        ):
-            aspect_json = mce.get("aspect", {}).get("json", mce.get("aspect", {}))
-            for up in aspect_json.get("upstreams", []):
-                assert up.get("dataset") != producer_element_urn, (
-                    f"fallback must not attribute cross-DM edge to single named "
-                    f"element when DM has blank-named siblings; got edge "
-                    f"{consumer_element_urn} -> {producer_element_urn}"
-                )
+    upstream_edges = [
+        up.get("dataset")
+        for mce in mces
+        if mce.get("entityUrn") == consumer_element_urn
+        and mce.get("aspectName") == "upstreamLineage"
+        for up in mce.get("aspect", {})
+        .get("json", mce.get("aspect", {}))
+        .get("upstreams", [])
+    ]
+    assert producer_element_urn in upstream_edges, (
+        f"data-model entry should resolve edge to named producer element "
+        f"{producer_element_urn}; got {upstream_edges}"
+    )
 
 
 @pytest.mark.integration

--- a/metadata-ingestion/tests/unit/sigma/test_dm_element_fgl.py
+++ b/metadata-ingestion/tests/unit/sigma/test_dm_element_fgl.py
@@ -588,3 +588,72 @@ def test_cross_dm_collision_picks_first_sorted_urn() -> None:
     assert lineages[0].upstreams == [builder.make_schema_field_urn(urn_aaa, "col")]
     assert source.reporter.data_model_element_fgl_cross_dm_collision_pick_first == 1
     assert source.reporter.data_model_element_fgl_cross_dm_resolved == 1
+
+
+def test_cross_dm_collision_entity_level_breaks_tie() -> None:
+    """When exactly one collision candidate is a confirmed entity-level upstream,
+    it wins without incrementing the collision counter."""
+    source = _source()
+    urn_correct = _urn("correct-dm-element")
+    urn_other = _urn("other-dm-element")
+    downstream_urn = _urn("elem-downstream")
+    element = _element(
+        "elem-downstream",
+        "Downstream",
+        [_column("c1", "col", "[shared_name/col]")],
+    )
+
+    lineages = _build(
+        source,
+        element,
+        element_dataset_urn=downstream_urn,
+        element_name_to_eids={"downstream": ["elem-downstream"]},
+        elementId_to_dataset_urn={"elem-downstream": downstream_urn},
+        # Only urn_correct is a confirmed entity-level upstream.
+        entity_level_upstream_urns={urn_correct},
+        cross_dm_element_urn_by_name={"shared_name": [urn_other, urn_correct]},
+        cross_dm_urn_to_cols={
+            urn_correct: {"col": "col"},
+            urn_other: {"col": "col"},
+        },
+    )
+
+    assert len(lineages) == 1
+    assert lineages[0].upstreams == [builder.make_schema_field_urn(urn_correct, "col")]
+    # Tie broken by entity-level upstream — no collision recorded.
+    assert source.reporter.data_model_element_fgl_cross_dm_collision_pick_first == 0
+    assert source.reporter.data_model_element_fgl_cross_dm_resolved == 1
+
+
+def test_cross_dm_singleton_not_in_entity_level_upstreams_still_emits() -> None:
+    """A singleton cross-DM candidate that is NOT in entity_level_upstream_urns
+    still emits FGL. The orphan filter is intentionally not applied to cross-DM
+    refs because Sigma's /lineage API does not always surface cross-DM formula
+    dependencies at the entity level."""
+    source = _source()
+    upstream_urn = _urn("other-dm-element")
+    downstream_urn = _urn("elem-downstream")
+    element = _element(
+        "elem-downstream",
+        "Downstream",
+        [_column("c1", "city", "[other_dm_element/city]")],
+    )
+
+    lineages = _build(
+        source,
+        element,
+        element_dataset_urn=downstream_urn,
+        element_name_to_eids={"downstream": ["elem-downstream"]},
+        elementId_to_dataset_urn={"elem-downstream": downstream_urn},
+        # upstream_urn is NOT in entity_level_upstream_urns.
+        entity_level_upstream_urns={_urn("some-warehouse-table")},
+        cross_dm_element_urn_by_name={"other_dm_element": [upstream_urn]},
+        cross_dm_urn_to_cols={upstream_urn: {"city": "city"}},
+    )
+
+    assert len(lineages) == 1
+    assert lineages[0].upstreams == [
+        builder.make_schema_field_urn(upstream_urn, "city")
+    ]
+    assert source.reporter.data_model_element_fgl_cross_dm_resolved == 1
+    assert source.reporter.data_model_element_fgl_cross_dm_deferred == 0

--- a/metadata-ingestion/tests/unit/sigma/test_dm_element_fgl.py
+++ b/metadata-ingestion/tests/unit/sigma/test_dm_element_fgl.py
@@ -663,3 +663,38 @@ def test_cross_dm_singleton_not_in_entity_level_upstreams_still_emits() -> None:
     ]
     assert source.reporter.data_model_element_fgl_cross_dm_resolved == 1
     assert source.reporter.data_model_element_fgl_cross_dm_deferred == 0
+
+
+def test_cross_dm_unknown_upstream_column_is_dropped() -> None:
+    """Formula ref column absent from the resolved upstream element's schema
+    increments cross_dm_dropped_unknown_upstream_column and emits no FGL."""
+    source = _source()
+    dm_url_id = "other-dm"
+    upstream_urn = _urn("other-dm-element")
+    downstream_urn = _urn("elem-downstream")
+    element = _element(
+        "elem-downstream",
+        "Downstream",
+        [_column("c1", "missing_col", "[other_dm_element/missing_col]")],
+        source_ids=[f"{dm_url_id}/suffix"],
+    )
+    source.dm_element_urn_by_name = {dm_url_id: {"other_dm_element": [upstream_urn]}}
+    # Upstream schema has "city" and "date" but NOT "missing_col".
+    source.dm_element_urn_to_cols = {upstream_urn: {"city": "city", "date": "date"}}
+
+    lineages = _build(
+        source,
+        element,
+        element_dataset_urn=downstream_urn,
+        element_name_to_eids={"downstream": ["elem-downstream"]},
+        elementId_to_dataset_urn={"elem-downstream": downstream_urn},
+        entity_level_upstream_urns={upstream_urn},
+    )
+
+    assert lineages == []
+    assert (
+        source.reporter.data_model_element_fgl_cross_dm_dropped_unknown_upstream_column
+        == 1
+    )
+    assert source.reporter.data_model_element_fgl_cross_dm_resolved == 0
+    assert source.reporter.data_model_element_fgl_cross_dm_deferred == 0

--- a/metadata-ingestion/tests/unit/sigma/test_dm_element_fgl.py
+++ b/metadata-ingestion/tests/unit/sigma/test_dm_element_fgl.py
@@ -14,6 +14,8 @@ from datahub.ingestion.source.sigma.sigma import SigmaSource
 def _source() -> SigmaSource:
     source = SigmaSource.__new__(SigmaSource)
     source.reporter = SigmaSourceReport()
+    source.dm_element_urn_by_name: Dict[str, Dict[str, List[str]]] = {}
+    source.dm_element_urn_to_cols: Dict[str, Dict[str, str]] = {}
     return source
 
 
@@ -75,8 +77,6 @@ def _build(
     elementId_to_dataset_urn: Dict[str, str] | None = None,
     entity_level_upstream_urns: Set[str] | None = None,
     upstream_elements: List[SigmaDataModelElement] | None = None,
-    cross_dm_element_urn_by_name: Dict[str, List[str]] | None = None,
-    cross_dm_urn_to_cols: Dict[str, Dict[str, str]] | None = None,
 ) -> list:
     all_elements = [element] + (upstream_elements or [])
     return source._build_dm_element_fine_grained_lineages(
@@ -86,8 +86,6 @@ def _build(
         elementId_to_dataset_urn=elementId_to_dataset_urn or {},
         entity_level_upstream_urns=entity_level_upstream_urns or set(),
         data_model=_data_model(all_elements),
-        cross_dm_element_urn_by_name=cross_dm_element_urn_by_name or {},
-        cross_dm_urn_to_cols=cross_dm_urn_to_cols or {},
     )
 
 
@@ -493,28 +491,29 @@ def test_name_collision_picks_first_sorted_urn() -> None:
     assert source.reporter.data_model_element_fgl_emitted == 1
 
 
-def test_cross_dm_ref_resolves_via_global_index() -> None:
-    """Bracket ref to an element name absent from the current DM but present in
-    another DM resolves via the global cross-DM index and emits FGL."""
+def test_cross_dm_ref_resolves_via_source_scoped_index() -> None:
+    """Bracket ref to an element absent from the current DM resolves when the
+    element's source_ids point to the DM that owns the named element."""
     source = _source()
+    dm_url_id = "other-dm"
     other_urn = _urn("other-dm-element")
     downstream_urn = _urn("elem-downstream")
     element = _element(
         "elem-downstream",
         "Downstream",
         [_column("c1", "city", "[other_dm_element/city]")],
+        source_ids=[f"{dm_url_id}/some-suffix"],
     )
+    source.dm_element_urn_by_name = {dm_url_id: {"other_dm_element": [other_urn]}}
+    source.dm_element_urn_to_cols = {other_urn: {"city": "city", "date": "date"}}
 
     lineages = _build(
         source,
         element,
         element_dataset_urn=downstream_urn,
-        # "other_dm_element" is NOT in the current DM's name map.
         element_name_to_eids={"downstream": ["elem-downstream"]},
         elementId_to_dataset_urn={"elem-downstream": downstream_urn},
         entity_level_upstream_urns={other_urn},
-        cross_dm_element_urn_by_name={"other_dm_element": [other_urn]},
-        cross_dm_urn_to_cols={other_urn: {"city": "city", "date": "date"}},
     )
 
     assert len(lineages) == 1
@@ -528,16 +527,24 @@ def test_cross_dm_ref_resolves_via_global_index() -> None:
     assert source.reporter.data_model_element_fgl_emitted == 0
 
 
-def test_cross_dm_unresolvable_ref_increments_deferred() -> None:
-    """Bracket ref to a name absent from both the current DM and the global
-    cross-DM index increments cross_dm_deferred."""
+def test_cross_dm_ref_not_in_source_dm_increments_deferred() -> None:
+    """Bracket ref to a name absent from the source DMs in element.source_ids
+    increments cross_dm_deferred — even if that name exists in an unrelated DM."""
     source = _source()
     downstream_urn = _urn("elem-downstream")
     element = _element(
         "elem-downstream",
         "Downstream",
         [_column("c1", "city", "[unknown_thing/city]")],
+        source_ids=["some-dm/suffix"],
     )
+    # "unknown_thing" not in "some-dm"; exists only in "unrelated-dm" which
+    # is not in source_ids — must not be linked.
+    source.dm_element_urn_by_name = {
+        "some-dm": {"some_dm_element": [_urn("some-dm-element")]},
+        "unrelated-dm": {"unknown_thing": [_urn("unrelated-element")]},
+    }
+    source.dm_element_urn_to_cols = {_urn("some-dm-element"): {"col": "col"}}
 
     lineages = _build(
         source,
@@ -546,9 +553,6 @@ def test_cross_dm_unresolvable_ref_increments_deferred() -> None:
         element_name_to_eids={"downstream": ["elem-downstream"]},
         elementId_to_dataset_urn={"elem-downstream": downstream_urn},
         entity_level_upstream_urns={_urn("some-other-element")},
-        # "unknown_thing" is not in the global index.
-        cross_dm_element_urn_by_name={"some_dm_element": [_urn("some-dm-element")]},
-        cross_dm_urn_to_cols={_urn("some-dm-element"): {"col": "col"}},
     )
 
     assert lineages == []
@@ -557,8 +561,7 @@ def test_cross_dm_unresolvable_ref_increments_deferred() -> None:
 
 
 def test_cross_dm_collision_picks_first_sorted_urn() -> None:
-    """Two DMs share an element name; cross-DM resolver picks sorted[0],
-    matching the intra-DM collision precedent."""
+    """Two source DMs share an element name; resolver picks sorted[0]."""
     source = _source()
     urn_aaa = _urn("aaa-dm-element")
     urn_zzz = _urn("zzz-dm-element")
@@ -567,7 +570,13 @@ def test_cross_dm_collision_picks_first_sorted_urn() -> None:
         "elem-downstream",
         "Downstream",
         [_column("c1", "col", "[shared_name/col]")],
+        source_ids=["dm-zzz/s1", "dm-aaa/s2"],
     )
+    source.dm_element_urn_by_name = {
+        "dm-aaa": {"shared_name": [urn_aaa]},
+        "dm-zzz": {"shared_name": [urn_zzz]},
+    }
+    source.dm_element_urn_to_cols = {urn_aaa: {"col": "col"}, urn_zzz: {"col": "col"}}
 
     lineages = _build(
         source,
@@ -576,15 +585,10 @@ def test_cross_dm_collision_picks_first_sorted_urn() -> None:
         element_name_to_eids={"downstream": ["elem-downstream"]},
         elementId_to_dataset_urn={"elem-downstream": downstream_urn},
         entity_level_upstream_urns={urn_aaa, urn_zzz},
-        # sorted([urn_aaa, urn_zzz])[0] == urn_aaa since "aaa" < "zzz"
-        cross_dm_element_urn_by_name={"shared_name": [urn_zzz, urn_aaa]},
-        cross_dm_urn_to_cols={
-            urn_aaa: {"col": "col"},
-            urn_zzz: {"col": "col"},
-        },
     )
 
     assert len(lineages) == 1
+    # sorted([urn_aaa, urn_zzz])[0] == urn_aaa since "aaa" < "zzz"
     assert lineages[0].upstreams == [builder.make_schema_field_urn(urn_aaa, "col")]
     assert source.reporter.data_model_element_fgl_cross_dm_collision_pick_first == 1
     assert source.reporter.data_model_element_fgl_cross_dm_resolved == 1
@@ -601,7 +605,16 @@ def test_cross_dm_collision_entity_level_breaks_tie() -> None:
         "elem-downstream",
         "Downstream",
         [_column("c1", "col", "[shared_name/col]")],
+        source_ids=["dm-correct/s1", "dm-other/s2"],
     )
+    source.dm_element_urn_by_name = {
+        "dm-correct": {"shared_name": [urn_correct]},
+        "dm-other": {"shared_name": [urn_other]},
+    }
+    source.dm_element_urn_to_cols = {
+        urn_correct: {"col": "col"},
+        urn_other: {"col": "col"},
+    }
 
     lineages = _build(
         source,
@@ -609,35 +622,31 @@ def test_cross_dm_collision_entity_level_breaks_tie() -> None:
         element_dataset_urn=downstream_urn,
         element_name_to_eids={"downstream": ["elem-downstream"]},
         elementId_to_dataset_urn={"elem-downstream": downstream_urn},
-        # Only urn_correct is a confirmed entity-level upstream.
         entity_level_upstream_urns={urn_correct},
-        cross_dm_element_urn_by_name={"shared_name": [urn_other, urn_correct]},
-        cross_dm_urn_to_cols={
-            urn_correct: {"col": "col"},
-            urn_other: {"col": "col"},
-        },
     )
 
     assert len(lineages) == 1
     assert lineages[0].upstreams == [builder.make_schema_field_urn(urn_correct, "col")]
-    # Tie broken by entity-level upstream — no collision recorded.
     assert source.reporter.data_model_element_fgl_cross_dm_collision_pick_first == 0
     assert source.reporter.data_model_element_fgl_cross_dm_resolved == 1
 
 
 def test_cross_dm_singleton_not_in_entity_level_upstreams_still_emits() -> None:
-    """A singleton cross-DM candidate that is NOT in entity_level_upstream_urns
-    still emits FGL. The orphan filter is intentionally not applied to cross-DM
-    refs because Sigma's /lineage API does not always surface cross-DM formula
+    """A singleton cross-DM candidate not in entity_level_upstream_urns still
+    emits FGL — Sigma's /lineage API does not always surface cross-DM formula
     dependencies at the entity level."""
     source = _source()
+    dm_url_id = "other-dm"
     upstream_urn = _urn("other-dm-element")
     downstream_urn = _urn("elem-downstream")
     element = _element(
         "elem-downstream",
         "Downstream",
         [_column("c1", "city", "[other_dm_element/city]")],
+        source_ids=[f"{dm_url_id}/suffix"],
     )
+    source.dm_element_urn_by_name = {dm_url_id: {"other_dm_element": [upstream_urn]}}
+    source.dm_element_urn_to_cols = {upstream_urn: {"city": "city"}}
 
     lineages = _build(
         source,
@@ -645,10 +654,7 @@ def test_cross_dm_singleton_not_in_entity_level_upstreams_still_emits() -> None:
         element_dataset_urn=downstream_urn,
         element_name_to_eids={"downstream": ["elem-downstream"]},
         elementId_to_dataset_urn={"elem-downstream": downstream_urn},
-        # upstream_urn is NOT in entity_level_upstream_urns.
         entity_level_upstream_urns={_urn("some-warehouse-table")},
-        cross_dm_element_urn_by_name={"other_dm_element": [upstream_urn]},
-        cross_dm_urn_to_cols={upstream_urn: {"city": "city"}},
     )
 
     assert len(lineages) == 1

--- a/metadata-ingestion/tests/unit/sigma/test_dm_element_fgl.py
+++ b/metadata-ingestion/tests/unit/sigma/test_dm_element_fgl.py
@@ -75,6 +75,8 @@ def _build(
     elementId_to_dataset_urn: Dict[str, str] | None = None,
     entity_level_upstream_urns: Set[str] | None = None,
     upstream_elements: List[SigmaDataModelElement] | None = None,
+    cross_dm_element_urn_by_name: Dict[str, List[str]] | None = None,
+    cross_dm_urn_to_cols: Dict[str, Dict[str, str]] | None = None,
 ) -> list:
     all_elements = [element] + (upstream_elements or [])
     return source._build_dm_element_fine_grained_lineages(
@@ -84,6 +86,8 @@ def _build(
         elementId_to_dataset_urn=elementId_to_dataset_urn or {},
         entity_level_upstream_urns=entity_level_upstream_urns or set(),
         data_model=_data_model(all_elements),
+        cross_dm_element_urn_by_name=cross_dm_element_urn_by_name or {},
+        cross_dm_urn_to_cols=cross_dm_urn_to_cols or {},
     )
 
 
@@ -487,3 +491,100 @@ def test_name_collision_picks_first_sorted_urn() -> None:
     assert lineages[0].upstreams == [builder.make_schema_field_urn(urn_aaa, "team1")]
     assert source.reporter.data_model_element_fgl_collision_pick_first == 1
     assert source.reporter.data_model_element_fgl_emitted == 1
+
+
+def test_cross_dm_ref_resolves_via_global_index() -> None:
+    """Bracket ref to an element name absent from the current DM but present in
+    another DM resolves via the global cross-DM index and emits FGL."""
+    source = _source()
+    other_urn = _urn("other-dm-element")
+    downstream_urn = _urn("elem-downstream")
+    element = _element(
+        "elem-downstream",
+        "Downstream",
+        [_column("c1", "city", "[other_dm_element/city]")],
+    )
+
+    lineages = _build(
+        source,
+        element,
+        element_dataset_urn=downstream_urn,
+        # "other_dm_element" is NOT in the current DM's name map.
+        element_name_to_eids={"downstream": ["elem-downstream"]},
+        elementId_to_dataset_urn={"elem-downstream": downstream_urn},
+        entity_level_upstream_urns={other_urn},
+        cross_dm_element_urn_by_name={"other_dm_element": [other_urn]},
+        cross_dm_urn_to_cols={other_urn: {"city": "city", "date": "date"}},
+    )
+
+    assert len(lineages) == 1
+    assert lineages[0].upstreams == [builder.make_schema_field_urn(other_urn, "city")]
+    assert lineages[0].downstreams == [
+        builder.make_schema_field_urn(downstream_urn, "city")
+    ]
+    assert source.reporter.data_model_element_fgl_cross_dm_resolved == 1
+    assert source.reporter.data_model_element_fgl_cross_dm_deferred == 0
+    # Cross-DM FGL does not tick the intra-DM emit counter.
+    assert source.reporter.data_model_element_fgl_emitted == 0
+
+
+def test_cross_dm_unresolvable_ref_increments_deferred() -> None:
+    """Bracket ref to a name absent from both the current DM and the global
+    cross-DM index increments cross_dm_deferred."""
+    source = _source()
+    downstream_urn = _urn("elem-downstream")
+    element = _element(
+        "elem-downstream",
+        "Downstream",
+        [_column("c1", "city", "[unknown_thing/city]")],
+    )
+
+    lineages = _build(
+        source,
+        element,
+        element_dataset_urn=downstream_urn,
+        element_name_to_eids={"downstream": ["elem-downstream"]},
+        elementId_to_dataset_urn={"elem-downstream": downstream_urn},
+        entity_level_upstream_urns={_urn("some-other-element")},
+        # "unknown_thing" is not in the global index.
+        cross_dm_element_urn_by_name={"some_dm_element": [_urn("some-dm-element")]},
+        cross_dm_urn_to_cols={_urn("some-dm-element"): {"col": "col"}},
+    )
+
+    assert lineages == []
+    assert source.reporter.data_model_element_fgl_cross_dm_deferred == 1
+    assert source.reporter.data_model_element_fgl_cross_dm_resolved == 0
+
+
+def test_cross_dm_collision_picks_first_sorted_urn() -> None:
+    """Two DMs share an element name; cross-DM resolver picks sorted[0],
+    matching the intra-DM collision precedent."""
+    source = _source()
+    urn_aaa = _urn("aaa-dm-element")
+    urn_zzz = _urn("zzz-dm-element")
+    downstream_urn = _urn("elem-downstream")
+    element = _element(
+        "elem-downstream",
+        "Downstream",
+        [_column("c1", "col", "[shared_name/col]")],
+    )
+
+    lineages = _build(
+        source,
+        element,
+        element_dataset_urn=downstream_urn,
+        element_name_to_eids={"downstream": ["elem-downstream"]},
+        elementId_to_dataset_urn={"elem-downstream": downstream_urn},
+        entity_level_upstream_urns={urn_aaa, urn_zzz},
+        # sorted([urn_aaa, urn_zzz])[0] == urn_aaa since "aaa" < "zzz"
+        cross_dm_element_urn_by_name={"shared_name": [urn_zzz, urn_aaa]},
+        cross_dm_urn_to_cols={
+            urn_aaa: {"col": "col"},
+            urn_zzz: {"col": "col"},
+        },
+    )
+
+    assert len(lineages) == 1
+    assert lineages[0].upstreams == [builder.make_schema_field_urn(urn_aaa, "col")]
+    assert source.reporter.data_model_element_fgl_cross_dm_collision_pick_first == 1
+    assert source.reporter.data_model_element_fgl_cross_dm_resolved == 1

--- a/metadata-ingestion/tests/unit/sigma/test_dm_element_fgl.py
+++ b/metadata-ingestion/tests/unit/sigma/test_dm_element_fgl.py
@@ -14,8 +14,8 @@ from datahub.ingestion.source.sigma.sigma import SigmaSource
 def _source() -> SigmaSource:
     source = SigmaSource.__new__(SigmaSource)
     source.reporter = SigmaSourceReport()
-    source.dm_element_urn_by_name: Dict[str, Dict[str, List[str]]] = {}
-    source.dm_element_urn_to_cols: Dict[str, Dict[str, str]] = {}
+    source.dm_element_urn_by_name = {}
+    source.dm_element_urn_to_cols = {}
     return source
 
 

--- a/metadata-ingestion/tests/unit/sigma/test_sigma_api.py
+++ b/metadata-ingestion/tests/unit/sigma/test_sigma_api.py
@@ -811,6 +811,61 @@ class TestAssembleDataModelFileMetaFallback:
         assert dm.badge is None
 
 
+class TestSourceDmElementNamesEdgeCases:
+    """Guards the guards: the ``elif entry_type == "data-model"`` branch in
+    ``_assemble_data_model`` rejects entries with a non-string dataModelId or
+    a whitespace-only name.  Without these checks, a malformed API response
+    could silently produce empty-string keys or blank element names in
+    ``source_dm_element_names``.
+    """
+
+    def _dm(self) -> SigmaDataModel:
+        return SigmaDataModel.model_validate(
+            {
+                "dataModelId": "dm-uuid-1",
+                "name": "My DM",
+                "createdAt": _dt.datetime(2024, 1, 1, tzinfo=_dt.timezone.utc),
+                "updatedAt": _dt.datetime(2024, 1, 2, tzinfo=_dt.timezone.utc),
+            }
+        )
+
+    def _assemble_with_entries(
+        self, lineage_entries: List[Dict[str, Any]]
+    ) -> SigmaDataModel:
+        api = _create_sigma_api()
+        dm = self._dm()
+        with (
+            patch.object(api, "_get_data_model_elements", return_value=[]),
+            patch.object(api, "_get_data_model_columns", return_value=[]),
+            patch.object(
+                api, "_get_data_model_lineage_entries", return_value=lineage_entries
+            ),
+        ):
+            api._assemble_data_model(dm, None)
+        return dm
+
+    def test_non_string_src_dm_id_is_ignored(self) -> None:
+        # dataModelId is an int (malformed API response) — must not be stored.
+        dm = self._assemble_with_entries(
+            [{"type": "data-model", "dataModelId": 42, "name": "Sales"}]
+        )
+        assert dm.source_dm_element_names == {}
+
+    def test_whitespace_only_name_is_ignored(self) -> None:
+        # name is all whitespace — strip() would produce "", must not be stored.
+        dm = self._assemble_with_entries(
+            [{"type": "data-model", "dataModelId": "src-dm-id", "name": "   "}]
+        )
+        assert dm.source_dm_element_names == {}
+
+    def test_valid_entry_is_stored(self) -> None:
+        # Positive control: a well-formed entry must be stored normally.
+        dm = self._assemble_with_entries(
+            [{"type": "data-model", "dataModelId": "src-dm-id", "name": "  Revenue  "}]
+        )
+        assert dm.source_dm_element_names == {"src-dm-id": ["Revenue"]}
+
+
 def _paginated_response(
     entries: List[Dict[str, Any]],
     *,


### PR DESCRIPTION
Extends intra-DM resolver to consult the globally-populatedcross-DM bridge index when a bracket ref doesn't match any sibling element in the current DM. Validates the column on the resolved upstream and emits FineGrainedLineage

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
