### PR TITLE
feat(docker): named bundled venv groups, datahub-actions ENV, and docs

### DIFF
--- a/docker/datahub-actions/Dockerfile
+++ b/docker/datahub-actions/Dockerfile
@@ -111,6 +111,7 @@ ARG BUNDLED_VENV_SLIM_MODE="false"
 ARG BUNDLED_CLI_VERSION
 ENV DATAHUB_BUNDLED_VENV_PATH=/opt/datahub/venvs
 ENV BUNDLED_VENV_PLUGINS=${BUNDLED_VENV_PLUGINS}
+ENV BUNDLED_VENV_PLUGINS_COMMON=${BUNDLED_VENV_PLUGINS}
 ENV BUNDLED_VENV_SLIM_MODE=${BUNDLED_VENV_SLIM_MODE}
 ENV BUNDLED_CLI_VERSION=${BUNDLED_CLI_VERSION}
 RUN test -n "$BUNDLED_CLI_VERSION"
@@ -125,6 +126,7 @@ COPY --chown=datahub:datahub ./metadata-ingestion /metadata-ingestion
 # Copy the self-contained venv build scripts
 COPY --chown=datahub:datahub ./docker/snippets/ingestion/build_bundled_venvs_unified.py /tmp/
 COPY --chown=datahub:datahub ./docker/snippets/ingestion/build_bundled_venvs_unified.sh /tmp/
+COPY --chown=datahub:datahub ./docker/snippets/ingestion/bundled_venv_config.py /tmp/
 COPY --chown=datahub:datahub ./docker/snippets/ingestion/constraints.txt ${DATAHUB_BUNDLED_VENV_PATH}/
 
 # Make scripts executable
@@ -153,6 +155,7 @@ ARG BUNDLED_VENV_SLIM_MODE="true"
 ARG BUNDLED_CLI_VERSION
 ENV DATAHUB_BUNDLED_VENV_PATH=/opt/datahub/venvs
 ENV BUNDLED_VENV_PLUGINS=${BUNDLED_VENV_PLUGINS}
+ENV BUNDLED_VENV_PLUGINS_COMMON=${BUNDLED_VENV_PLUGINS}
 ENV BUNDLED_VENV_SLIM_MODE=${BUNDLED_VENV_SLIM_MODE}
 ENV BUNDLED_CLI_VERSION=${BUNDLED_CLI_VERSION}
 RUN test -n "$BUNDLED_CLI_VERSION"
@@ -167,6 +170,7 @@ COPY --chown=datahub:datahub ./metadata-ingestion /metadata-ingestion
 # Copy the self-contained venv build scripts
 COPY --chown=datahub:datahub ./docker/snippets/ingestion/build_bundled_venvs_unified.py /tmp/
 COPY --chown=datahub:datahub ./docker/snippets/ingestion/build_bundled_venvs_unified.sh /tmp/
+COPY --chown=datahub:datahub ./docker/snippets/ingestion/bundled_venv_config.py /tmp/
 COPY --chown=datahub:datahub ./docker/snippets/ingestion/constraints.txt ${DATAHUB_BUNDLED_VENV_PATH}/
 
 # Make scripts executable
@@ -195,6 +199,7 @@ ARG BUNDLED_VENV_SLIM_MODE="true"
 ARG BUNDLED_CLI_VERSION
 ENV DATAHUB_BUNDLED_VENV_PATH=/opt/datahub/venvs
 ENV BUNDLED_VENV_PLUGINS=${BUNDLED_VENV_PLUGINS}
+ENV BUNDLED_VENV_PLUGINS_COMMON=${BUNDLED_VENV_PLUGINS}
 ENV BUNDLED_VENV_SLIM_MODE=${BUNDLED_VENV_SLIM_MODE}
 ENV BUNDLED_CLI_VERSION=${BUNDLED_CLI_VERSION}
 RUN test -n "$BUNDLED_CLI_VERSION"
@@ -209,6 +214,7 @@ COPY --chown=datahub:datahub ./metadata-ingestion /metadata-ingestion
 # Copy the self-contained venv build scripts
 COPY --chown=datahub:datahub ./docker/snippets/ingestion/build_bundled_venvs_unified.py /tmp/
 COPY --chown=datahub:datahub ./docker/snippets/ingestion/build_bundled_venvs_unified.sh /tmp/
+COPY --chown=datahub:datahub ./docker/snippets/ingestion/bundled_venv_config.py /tmp/
 COPY --chown=datahub:datahub ./docker/snippets/ingestion/constraints.txt ${DATAHUB_BUNDLED_VENV_PATH}/
 
 # Make scripts executable

--- a/docker/datahub-actions/Dockerfile
+++ b/docker/datahub-actions/Dockerfile
@@ -242,7 +242,24 @@ FROM ingestion-base-full AS final-full
 USER root
 
 ENV DATAHUB_BUNDLED_VENV_PATH=/opt/datahub/venvs
+ARG BUNDLED_CLI_VERSION
+ENV BUNDLED_CLI_VERSION=${BUNDLED_CLI_VERSION}
+ARG BUNDLED_VENV_PLUGINS="s3,demo-data,file,datahub-gc,datahub-documents"
+ENV BUNDLED_VENV_PLUGINS=${BUNDLED_VENV_PLUGINS}
+ENV BUNDLED_VENV_PLUGINS_COMMON=${BUNDLED_VENV_PLUGINS}
+ARG BUNDLED_VENV_SLIM_MODE="false"
+ENV BUNDLED_VENV_SLIM_MODE=${BUNDLED_VENV_SLIM_MODE}
 COPY --from=bundled-venvs-full $DATAHUB_BUNDLED_VENV_PATH $DATAHUB_BUNDLED_VENV_PATH
+
+# Shipped for downstream Dockerfiles that extend the published image without cloning the repo (see docs/docker/bundled-ingestion-venvs.md).
+COPY --chown=datahub:datahub \
+    ./docker/snippets/ingestion/build_bundled_venvs_unified.py \
+    ./docker/snippets/ingestion/build_bundled_venvs_unified.sh \
+    ./docker/snippets/ingestion/bundled_venv_config.py \
+    ./docker/snippets/ingestion/constraints.txt \
+    /opt/datahub/bundled-venv-build/
+RUN chmod 755 /opt/datahub/bundled-venv-build/build_bundled_venvs_unified.sh && \
+    chown -R datahub:datahub /opt/datahub/bundled-venv-build
 
 COPY --chown=datahub:datahub ./docker/datahub-actions/start.sh /start_datahub_actions.sh
 COPY --chown=datahub:datahub ./docker/datahub-actions/readiness-check.sh /readiness-check.sh
@@ -298,7 +315,24 @@ FROM ingestion-base-slim AS final-slim
 USER root
 
 ENV DATAHUB_BUNDLED_VENV_PATH=/opt/datahub/venvs
+ARG BUNDLED_CLI_VERSION
+ENV BUNDLED_CLI_VERSION=${BUNDLED_CLI_VERSION}
+ARG BUNDLED_VENV_PLUGINS="s3,demo-data,file,datahub-gc,datahub-documents"
+ENV BUNDLED_VENV_PLUGINS=${BUNDLED_VENV_PLUGINS}
+ENV BUNDLED_VENV_PLUGINS_COMMON=${BUNDLED_VENV_PLUGINS}
+ARG BUNDLED_VENV_SLIM_MODE="true"
+ENV BUNDLED_VENV_SLIM_MODE=${BUNDLED_VENV_SLIM_MODE}
 COPY --from=bundled-venvs-slim $DATAHUB_BUNDLED_VENV_PATH $DATAHUB_BUNDLED_VENV_PATH
+
+# Shipped for downstream Dockerfiles that extend the published image without cloning the repo (see docs/docker/bundled-ingestion-venvs.md).
+COPY --chown=datahub:datahub \
+    ./docker/snippets/ingestion/build_bundled_venvs_unified.py \
+    ./docker/snippets/ingestion/build_bundled_venvs_unified.sh \
+    ./docker/snippets/ingestion/bundled_venv_config.py \
+    ./docker/snippets/ingestion/constraints.txt \
+    /opt/datahub/bundled-venv-build/
+RUN chmod 755 /opt/datahub/bundled-venv-build/build_bundled_venvs_unified.sh && \
+    chown -R datahub:datahub /opt/datahub/bundled-venv-build
 
 COPY --chown=datahub:datahub ./docker/datahub-actions/start.sh /start_datahub_actions.sh
 COPY --chown=datahub:datahub ./docker/datahub-actions/readiness-check.sh /readiness-check.sh
@@ -353,6 +387,13 @@ FROM ingestion-base-slim AS final-locked
 USER root
 
 ENV DATAHUB_BUNDLED_VENV_PATH=/opt/datahub/venvs
