### PR TITLE
fix(rest-emitter): propagate tcp_keepalive through DataHubGraph

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/graph/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/client.py
@@ -174,6 +174,7 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
             client_mode=config.client_mode,
             datahub_component=config.datahub_component,
             server_config_refresh_interval=config.server_config_refresh_interval,
+            tcp_keepalive=self.config.tcp_keepalive,
         )
         self.server_id: str = _MISSING_SERVER_ID
         self._query_projector: Optional["QueryProjector"] = None
@@ -251,6 +252,7 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
                 client_mode=session_config.client_mode,
                 datahub_component=session_config.datahub_component,
                 server_config_refresh_interval=emitter._server_config_refresh_interval,
+                tcp_keepalive=session_config.tcp_keepalive,
             )
         )
 

--- a/metadata-ingestion/src/datahub/ingestion/graph/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/config.py
@@ -34,5 +34,9 @@ class DatahubClientConfig(ConfigModel):
     client_mode: Optional[ClientMode] = None
     datahub_component: Optional[str] = None
     server_config_refresh_interval: Optional[int] = None
+    # Enables TCP keepalive on the underlying HTTP session, which prevents idle
+    # connections from being silently dropped by intermediaries (e.g. NAT
+    # gateways) and surfacing as SSLEOFError on reuse.
+    tcp_keepalive: bool = False
 
     model_config = ConfigDict(extra="ignore")

--- a/metadata-ingestion/src/datahub/ingestion/sink/datahub_rest.py
+++ b/metadata-ingestion/src/datahub/ingestion/sink/datahub_rest.py
@@ -75,7 +75,6 @@ class DatahubRestSinkConfig(DatahubClientConfig):
     mode: RestSinkMode = _DEFAULT_REST_SINK_MODE
     endpoint: RestSinkEndpoint = DEFAULT_REST_EMITTER_ENDPOINT
     server_config_refresh_interval: Optional[int] = None
-    tcp_keepalive: bool = False
 
     # These only apply in async modes.
     max_threads: pydantic.PositiveInt = _DEFAULT_REST_SINK_MAX_THREADS

--- a/metadata-ingestion/tests/unit/cli/test_config_utils.py
+++ b/metadata-ingestion/tests/unit/cli/test_config_utils.py
@@ -241,6 +241,7 @@ class TestConfigUtils:
                     "retry_status_codes": None,
                     "timeout_sec": None,
                     "server_config_refresh_interval": None,
+                    "tcp_keepalive": False,
                 }
             }
             assert mock_persist.call_args[0][0] == expected_config
@@ -291,6 +292,7 @@ class TestConfigUtils:
                     "retry_status_codes": None,
                     "timeout_sec": None,
                     "server_config_refresh_interval": None,
+                    "tcp_keepalive": False,
                 },
                 "other": {"setting": "value"},
             }
@@ -321,6 +323,7 @@ class TestConfigUtils:
                     "retry_status_codes": None,
                     "timeout_sec": None,
                     "server_config_refresh_interval": None,
+                    "tcp_keepalive": False,
                 }
             }
             assert mock_persist.call_args[0][0] == expected_config

--- a/metadata-ingestion/tests/unit/sdk/test_rest_emitter.py
+++ b/metadata-ingestion/tests/unit/sdk/test_rest_emitter.py
@@ -2487,6 +2487,45 @@ class TestRequestsSessionConfig:
         assert type(emitter._session.get_adapter("http://example.com")) is HTTPAdapter
 
 
+class TestDataHubGraphTcpKeepalive:
+    """Regression tests covering tcp_keepalive propagation from a RestEmitter
+    into the DataHubGraph it builds via to_graph() / from_emitter().
+
+    DataHubGraph.from_emitter() and DataHubGraph.__init__() must carry the
+    flag through when reconstructing the underlying session, otherwise
+    ingestion (which goes through the graph, not the original emitter)
+    silently reverts to a session without TCP keepalive enabled.
+    """
+
+    def test_from_emitter_propagates_tcp_keepalive_true(self):
+        """from_emitter() must carry tcp_keepalive=True through to the graph's session."""
+        emitter = DataHubRestEmitter("http://localhost:8080", tcp_keepalive=True)
+        graph = emitter.to_graph()
+        assert graph._session_config.tcp_keepalive is True
+        assert isinstance(
+            graph._session.get_adapter("https://example.com"), _KeepAliveHTTPAdapter
+        )
+
+    def test_from_emitter_propagates_tcp_keepalive_false(self):
+        """from_emitter() must also faithfully preserve tcp_keepalive=False."""
+        emitter = DataHubRestEmitter("http://localhost:8080", tcp_keepalive=False)
+        graph = emitter.to_graph()
+        assert graph._session_config.tcp_keepalive is False
+        assert type(graph._session.get_adapter("https://example.com")) is HTTPAdapter
+
+    def test_datahub_graph_constructed_with_tcp_keepalive(self):
+        """Constructing a DataHubGraph with tcp_keepalive=True wires up the keepalive adapter."""
+        from datahub.ingestion.graph.client import DataHubGraph
+        from datahub.ingestion.graph.config import DatahubClientConfig
+
+        graph = DataHubGraph(
+            DatahubClientConfig(server="http://localhost:8080", tcp_keepalive=True)
+        )
+        assert isinstance(
+            graph._session.get_adapter("https://example.com"), _KeepAliveHTTPAdapter
+        )
+
+
 class TestWeightedRetry:
     """Tests for the WeightedRetry class that provides weighted retry logic for 429 responses."""
 

