### PR TITLE
fix(browse): use platform instance URN in default BrowsePathsV2 generation

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/utils/BrowsePathV2Utils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/utils/BrowsePathV2Utils.java
@@ -5,6 +5,8 @@ import static com.linkedin.metadata.Constants.CONTAINER_ASPECT_NAME;
 import com.linkedin.common.BrowsePathEntry;
 import com.linkedin.common.BrowsePathEntryArray;
 import com.linkedin.common.BrowsePathsV2;
+import com.linkedin.common.urn.DataPlatformInstanceUrn;
+import com.linkedin.common.urn.DataPlatformUrn;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.DataMap;
 import com.linkedin.entity.EntityResponse;
@@ -67,6 +69,8 @@ public class BrowsePathV2Utils {
           BrowsePathEntryArray defaultDatasetPathEntries =
               getDefaultDatasetPathEntries(dsKey.getName(), dataPlatformDelimiter);
           if (defaultDatasetPathEntries.size() > 0) {
+            tryResolvePlatformInstanceEntry(
+                opContext, defaultDatasetPathEntries, dsKey.getPlatform(), entityService);
             browsePathEntries.addAll(defaultDatasetPathEntries);
           } else {
             browsePathEntries.add(createBrowsePathEntry(DEFAULT_FOLDER_NAME, null));
@@ -109,6 +113,45 @@ public class BrowsePathV2Utils {
       pathEntry.setUrn(urn);
     }
     return pathEntry;
+  }
+
+  /**
+   * If the first plain-name segment of a default dataset browse path corresponds to an existing
+   * DataPlatformInstance entity, replaces it with a URN-form entry to match the format produced by
+   * Python ingestion's {@code auto_browse_path_v2} processor.
+   *
+   * <p>This prevents duplicate navigation folders in the Browse UI when GMS generates a default
+   * BrowsePathsV2 for a lineage-only entity (never directly schema-ingested) whose platform
+   * instance is already registered in the catalog. Without this fix, those entities appear under a
+   * plain-name folder (e.g. {@code ␟myinstance}) while directly-ingested entities appear under the
+   * URN-form folder (e.g. {@code ␟urn:li:dataPlatformInstance:(...)}), creating two separate
+   * navigation trees for the same logical location.
+   *
+   * <p>No-op if entries is empty, if the DataPlatformInstance entity does not exist, or if any
+   * exception occurs during resolution.
+   */
+  private static void tryResolvePlatformInstanceEntry(
+      @Nonnull OperationContext opContext,
+      @Nonnull BrowsePathEntryArray entries,
+      @Nonnull Urn platformUrn,
+      @Nonnull EntityService<?> entityService) {
+    if (entries.isEmpty()) {
+      return;
+    }
+    try {
+      String firstSegment = entries.get(0).getId();
+      DataPlatformInstanceUrn platformInstanceUrn =
+          new DataPlatformInstanceUrn(DataPlatformUrn.createFromUrn(platformUrn), firstSegment);
+      if (entityService.exists(opContext, platformInstanceUrn, true)) {
+        entries.set(0, createBrowsePathEntry(platformInstanceUrn.toString(), platformInstanceUrn));
+      }
+    } catch (Exception e) {
+      log.warn(
+          "Failed to resolve platform instance URN for first browse path segment '{}', "
+              + "falling back to plain-name: {}",
+          entries.get(0).getId(),
+          e.getMessage());
+    }
   }
 
   private static void aggregateParentContainers(

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/utils/BrowsePathV2UtilsTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/utils/BrowsePathV2UtilsTest.java
@@ -3,7 +3,6 @@ package com.linkedin.metadata.search.utils;
 import static com.linkedin.metadata.Constants.CONTAINER_ASPECT_NAME;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -29,11 +28,9 @@ import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.utils.EntityKeyUtils;
 import io.datahubproject.metadata.context.OperationContext;
 import java.net.URISyntaxException;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -229,18 +226,10 @@ public class BrowsePathV2UtilsTest {
     Urn datasetUrn = UrnUtils.getUrn(snowflakeDatasetUrn);
     EntityService mockService = mock(EntityService.class);
 
-    // Stub the abstract exists() to indicate the DataPlatformInstance entity exists.
-    // exists(opContext, urn, true) delegates: → exists(Collection, true, false)
-    //   → exists(Collection, null, true, false)  [abstract — stubbed here]
     DataPlatformInstanceUrn platformInstanceUrn =
         new DataPlatformInstanceUrn(new DataPlatformUrn("snowflake"), "myinstance");
-    when(mockService.exists(
-            any(OperationContext.class),
-            any(Collection.class),
-            isNull(),
-            anyBoolean(),
-            anyBoolean()))
-        .thenReturn(Set.of(platformInstanceUrn));
+    when(mockService.exists(any(OperationContext.class), eq(platformInstanceUrn), anyBoolean()))
+        .thenReturn(true);
 
     BrowsePathsV2 browsePathsV2 =
         BrowsePathV2Utils.getDefaultBrowsePathV2(

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/utils/BrowsePathV2UtilsTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/utils/BrowsePathV2UtilsTest.java
@@ -2,6 +2,8 @@ package com.linkedin.metadata.search.utils;
 
 import static com.linkedin.metadata.Constants.CONTAINER_ASPECT_NAME;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -10,6 +12,8 @@ import com.linkedin.common.BrowsePathEntry;
 import com.linkedin.common.BrowsePathEntryArray;
 import com.linkedin.common.BrowsePathsV2;
 import com.linkedin.common.FabricType;
+import com.linkedin.common.urn.DataPlatformInstanceUrn;
+import com.linkedin.common.urn.DataPlatformUrn;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.container.Container;
@@ -25,9 +29,11 @@ import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.utils.EntityKeyUtils;
 import io.datahubproject.metadata.context.OperationContext;
 import java.net.URISyntaxException;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -209,6 +215,88 @@ public class BrowsePathV2UtilsTest {
     expectedPath = new BrowsePathEntryArray();
     entry1 = new BrowsePathEntry().setId(dataFlowUrn.toString()).setUrn(dataFlowUrn);
     expectedPath.add(entry1);
+    Assert.assertEquals(browsePathsV2.getPath(), expectedPath);
+  }
+
+  /**
+   * When a Snowflake DataPlatformInstance entity already exists, the default BrowsePathsV2 should
+   * use the URN-form entry for the platform instance segment (matching Python ingestion output).
+   */
+  @Test
+  public void testGetDefaultDatasetBrowsePathV2WithPlatformInstance() throws URISyntaxException {
+    String snowflakeDatasetUrn =
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,myinstance.DB.SCHEMA.TABLE,PROD)";
+    Urn datasetUrn = UrnUtils.getUrn(snowflakeDatasetUrn);
+    EntityService mockService = mock(EntityService.class);
+
+    // Stub the abstract exists() to indicate the DataPlatformInstance entity exists.
+    // exists(opContext, urn, true) delegates: → exists(Collection, true, false)
+    //   → exists(Collection, null, true, false)  [abstract — stubbed here]
+    DataPlatformInstanceUrn platformInstanceUrn =
+        new DataPlatformInstanceUrn(new DataPlatformUrn("snowflake"), "myinstance");
+    when(mockService.exists(
+            any(OperationContext.class),
+            any(Collection.class),
+            isNull(),
+            anyBoolean(),
+            anyBoolean()))
+        .thenReturn(Set.of(platformInstanceUrn));
+
+    BrowsePathsV2 browsePathsV2 =
+        BrowsePathV2Utils.getDefaultBrowsePathV2(
+            mock(OperationContext.class), datasetUrn, this.registry, '.', mockService, false);
+
+    BrowsePathEntryArray expectedPath = new BrowsePathEntryArray();
+    // First entry: URN-form platform instance (corrected by tryResolvePlatformInstanceEntry)
+    expectedPath.add(
+        new BrowsePathEntry().setId(platformInstanceUrn.toString()).setUrn(platformInstanceUrn));
+    // Remaining entries: plain-name database and schema segments
+    expectedPath.add(new BrowsePathEntry().setId("DB"));
+    expectedPath.add(new BrowsePathEntry().setId("SCHEMA"));
+    Assert.assertEquals(browsePathsV2.getPath(), expectedPath);
+  }
+
+  /**
+   * When the DataPlatformInstance entity does NOT exist yet (e.g. lineage runs before schema
+   * ingestion), the plain-name fallback behavior is preserved unchanged.
+   */
+  @Test
+  public void testGetDefaultDatasetBrowsePathV2WithoutPlatformInstance() throws URISyntaxException {
+    String snowflakeDatasetUrn =
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,myinstance.DB.SCHEMA.TABLE,PROD)";
+    Urn datasetUrn = UrnUtils.getUrn(snowflakeDatasetUrn);
+    // No stubbing → exists() returns empty Set → tryResolvePlatformInstanceEntry is a no-op
+    EntityService mockService = mock(EntityService.class);
+
+    BrowsePathsV2 browsePathsV2 =
+        BrowsePathV2Utils.getDefaultBrowsePathV2(
+            mock(OperationContext.class), datasetUrn, this.registry, '.', mockService, false);
+
+    BrowsePathEntryArray expectedPath = new BrowsePathEntryArray();
+    expectedPath.add(new BrowsePathEntry().setId("myinstance"));
+    expectedPath.add(new BrowsePathEntry().setId("DB"));
+    expectedPath.add(new BrowsePathEntry().setId("SCHEMA"));
+    Assert.assertEquals(browsePathsV2.getPath(), expectedPath);
+  }
+
+  /**
+   * BigQuery datasets without a platform instance: exists() returns false, entries are unchanged.
+   */
+  @Test
+  public void testGetDefaultDatasetBrowsePathV2BigQueryNoPlatformInstance()
+      throws URISyntaxException {
+    // DATASET_URN = urn:li:dataset:(urn:li:dataPlatform:bigquery,test.a.b,DEV)
+    Urn datasetUrn = UrnUtils.getUrn(DATASET_URN);
+    // No stubbing → exists() returns empty Set → no change
+    EntityService mockService = mock(EntityService.class);
+
+    BrowsePathsV2 browsePathsV2 =
+        BrowsePathV2Utils.getDefaultBrowsePathV2(
+            mock(OperationContext.class), datasetUrn, this.registry, '.', mockService, false);
+
+    BrowsePathEntryArray expectedPath = new BrowsePathEntryArray();
+    expectedPath.add(new BrowsePathEntry().setId("test"));
+    expectedPath.add(new BrowsePathEntry().setId("a"));
     Assert.assertEquals(browsePathsV2.getPath(), expectedPath);
   }
 


### PR DESCRIPTION
## Summary

- **Bug:** GMS default `BrowsePathsV2` generation splits dataset names by platform delimiter to produce plain-name path segments (e.g. `{id:"myinstance", urn:null}`). Python ingestion's `auto_browse_path_v2` processor produces URN-form entries (e.g. `{id:"urn:li:dataPlatformInstance:(...)", urn:...}`). Lineage-only entities — which get their browse path set permanently by the GMS default and are never overwritten by Python — appear under a **different top-level folder** than directly-ingested entities, creating two distinct navigation trees for the same logical location.
- **Fix:** In `BrowsePathV2Utils.getDefaultBrowsePathV2()`, after producing the name-split dataset path entries, call `tryResolvePlatformInstanceEntry()`. This checks whether the first segment matches an existing `DataPlatformInstance` entity (via a single `EntityService.exists()` key-existence check) and, if so, replaces the plain-name entry with the URN-form entry — matching Python ingestion output.
- **Safety:** The lookup is wrapped in `try/catch`; any failure (entity not found, URN parse error) silently falls back to the existing plain-name behaviour.

## Files Changed

- `metadata-io/src/main/java/com/linkedin/metadata/search/utils/BrowsePathV2Utils.java` — new `tryResolvePlatformInstanceEntry()` private method + one-line call in the DATASET case
- `metadata-io/src/test/java/com/linkedin/metadata/search/utils/BrowsePathV2UtilsTest.java` — 3 new tests: platform instance exists (URN-form output), platform instance absent (plain-name fallback), BigQuery without platform instance (unchanged)

## Root Cause

A Snowflake environment with a registered platform instance had two overlapping browse path formats for the same platform instance:
- `␟myinstance` — entities whose `BrowsePathsV2` was written by the GMS default (lineage-only stubs)
- `␟urn:li:dataPlatformInstance:(urn:li:dataPlatform:snowflake,myinstance)` — entities ingested via Snowflake schema ingestion

Both appear as "myinstance" in the Navigate sidebar but are treated as distinct locations in search, requiring two separate filter values to capture all entities under that platform instance.

## Test Plan

- [x] Spotless formatting passes (pre-commit hook ran clean on commit)
- [ ] CI: `./gradlew :metadata-io:test --tests "com.linkedin.metadata.search.utils.BrowsePathV2UtilsTest" -x generateGitPropertiesGlobal` — all 8 tests (5 existing + 3 new) should pass

## What Does NOT Change

- `DefaultAspectsUtil.java` — `useContainerPaths=false` is preserved; the fix operates entirely inside `BrowsePathV2Utils`
- Python ingestion — already produces correct URN-form output; no changes needed
- `BackfillBrowsePathsV2Step` — not modified; retroactive fix for existing entities is a separate follow-up

## Checklist

- [x] PR conforms to [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format)
- [ ] Links to related issues (if applicable)
- [x] Tests added/updated
- [ ] Docs added/updated (not applicable)
- [ ] Breaking changes documented in `docs/how/updating-datahub.md` (not applicable — no breaking change)