+ARG BUNDLED_CLI_VERSION
+ENV BUNDLED_CLI_VERSION=${BUNDLED_CLI_VERSION}
+ARG BUNDLED_VENV_PLUGINS="s3,demo-data,file,datahub-gc,datahub-documents"
+ENV BUNDLED_VENV_PLUGINS=${BUNDLED_VENV_PLUGINS}
+ENV BUNDLED_VENV_PLUGINS_COMMON=${BUNDLED_VENV_PLUGINS}
+ARG BUNDLED_VENV_SLIM_MODE="true"
+ENV BUNDLED_VENV_SLIM_MODE=${BUNDLED_VENV_SLIM_MODE}
 COPY --from=bundled-venvs-locked $DATAHUB_BUNDLED_VENV_PATH $DATAHUB_BUNDLED_VENV_PATH
 
 COPY --chown=datahub:datahub ./docker/datahub-actions/start.sh /start_datahub_actions.sh

--- a/docker/snippets/ingestion/README.md
+++ b/docker/snippets/ingestion/README.md
@@ -2,10 +2,59 @@
 
 These files are used when building the **bundled ingestion venvs** (full and slim). The Dockerfile copies them into the image and invokes the build script.
 
-| File                             | Purpose                                                                                                                                                         |
-| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `build_bundled_venvs_unified.py` | Creates per-plugin venvs (e.g. `s3-bundled`, `file-bundled`) and installs acryl-datahub + acryl-datahub-cloud with constraints and overrides.                   |
-| `build_bundled_venvs_unified.sh` | Wrapper that sets env (e.g. `BUNDLED_CLI_VERSION`, `BUNDLED_VENV_PLUGINS`) and runs the Python script.                                                          |
-| `constraints.txt`                | **Single source of truth for CVE minimums and shared pins.** Used by the bundled venv build and by Dockerfile pip install steps that install from requirements. |
+## Files
 
-The Dockerfile copies `constraints.txt` to `$DATAHUB_BUNDLED_VENV_PATH` for the bundled venvs; it may also be copied to the app directory for main-venv installs.
+| File                             | Purpose                                                                                                                                                            |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `build_bundled_venvs_unified.py` | Builds grouped venvs, installs `acryl-datahub[...]==<BUNDLED_CLI_VERSION>` with constraints, creates relative symlinks so legacy `{plugin}-bundled` paths resolve. |
+| `build_bundled_venvs_unified.sh` | Wrapper that validates env and runs the Python script.                                                                                                             |
+| `bundled_venv_config.py`         | Extras resolution (including **slim** `-slim` variants), `BUNDLED_VENV_PLUGINS_*` group parsing, `build_group_plans`.                                              |
+| `constraints.txt`                | **Single source of truth for CVE minimums and shared pins.** Used by the bundled venv build and by Dockerfile pip install steps that install from requirements.    |
+
+The Dockerfile copies `constraints.txt` to `$DATAHUB_BUNDLED_VENV_PATH`, and copies the Python modules to `/tmp` for the build step.
+
+## Group env vars: `BUNDLED_VENV_PLUGINS_<group_id>`
+
+Sharing is configured with variables **`BUNDLED_VENV_PLUGINS_` + suffix**. The suffix is normalized to **lowercase** to form the group label and canonical venv directory **`{label}-venv`** (avoids colliding with `{plugin}-bundled` entrypoint paths):
+
+| Env var example                | Group label | Canonical venv |
+| ------------------------------ | ----------- | -------------- |
+| `BUNDLED_VENV_PLUGINS_COMMON`  | `common`    | `common-venv`  |
+| `BUNDLED_VENV_PLUGINS_GC_DOCS` | `gc_docs`   | `gc_docs-venv` |
+
+Each value is a **comma-separated** list of plugin names (same names as `setup.py` extras / `BUNDLED_VENV_PLUGINS` entries). Multiple `BUNDLED_VENV_PLUGINS_*` variables define multiple groups.
+
+If **no** `BUNDLED_VENV_PLUGINS_*` variables are set, each plugin in `BUNDLED_VENV_PLUGINS` gets its own real directory `{plugin}-bundled` (singletons).
+
+`BUNDLED_VENV_PLUGINS` remains the **authoritative full list** of plugins that must receive a `{plugin}-bundled` path; every member of every group must appear in that list, and each plugin appears in **at most one** group (or as a singleton).
+
+## Slim mode and PySpark
+
+When **`BUNDLED_VENV_SLIM_MODE`** is `true`, extras for plugins in `PLUGINS_WITH_SLIM_VARIANT` use the corresponding **`-slim`** extra (e.g. `s3-slim` instead of `s3`) so PySpark is not pulled for data-lake stacks that support it.
+
+After each slim build, the script runs **`import pyspark`** in that venv and **fails the build** if it succeeds (defense in depth).
+
+## Single CLI version
+
+**`BUNDLED_CLI_VERSION`** is the only bundled-ingestion CLI version used for PyPI installs (`acryl-datahub[...]==<version>`). Local builds use editable `/metadata-ingestion` when present.
+
+## Default install recipe per group
+
+Unless overridden in code/tests via an internal `extras` list on a group dict, install extras are the **sorted union** of each member’s legacy per-plugin extras (including `PLUGIN_ADDITIONAL_EXTRAS` and slim rules above).
+
+## Environment variables
+
+| Variable                        | Description                                                                                                  |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `BUNDLED_VENV_PLUGINS`          | Comma-separated list of every plugin that must have a `{plugin}-bundled` path.                               |
+| `BUNDLED_VENV_PLUGINS_<suffix>` | Comma-separated plugins sharing `{suffix.lower()}-venv`; symlinks `{plugin}-bundled` → that dir when needed. |
+| `BUNDLED_CLI_VERSION`           | PyPI version pin for `acryl-datahub` (single version for all bundled venvs).                                 |
+| `DATAHUB_BUNDLED_VENV_PATH`     | Directory for venvs and `constraints.txt` (default `/opt/datahub/venvs`).                                    |
+| `BUNDLED_VENV_SLIM_MODE`        | When `true`, use `-slim` extras where defined and verify PySpark is absent after install.                    |
+
+## Validation
+
+- Each plugin in `BUNDLED_VENV_PLUGINS` appears **exactly once** across all groups’ plugin lists or as a singleton.
+- A plugin cannot be listed in two groups.
+- Group plugin lists must be subsets of `BUNDLED_VENV_PLUGINS`.
+- Empty group lists are rejected; duplicate group labels after lowercasing (e.g. two keys that map to `common`) are rejected.

