### PR TITLE
ci(workflows): add 60m timeouts for Docker image build jobs

### DIFF
--- a/.github/workflows/docker-ingestion-smoke.yml
+++ b/.github/workflows/docker-ingestion-smoke.yml
@@ -54,6 +54,7 @@ jobs:
     name: Build and Push Docker Image to Docker Hub
     runs-on: ubuntu-latest
     needs: setup
+    timeout-minutes: 60
     if: ${{ needs.setup.outputs.publish == 'true' }}
     steps:
       - name: Check out the repo

--- a/.github/workflows/docker-quickstart-ai.yml
+++ b/.github/workflows/docker-quickstart-ai.yml
@@ -60,7 +60,7 @@ jobs:
   ai-smoke-test:
     name: "Quickstart AI + Semantic Search Smoke Test"
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 120
 
     steps:
       # -----------------------------------------------------------------------
@@ -89,6 +89,7 @@ jobs:
       # -----------------------------------------------------------------------
 
       - name: Build quickstart Docker images
+        timeout-minutes: 60
         run: ./gradlew :docker:buildImagesQuickstart -Ptag=${{ env.DATAHUB_VERSION }}
         env:
           DOCKER_BUILDKIT: "1"

--- a/.github/workflows/docker-quickstart-ai.yml
+++ b/.github/workflows/docker-quickstart-ai.yml
@@ -60,7 +60,7 @@ jobs:
   ai-smoke-test:
     name: "Quickstart AI + Semantic Search Smoke Test"
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 90
 
     steps:
       # -----------------------------------------------------------------------

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -201,6 +201,7 @@ jobs:
     name: Build all images
     runs-on: ${{ needs.setup.outputs.build_runner_type }}
     needs: setup
+    timeout-minutes: 60
     if: ${{ needs.setup.outputs.use_depot_cache == 'true' }} # On fork, smoke test job does the build since depot cache is not available
     outputs:
       build_id: ${{ steps.capture-build-id.outputs.build_id }}
@@ -572,6 +573,7 @@ jobs:
           docker system df -v
 
       - name: build images
+        timeout-minutes: 60
         if: ${{ needs.setup.outputs.use_depot_cache != 'true' }}
         run: |
           ./gradlew :docker:buildImagesQuickstartDebugConsumers -Ptag=${{ needs.setup.outputs.tag }} -PpythonDockerVersion=${{ needs.setup.outputs.python_release_version }} -PdockerRegistry=${{ env.DOCKER_REGISTRY }}


### PR DESCRIPTION
- docker-unified: 60m on base_build job; 60m step cap for fork build images

- docker-ingestion-smoke: 60m on build-smoke job

- docker-quickstart-ai: 60m on Build quickstart Docker images step;

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