--- a/metadata-ingestion/tests/unit/test_rest_sink.py
+++ b/metadata-ingestion/tests/unit/test_rest_sink.py
@@ -343,6 +343,35 @@ def test_resolve_gms_emit_mode(sink_mode, configured_emit_mode, expected_emit_mo
     assert _resolve_gms_emit_mode(sink_mode, configured_emit_mode) == expected_emit_mode
 
 
+class TestDatahubRestSinkTcpKeepalive:
+    """Regression tests covering end-to-end tcp_keepalive propagation through
+    the REST sink: from the recipe config, through the sink config, into the
+    per-thread DataHubRestEmitter, and finally into the underlying
+    requests.Session adapter. We verify the full chain here so a future
+    refactor can't silently regress it.
+    """
+
+    def test_sink_make_emitter_passes_tcp_keepalive(self):
+        """DatahubRestSink._make_emitter must hand tcp_keepalive to the emitter."""
+        from requests.adapters import HTTPAdapter
+
+        from datahub.emitter.rest_emitter import _KeepAliveHTTPAdapter
+        from datahub.ingestion.sink.datahub_rest import (
+            DatahubRestSink,
+            DatahubRestSinkConfig,
+        )
+
+        cfg = DatahubRestSinkConfig(server="http://localhost:8080", tcp_keepalive=True)
+        emitter = DatahubRestSink._make_emitter(cfg)
+        assert isinstance(
+            emitter._session.get_adapter("https://example.com"), _KeepAliveHTTPAdapter
+        )
+
+        cfg = DatahubRestSinkConfig(server="http://localhost:8080", tcp_keepalive=False)
+        emitter = DatahubRestSink._make_emitter(cfg)
+        assert type(emitter._session.get_adapter("https://example.com")) is HTTPAdapter
+
+
 def test_emit_batch_wrapper_uses_resolved_emit_mode():
     """Regression test: _emit_batch_wrapper must pass self._gms_emit_mode to emit_mcps."""
 


### PR DESCRIPTION
## Summary

Wire the `tcp_keepalive` flag through `DataHubGraph` so it actually reaches the underlying `requests.Session`. Previously ( #17220 ) a recipe with `tcp_keepalive: true` would enable keepalive on the initial sink emitter but silently revert to a plain `HTTPAdapter` once the emitter was converted to a graph for ingestion.

## Motivation

Long-running ingestions (e.g. MSSQL, Snowflake) that go idle for several minutes have been failing with `SSLEOFError` at the connection layer when intermediaries such as NAT gateways drop idle TCP connections. The retry loop never sees these because they are raised below the HTTP layer.

A previous change added `tcp_keepalive` support to `DataHubRestEmitter` and `DatahubRestSink` to fix exactly this. However, while the initial sink emitter correctly received the flag, every code path that goes through `sink.emitter.to_graph()` (which is what the pipeline actually uses to emit) ended up with a session that had keepalive disabled, so the fix never took effect for ingestion.

The trace from the bug report:

```
Building session with tcp_keepalive=True;  using _KeepAliveHTTPAdapter   # initial sink emitter
Building session with tcp_keepalive=False; using HTTPAdapter             # graph emitter (bug)
AssertionError: self.tcp_keepalive
```

## Changes Overview

**Bug Fixes:**

- `DatahubClientConfig` now carries `tcp_keepalive: bool = False`. It was the missing field that caused the flag to be dropped when constructing a graph from an emitter.
- `DataHubGraph.__init__` forwards `self.config.tcp_keepalive` to its `DatahubRestEmitter` superclass, so `DataHubGraph(DatahubClientConfig(..., tcp_keepalive=True))` now produces a keepalive session.
- `DataHubGraph.from_emitter` copies `tcp_keepalive` from the source emitter's session config into the new client config. This is the path that `to_graph()` and the ingestion pipeline use.

**Modifications:**

- Removed the redundant `tcp_keepalive` override on `DatahubRestSinkConfig` — it now inherits the field directly from `DatahubClientConfig`.

**No behavior change for users who don't set `tcp_keepalive`** — default remains `False`.

## Architecture / Design Notes

The bug was a classic config-propagation gap. There are three session-creation sites in the ingestion pipeline flow:

1. `DatahubRestSink.__init__` builds the initial emitter from the recipe → already correct.
2. `sink.emitter.to_graph()` constructs a `DataHubGraph` via `DataHubGraph.from_emitter(emitter)` → was dropping the flag.
3. `DataHubGraph.__init__` then re-runs `super().__init__()` which calls `RequestsSessionConfig.build_session()` → was receiving `tcp_keepalive=False` because of (2).

The fix closes (2) and (3) so all three sites observe the same value. No new types, no new env vars, no new public surface — just the missing field and two `tcp_keepalive=...` arguments.

## Testing

Validated across six layers, from unit tests up to a real ingestion run with kernel-level proof.

**1. Focused regression tests for the fix**

- `TestDataHubGraphTcpKeepalive` in `tests/unit/sdk/test_rest_emitter.py`
  - `test_from_emitter_propagates_tcp_keepalive_true` — `RestEmitter(tcp_keepalive=True).to_graph()` produces a session with `_KeepAliveHTTPAdapter`.
  - `test_from_emitter_propagates_tcp_keepalive_false` — symmetric negative case.
  - `test_datahub_graph_constructed_with_tcp_keepalive` — `DataHubGraph(DatahubClientConfig(..., tcp_keepalive=True))` directly produces a keepalive session.
- `TestDatahubRestSinkTcpKeepalive` in `tests/unit/test_rest_sink.py`
  - `test_sink_make_emitter_passes_tcp_keepalive` — full sink chain: recipe config → `DatahubRestSinkConfig` → per-thread `DataHubRestEmitter` → `_KeepAliveHTTPAdapter` mounted on the live `requests.Session`.

All 4 pass.

**2. Broader related test suites**

Re-ran the surrounding suites that share the modified code paths:

- `tests/unit/sdk/test_rest_emitter.py` (full file — emitter, session config, retries, batching)
- `tests/unit/test_rest_sink.py` (full file — sink modes, emit modes, batching)
- `tests/unit/test_pipeline.py` (pipeline construction, including `sink.emitter.to_graph()`)
- `tests/unit/graph/` (DataHubGraph client tests)

All green.

**3. Lint**

`ruff check` over the four touched source files: clean.

**4. Type check**

`mypy` over the same files: no new errors. (One pre-existing `ConfigDict(extra=\"ignore\")` warning is upstream Pydantic/mypy and unrelated.)

**5. Kernel-level runtime verification**

A standalone script opens a real connection through the configured `DataHubGraph`, fishes the live socket out of the urllib3 connection pool, and inspects it with `getsockopt`:

| Recipe | `SO_KEEPALIVE` on live socket | Verdict |
|---|---|---|
| `tcp_keepalive: false` | `0` | disabled, as expected |
| `tcp_keepalive: true` | `8` (macOS) / `1` (Linux) | **enabled** |

Verdict logic treats any non-zero value as enabled (macOS reports `8`, not `1`).

**6. End-to-end real `datahub ingest`**

Ran a real ingestion against a fresh local Docker quickstart GMS with debug logging.

Before the fix:

```
Building session with tcp_keepalive=True;  using _KeepAliveHTTPAdapter   # sink emitter
Building session with tcp_keepalive=False; using HTTPAdapter             # graph (BUG)
```

After the fix — three session-creation sites, all consistent:

```
Building session with tcp_keepalive=True; using _KeepAliveHTTPAdapter   # sink emitter
Building session with tcp_keepalive=True; using _KeepAliveHTTPAdapter   # graph (from to_graph())
Building session with tcp_keepalive=True; using _KeepAliveHTTPAdapter   # per-thread sink emitter
```

…and ingestion completes successfully. The original `AssertionError` from `to_graph()` no longer reproduces.

## Impact Assessment

- **Affected components:** `DatahubClientConfig`, `DataHubGraph`, `DatahubRestSinkConfig`. All other call sites of these classes are unchanged because the new field defaults to `False`.
- **Breaking changes:** None. Default behavior is unchanged. Users who set `tcp_keepalive: true` in their recipe now get the behavior they were already asking for.
- **Performance impact:** Negligible. TCP keepalive is a kernel-level socket option; cost is a few keepalive probe packets per long-idle connection.
- **Risk level:** Low. The fix is a config-propagation patch, fully covered by unit tests, and the default is unchanged.

## Deployment Notes

- No configuration changes required.
- No migrations.
- No feature flag.
- Rollback: revert is safe; users on the broken behavior simply continue to hit the original `SSLEOFError` path.