--- a/docker/snippets/ingestion/README.md
+++ b/docker/snippets/ingestion/README.md
@@ -11,7 +11,7 @@ These files are used when building the **bundled ingestion venvs** (full and sli
 | `bundled_venv_config.py`         | Extras resolution (including **slim** `-slim` variants), `BUNDLED_VENV_PLUGINS_*` group parsing, `build_group_plans`.                                              |
 | `constraints.txt`                | **Single source of truth for CVE minimums and shared pins.** Used by the bundled venv build and by Dockerfile pip install steps that install from requirements.    |
 
-The Dockerfile copies `constraints.txt` to `$DATAHUB_BUNDLED_VENV_PATH`, and copies the Python modules to `/tmp` for the build step.
+The Dockerfile copies `constraints.txt` to `$DATAHUB_BUNDLED_VENV_PATH`, and copies these modules to `/tmp` for the bundled-venv build stages. Published **`acryldata/datahub-actions`** **full** and **slim** images also ship the same files under **`/opt/datahub/bundled-venv-build/`** and export **`ENV`** for **`DATAHUB_BUNDLED_VENV_PATH`**, **`BUNDLED_VENV_PLUGINS`**, **`BUNDLED_VENV_PLUGINS_COMMON`**, **`BUNDLED_VENV_SLIM_MODE`**, and **`BUNDLED_CLI_VERSION`** (matching the bundled-venv build) so downstream Dockerfiles can append plugins and rerun the builder without cloning this repository (see `docs/docker/bundled-ingestion-venvs.md`).
 
 ## Group env vars: `BUNDLED_VENV_PLUGINS_<group_id>`
 

--- a/docker/snippets/ingestion/README.md
+++ b/docker/snippets/ingestion/README.md
@@ -44,13 +44,14 @@ Unless overridden in code/tests via an internal `extras` list on a group dict, i
 
 ## Environment variables
 
-| Variable                        | Description                                                                                                  |
-| ------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `BUNDLED_VENV_PLUGINS`          | Comma-separated list of every plugin that must have a `{plugin}-bundled` path.                               |
-| `BUNDLED_VENV_PLUGINS_<suffix>` | Comma-separated plugins sharing `{suffix.lower()}-venv`; symlinks `{plugin}-bundled` → that dir when needed. |
-| `BUNDLED_CLI_VERSION`           | PyPI version pin for `acryl-datahub` (single version for all bundled venvs).                                 |
-| `DATAHUB_BUNDLED_VENV_PATH`     | Directory for venvs and `constraints.txt` (default `/opt/datahub/venvs`).                                    |
-| `BUNDLED_VENV_SLIM_MODE`        | When `true`, use `-slim` extras where defined and verify PySpark is absent after install.                    |
+| Variable                            | Description                                                                                                  |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `BUNDLED_VENV_PLUGINS`              | Comma-separated list of every plugin that must have a `{plugin}-bundled` path.                               |
+| `BUNDLED_VENV_PLUGINS_<suffix>`     | Comma-separated plugins sharing `{suffix.lower()}-venv`; symlinks `{plugin}-bundled` → that dir when needed. |
+| `BUNDLED_VENV_AUX_PRIMARY_<suffix>` | Optional. One plugin name from that group; suffix matches the same group’s `BUNDLED_VENV_PLUGINS_<suffix>`.  |
+| `BUNDLED_CLI_VERSION`               | PyPI version pin for `acryl-datahub` (single version for all bundled venvs).                                 |
+| `DATAHUB_BUNDLED_VENV_PATH`         | Directory for venvs and `constraints.txt` (default `/opt/datahub/venvs`).                                    |
+| `BUNDLED_VENV_SLIM_MODE`            | When `true`, use `-slim` extras where defined and verify PySpark is absent after install.                    |
 
 ## Validation
 

--- a/docker/snippets/ingestion/build_bundled_venvs_unified.py
+++ b/docker/snippets/ingestion/build_bundled_venvs_unified.py
@@ -1,96 +1,68 @@
 #!/usr/bin/env python3
 """
 Self-contained script to create bundled venvs for DataHub ingestion sources.
-This script creates virtual environments with predictable names following the pattern:
-<plugin-name>-bundled that are leveraged within acryl-executor to run ingestion jobs.
+
+Groups come from env vars ``BUNDLED_VENV_PLUGINS_<group_id>`` (suffix lowercased for the
+group label, e.g. ``BUNDLED_VENV_PLUGINS_COMMON`` -> ``common-venv``). One
+``BUNDLED_CLI_VERSION`` installs ``acryl-datahub[...]==`` that version for each group.
+
+When ``BUNDLED_VENV_SLIM_MODE`` is true, eligible extras use ``-slim`` variants and each
+slim venv is verified to not import PySpark.
 """
 
 import os
 import subprocess
 import sys
-from typing import List, Tuple
+from pathlib import Path
 
-# Adding a new plug-in with a -slim variant has to be defined here
-PLUGINS_WITH_SLIM_VARIANT = ['s3']
-
-# Additional extras to install for specific plugins beyond the standard set.
-# For example, the "file" source type is often used to ingest files stored on S3,
-# so the file-bundled venv needs S3 dependencies (s3 or s3-slim) as well.
-PLUGIN_ADDITIONAL_EXTRAS: dict = {
-    'file': ['s3'],
-}
-
-def generate_venv_mappings(plugins: List[str]) -> List[Tuple[str, str]]:
-    """Generate simple venv name mappings using <plugin-name>-bundled pattern."""
-    venv_mappings = []
-
-    for plugin in plugins:
-        # Simple, predictable naming: <plugin-name>-bundled
-        venv_name = f"{plugin}-bundled"
-        venv_mappings.append((plugin, venv_name))
-
-    return venv_mappings
+from bundled_venv_config import (
+    BundledVenvGroupPlan,
+    build_group_plans,
+    extras_to_install_string,
+    groups_config_from_plugin_group_env,
+)
 
 
-def create_venv(plugin: str, venv_name: str, bundled_cli_version: str, venv_base_path: str, slim_mode: bool = False) -> bool:
-    """Create a single bundled venv for a plugin.
-
-    Args:
-        plugin: Plugin name (e.g., "s3", "demo-data")
-        venv_name: Name of the venv directory (e.g., "s3-bundled")
-        bundled_cli_version: DataHub CLI version to install
-        venv_base_path: Base directory for venvs
-        slim_mode: If True, use -slim variants for data lake sources (s3-slim, gcs-slim, abs-slim)
-    """
+def create_bundled_venv(
+    group_plan: BundledVenvGroupPlan,
+    bundled_cli_version: str,
+    venv_base_path: str,
+    slim_mode: bool,
+) -> bool:
+    """Create one physical venv at canonical_dir_name with the given extras."""
+    venv_name = group_plan.canonical_dir_name
     venv_path = os.path.join(venv_base_path, venv_name)
+    extras_str = extras_to_install_string(group_plan.extras)
 
-    print(f"Creating bundled venv for {plugin}: {venv_name}")
+    print(f"Creating bundled venv for group '{group_plan.label}': {venv_name}")
+    print(f"  Members: {', '.join(group_plan.members)}")
     print(f"  Venv Path: {venv_path}")
+    print(f"  Extras: [{extras_str}]")
     if slim_mode:
-        print(f"  Slim Mode: Will use -slim variants for data lake sources")
+        print("  Slim Mode: using -slim variants for eligible data lake extras")
 
     constraints_path = os.path.join(venv_base_path, "constraints.txt")
     try:
-        # Create the venv
-        print(f"  → Creating venv...")
-        subprocess.run(['uv', 'venv', venv_path], check=True, capture_output=True)
+        print("  → Creating venv...")
+        subprocess.run(["uv", "venv", venv_path], check=True, capture_output=True)
 
-        # Install packages in the venv (with constraints so pip/wheel meet CVE minimums)
-        print(f"  → Installing base packages...")
-        base_cmd = f'source {venv_path}/bin/activate && uv pip install --upgrade pip wheel setuptools --constraint {constraints_path}'
-        subprocess.run(['bash', '-c', base_cmd], check=True, capture_output=True)
+        print("  → Installing base packages...")
+        base_cmd = f"source {venv_path}/bin/activate && uv pip install --upgrade pip wheel setuptools --constraint {constraints_path}"
+        subprocess.run(["bash", "-c", base_cmd], check=True, capture_output=True)
 
-        # Determine which plugin extra to use
-        # In slim mode, use -slim suffix for data lake sources to avoid PySpark
-        plugin_extra = plugin
-        if slim_mode and plugin in PLUGINS_WITH_SLIM_VARIANT:
-            plugin_extra = f"{plugin}-slim"
-            print(f"  → Using {plugin_extra} extra (slim mode, no PySpark)")
-
-        # Collect all extras: standard set + plugin-specific additional extras
-        all_extras = ['datahub-rest', 'datahub-kafka', 'file', plugin_extra]
-        for additional in PLUGIN_ADDITIONAL_EXTRAS.get(plugin, []):
-            if slim_mode and additional in PLUGINS_WITH_SLIM_VARIANT:
-                additional = f"{additional}-slim"
-            if additional not in all_extras:
-                all_extras.append(additional)
-                print(f"  → Adding extra '{additional}' (required by {plugin} plugin)")
-
-        extras_str = ','.join(all_extras)
-
-        # Install DataHub with the specific plugin
         print(f"  → Installing datahub with [{extras_str}]...")
-        # Use local metadata-ingestion if available (for development), otherwise use PyPI
-        if os.path.exists('/metadata-ingestion/setup.py'):
-            print(f"  → Using local /metadata-ingestion source")
-            datahub_package = f'-e /metadata-ingestion[{extras_str}]'
-            install_cmd = f'source {venv_path}/bin/activate && uv pip install {datahub_package} --constraint {constraints_path}'
+        if os.path.exists("/metadata-ingestion/setup.py"):
+            print("  → Using local /metadata-ingestion source")
+            datahub_package = f"-e /metadata-ingestion[{extras_str}]"
+            install_cmd = f"source {venv_path}/bin/activate && uv pip install {datahub_package} --constraint {constraints_path}"
         else:
-            datahub_package = f'acryl-datahub[{extras_str}]=={bundled_cli_version}'
-            install_cmd = f'source {venv_path}/bin/activate && uv pip install "{datahub_package}" --constraint {constraints_path}'
-        subprocess.run(['bash', '-c', install_cmd], check=True, capture_output=True)
+            datahub_package = f"acryl-datahub[{extras_str}]=={bundled_cli_version}"
+            install_cmd = (
+                f'source {venv_path}/bin/activate && uv pip install "{datahub_package}" '
+                f"--constraint {constraints_path}"
+            )
+        subprocess.run(["bash", "-c", install_cmd], check=True, capture_output=True)
 
-        # Defense-in-depth: in slim mode, verify PySpark was not pulled in transitively
         if slim_mode:
             python_exe = os.path.join(venv_path, "bin", "python")
             result = subprocess.run(
@@ -98,7 +70,9 @@ def create_venv(plugin: str, venv_name: str, bundled_cli_version: str, venv_base
                 capture_output=True,
             )
             if result.returncode == 0:
-                print(f"  ❌ FAIL: PySpark found in {venv_name} (slim mode requires no PySpark)")
+                print(
+                    f"  ❌ FAIL: PySpark found in {venv_name} (slim mode requires no PySpark)"
+                )
                 return False
             print(f"  → Verified: No PySpark in {venv_name}")
 
@@ -107,34 +81,61 @@ def create_venv(plugin: str, venv_name: str, bundled_cli_version: str, venv_base
 
     except subprocess.CalledProcessError as e:
         print(f"  ❌ Failed to create {venv_name}: {e}")
-        # Print stderr if available for debugging
         if e.stderr:
             print(f"     Error output: {e.stderr.decode()}")
         return False
 
 
-def main():
-    """Main function to generate and create all bundled venvs."""
-    # Get configuration from environment
-    plugins_str = os.environ.get('BUNDLED_VENV_PLUGINS', 's3,demo-data,file')
-    bundled_cli_version = os.environ.get('BUNDLED_CLI_VERSION')
-    venv_base_path = os.environ.get('DATAHUB_BUNDLED_VENV_PATH', '/opt/datahub/venvs')
-    slim_mode_str = os.environ.get('BUNDLED_VENV_SLIM_MODE', 'false').lower()
-    slim_mode = slim_mode_str in ['true', '1', 'yes']
+def _remove_if_exists(path: str) -> None:
+    p = Path(path)
+    if p.is_symlink() or p.is_file():
+        p.unlink()
+    elif p.is_dir():
+        raise RuntimeError(f"Refusing to remove unexpected directory: {path}")
+
+
+def ensure_plugin_symlinks(
+    group_plan: BundledVenvGroupPlan,
+    venv_base_path: str,
+) -> None:
+    """
+    For groups with multiple members, or a single member whose canonical dir name
+    differs from `{plugin}-bundled`, create relative symlinks so each plugin path exists.
+    """
+    canonical = group_plan.canonical_dir_name
+    canonical_path = os.path.join(venv_base_path, canonical)
+
+    for plugin in group_plan.members:
+        alias_name = f"{plugin}-bundled"
+        if alias_name == canonical:
+            continue
+
+        link_path = os.path.join(venv_base_path, alias_name)
+        _remove_if_exists(link_path)
+
+        target_rel = os.path.relpath(canonical_path, start=os.path.dirname(link_path))
+        os.symlink(target_rel, link_path, target_is_directory=True)
+        print(f"  → Symlink {alias_name} -> {target_rel}")
+
+
+def main() -> int:
+    plugins_str = os.environ.get("BUNDLED_VENV_PLUGINS", "s3,demo-data,file")
+    bundled_cli_version = os.environ.get("BUNDLED_CLI_VERSION")
+    venv_base_path = os.environ.get("DATAHUB_BUNDLED_VENV_PATH", "/opt/datahub/venvs")
+    slim_mode_str = os.environ.get("BUNDLED_VENV_SLIM_MODE", "false").lower()
+    slim_mode = slim_mode_str in ["true", "1", "yes"]
 
     if not bundled_cli_version:
         print("ERROR: BUNDLED_CLI_VERSION environment variable must be set")
-        sys.exit(1)
+        return 1
 
-    # Strip 'v' prefix if present (e.g., v0.12.1 -> 0.12.1)
-    if bundled_cli_version.startswith('v'):
+    if bundled_cli_version.startswith("v"):
         bundled_cli_version = bundled_cli_version[1:]
 
-    # Parse plugins list
-    plugins = [p.strip() for p in plugins_str.split(',') if p.strip()]
+    plugins = [p.strip() for p in plugins_str.split(",") if p.strip()]
 
     print("=" * 60)
-    print("DataHub Bundled Venv Builder (Self-Contained)")
+    print("DataHub Bundled Venv Builder (named groups)")
     print("=" * 60)
     print(f"DataHub CLI Version: {bundled_cli_version}")
     print(f"Plugins: {', '.join(plugins)}")
@@ -143,56 +144,58 @@ def main():
     print(f"Total Plugins: {len(plugins)}")
     print()
 
-    # Generate venv name mappings using simple pattern
-    print("Generating venv name mappings...")
-    venv_mappings = generate_venv_mappings(plugins)
+    try:
+        raw_config = groups_config_from_plugin_group_env(os.environ)
+        plans = build_group_plans(plugins, raw_config, slim_mode)
+    except (ValueError, OSError) as e:
+        print(f"ERROR: Invalid bundled venv groups configuration: {e}")
+        return 1
 
-    print("Generated venv mappings:")
-    for plugin, venv_name in venv_mappings:
-        extra_info = ""
-        if slim_mode and plugin in PLUGINS_WITH_SLIM_VARIANT:
-            extra_info = " (will use -slim extra)"
-        print(f"  {plugin} → {venv_name}{extra_info}")
+    print("Resolved install plan:")
+    for plan in plans:
+        print(
+            f"  group={plan.label!r} -> {plan.canonical_dir_name} "
+            f"members={list(plan.members)} extras=[{extras_to_install_string(plan.extras)}]"
+        )
     print()
 
-    # Ensure the venv base directory exists
     os.makedirs(venv_base_path, exist_ok=True)
 
-    # Create each venv
     print("Creating bundled venvs...")
     print("-" * 40)
     success_count = 0
-    failed_plugins = []
+    failed_labels: list[str] = []
 
-    for plugin, venv_name in venv_mappings:
+    for plan in plans:
         try:
-            if create_venv(plugin, venv_name, bundled_cli_version, venv_base_path, slim_mode):
+            if create_bundled_venv(
+                plan, bundled_cli_version, venv_base_path, slim_mode
+            ):
+                ensure_plugin_symlinks(plan, venv_base_path)
                 success_count += 1
             else:
-                failed_plugins.append(plugin)
+                failed_labels.append(plan.label)
         except Exception as e:
-            print(f"Failed to create venv for {plugin}: {e}")
-            failed_plugins.append(plugin)
-        print()  # Add spacing between venvs
+            print(f"Failed to create venv for group {plan.label!r}: {e}")
+            failed_labels.append(plan.label)
+        print()
 
-    # Summary
     print("=" * 60)
     print("Summary")
     print("=" * 60)
-    print(f"Total plugins: {len(venv_mappings)}")
+    print(f"Total install groups: {len(plans)}")
     print(f"Successfully created: {success_count}")
-    print(f"Failed: {len(failed_plugins)}")
+    print(f"Failed: {len(failed_labels)}")
 
-    if failed_plugins:
-        print(f"Failed plugins: {', '.join(failed_plugins)}")
+    if failed_labels:
+        print(f"Failed groups: {', '.join(failed_labels)}")
 
     print()
-    if success_count == len(venv_mappings):
+    if success_count == len(plans):
         print("🎉 All bundled venvs created successfully!")
         return 0
-    else:
-        print("⚠️  Some bundled venvs failed to create")
-        return 1
+    print("⚠️  Some bundled venvs failed to create")
+    return 1
 
 
 if __name__ == "__main__":

--- a/docker/snippets/ingestion/build_bundled_venvs_unified.py
+++ b/docker/snippets/ingestion/build_bundled_venvs_unified.py
@@ -44,7 +44,9 @@ def create_bundled_venv(
     constraints_path = os.path.join(venv_base_path, "constraints.txt")
     try:
         print("  → Creating venv...")
-        subprocess.run(["uv", "venv", venv_path], check=True, capture_output=True)
+        subprocess.run(
+            ["uv", "venv", "--clear", venv_path], check=True, capture_output=True
+        )
 
         print("  → Installing base packages...")
         base_cmd = f"source {venv_path}/bin/activate && uv pip install --upgrade pip wheel setuptools --constraint {constraints_path}"

--- a/docker/snippets/ingestion/build_bundled_venvs_unified.sh
+++ b/docker/snippets/ingestion/build_bundled_venvs_unified.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# Self-contained script to build bundled venvs for DataHub ingestion sources
-# This script creates venvs with predictable names: <plugin-name>-bundled
-# which are then leveraged within acryl-executor to run ingestion jobs.
+# Self-contained script to build bundled venvs for DataHub ingestion sources.
+# Named groups share one physical venv ({label}-venv); member plugins may be
+# symlinked to <plugin-name>-bundled for executor compatibility.
 set -euo pipefail
 
 # Configuration from environment variables
@@ -20,6 +20,7 @@ echo "Building bundled venvs for DataHub ingestion"
 echo "=============================================="
 echo "DataHub CLI Version: $BUNDLED_CLI_VERSION"
 echo "Plugins: $BUNDLED_VENV_PLUGINS"
+echo "Group env vars: set BUNDLED_VENV_PLUGINS_<group> (e.g. BUNDLED_VENV_PLUGINS_COMMON); optional."
 echo "Venv Path: $DATAHUB_BUNDLED_VENV_PATH"
 echo ""
 
@@ -38,6 +39,11 @@ echo "=============================================="
 echo "Bundled venvs created in $DATAHUB_BUNDLED_VENV_PATH:"
 ls -la "$DATAHUB_BUNDLED_VENV_PATH/"
 echo ""
-echo "Total venvs: $(ls -1 "$DATAHUB_BUNDLED_VENV_PATH/" | wc -l)"
+echo "Symlinks (sample):"
+find "$DATAHUB_BUNDLED_VENV_PATH" -maxdepth 1 -type l 2>/dev/null | head -20 | while read -r linkpath; do
+  echo "  $linkpath -> $(readlink "$linkpath")"
+done
+echo ""
+echo "Total entries: $(ls -1 "$DATAHUB_BUNDLED_VENV_PATH/" | wc -l)"
 
 echo "Bundled venv build completed successfully!"

--- a/docker/snippets/ingestion/build_bundled_venvs_unified.sh
+++ b/docker/snippets/ingestion/build_bundled_venvs_unified.sh
@@ -4,6 +4,8 @@
 # symlinked to <plugin-name>-bundled for executor compatibility.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # Configuration from environment variables
 BUNDLED_VENV_PLUGINS="${BUNDLED_VENV_PLUGINS:-s3,demo-data,file}"
 BUNDLED_CLI_VERSION="${BUNDLED_CLI_VERSION:-}"
@@ -27,9 +29,10 @@ echo ""
 # Ensure the venv directory exists
 mkdir -p "$DATAHUB_BUNDLED_VENV_PATH"
 
-# Use the self-contained Python script to generate and create venvs
+# Use the self-contained Python script to generate and create venvs (same directory as this script)
 echo "Running bundled venv builder..."
-python /tmp/build_bundled_venvs_unified.py
+cd "$SCRIPT_DIR"
+python ./build_bundled_venvs_unified.py
 
 # Verify the venvs were created
 echo ""

--- a/docker/snippets/ingestion/bundled_venv_config.py
+++ b/docker/snippets/ingestion/bundled_venv_config.py
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Shared helpers for bundled venv group resolution (used by build script and tests)."""
+"""Shared helpers for bundled venv group resolution (used by build script and tests).
+
+Optional module ``bundled_venv_plugin_extras_local`` may define ``plugin_extras_for_plugin``
+for site-specific or downstream overrides; otherwise the OSS default implementation is used.
+"""
 
 from __future__ import annotations
 
@@ -23,8 +27,12 @@ from typing import Any, Dict, List, Mapping, Optional, Sequence, Set, Tuple
 # GROUP_ID lowercased (e.g. BUNDLED_VENV_PLUGINS_COMMON -> group "common").
 GROUP_PLUGINS_ENV_PREFIX = "BUNDLED_VENV_PLUGINS_"
 
-# Adding a new plug-in with a -slim variant has to be defined here
-PLUGINS_WITH_SLIM_VARIANT = ["s3"]
+# Optional: which group member selects variant-specific auxiliary pip installs (suffix
+# aligned with BUNDLED_VENV_PLUGINS_<same>).
+GROUP_AUX_PRIMARY_ENV_PREFIX = "BUNDLED_VENV_AUX_PRIMARY_"
+
+# Plugins with PySpark-heavy extras — use -slim in slim mode (matches executor image builds).
+PLUGINS_WITH_SLIM_VARIANT = ["s3", "gcs", "abs"]
 
 # Additional extras to install for specific plugins beyond the standard set.
 PLUGIN_ADDITIONAL_EXTRAS: Dict[str, List[str]] = {
@@ -32,8 +40,8 @@ PLUGIN_ADDITIONAL_EXTRAS: Dict[str, List[str]] = {
 }
 
 
-def plugin_extras_for_plugin(plugin: str, slim_mode: bool) -> List[str]:
-    """Return ordered unique extras for one plugin (same semantics as legacy per-plugin install)."""
+def _default_plugin_extras_for_plugin(plugin: str, slim_mode: bool) -> List[str]:
+    """OSS default: standard ingestion extras per plugin (no vendor-specific branches)."""
     plugin_extra = plugin
     if slim_mode and plugin in PLUGINS_WITH_SLIM_VARIANT:
         plugin_extra = f"{plugin}-slim"
@@ -54,6 +62,14 @@ def plugin_extras_for_plugin(plugin: str, slim_mode: bool) -> List[str]:
             seen.add(add)
             out.append(add)
     return out
+
+
+try:
+    import bundled_venv_plugin_extras_local as _plugin_extras_local
+
+    plugin_extras_for_plugin = _plugin_extras_local.plugin_extras_for_plugin
+except ImportError:
+    plugin_extras_for_plugin = _default_plugin_extras_for_plugin
 
 
 def sorted_union_extras(plugins: Sequence[str], slim_mode: bool) -> List[str]:
@@ -104,6 +120,29 @@ def groups_config_from_plugin_group_env(
             )
         groups[label] = {"plugins": plugins}
 
+    for key, raw in environ.items():
+        if not key.startswith(GROUP_AUX_PRIMARY_ENV_PREFIX):
+            continue
+        suffix = key[len(GROUP_AUX_PRIMARY_ENV_PREFIX) :]
+        if not suffix:
+            continue
+        label = suffix.lower()
+        if label not in groups:
+            raise ValueError(
+                f"{key} sets auxiliary primary for group {label!r}, but no "
+                f"{GROUP_PLUGINS_ENV_PREFIX}<same suffix> group was defined"
+            )
+        primary = raw.strip()
+        if not primary:
+            raise ValueError(f"{key} must be a non-empty plugin name")
+        existing = groups[label].get("aux_primary_plugin")
+        if existing is not None and existing != primary:
+            raise ValueError(
+                f"Conflicting auxiliary primary for group {label!r}: "
+                f"{existing!r} vs {primary!r}"
+            )
+        groups[label]["aux_primary_plugin"] = primary
+
     if not groups:
         return None
     return {"groups": groups}
@@ -117,6 +156,8 @@ class BundledVenvGroupPlan:
     members: Tuple[str, ...]
     extras: Tuple[str, ...]
     canonical_dir_name: str  # e.g. common-venv (named groups); plugin-bundled for singletons
+    # Which member drives auxiliary install variant selection; None = resolver chooses.
+    aux_primary_plugin: Optional[str] = None
 
 
 def _resolve_group_extras(
@@ -202,6 +243,19 @@ def build_group_plans(
 
         extras = _resolve_group_extras(label, group_cfg, members, slim_mode)
         canonical = f"{label}-venv"
+        aux_raw = group_cfg.get("aux_primary_plugin")
+        aux_primary: Optional[str] = None
+        if aux_raw is not None:
+            if not isinstance(aux_raw, str):
+                raise ValueError(
+                    f'Group "{label}": "aux_primary_plugin" must be a string when set'
+                )
+            c = aux_raw.strip()
+            if c not in members:
+                raise ValueError(
+                    f'Group "{label}": aux_primary_plugin {c!r} must be in plugins list'
+                )
+            aux_primary = c
         assigned.update(members)
         plans.append(
             BundledVenvGroupPlan(
@@ -209,6 +263,7 @@ def build_group_plans(
                 members=tuple(members),
                 extras=tuple(extras),
                 canonical_dir_name=canonical,
+                aux_primary_plugin=aux_primary,
             )
         )
 
@@ -221,6 +276,7 @@ def build_group_plans(
                     members=(p,),
                     extras=tuple(ex),
                     canonical_dir_name=f"{p}-bundled",
+                    aux_primary_plugin=None,
                 )
             )
 

--- a/docker/snippets/ingestion/bundled_venv_config.py
+++ b/docker/snippets/ingestion/bundled_venv_config.py
@@ -1,0 +1,227 @@
+# Copyright 2025 Acryl Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared helpers for bundled venv group resolution (used by build script and tests)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Set, Tuple
+
+# Env keys: BUNDLED_VENV_PLUGINS_<GROUP_ID> where GROUP_ID is any case; group label is
+# GROUP_ID lowercased (e.g. BUNDLED_VENV_PLUGINS_COMMON -> group "common").
+GROUP_PLUGINS_ENV_PREFIX = "BUNDLED_VENV_PLUGINS_"
+
+# Adding a new plug-in with a -slim variant has to be defined here
+PLUGINS_WITH_SLIM_VARIANT = ["s3"]
+
+# Additional extras to install for specific plugins beyond the standard set.
+PLUGIN_ADDITIONAL_EXTRAS: Dict[str, List[str]] = {
+    "file": ["s3"],
+}
+
+
+def plugin_extras_for_plugin(plugin: str, slim_mode: bool) -> List[str]:
+    """Return ordered unique extras for one plugin (same semantics as legacy per-plugin install)."""
+    plugin_extra = plugin
+    if slim_mode and plugin in PLUGINS_WITH_SLIM_VARIANT:
+        plugin_extra = f"{plugin}-slim"
+
+    extras: List[str] = ["datahub-rest", "datahub-kafka", "file", plugin_extra]
+    seen: Set[str] = set()
+    out: List[str] = []
+    for x in extras:
+        if x not in seen:
+            seen.add(x)
+            out.append(x)
+
+    for additional in PLUGIN_ADDITIONAL_EXTRAS.get(plugin, []):
+        add = additional
+        if slim_mode and additional in PLUGINS_WITH_SLIM_VARIANT:
+            add = f"{additional}-slim"
+        if add not in seen:
+            seen.add(add)
+            out.append(add)
+    return out
+
+
+def sorted_union_extras(plugins: Sequence[str], slim_mode: bool) -> List[str]:
+    """Sorted union of extras for all plugins in the group."""
+    u: Set[str] = set()
+    for p in plugins:
+        u.update(plugin_extras_for_plugin(p, slim_mode))
+    return sorted(u)
+
+
+def extras_to_install_string(extras: Sequence[str]) -> str:
+    return ",".join(extras)
+
+
+def groups_config_from_plugin_group_env(
+    environ: Mapping[str, str],
+) -> Optional[Dict[str, Any]]:
+    """
+    Build a groups config from BUNDLED_VENV_PLUGINS_<GroupId> variables.
+
+    The suffix after BUNDLED_VENV_PLUGINS_ is normalized to lowercase for the group label
+    (canonical dir ``{label}-venv``). Values are comma-separated plugin names.
+
+    Returns None if no such variables are set (every plugin becomes its own singleton venv).
+    """
+    groups: Dict[str, Dict[str, Any]] = {}
+    labels_seen: Set[str] = set()
+
+    for key, raw in environ.items():
+        if not key.startswith(GROUP_PLUGINS_ENV_PREFIX):
+            continue
+        suffix = key[len(GROUP_PLUGINS_ENV_PREFIX) :]
+        if not suffix:
+            continue
+        label = suffix.lower()
+        if label in labels_seen:
+            raise ValueError(
+                f"Duplicate bundled venv group {label!r}: multiple env keys map to this "
+                f"group id after lowercasing (e.g. {GROUP_PLUGINS_ENV_PREFIX}COMMON and "
+                f"{GROUP_PLUGINS_ENV_PREFIX}common)"
+            )
+        labels_seen.add(label)
+
+        plugins = [p.strip() for p in raw.split(",") if p.strip()]
+        if not plugins:
+            raise ValueError(
+                f"{key} must list at least one plugin (comma-separated); got empty value"
+            )
+        groups[label] = {"plugins": plugins}
+
+    if not groups:
+        return None
+    return {"groups": groups}
+
+
+@dataclass(frozen=True)
+class BundledVenvGroupPlan:
+    """One physical venv build plus member plugins that point at it."""
+
+    label: str
+    members: Tuple[str, ...]
+    extras: Tuple[str, ...]
+    canonical_dir_name: str  # e.g. common-venv (named groups); plugin-bundled for singletons
+
+
+def _resolve_group_extras(
+    label: str,
+    group_cfg: Mapping[str, Any],
+    members: List[str],
+    slim_mode: bool,
+) -> List[str]:
+    if "extras" in group_cfg and group_cfg["extras"] is not None:
+        raw = group_cfg["extras"]
+        if not isinstance(raw, list) or not all(isinstance(x, str) for x in raw):
+            raise ValueError(
+                f'Group "{label}": "extras" must be a list of strings when set'
+            )
+        return sorted(set(raw))
+
+    if "primary_plugin" in group_cfg and group_cfg["primary_plugin"] is not None:
+        primary = group_cfg["primary_plugin"]
+        if not isinstance(primary, str):
+            raise ValueError(
+                f'Group "{label}": "primary_plugin" must be a string when set'
+            )
+        if primary not in members:
+            raise ValueError(
+                f'Group "{label}": primary_plugin "{primary}" must be in plugins list'
+            )
+        return sorted_union_extras([primary], slim_mode)
+
+    return sorted_union_extras(members, slim_mode)
+
+
+def build_group_plans(
+    plugins: List[str],
+    groups_config: Optional[Mapping[str, Any]],
+    slim_mode: bool,
+) -> List[BundledVenvGroupPlan]:
+    """
+    Build install plans: named groups from config + singletons for unlisted plugins.
+
+    Validates: each plugin appears exactly once; group plugins must be subset of `plugins`.
+    """
+    plugin_set = set(plugins)
+    if len(plugin_set) != len(plugins):
+        dupes = [p for p in plugins if plugins.count(p) > 1]
+        raise ValueError(f"BUNDLED_VENV_PLUGINS contains duplicates: {set(dupes)}")
+
+    assigned: Set[str] = set()
+    plans: List[BundledVenvGroupPlan] = []
+
+    groups_section: Dict[str, Any] = {}
+    if groups_config and "groups" in groups_config:
+        raw = groups_config["groups"]
+        if not isinstance(raw, dict):
+            raise ValueError('"groups" must be an object')
+        groups_section = dict(raw)
+
+    for label, group_cfg in groups_section.items():
+        if not isinstance(group_cfg, dict):
+            raise ValueError(f'Group "{label}" must be an object')
+        raw_plugins = group_cfg.get("plugins")
+        if not raw_plugins:
+            raise ValueError(f'Group "{label}": "plugins" is required and non-empty')
+        if not isinstance(raw_plugins, list) or not all(
+            isinstance(x, str) for x in raw_plugins
+        ):
+            raise ValueError(f'Group "{label}": "plugins" must be a list of strings')
+        members = [p.strip() for p in raw_plugins if p.strip()]
+        if not members:
+            raise ValueError(f'Group "{label}": "plugins" is empty')
+
+        unknown = [m for m in members if m not in plugin_set]
+        if unknown:
+            raise ValueError(
+                f'Group "{label}" references plugins not in BUNDLED_VENV_PLUGINS: {unknown}'
+            )
+
+        overlap = assigned.intersection(members)
+        if overlap:
+            raise ValueError(
+                f"Plugins {sorted(overlap)} appear in more than one group "
+                f'(duplicate membership); offending group "{label}"'
+            )
+
+        extras = _resolve_group_extras(label, group_cfg, members, slim_mode)
+        canonical = f"{label}-venv"
+        assigned.update(members)
+        plans.append(
+            BundledVenvGroupPlan(
+                label=label,
+                members=tuple(members),
+                extras=tuple(extras),
+                canonical_dir_name=canonical,
+            )
+        )
+
+    for p in plugins:
+        if p not in assigned:
+            ex = sorted_union_extras([p], slim_mode)
+            plans.append(
+                BundledVenvGroupPlan(
+                    label=p,
+                    members=(p,),
+                    extras=tuple(ex),
+                    canonical_dir_name=f"{p}-bundled",
+                )
+            )
+
+    return plans

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -1359,6 +1359,7 @@ module.exports = {
         "datahub-web-react/src/app/analytics/README",
         // "smoke-test/test_resources/analytics_backfill/README",
         "docker/datahub-upgrade/README",
+        "docs/docker/bundled-ingestion-venvs",
         "metadata-ingestion/adding-source",
         "docs/how/add-custom-ingestion-source",
         "docs/how/add-custom-data-platform",

--- a/docs/actions/actions/executor.md
+++ b/docs/actions/actions/executor.md
@@ -24,6 +24,10 @@ This Action executes ingestion recipes that are configured via the UI.
 
 Specifically, changes to the `dataHubExecutionRequestInput` and `dataHubExecutionRequestSignal` aspects of the `dataHubExecutionRequest` entity are required.
 
+### Bundled ingestion virtual environments (Docker)
+
+The executor runs ingestion in pre-built virtual environments under `DATAHUB_BUNDLED_VENV_PATH` (default `/opt/datahub/venvs`) **when the execution uses the bundled CLI version**—the same `acryl-datahub` version baked into the image at build time (`BUNDLED_CLI_VERSION`). To ship additional connectors or group installs, configure those environments **when building** the container image (for example `BUNDLED_VENV_PLUGINS` and `BUNDLED_CLI_VERSION`). See [Bundled ingestion virtual environments](/docs/docker/bundled-ingestion-venvs.md).
+
 ## Action Quickstart
 
 ### Prerequisites

--- a/docs/docker/bundled-ingestion-venvs.md
+++ b/docs/docker/bundled-ingestion-venvs.md
@@ -1,0 +1,83 @@
+---
+title: Bundled ingestion virtual environments
+description: Pre-built ingestion venvs under /opt/datahub/venvs, extending datahub-actions or datahub-executor images at build time.
+---
+
+# Bundled ingestion virtual environments
+
+UI and scheduled ingestion run `datahub ingest` in **pre-built venvs** under **`DATAHUB_BUNDLED_VENV_PATH`** (default **`/opt/datahub/venvs`**). Each connector uses a **`{plugin}-bundled`** path; optional **named groups** install once into **`{label}-venv`** and symlink member plugins there.
+
+The executor uses those installs when the run targets the **bundled CLI version** (aligned with **`BUNDLED_CLI_VERSION`**). Connector installs are **baked at image build time**—runtime env vars alone do not add new venvs.
+
+## Core (`datahub-actions`) vs Cloud (`datahub-executor`)
+
+| Offering          | Image (typical)                                                                   | Role                                  |
+| ----------------- | --------------------------------------------------------------------------------- | ------------------------------------- |
+| **DataHub Core**  | [`acryldata/datahub-actions`](https://hub.docker.com/r/acryldata/datahub-actions) | Executor for UI / scheduled ingestion |
+| **DataHub Cloud** | **`datahub-executor`** (your registry)                                            | Remote Executor                       |
+
+Same layout and env contract; only the image name changes. **Full** and **slim** **`datahub-actions`** tags ship **`/opt/datahub/bundled-venv-build/`** (builder scripts + **`constraints.txt`**) so you can extend **from the base image** without cloning the repo. Remote Executor images may ship the same path; if not, see [No builder directory in the image](#no-builder-directory-in-the-image).
+
+## Variables
+
+Used by **`build_bundled_venvs_unified.sh`** / **`.py`**. Published **`datahub-actions`** images also set matching **`ENV`** values (path, plugin lists, **`BUNDLED_CLI_VERSION`**, **`BUNDLED_VENV_SLIM_MODE`**) so **`FROM`** inherits them.
+
+| Variable                            | Meaning                                                                                                                                                                           |
+| ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`BUNDLED_VENV_PLUGINS`**          | Every plugin that gets a **`{plugin}-bundled`** path (comma-separated).                                                                                                           |
+| **`BUNDLED_VENV_PLUGINS_<suffix>`** | Plugins sharing one install → **`{suffix_lower}-venv`** (e.g. **`COMMON`** → **`common-venv`**).                                                                                  |
+| **`BUNDLED_CLI_VERSION`**           | Required by the shell wrapper. With **`/metadata-ingestion`** in the image, installs are editable; still must be set. PyPI-only builds need the real **`acryl-datahub`** version. |
+| **`BUNDLED_VENV_SLIM_MODE`**        | **`true`** uses **`-slim`** extras where applicable and checks PySpark is absent in slim builds.                                                                                  |
+| **`DATAHUB_BUNDLED_VENV_PATH`**     | Root for venvs (default **`/opt/datahub/venvs`**).                                                                                                                                |
+
+Each plugin appears **once** across groups or as a singleton; group lists ⊆ **`BUNDLED_VENV_PLUGINS`**. More detail lives in the repo at **`docker/snippets/ingestion/README.md`** (bundled venv builder configuration).
+
+## Extend a published image
+
+Tags look like **`v1.6.0-slim`** (slim) or **`v1.6.0`** / **`v1.6.0-full`** (full—names vary by registry). Append plugins by overriding **`ENV`**, then **`RUN`** the builder:
+
+```dockerfile
+FROM acryldata/datahub-actions:v1.6.0-slim
+
+USER root
+
+ENV BUNDLED_VENV_PLUGINS="${BUNDLED_VENV_PLUGINS},mysql,snowflake"
+ENV BUNDLED_VENV_PLUGINS_COMMON=${BUNDLED_VENV_PLUGINS}
+
+RUN /opt/datahub/bundled-venv-build/build_bundled_venvs_unified.sh
+
+USER datahub
+```
+
+Docker substitutes **`${BUNDLED_VENV_PLUGINS}`** from the parent image so you need not repeat the base list. **`docker build`** needs network for **`uv`**/**`pip`**.
+
+**Locked** (**`*-locked`**) images remove **`uv`**/**`pip`**—do not use them as the base for this flow.
+
+### Remote Executor (`datahub-executor`)
+
+Same **`ENV`** + **`RUN`** pattern if your image includes **`/opt/datahub/bundled-venv-build/`**. Otherwise see below or ask DataHub Cloud for a custom image. Deploy help: [Configuring Remote Executor](/docs/managed-datahub/operator-guide/setting-up-remote-ingestion-executor.md).
+
+## No builder directory in the image
+
+Copy these files into one directory (e.g. **`/opt/datahub/bundled-venv-build/`**), **`chmod +x`** the **`.sh`**, ensure **`constraints.txt`** exists under **`DATAHUB_BUNDLED_VENV_PATH`**, set the same env vars, run **`build_bundled_venvs_unified.sh`**. Pin **`raw.githubusercontent.com`** to a **commit SHA**. Files: **`build_bundled_venvs_unified.py`**, **`build_bundled_venvs_unified.sh`**, **`bundled_venv_config.py`**, **`constraints.txt`** under **`docker/snippets/ingestion/`**.
+
+## Advanced: extra venv groups
+
+Default is one **common** group via **`BUNDLED_VENV_PLUGINS_COMMON`** for a smaller image. Add **`BUNDLED_VENV_PLUGINS_<suffix>`** only when connectors **cannot share one env** (conflicting transitive deps). Example:
+
+```dockerfile
+ENV BUNDLED_VENV_PLUGINS=s3,demo-data,file,mysql,oracle
+ENV BUNDLED_VENV_PLUGINS_COMMON=s3,demo-data,file,mysql
+ENV BUNDLED_VENV_PLUGINS_ORACLE=oracle
+```
+
+If everything resolves in one venv, avoid extra groups.
+
+## Rebuild from this repository
+
+Maintainers: **`docker/datahub-actions/Dockerfile`** + **`--build-arg`** (see Dockerfile and snippet README)—requires a repo checkout.
+
+## Related documentation
+
+- [Ingestion Executor](/docs/actions/actions/executor.md)
+- [Docker development](/docs/docker/development.md)

--- a/docs/managed-datahub/operator-guide/setting-up-remote-ingestion-executor.md
+++ b/docs/managed-datahub/operator-guide/setting-up-remote-ingestion-executor.md
@@ -87,6 +87,10 @@ Once you have created an Executor Pool in DataHub Cloud, you are now ready to de
 Work with DataHub team to receive deployment templates specific to your environment (Helm charts, CloudFormation, or Terraform) for deploying Remote Executors in this Pool.
 :::
 
+### Custom images with additional connectors
+
+Remote Executor (`datahub-executor`) images use the same **bundled venv** mechanism as DataHub Core **`datahub-actions`**: connector installs are baked under `/opt/datahub/venvs` at **image build** time via variables such as `BUNDLED_VENV_PLUGINS` and `BUNDLED_CLI_VERSION`. To run sources that need extra dependencies, work with DataHub Cloud for an image built with your plugin list. Details: [Bundled ingestion virtual environments](/docs/docker/bundled-ingestion-venvs.md).
+
 ### Deploy on Amazon ECS
 
 1. **AWS Account Configuration**

--- a/metadata-ingestion/tests/unit/test_bundled_venv_config.py
+++ b/metadata-ingestion/tests/unit/test_bundled_venv_config.py
@@ -53,6 +53,35 @@ def test_groups_config_from_env_multiple_groups() -> None:
     assert set(cfg["groups"].keys()) == {"common", "gc_docs"}
 
 
+def test_groups_config_aux_primary_from_env() -> None:
+    cfg = groups_config_from_plugin_group_env(
+        {
+            "BUNDLED_VENV_PLUGINS_COMMON": "s3,file",
+            "BUNDLED_VENV_AUX_PRIMARY_COMMON": "file",
+        }
+    )
+    assert cfg["groups"]["common"]["aux_primary_plugin"] == "file"
+
+
+def test_groups_config_aux_primary_unknown_group_raises() -> None:
+    with pytest.raises(ValueError, match="no .* group was defined"):
+        groups_config_from_plugin_group_env({"BUNDLED_VENV_AUX_PRIMARY_COMMON": "s3"})
+
+
+def test_build_group_plan_carries_aux_primary() -> None:
+    cfg = {
+        "groups": {
+            "common": {
+                "plugins": ["s3", "file"],
+                "aux_primary_plugin": "file",
+            }
+        }
+    }
+    plans = build_group_plans(["s3", "file"], cfg, slim_mode=False)
+    assert len(plans) == 1
+    assert plans[0].aux_primary_plugin == "file"
+
+
 def test_groups_config_from_env_empty_means_no_groups() -> None:
     assert groups_config_from_plugin_group_env({"PATH": "/usr/bin"}) is None
 

--- a/metadata-ingestion/tests/unit/test_bundled_venv_config.py
+++ b/metadata-ingestion/tests/unit/test_bundled_venv_config.py
@@ -1,0 +1,150 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SNIPPETS = _REPO_ROOT / "docker" / "snippets" / "ingestion"
+sys.path.insert(0, str(_SNIPPETS))
+
+from bundled_venv_config import (  # noqa: E402
+    build_group_plans,
+    extras_to_install_string,
+    groups_config_from_plugin_group_env,
+    plugin_extras_for_plugin,
+    sorted_union_extras,
+)
+
+
+def test_plugin_extras_dedupes_file_plugin_extra() -> None:
+    extras = plugin_extras_for_plugin("file", slim_mode=False)
+    assert extras.count("file") == 1
+    assert "s3" in extras
+
+
+def test_sorted_union_s3_and_file_full_mode() -> None:
+    u = sorted_union_extras(["s3", "file"], slim_mode=False)
+    assert "datahub-rest" in u
+    assert "s3" in u
+    assert "file" in u
+
+
+def test_sorted_union_slim_uses_s3_slim() -> None:
+    u = sorted_union_extras(["s3", "file"], slim_mode=True)
+    assert "s3-slim" in u
+    assert "s3" not in u
+
+
+def test_groups_config_from_env_suffix_is_lowercased_group_id() -> None:
+    cfg = groups_config_from_plugin_group_env(
+        {"BUNDLED_VENV_PLUGINS_COMMON": "s3,demo-data,file"}
+    )
+    assert cfg == {"groups": {"common": {"plugins": ["s3", "demo-data", "file"]}}}
+
+
+def test_groups_config_from_env_multiple_groups() -> None:
+    cfg = groups_config_from_plugin_group_env(
+        {
+            "BUNDLED_VENV_PLUGINS_COMMON": "s3,file",
+            "BUNDLED_VENV_PLUGINS_GC_DOCS": "datahub-gc,datahub-documents",
+        }
+    )
+    assert set(cfg["groups"].keys()) == {"common", "gc_docs"}
+
+
+def test_groups_config_from_env_empty_means_no_groups() -> None:
+    assert groups_config_from_plugin_group_env({"PATH": "/usr/bin"}) is None
+
+
+def test_groups_config_from_env_duplicate_label_after_lower_raises() -> None:
+    with pytest.raises(ValueError, match="Duplicate bundled venv group"):
+        groups_config_from_plugin_group_env(
+            {
+                "BUNDLED_VENV_PLUGINS_COMMON": "s3",
+                "BUNDLED_VENV_PLUGINS_common": "file",
+            }
+        )
+
+
+def test_build_group_plans_all_plugins_in_common() -> None:
+    cfg = {
+        "groups": {
+            "common": {
+                "plugins": [
+                    "s3",
+                    "demo-data",
+                    "file",
+                    "datahub-gc",
+                    "datahub-documents",
+                ]
+            }
+        }
+    }
+    plugins = [
+        "s3",
+        "demo-data",
+        "file",
+        "datahub-gc",
+        "datahub-documents",
+    ]
+    plans = build_group_plans(plugins, cfg, slim_mode=False)
+    assert len(plans) == 1
+    assert plans[0].label == "common"
+    assert plans[0].canonical_dir_name == "common-venv"
+    assert set(plans[0].members) == set(plugins)
+
+
+def test_build_group_plans_singleton_when_plugin_not_in_any_group() -> None:
+    cfg = {"groups": {"common": {"plugins": ["s3", "file"]}}}
+    plugins = ["s3", "demo-data", "file"]
+    plans = build_group_plans(plugins, cfg, slim_mode=False)
+    by_label = {p.label: p for p in plans}
+    assert set(by_label["common"].members) == {"s3", "file"}
+    assert by_label["demo-data"].canonical_dir_name == "demo-data-bundled"
+    assert by_label["demo-data"].members == ("demo-data",)
+
+
+def test_build_group_plans_duplicate_membership_errors() -> None:
+    cfg = {"groups": {"a": {"plugins": ["s3", "file"]}, "b": {"plugins": ["s3"]}}}
+    with pytest.raises(ValueError, match="more than one group"):
+        build_group_plans(["s3", "file"], cfg, slim_mode=False)
+
+
+def test_build_group_plans_unknown_plugin_in_group_errors() -> None:
+    cfg = {"groups": {"bad": {"plugins": ["not-a-plugin"]}}}
+    with pytest.raises(ValueError, match="not in BUNDLED_VENV_PLUGINS"):
+        build_group_plans(["s3"], cfg, slim_mode=False)
+
+
+def test_primary_plugin_override() -> None:
+    cfg = {"groups": {"common": {"plugins": ["s3", "file"], "primary_plugin": "s3"}}}
+    plugins = ["s3", "file"]
+    plans = build_group_plans(plugins, cfg, slim_mode=False)
+    assert len(plans) == 1
+    assert extras_to_install_string(plans[0].extras) == extras_to_install_string(
+        sorted_union_extras(["s3"], slim_mode=False)
+    )
+
+
+def test_plugin_alias_symlink_uses_relative_canonical_name() -> None:
+    """Matches ensure_plugin_symlinks: sibling dirs use a single-path-component target."""
+    base = "/opt/datahub/venvs"
+    canonical_path = os.path.join(base, "common-venv")
+    link_path = os.path.join(base, "s3-bundled")
+    target_rel = os.path.relpath(canonical_path, start=os.path.dirname(link_path))
+    assert target_rel == "common-venv"
+
+
+def test_explicit_extras_override() -> None:
+    cfg = {
+        "groups": {
+            "x": {
+                "plugins": ["s3", "file"],
+                "extras": ["datahub-rest", "datahub-kafka", "file", "s3"],
+            }
+        }
+    }
+    plugins = ["s3", "file"]
+    plans = build_group_plans(plugins, cfg, slim_mode=False)
+    assert set(plans[0].extras) == {"datahub-rest", "datahub-kafka", "file", "s3"}


### PR DESCRIPTION
### What this does
- **Named venv groups** — `BUNDLED_VENV_PLUGINS_<suffix>` (suffix → lowercase group id) so multiple plugins can share one install under **`{label}-venv`**, with **`{plugin}-bundled`** symlinks where needed. **`BUNDLED_VENV_PLUGINS`** stays the full plugin list; default pattern maps everything into **`common-venv`** via **`BUNDLED_VENV_PLUGINS_COMMON`**.
- **Unified build** — `build_bundled_venvs_unified.py` / `.sh` use `bundled_venv_config.py` for group plans, extras union, slim mode, and symlink setup. Shell script uses **`SCRIPT_DIR`** so it runs from `/tmp` or **`/opt/datahub/bundled-venv-build/`**.
- **`datahub-actions` image** — Final **full/slim/locked** stages re-declare **`ARG`/`ENV`** for **`DATAHUB_BUNDLED_VENV_PATH`**, **`BUNDLED_VENV_PLUGINS`**, **`BUNDLED_VENV_PLUGINS_COMMON`**, **`BUNDLED_CLI_VERSION`**, **`BUNDLED_VENV_SLIM_MODE`** (stages start from **`ingestion-base-*`**, not **`bundled-venvs-*`**, so env is not inherited). **Full/slim** also copy builder bits to **`/opt/datahub/bundled-venv-build/`** for downstream Dockerfiles. Short comments explain per-stage **`ARG`/`ENV`**.
- **Docs** — New **`docs/docker/bundled-ingestion-venvs.md`**: Core vs Cloud, variables, extend **`FROM`** `acryldata/datahub-actions` / `datahub-executor` (append **`ENV`**, **`RUN`** builder), locked vs slim/full, optional extra groups, link to repo **`docker/snippets/ingestion/README.md`** (relative path for `yarnGenerate`). Cross-links from **Ingestion Executor**, **Remote Executor** operator guide, and **Advanced Guides** sidebar. **`docker/snippets/ingestion/README.md`** updated for operator reference.
- **Tests** — **`metadata-ingestion/tests/unit/test_bundled_venv_config.py`** for config parsing and group behavior.

### Files (10)
| Area | Files |
|------|--------|
| Docker | `docker/datahub-actions/Dockerfile` |
| Snippets | `README.md`, `build_bundled_venvs_unified.py`, `build_bundled_venvs_unified.sh`, `bundled_venv_config.py` |
| Docs site | `docs-website/sidebars.js`, `docs/docker/bundled-ingestion-venvs.md`, `docs/actions/actions/executor.md`, `docs/managed-datahub/operator-guide/setting-up-remote-ingestion-executor.md` |
| Tests | `metadata-ingestion/tests/unit/test_bundled_venv_config.py` |