### PR TITLE
build(oracle-ic): set RUNPATH=$ORIGIN on libclntsh.so to make lib_dir self-sufficient

### DIFF
--- a/docker/snippets/oracle_instantclient.sh
+++ b/docker/snippets/oracle_instantclient.sh
@@ -13,6 +13,15 @@
 #   - Debian/Ubuntu (multiarch): often only libaio.so.1t64 under /usr/lib/*-linux-gnu/
 #   - Wolfi: libaio.so.1 under /usr/lib, while client libs may still look beside multiarch paths
 # link_libaio_for_oracle() adds symlinks so resolution succeeds in both cases.
+#
+# RUNPATH: Oracle ships libclntsh.so without a RUNPATH, so its DT_NEEDED deps
+# (libnnz*, libclntshcore, libons, ...) can only be located via LD_LIBRARY_PATH
+# or /etc/ld.so.cache. That breaks any caller that points at this directory
+# from a process whose loader env isn't set up — e.g. python-oracledb's
+# init_oracle_client(lib_dir=...) on a stock Linux box. patch_oracle_runpath()
+# embeds RUNPATH=$ORIGIN into the client libs so the loader looks in their own
+# directory first. We still ldconfig the dir below as defense in depth.
+# See https://github.com/oracle/python-oracledb/issues/578.
 set -euxo pipefail
 
 IC_VERSION=23.26.1.0.0
@@ -34,6 +43,42 @@ link_libaio_for_oracle() {
   done
 }
 
+# Make patchelf available regardless of which base image we're on. Returns
+# non-zero if no supported package manager is found, so the caller can decide
+# whether to skip RUNPATH patching.
+ensure_patchelf() {
+  if command -v patchelf >/dev/null 2>&1; then return 0; fi
+  if command -v apt-get >/dev/null 2>&1; then
+    DEBIAN_FRONTEND=noninteractive apt-get update -qq \
+      && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends patchelf
+  elif command -v apk >/dev/null 2>&1; then
+    apk add --no-cache patchelf
+  else
+    return 1
+  fi
+}
+
+# Embed RUNPATH=$ORIGIN into every .so* in the IC directory so the dynamic
+# linker can resolve their DT_NEEDED deps from the directory itself, without
+# any external configuration. See header comment for context.
+patch_oracle_runpath() {
+  if ! ensure_patchelf; then
+    echo "patchelf unavailable; skipping RUNPATH=\$ORIGIN patch (ldconfig fallback still applies)" >&2
+    return 0
+  fi
+  # Patch real files only; the compatibility symlinks Oracle ships
+  # (e.g. libclntsh.so -> libclntsh.so.23.1) transparently inherit the new
+  # RUNPATH from their target.
+  find "/opt/oracle/${IC_UNZIP_DIR}" -maxdepth 1 -type f -name '*.so*' -print0 \
+    | while IFS= read -r -d '' so; do
+        # shellcheck disable=SC2016
+        # $ORIGIN is a dynamic-linker token, not a shell variable; pass it
+        # through literally for patchelf to embed in the DT_RUNPATH.
+        patchelf --set-rpath '$ORIGIN' "$so" 2>/dev/null \
+          || echo "patchelf failed on $so (continuing)" >&2
+      done
+}
+
 # Download the Basic package for this CPU. Oracle publishes separate zips (x64 vs arm64) with
 # the same version string. Other architectures are not supported here.
 ic_base_url="https://download.oracle.com/otn_software/linux/instantclient/${IC_OTN_ID}"
@@ -52,6 +97,9 @@ rm -f "$zip"
 
 # Ensure libaio can be found the way Oracle's shared libraries expect (see header).
 link_libaio_for_oracle
+
+# Make the client libs self-locating so they work regardless of LD_LIBRARY_PATH/ldconfig.
+patch_oracle_runpath
 
 # Register the client directory with the dynamic linker (libclntsh.so, etc.).
 sh -c "echo /opt/oracle/${IC_UNZIP_DIR} > /etc/ld.so.conf.d/oracle-instantclient.conf"


### PR DESCRIPTION
## 📋 Summary
Patch the Oracle Instant Client `.so` files at image-build time to embed `RUNPATH=$ORIGIN`, so libraries inside the IC directory can find each other without any external loader configuration. This is the long-term complement to #17265 (the per-process `ctypes` preload).

## 🎯 Motivation
Oracle ships `libclntsh.so` on Linux **without a `RUNPATH`/`RPATH`**. When something dlopens `libclntsh.so` by absolute path — which is exactly what python-oracledb does when you pass `init_oracle_client(lib_dir=...)` — the loader still has to resolve its `DT_NEEDED` deps (`libnnz*.so`, `libclntshcore.so`, `libons.so`, …) through `LD_LIBRARY_PATH` / `/etc/ld.so.cache`. Hosts where those aren't configured get `DPI-1047`.

