### PR TITLE
fix(ingest/oracle): make thick_mode_lib_dir work on Linux via ctypes preload

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/oracle.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/oracle.py
@@ -1,4 +1,6 @@
+import ctypes
 import datetime
+import glob
 import logging
 import os
 import platform
@@ -29,7 +31,7 @@ from sqlalchemy.sql import sqltypes
 from sqlalchemy.types import FLOAT, INTEGER, TIMESTAMP
 
 import datahub.metadata.schema_classes as models
-from datahub.configuration.common import AllowDenyPattern
+from datahub.configuration.common import AllowDenyPattern, ConfigurationError
 from datahub.emitter.mce_builder import (
     DEFAULT_ENV,
     make_data_job_urn,
@@ -378,6 +380,70 @@ DB_NAME_QUERY = """
 """
 
 
+# Oracle Instant Client shared libs in the order they should be preloaded.
+# libclntsh is last because it has DT_NEEDED entries on the others; loading
+# the deps first by absolute path puts them in the process namespace by SONAME
+# so the linker reuses them when libclntsh is opened.
+_ORACLE_PRELOAD_PATTERNS = (
+    "libnnz*.so*",
+    "libclntshcore.so*",
+    "libons.so*",
+    "libipc1.so*",
+    "libmql1.so*",
+    "libociei.so*",
+    "libclntsh.so*",
+)
+
+
+def _preload_oracle_client_libs(lib_dir: str) -> None:
+    """Preload Oracle Instant Client libs from ``lib_dir`` so that
+    ``oracledb.init_oracle_client()`` succeeds on Linux without needing
+    ``LD_LIBRARY_PATH`` or ``ldconfig`` to be configured.
+
+    Background: on Linux, Oracle ships ``libclntsh.so`` without
+    ``RUNPATH=$ORIGIN``. Even when python-oracledb / ODPI-C dlopens
+    ``libclntsh.so`` via an absolute path (which is what ``lib_dir`` does),
+    the dynamic linker still has to resolve its DT_NEEDED dependencies
+    (``libnnz*.so``, ``libclntshcore.so``, ``libons.so``, ...) through the
+    normal ``LD_LIBRARY_PATH`` / ``ld.so.cache`` rules. With neither
+    configured, the load fails with DPI-1047.
+
+    Setting ``LD_LIBRARY_PATH`` from Python doesn't help: glibc's loader
+    reads it once at process startup. Loading each ``.so`` by absolute path
+    with ``RTLD_GLOBAL`` does work — once an object is mapped, the linker
+    looks it up by SONAME for subsequent ``dlopen()`` calls and finds it.
+
+    See https://github.com/oracle/python-oracledb/issues/578 for the upstream
+    discussion confirming this can only be fixed by preloading from the client
+    side or by patching ``RUNPATH=$ORIGIN`` into ``libclntsh.so`` itself.
+    """
+    if not os.path.isdir(lib_dir):
+        raise ConfigurationError(
+            f"thick_mode_lib_dir={lib_dir!r} does not exist or is not a directory"
+        )
+
+    loaded_any = False
+    for pattern in _ORACLE_PRELOAD_PATTERNS:
+        for path in sorted(glob.glob(os.path.join(lib_dir, pattern))):
+            try:
+                ctypes.CDLL(path, mode=ctypes.RTLD_GLOBAL)
+                loaded_any = True
+                logger.debug("Preloaded Oracle client lib: %s", path)
+            except OSError as e:
+                # Non-fatal: a missing satellite lib (e.g. libipc1 in older
+                # client releases) is fine as long as libclntsh and its actual
+                # deps load. Keep going so we surface a useful error from
+                # init_oracle_client() if anything critical is missing.
+                logger.debug("Skipping %s while preloading: %s", path, e)
+
+    if not loaded_any:
+        raise ConfigurationError(
+            f"No Oracle Instant Client libraries found in {lib_dir!r}. "
+            "Verify the path points to an unpacked Instant Client (it should "
+            "contain libclntsh.so* and libnnz*.so*)."
+        )
+
+
 def _setup_oracle_compatibility() -> None:
     """
     Set up Oracle compatibility for SQLAlchemy.
@@ -466,8 +532,13 @@ class OracleConfig(BasicSQLAlchemyConfig, BaseUsageConfig):
     )
     thick_mode_lib_dir: Optional[str] = Field(
         default=None,
-        description="If using thick mode on Windows or Mac, set thick_mode_lib_dir to the oracle client libraries path. "
-        "On Linux, this value is ignored, as ldconfig or LD_LIBRARY_PATH will define the location.",
+        description="Path to the directory containing the Oracle Instant Client libraries. "
+        "Required on Windows and Mac when enable_thick_mode is true. "
+        "Optional on Linux: when set, the connector preloads the client libraries "
+        "from this directory before initializing python-oracledb, which makes "
+        "thick mode work without needing ldconfig or LD_LIBRARY_PATH to be set "
+        "(see https://github.com/oracle/python-oracledb/issues/578). When unset "
+        "on Linux, the standard ldconfig / LD_LIBRARY_PATH search is used.",
     )
     # Stored procedures configuration
     include_stored_procedures: bool = Field(
@@ -1297,11 +1368,21 @@ class OracleSource(SQLAlchemySource):
         # create_engine, which is called in get_inspectors()
         # https://python-oracledb.readthedocs.io/en/latest/user_guide/initialization.html#enabling-python-oracledb-thick-mode
         if self.config.enable_thick_mode:
-            if platform.system() == "Darwin" or platform.system() == "Windows":
-                # windows and mac os require lib_dir to be set explicitly
+            if platform.system() in ("Darwin", "Windows"):
+                # Mac/Windows: lib_dir is required and is enough; the platform's
+                # loader handles the dependent libs.
                 oracledb.init_oracle_client(lib_dir=self.config.thick_mode_lib_dir)
+            elif self.config.thick_mode_lib_dir:
+                # Linux: passing lib_dir to init_oracle_client() locates
+                # libclntsh.so itself but the loader still falls back to
+                # LD_LIBRARY_PATH / ld.so.cache for its DT_NEEDED deps, which
+                # fails on hosts that don't have ldconfig set up. Preload every
+                # .so in lib_dir by absolute path with RTLD_GLOBAL so the deps
+                # are resolved by SONAME from the process namespace.
+                _preload_oracle_client_libs(self.config.thick_mode_lib_dir)
+                oracledb.init_oracle_client()
             else:
-                # linux requires configurating the library path with ldconfig or LD_LIBRARY_PATH
+                # Linux without thick_mode_lib_dir: rely on ldconfig / LD_LIBRARY_PATH.
                 oracledb.init_oracle_client()
 
         # Pre-fetch schemas from DataHub when not ingesting all tables/views so that

--- a/metadata-ingestion/tests/unit/test_oracle_source.py
+++ b/metadata-ingestion/tests/unit/test_oracle_source.py
@@ -1,5 +1,7 @@
+import os
 import unittest.mock
 from datetime import datetime
+from typing import List, Optional
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -9,7 +11,7 @@ from sqlalchemy.dialects.oracle.base import ischema_names
 from sqlalchemy.engine import Inspector
 from sqlalchemy.sql import sqltypes
 
-from datahub.configuration.common import AllowDenyPattern
+from datahub.configuration.common import AllowDenyPattern, ConfigurationError
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.source.sql.oracle import (
     VSQL_USAGE_QUERY,
@@ -19,6 +21,7 @@ from datahub.ingestion.source.sql.oracle import (
     OracleSource,
     ProcedureDependencies,
     VSqlPrerequisiteCheckResult,
+    _preload_oracle_client_libs,
     extra_oracle_types,
 )
 from datahub.ingestion.source.sql.sql_report import SQLSourceReport
@@ -1423,3 +1426,128 @@ def test_extra_oracle_types_registered_during_workunits_iteration():
             list(source.get_workunits())
 
     assert all(registered_during_iteration)
+
+
+def _make_thick_mode_config(thick_mode_lib_dir: Optional[str] = None) -> OracleConfig:
+    return OracleConfig(
+        username="user",
+        password="password",
+        host_port="host:1521",
+        service_name="svc01",
+        enable_thick_mode=True,
+        thick_mode_lib_dir=thick_mode_lib_dir,
+    )
+
+
+def test_preload_oracle_client_libs_loads_in_dependency_order(tmp_path):
+    """Deps must be opened before libclntsh; missing optional libs are skipped silently."""
+    # Create stub files for some but not all of the patterns the helper looks for.
+    # libipc1 / libmql1 / libociei are intentionally absent — they are optional in
+    # newer Instant Client releases and the helper must tolerate that.
+    files = [
+        "libnnz12.so",
+        "libclntshcore.so.21.1",
+        "libons.so",
+        "libclntsh.so.21.1",
+    ]
+    for name in files:
+        (tmp_path / name).write_bytes(b"")
+
+    loaded: List[str] = []
+
+    class _FakeCDLL:
+        def __init__(self, path: str, mode: int) -> None:
+            loaded.append(os.path.basename(path))
+
+    with patch("datahub.ingestion.source.sql.oracle.ctypes.CDLL", _FakeCDLL):
+        _preload_oracle_client_libs(str(tmp_path))
+
+    # Dependencies before libclntsh — that's the whole point of the helper.
+    assert loaded[-1] == "libclntsh.so.21.1"
+    assert "libnnz12.so" in loaded
+    assert "libclntshcore.so.21.1" in loaded
+    assert "libons.so" in loaded
+    # nnz must precede libclntsh; libclntshcore likewise.
+    assert loaded.index("libnnz12.so") < loaded.index("libclntsh.so.21.1")
+    assert loaded.index("libclntshcore.so.21.1") < loaded.index("libclntsh.so.21.1")
+
+
+def test_preload_oracle_client_libs_raises_when_dir_missing(tmp_path):
+    bogus = tmp_path / "does-not-exist"
+
+    with pytest.raises(ConfigurationError, match="does not exist"):
+        _preload_oracle_client_libs(str(bogus))
+
+
+def test_preload_oracle_client_libs_raises_when_dir_empty(tmp_path):
+    # Directory exists but contains no Oracle libs — surfaces a clearer error
+    # than the cryptic DPI-1047 we'd otherwise get downstream.
+    with pytest.raises(ConfigurationError, match="No Oracle Instant Client libraries"):
+        _preload_oracle_client_libs(str(tmp_path))
+
+
+def test_preload_oracle_client_libs_skips_individual_load_failures(tmp_path):
+    """One bad .so should not abort the whole preload — log and continue."""
+    for name in ["libnnz12.so", "libclntsh.so.21.1"]:
+        (tmp_path / name).write_bytes(b"")
+
+    attempts: List[str] = []
+
+    class _FlakyCDLL:
+        def __init__(self, path: str, mode: int) -> None:
+            attempts.append(os.path.basename(path))
+            if path.endswith("libnnz12.so"):
+                raise OSError("synthetic load failure")
+
+    with patch("datahub.ingestion.source.sql.oracle.ctypes.CDLL", _FlakyCDLL):
+        _preload_oracle_client_libs(str(tmp_path))
+
+    assert "libnnz12.so" in attempts
+    assert "libclntsh.so.21.1" in attempts
+
+
+@patch("datahub.ingestion.source.sql.oracle.platform.system", return_value="Linux")
+@patch("datahub.ingestion.source.sql.oracle._preload_oracle_client_libs")
+@patch("datahub.ingestion.source.sql.oracle.oracledb")
+def test_oracle_source_linux_preloads_when_lib_dir_set(
+    mock_oracledb, mock_preload, _mock_platform, tmp_path
+):
+    config = _make_thick_mode_config(thick_mode_lib_dir=str(tmp_path))
+
+    OracleSource(config, PipelineContext("test-thick-linux-preload"))
+
+    mock_preload.assert_called_once_with(str(tmp_path))
+    # On Linux we must NOT pass lib_dir to init_oracle_client(): the preload
+    # already put the libs in the process namespace, and passing lib_dir is
+    # what triggers the DT_NEEDED resolution failure described in oracle/python-oracledb#578.
+    mock_oracledb.init_oracle_client.assert_called_once_with()
+
+
+@patch("datahub.ingestion.source.sql.oracle.platform.system", return_value="Linux")
+@patch("datahub.ingestion.source.sql.oracle._preload_oracle_client_libs")
+@patch("datahub.ingestion.source.sql.oracle.oracledb")
+def test_oracle_source_linux_skips_preload_when_lib_dir_unset(
+    mock_oracledb, mock_preload, _mock_platform
+):
+    config = _make_thick_mode_config(thick_mode_lib_dir=None)
+
+    OracleSource(config, PipelineContext("test-thick-linux-no-preload"))
+
+    mock_preload.assert_not_called()
+    mock_oracledb.init_oracle_client.assert_called_once_with()
+
+
+@patch("datahub.ingestion.source.sql.oracle.platform.system", return_value="Darwin")
+@patch("datahub.ingestion.source.sql.oracle._preload_oracle_client_libs")
+@patch("datahub.ingestion.source.sql.oracle.oracledb")
+def test_oracle_source_mac_passes_lib_dir_without_preload(
+    mock_oracledb, mock_preload, _mock_platform, tmp_path
+):
+    config = _make_thick_mode_config(thick_mode_lib_dir=str(tmp_path))
+
+    OracleSource(config, PipelineContext("test-thick-mac"))
+
+    # macOS uses dyld, not glibc's loader, so no preload trick is needed —
+    # init_oracle_client(lib_dir=...) is sufficient.
+    mock_preload.assert_not_called()
+    mock_oracledb.init_oracle_client.assert_called_once_with(lib_dir=str(tmp_path))


### PR DESCRIPTION
## 📋 Summary
Make `thick_mode_lib_dir` actually work on Linux by preloading the Oracle Instant Client shared libraries via `ctypes` before calling `oracledb.init_oracle_client()`, so customers no longer need `LD_LIBRARY_PATH` / `ldconfig` configured on the executor host.

## 🎯 Motivation
A customer running Oracle ingestion in thick mode on a remote executor hits `DPI-1047: Cannot locate a 64-bit Oracle Client library` even after setting `thick_mode_lib_dir`. Today the Linux branch ignores that config entirely and relies on `ldconfig` / `LD_LIBRARY_PATH`, which is brittle on locked-down or containerised executor images.

Root cause is upstream: Oracle ships `libclntsh.so` on Linux **without `RUNPATH=$ORIGIN`**, so even when ODPI-C `dlopen`s `libclntsh.so` by absolute path (which is what passing `lib_dir` does), the dynamic linker still has to resolve its `DT_NEEDED` deps (`libnnz*`, `libclntshcore`, `libons`, …) through `LD_LIBRARY_PATH` / `ld.so.cache`. Setting `LD_LIBRARY_PATH` from Python doesn't help — glibc reads it once at process startup. The python-oracledb maintainer confirms this in [oracle/python-oracledb#578](https://github.com/oracle/python-oracledb/issues/578) and says it can only be fixed client-side or by patching the rpath of `libclntsh.so` itself.

So just forwarding `lib_dir=` to `init_oracle_client()` on Linux would change the error from `cannot find libclntsh.so` to `cannot find libnnz.so` — net zero. We have to load the dependent libs into the process address space ourselves.

## 🔧 Changes Overview

**Modifications**
- `OracleSource.__init__` now branches on platform:
  - **Linux + `thick_mode_lib_dir` set** → preload all `.so`s in that directory by absolute path with `ctypes.CDLL(..., RTLD_GLOBAL)`, then call `oracledb.init_oracle_client()` with no args.
  - **Linux + `thick_mode_lib_dir` unset** → unchanged (rely on `ldconfig` / `LD_LIBRARY_PATH`).
  - **Mac / Windows** → unchanged (`init_oracle_client(lib_dir=...)`).
- `thick_mode_lib_dir` field description updated to document that it now works on Linux.

**New helper**
- `_preload_oracle_client_libs(lib_dir)` in `oracle.py`. Loads `libnnz*`, `libclntshcore`, `libons`, optional satellites, and `libclntsh` last — order matters because `libclntsh` has `DT_NEEDED` entries on the others. Surfaces a clear `ConfigurationError` when the directory is missing or contains no Oracle libs (much more useful than the cryptic DPI-1047 we'd otherwise hit downstream). Per-file load failures are logged at DEBUG and tolerated, since e.g. `libipc1` isn't shipped in every Instant Client release.

## 🏗️ Architecture/Design Notes

**Why `ctypes.CDLL(path, RTLD_GLOBAL)` instead of e.g. setting an env var?**
Once an `.so` is mapped via `dlopen` with `RTLD_GLOBAL`, the dynamic linker registers the resolved object **by SONAME** in the process's symbol namespace. When `libclntsh.so` later `dlopen`s its `DT_NEEDED` deps from inside ODPI-C, the linker sees them already resident and reuses them — completely bypassing the missing `RUNPATH`. This is the same trick LD preloading uses; we're just doing it explicitly from Python.

**Scope of the side effect**
The preload is **per-process**, not global:
- It only mutates the calling Python process's address space.
- Nothing changes on the host filesystem, `/etc/ld.so.cache`, env vars, sibling processes, or processes spawned later via `subprocess`/`exec`.
- Within the process, the libs stay mapped until exit. Fine for an ingestion worker.

**Trade-offs considered**
- Forwarding `lib_dir` to `init_oracle_client()` on Linux: rejected, see motivation.
- `patchelf --set-rpath '$ORIGIN'` on `libclntsh.so` in `docker/snippets/oracle_instantclient.sh`: complementary, only fixes images we build. Worth doing as a follow-up for defense in depth, but doesn't help customers running their own executor images.

## 🧪 Testing
Added 7 unit tests in `tests/unit/test_oracle_source.py`:

**Helper-level (`_preload_oracle_client_libs`):**
- Loads deps before `libclntsh` (preserving the order that makes the workaround actually work).
- Tolerates missing optional libs (e.g. `libipc1`, `libociei`).
- Raises a clear `ConfigurationError` for missing directory and for empty directory.
- Continues past per-file `OSError` instead of aborting the whole preload.

**Call-site (`OracleSource.__init__`):**
- Linux + `thick_mode_lib_dir` set → preload runs, `init_oracle_client()` is called **without** `lib_dir`.
- Linux + `thick_mode_lib_dir` unset → preload skipped, unchanged behavior.
- macOS + `thick_mode_lib_dir` set → no preload, `init_oracle_client(lib_dir=...)` as before.

All 51 tests in `test_oracle_source.py` pass; `ruff` and `mypy` clean.

## 📊 Impact Assessment
- **Affected Components:** Oracle ingestion source only. The two changed code paths are guarded behind `enable_thick_mode == True`, so default (thin-mode) ingestion is completely untouched.
- **Breaking Changes:** None. The Linux behavior when `thick_mode_lib_dir` is unset is identical to before. When it _is_ set, the previous behavior was to silently ignore it and fall through to `ldconfig` resolution; we now actually honor it. Anyone who was setting `thick_mode_lib_dir` on Linux today was either a) already working because `ldconfig` was set up correctly (still works), or b) hitting DPI-1047 (now fixed).
- **Performance Impact:** A handful of extra `dlopen()` calls at source initialization. Negligible.
- **Risk Level:** Low. Purely additive for the misconfigured-Linux case; existing code paths unchanged.

## 🚀 Deployment Notes
- No new dependencies — `ctypes` and `glob` are stdlib.
- Customers experiencing DPI-1047 in thick mode on Linux can now set `thick_mode_lib_dir` in their recipe and have it work without touching the host's `ldconfig`/`LD_LIBRARY_PATH`.
- Our own Docker image (`docker/snippets/oracle_instantclient.sh`) is unaffected — it already configures `ldconfig`, so the unset-`thick_mode_lib_dir` path keeps working.

## 🔗 References
- Upstream confirmation: [oracle/python-oracledb#578](https://github.com/oracle/python-oracledb/issues/578)
- Failure mode: Oracle DPI-1047 error
- Related: `docker/snippets/oracle_instantclient.sh` (potential follow-up: `patchelf --set-rpath '\$ORIGIN' libclntsh.so` for defense in depth)

## ❓ Questions for Reviewers
- Should we also do the `patchelf` change to our base image as a follow-up PR? It would be self-fixing for our images but only ours.
- Description for `thick_mode_lib_dir` now applies to all three platforms — happy to split it back into platform-specific guidance if that reads better.


Made with [Cursor](https://cursor.com)