### PR TITLE
docs(observe): add Data Observability Agent (private beta) section to Data Health Dashboard

### DIFF
--- a/docs/managed-datahub/observe/data-health-dashboard.md
+++ b/docs/managed-datahub/observe/data-health-dashboard.md
@@ -84,8 +84,7 @@ Tell the agent which tables (or which slice of your data landscape) you care abo
 - **Freshness** — for tables on a regular refresh cadence
 - **Volume** — for tables with expected row counts or growth rates
 - **Field** — column-level quality (null checks, format validation, statistical monitoring)
-- **Schema** — to catch breaking changes like dropped columns or type changes
-- **SQL** — for custom business-logic checks (e.g., revenue > 0, no orphaned records)
+- ...and more
 
 The agent picks an appropriate source type automatically based on whether the dataset has an active platform connection or only DataHub metadata, and creates assertions in active mode so they start running immediately.
 

--- a/docs/managed-datahub/observe/data-health-dashboard.md
+++ b/docs/managed-datahub/observe/data-health-dashboard.md
@@ -67,7 +67,7 @@ In addition, both the `By Tables` tab and the `Incidents` tab will apply your gl
   <img width="80%"  src="https://raw.githubusercontent.com/datahub-project/static-assets/main/imgs/observe/data-health/view-applied.png"/>
 </p>
 
-## Data Observability Agent <span style={{ fontSize: '0.7em', verticalAlign: 'middle', padding: '2px 8px', borderRadius: '12px', background: '#f0e7ff', color: '#5b3aaa', fontWeight: 600 }}>Private Beta</span>
+## Data Observability Agent (Private Beta)
 
 The Data Observability Agent is an AI assistant embedded directly in the Data Health Dashboard. It helps you go from "I have a lot of tables and not enough monitors" to "the right checks are in place, and I know where to focus first" — without leaving the dashboard.
 

--- a/docs/managed-datahub/observe/data-health-dashboard.md
+++ b/docs/managed-datahub/observe/data-health-dashboard.md
@@ -79,7 +79,7 @@ The Data Observability Agent is an AI assistant embedded directly in the Data He
 
 **1. Setting up anomaly detection and data quality checks**
 
-Tell the agent which tables (or which slice of your data landscape) you care about, and it will recommend and create the right assertions for you:
+Tell the agent what slice of your data landscape you care most about — or let it figure out what's most important for you — and it will recommend and create the right assertions:
 
 - **Freshness** — for tables on a regular refresh cadence
 - **Volume** — for tables with expected row counts or growth rates

--- a/docs/managed-datahub/observe/data-health-dashboard.md
+++ b/docs/managed-datahub/observe/data-health-dashboard.md
@@ -67,6 +67,44 @@ In addition, both the `By Tables` tab and the `Incidents` tab will apply your gl
   <img width="80%"  src="https://raw.githubusercontent.com/datahub-project/static-assets/main/imgs/observe/data-health/view-applied.png"/>
 </p>
 
+## Data Observability Agent <span style={{ fontSize: '0.7em', verticalAlign: 'middle', padding: '2px 8px', borderRadius: '12px', background: '#f0e7ff', color: '#5b3aaa', fontWeight: 600 }}>Private Beta</span>
+
+The Data Observability Agent is an AI assistant embedded directly in the Data Health Dashboard. It helps you go from "I have a lot of tables and not enough monitors" to "the right checks are in place, and I know where to focus first" — without leaving the dashboard.
+
+<p align="left">
+  <img width="80%"  src="https://raw.githubusercontent.com/datahub-project/static-assets/main/imgs/observe/data-health/agent.png"/>
+</p>
+
+### What it can help with
+
+**1. Setting up anomaly detection and data quality checks**
+
+Tell the agent which tables (or which slice of your data landscape) you care about, and it will recommend and create the right assertions for you:
+
+- **Freshness** — for tables on a regular refresh cadence
+- **Volume** — for tables with expected row counts or growth rates
+- **Field** — column-level quality (null checks, format validation, statistical monitoring)
+- **Schema** — to catch breaking changes like dropped columns or type changes
+- **SQL** — for custom business-logic checks (e.g., revenue > 0, no orphaned records)
+
+The agent picks an appropriate source type automatically based on whether the dataset has an active platform connection or only DataHub metadata, and creates assertions in active mode so they start running immediately.
+
+**2. Identifying where to focus**
+
+The agent can scan your assertion landscape to surface what matters most — recent assertion failures that are most concerning, tables that lack monitoring coverage, flaky checks worth investigating, and broader trends across your domain or team's tables. Use it to triage Data Health at the start of the day or after an incident.
+
+### Example questions to ask
+
+- _"Set up anomaly detection for my datasets"_
+- _"What critical tables am I missing monitoring for?"_
+- _"Give me a health report across my datasets"_
+- _"Which assertions failed in the last 7 days?"_
+- _"Add a freshness check on `prod.analytics.orders` — it should land daily by 6am UTC"_
+
+### Access
+
+The Data Observability Agent is currently in **private beta**. Reach out to your DataHub representative to enable it for your instance.
+
 ## Monitoring Rules
 
 Monitoring Rules let you automatically apply [Smart Assertions](./smart-assertions.md) (AI anomaly monitors) across your data landscape using search-based predicates. Instead of manually creating assertions on individual tables, you define a rule that describes _which_ datasets should be monitored and _what_ to monitor, and DataHub takes care of the rest.


### PR DESCRIPTION
## Summary

Adds a new **Data Observability Agent** section to the Data Health Dashboard docs (above Monitoring Rules), describing the AI assistant currently in private beta.

The section covers the agent's two main user-facing focus areas:

1. **Setting up anomaly detection and data quality checks** — recommending and creating Freshness, Volume, Field, Schema, and SQL assertions on tables the user cares about, with sensible source-type defaults based on platform connectivity.
2. **Identifying where to focus** — surfacing recent failures, missing monitoring coverage, and broader trends across the user's data landscape.

Includes a screenshot reference (added separately to the static-assets repo) and example questions to ask the agent.

## Test plan

- [x] `./gradlew :datahub-web-react:mdPrettierWrite` — markdown formatting passes
- [ ] Visual review on the Docusaurus site (private-beta badge renders correctly via inline JSX styles)
- [ ] Confirm linked screenshot resolves once `static-assets` change is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)