The python-oracledb maintainer documents the only proper fix in [oracle/python-oracledb#578](https://github.com/oracle/python-oracledb/issues/578):

> "The fix for this should be in the instant client itself. The `libclntsh.so` should have an rpath of `$ORIGIN`. This will instruct the library to search in its own directory too and it would find the needed `.so` files. Once this is done, `lib_dir` works without issues even on Linux."

We do this here for our published images. PR #17265 already added a per-process `ctypes` preload as the runtime workaround for arbitrary host images we don't control; this PR makes it so any caller — `sqlplus`, `python-oracledb`, anyone — can just point `lib_dir` at our IC directory and have it work.

## 🔧 Changes Overview

**Modifications (`docker/snippets/oracle_instantclient.sh`):**
- New `ensure_patchelf` helper that detects `apt`/`apk` and installs `patchelf` (covers both Ubuntu 24.04 and Wolfi base images that consume this snippet).
- New `patch_oracle_runpath` helper that runs `patchelf --set-rpath '$ORIGIN'` on every `.so*` in `/opt/oracle/${IC_UNZIP_DIR}` after unzip.
- Header comment updated to document the RUNPATH fix and link upstream issue #578.
- Falls back gracefully (logs and continues) if `patchelf` can't be installed — the existing `ldconfig` setup still applies, so behavior is at worst unchanged.

**No changes** to consuming Dockerfiles. The snippet remains a single self-contained `RUN` step.

## 🏗️ Architecture/Design Notes

**Why `RUNPATH=$ORIGIN`:**
`$ORIGIN` is a dynamic-linker token meaning "the directory containing the calling object". Setting it as the lib's `RUNPATH` makes `libclntsh.so` look for its `DT_NEEDED` siblings in its own install directory first — exactly where Oracle ships them — before falling back to `LD_LIBRARY_PATH` and `ld.so.cache`. This is what most well-behaved third-party Linux libraries do (e.g. CUDA, Intel MKL).

**`RUNPATH` vs `RPATH`:**
`patchelf --set-rpath` sets `DT_RUNPATH` by default (modern, supports `$ORIGIN`, only used for direct `DT_NEEDED` resolution — which is exactly our case). We don't pass `--force-rpath`. This is the right knob for Oracle's case where the deps are direct `DT_NEEDED` entries of `libclntsh.so`.

**Why patch all `.so*`, not just `libclntsh.so`:**
`patchelf --set-rpath` is idempotent and harmless on libs that don't need it. Patching the whole directory is defensive against:
- `libnnz*.so` having its own `DT_NEEDED` chain that benefits from `$ORIGIN`.
- Future Oracle releases shipping additional satellite libs with the same bug.

We use `find -type f` so the compatibility symlinks Oracle ships (e.g. `libclntsh.so → libclntsh.so.23.1`) are skipped — they transparently inherit the patched `RUNPATH` from their target.

**Defense in depth:**
The existing `ldconfig` registration is kept intact. The two mechanisms are independent:
- `RUNPATH=$ORIGIN`: makes the libs self-locating for any caller pointing at the directory directly.
- `ldconfig`: makes them findable by SONAME from anywhere on the system.

Either mechanism alone is sufficient for our images; together they cover every realistic invocation path.

## 🧪 Testing

**Static checks:**
- `bash -n` passes; `shellcheck` clean (the SC2016 single-quote `$ORIGIN` advisory is intentional and suppressed with an explanatory directive).

**Manual verification (recommended before merge):**
```bash
# Build one of the affected images and inspect the result:
docker build -f docker/datahub-ingestion-base/Dockerfile --target ingestion-base-full -t ic-rpath-test .
docker run --rm ic-rpath-test \
  bash -c 'readelf -d /opt/oracle/instantclient_23_26/libclntsh.so.23.1 | grep -E "RPATH|RUNPATH"'
# Expected output: 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN]
```

Smoke test from a process with no `LD_LIBRARY_PATH` and a temporarily disabled `ldconfig` cache:
```bash
docker run --rm ic-rpath-test bash -c '
  rm /etc/ld.so.conf.d/oracle-instantclient.conf && ldconfig
  python -c "
import oracledb
oracledb.init_oracle_client(lib_dir=\"/opt/oracle/instantclient_23_26\")
print(\"thick mode initialised:\", oracledb.is_thin_mode() == False)
"'
```
With `$ORIGIN` patched, this should succeed without any other env changes. Without the patch, it would fail with `DPI-1047`.

## 📊 Impact Assessment
- **Affected Components:** `datahub-ingestion`, `datahub-ingestion-base`, `datahub-actions` Docker images (full variants) and any Dockerfile pulling in `docker/snippets/ingestion_full_deps`.
- **Breaking Changes:** None. RUNPATH only changes resolution behavior in scenarios that previously failed; existing successful resolution paths are unchanged. The added `apt-get install patchelf` (Ubuntu) / `apk add patchelf` (Wolfi) adds ~150–250 KB to the image — negligible.
- **Performance Impact:** Build-time only: one `apt`/`apk` install + one pass of `patchelf` over ~10 files. A few seconds per image build. Runtime is unaffected.
- **Risk Level:** Low. The change is additive, has a built-in fallback (skips with a warning if `patchelf` can't be installed), and preserves the previous `ldconfig` behavior.

## 🚀 Deployment Notes
- Take effect on the next image build of `datahub-ingestion[-base]` and `datahub-actions`.
- Customers running their **own** executor images can either upgrade to a published image carrying this fix, or keep using the runtime workaround in PR #17265 (`thick_mode_lib_dir` config + `ctypes` preload).
- No config or env-var changes needed downstream.

## 🔗 References
- Upstream issue documenting the bug + this exact fix: [oracle/python-oracledb#578](https://github.com/oracle/python-oracledb/issues/578)
- Companion runtime fix: #17265 (per-process `ctypes` preload from the Oracle source)
- ELF `$ORIGIN` reference: [`man ld.so`](https://man7.org/linux/man-pages/man8/ld.so.8.html) → "Rpath token expansion"

## ❓ Questions for Reviewers
- Comfortable with the snippet self-installing `patchelf`, or would you prefer adding it to each consuming Dockerfile's `apt-get`/`apk add` line for explicitness? Self-install keeps the change to one file but does mean an extra `apt-get update` per image build.
- Should I also bump the Wolfi-based `datahub-actions` image to leave `patchelf` removed after use to keep the image as small as possible? My read is the ~150 KB isn't worth the extra complexity.

Made with [Cursor](https://cursor.com)