### PR TITLE
refactor(search): share ES by-query timeouts and MAE RestClient merge on shim

### DIFF
--- a/docker/datahub-mae-consumer/README.md
+++ b/docker/datahub-mae-consumer/README.md
@@ -4,3 +4,5 @@
 
 Refer to [DataHub MAE Consumer Job](../../metadata-jobs/mae-consumer-job) to have a quick understanding of the architecture and
 responsibility of this service for the DataHub.
+
+By-query `RequestOptions` (delete/update-by-query, etc.) use the **same** tuning as GMS: **`ELASTICSEARCH_BULK_BY_QUERY_SLOW_OPERATION_TIMEOUT_SECONDS`** → `elasticsearch.bulkProcessor.slowByQueryOperationTimeoutSeconds`. **MAE-specific** Elasticsearch settings are **`MAE_ELASTICSEARCH_SOCKET_TIMEOUT`** and **`MAE_ELASTICSEARCH_CONNECTION_REQUEST_TIMEOUT`** only (`maeConsumer.elasticsearch`), merged with global RestClient timeouts when **`MAE_CONSUMER_ENABLED=true`**. **`ELASTICSEARCH_BUILD_INDICES_SLOW_OPERATION_TIMEOUT_SECONDS`** is for system-update / build-indices jobs only, not the bulk processor. [`docker.env`](env/docker.env) sets longer RestClient values where appropriate.

--- a/docker/datahub-mae-consumer/env/docker.env
+++ b/docker/datahub-mae-consumer/env/docker.env
@@ -9,6 +9,9 @@ KAFKA_SCHEMAREGISTRY_URL=http://schema-registry:8081
 # KAFKA_SCHEMAREGISTRY_URL=http://datahub-gms:8080/schema-registry/api/
 ELASTICSEARCH_HOST=elasticsearch
 ELASTICSEARCH_PORT=9200
+# This service only runs MAE consumer ES clients and bulk processing; longer RestClient timeouts suit sustained indexing. Tune per cluster.
+ELASTICSEARCH_SOCKET_TIMEOUT=120000
+ELASTICSEARCH_CONNECTION_REQUEST_TIMEOUT=10000
 ES_BULK_REFRESH_POLICY=NONE
 NEO4J_HOST=http://neo4j:7474
 NEO4J_URI=bolt://neo4j

--- a/docs/deploy/environment-vars.md
+++ b/docs/deploy/environment-vars.md
@@ -387,6 +387,10 @@ When using traditional username/password authentication, both `CREATE_USER_USERN
 | `ELASTIC_ID_HASH_ALGO`                     | `MD5`           | ID hash algorithm                                            | GMS, MAE Consumer, MCE Consumer, System Update |
 | `ELASTICSEARCH_DATA_NODE_COUNT`            | `1`             | Number of Elasticsearch data nodes                           | GMS, MAE Consumer, MCE Consumer, System Update |
 
+#### MAE consumer (`metadata-jobs/mae-consumer-job`)
+
+The MAE consumer runs in **its own** process and shares the same `ESBulkProcessor` / `searchClientShim` wiring as GMS. **By-query** `RequestOptions` use **`ELASTICSEARCH_BULK_BY_QUERY_SLOW_OPERATION_TIMEOUT_SECONDS`** for both GMS and MAE (not separate MAE overrides). **MAE-only** tuning is RestClient-oriented: **`MAE_ELASTICSEARCH_SOCKET_TIMEOUT`**, **`MAE_ELASTICSEARCH_CONNECTION_REQUEST_TIMEOUT`**, etc. **`ELASTICSEARCH_BUILD_INDICES_SLOW_OPERATION_TIMEOUT_SECONDS`** applies only to **system-update / build-indices** (`elasticsearch.buildIndices`). [`docker/datahub-mae-consumer/env/docker.env`](../../docker/datahub-mae-consumer/env/docker.env) sets longer values than generic quickstart defaults where appropriate.
+
 #### SSL Context Configuration
 
 | Environment Variable                    | Default | Description                      | Components                                     |
@@ -403,22 +407,23 @@ When using traditional username/password authentication, both `CREATE_USER_USERN
 
 #### Bulk Operations Configuration
 
-| Environment Variable           | Default   | Description                   | Components        |
-| ------------------------------ | --------- | ----------------------------- | ----------------- |
-| `ES_BULK_DELETE_BATCH_SIZE`    | `5000`    | Bulk delete batch size        | GMS, MAE Consumer |
-| `ES_BULK_DELETE_SLICES`        | `auto`    | Bulk delete slices            | GMS, MAE Consumer |
-| `ES_BULK_DELETE_POLL_INTERVAL` | `30`      | Bulk delete poll interval     | GMS, MAE Consumer |
-| `ES_BULK_DELETE_POLL_UNIT`     | `SECONDS` | Bulk delete poll unit         | GMS, MAE Consumer |
-| `ES_BULK_DELETE_TIMEOUT`       | `30`      | Bulk delete timeout           | GMS, MAE Consumer |
-| `ES_BULK_DELETE_TIMEOUT_UNIT`  | `MINUTES` | Bulk delete timeout unit      | GMS, MAE Consumer |
-| `ES_BULK_DELETE_NUM_RETRIES`   | `3`       | Bulk delete number of retries | GMS, MAE Consumer |
-| `ES_BULK_ASYNC`                | `true`    | Enable async bulk operations  | GMS, MAE Consumer |
-| `ES_BULK_REQUESTS_LIMIT`       | `1000`    | Bulk requests limit           | GMS, MAE Consumer |
-| `ES_BULK_FLUSH_PERIOD`         | `1`       | Bulk flush period             | GMS, MAE Consumer |
-| `ES_BULK_NUM_RETRIES`          | `3`       | Bulk number of retries        | GMS, MAE Consumer |
-| `ES_BULK_RETRY_INTERVAL`       | `1`       | Bulk retry interval           | GMS, MAE Consumer |
-| `ES_BULK_REFRESH_POLICY`       | `NONE`    | Bulk refresh policy           | GMS, MAE Consumer |
-| `ES_BULK_ENABLE_BATCH_DELETE`  | `false`   | Enable batch delete           | GMS, MAE Consumer |
+| Environment Variable                                         | Default   | Description                                                                                                                                                                           | Components        |
+| ------------------------------------------------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| `ES_BULK_DELETE_BATCH_SIZE`                                  | `5000`    | Bulk delete batch size                                                                                                                                                                | GMS, MAE Consumer |
+| `ES_BULK_DELETE_SLICES`                                      | `auto`    | Bulk delete slices                                                                                                                                                                    | GMS, MAE Consumer |
+| `ES_BULK_DELETE_POLL_INTERVAL`                               | `30`      | Bulk delete poll interval                                                                                                                                                             | GMS, MAE Consumer |
+| `ES_BULK_DELETE_POLL_UNIT`                                   | `SECONDS` | Bulk delete poll unit                                                                                                                                                                 | GMS, MAE Consumer |
+| `ES_BULK_DELETE_TIMEOUT`                                     | `30`      | Bulk delete timeout                                                                                                                                                                   | GMS, MAE Consumer |
+| `ES_BULK_DELETE_TIMEOUT_UNIT`                                | `MINUTES` | Bulk delete timeout unit                                                                                                                                                              | GMS, MAE Consumer |
+| `ES_BULK_DELETE_NUM_RETRIES`                                 | `3`       | Bulk delete number of retries                                                                                                                                                         | GMS, MAE Consumer |
+| `ES_BULK_ASYNC`                                              | `true`    | Enable async bulk operations                                                                                                                                                          | GMS, MAE Consumer |
+| `ES_BULK_REQUESTS_LIMIT`                                     | `1000`    | Bulk requests limit                                                                                                                                                                   | GMS, MAE Consumer |
+| `ES_BULK_FLUSH_PERIOD`                                       | `1`       | Bulk flush period                                                                                                                                                                     | GMS, MAE Consumer |
+| `ES_BULK_NUM_RETRIES`                                        | `3`       | Bulk number of retries                                                                                                                                                                | GMS, MAE Consumer |
+| `ES_BULK_RETRY_INTERVAL`                                     | `1`       | Bulk retry interval                                                                                                                                                                   | GMS, MAE Consumer |
+| `ES_BULK_REFRESH_POLICY`                                     | `NONE`    | Bulk refresh policy                                                                                                                                                                   | GMS, MAE Consumer |
+| `ES_BULK_ENABLE_BATCH_DELETE`                                | `false`   | Enable batch delete                                                                                                                                                                   | GMS, MAE Consumer |
+| `ELASTICSEARCH_BULK_BY_QUERY_SLOW_OPERATION_TIMEOUT_SECONDS` | `180`     | Seconds; shared by-query `RequestOptions` on `ESBulkProcessor` (delete/update-by-query) for **GMS and MAE**; maps to `elasticsearch.bulkProcessor.slowByQueryOperationTimeoutSeconds` | GMS, MAE Consumer |
 
 #### Index Configuration
 
@@ -429,30 +434,31 @@ When using traditional username/password authentication, both `CREATE_USER_USERN
 
 #### Build Indices Configuration
 
-| Environment Variable                                            | Default                          | Description                                                          | Components    |
-| --------------------------------------------------------------- | -------------------------------- | -------------------------------------------------------------------- | ------------- |
-| `ELASTICSEARCH_BUILD_INDICES_ALLOW_DOC_COUNT_MISMATCH`          | `false`                          | Allow document count mismatch when clone indices is enabled          | System Update |
-| `ELASTICSEARCH_BUILD_INDICES_CLONE_INDICES`                     | `true`                           | Clone indices                                                        | System Update |
-| `ELASTICSEARCH_BUILD_INDICES_RETENTION_UNIT`                    | `DAYS`                           | Retention unit for indices                                           | System Update |
-| `ELASTICSEARCH_BUILD_INDICES_RETENTION_VALUE`                   | `60`                             | Retention value for indices                                          | System Update |
-| `ELASTICSEARCH_BUILD_INDICES_REINDEX_OPTIMIZATION_ENABLED`      | `true`                           | Enable reindex optimization                                          | System Update |
-| `ELASTICSEARCH_BUILD_INDICES_REINDEX_BATCH_SIZE`                | `5000`                           | Documents per scroll batch during reindex                            | System Update |
-| `ELASTICSEARCH_BUILD_INDICES_REINDEX_MAX_SLICES`                | `256`                            | Maximum parallel reindex slices (capped from target shards)          | System Update |
-| `ELASTICSEARCH_BUILD_INDICES_REINDEX_NO_PROGRESS_RETRY_MINUTES` | `5`                              | Minutes without document-count progress before re-triggering reindex | System Update |
-| `ELASTICSEARCH_NUM_SHARDS_PER_INDEX`                            | `${elasticsearch.dataNodeCount}` | Number of shards per index, defaults to dataNodeCount                | System Update |
-| `ELASTICSEARCH_NUM_REPLICAS_PER_INDEX`                          | `1`                              | Number of replicas per index                                         | System Update |
-| `ELASTICSEARCH_INDEX_BUILDER_NUM_RETRIES`                       | `3`                              | Index builder number of retries                                      | System Update |
-| `ELASTICSEARCH_INDEX_BUILDER_REFRESH_INTERVAL_SECONDS`          | `3`                              | Index builder refresh interval                                       | System Update |
-| `SEARCH_DOCUMENT_MAX_ARRAY_LENGTH`                              | `1000`                           | Maximum array length in search documents                             | System Update |
-| `SEARCH_DOCUMENT_MAX_OBJECT_KEYS`                               | `1000`                           | Maximum object keys in search documents                              | System Update |
-| `SEARCH_DOCUMENT_MAX_VALUE_LENGTH`                              | `4096`                           | Maximum value length in search documents                             | System Update |
-| `ELASTICSEARCH_MAIN_TOKENIZER`                                  | `null`                           | Main tokenizer                                                       | System Update |
-| `ELASTICSEARCH_INDEX_BUILDER_MAPPINGS_REINDEX`                  | `false`                          | Enable mappings reindex                                              | System Update |
-| `ELASTICSEARCH_INDEX_BUILDER_SETTINGS_REINDEX`                  | `false`                          | Enable settings reindex                                              | System Update |
-| `ELASTICSEARCH_INDEX_BUILDER_MAX_REINDEX_HOURS`                 | `0`                              | Maximum reindex hours (0 = no timeout)                               | System Update |
-| `ELASTICSEARCH_INDEX_BUILDER_SETTINGS_OVERRIDES`                | `null`                           | Index builder settings overrides                                     | System Update |
-| `ELASTICSEARCH_MIN_SEARCH_FILTER_LENGTH`                        | `3`                              | Minimum search filter length                                         | System Update |
-| `ELASTICSEARCH_INDEX_BUILDER_ENTITY_SETTINGS_OVERRIDES`         | `null`                           | Entity settings overrides                                            | System Update |
+| Environment Variable                                            | Default                          | Description                                                                                                                                                          | Components         |
+| --------------------------------------------------------------- | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| `ELASTICSEARCH_BUILD_INDICES_ALLOW_DOC_COUNT_MISMATCH`          | `false`                          | Allow document count mismatch when clone indices is enabled                                                                                                          | System Update      |
+| `ELASTICSEARCH_BUILD_INDICES_CLONE_INDICES`                     | `true`                           | Clone indices                                                                                                                                                        | System Update      |
+| `ELASTICSEARCH_BUILD_INDICES_RETENTION_UNIT`                    | `DAYS`                           | Retention unit for indices                                                                                                                                           | System Update      |
+| `ELASTICSEARCH_BUILD_INDICES_RETENTION_VALUE`                   | `60`                             | Retention value for indices                                                                                                                                          | System Update      |
+| `ELASTICSEARCH_BUILD_INDICES_REINDEX_OPTIMIZATION_ENABLED`      | `true`                           | Enable reindex optimization                                                                                                                                          | System Update      |
+| `ELASTICSEARCH_BUILD_INDICES_REINDEX_BATCH_SIZE`                | `5000`                           | Documents per scroll batch during reindex                                                                                                                            | System Update      |
+| `ELASTICSEARCH_BUILD_INDICES_REINDEX_MAX_SLICES`                | `256`                            | Maximum parallel reindex slices (capped from target shards)                                                                                                          | System Update      |
+| `ELASTICSEARCH_BUILD_INDICES_REINDEX_NO_PROGRESS_RETRY_MINUTES` | `5`                              | Minutes without document-count progress before re-triggering reindex                                                                                                 | System Update      |
+| `ELASTICSEARCH_BUILD_INDICES_SLOW_OPERATION_TIMEOUT_SECONDS`    | `180`                            | Seconds; HTTP socket timeout for slow **build-indices** / system-update operations (`ESIndexBuilder`, reindex, count, tasks—not `ESBulkProcessor` by-query defaults) | GMS, System Update |
+| `ELASTICSEARCH_NUM_SHARDS_PER_INDEX`                            | `${elasticsearch.dataNodeCount}` | Number of shards per index, defaults to dataNodeCount                                                                                                                | System Update      |
+| `ELASTICSEARCH_NUM_REPLICAS_PER_INDEX`                          | `1`                              | Number of replicas per index                                                                                                                                         | System Update      |
+| `ELASTICSEARCH_INDEX_BUILDER_NUM_RETRIES`                       | `3`                              | Index builder number of retries                                                                                                                                      | System Update      |
+| `ELASTICSEARCH_INDEX_BUILDER_REFRESH_INTERVAL_SECONDS`          | `3`                              | Index builder refresh interval                                                                                                                                       | System Update      |
+| `SEARCH_DOCUMENT_MAX_ARRAY_LENGTH`                              | `1000`                           | Maximum array length in search documents                                                                                                                             | System Update      |
+| `SEARCH_DOCUMENT_MAX_OBJECT_KEYS`                               | `1000`                           | Maximum object keys in search documents                                                                                                                              | System Update      |
+| `SEARCH_DOCUMENT_MAX_VALUE_LENGTH`                              | `4096`                           | Maximum value length in search documents                                                                                                                             | System Update      |
+| `ELASTICSEARCH_MAIN_TOKENIZER`                                  | `null`                           | Main tokenizer                                                                                                                                                       | System Update      |
+| `ELASTICSEARCH_INDEX_BUILDER_MAPPINGS_REINDEX`                  | `false`                          | Enable mappings reindex                                                                                                                                              | System Update      |
+| `ELASTICSEARCH_INDEX_BUILDER_SETTINGS_REINDEX`                  | `false`                          | Enable settings reindex                                                                                                                                              | System Update      |
+| `ELASTICSEARCH_INDEX_BUILDER_MAX_REINDEX_HOURS`                 | `0`                              | Maximum reindex hours (0 = no timeout)                                                                                                                               | System Update      |
+| `ELASTICSEARCH_INDEX_BUILDER_SETTINGS_OVERRIDES`                | `null`                           | Index builder settings overrides                                                                                                                                     | System Update      |
+| `ELASTICSEARCH_MIN_SEARCH_FILTER_LENGTH`                        | `3`                              | Minimum search filter length                                                                                                                                         | System Update      |
+| `ELASTICSEARCH_INDEX_BUILDER_ENTITY_SETTINGS_OVERRIDES`         | `null`                           | Entity settings overrides                                                                                                                                            | System Update      |
 
 #### Search Configuration
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/client/shim/impl/ElasticsearchRestClientAdapter.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/client/shim/impl/ElasticsearchRestClientAdapter.java
@@ -1,0 +1,45 @@
+package com.linkedin.metadata.search.elasticsearch.client.shim.impl;
+
+import java.io.IOException;
+import org.apache.http.Header;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+
+/**
+ * Maps OpenSearch shim types to Elasticsearch REST client types. Uses {@link OpenSearchRestRequest}
+ * / {@link OpenSearchRestRequestOptions} so this class can import Elasticsearch {@link Request},
+ * {@link Response}, and {@link RequestOptions} without colliding with OpenSearch shim types of the
+ * same simple name.
+ */
+public final class ElasticsearchRestClientAdapter {
+
+  private ElasticsearchRestClientAdapter() {}
+
+  public static Request toElasticsearchRequest(OpenSearchRestRequest request) {
+    var os = request.request();
+    Request esRequest = new Request(os.getMethod(), os.getEndpoint());
+    esRequest.addParameters(os.getParameters());
+    esRequest.setEntity(os.getEntity());
+    return esRequest;
+  }
+
+  public static RequestOptions toElasticsearchRequestOptions(OpenSearchRestRequestOptions options) {
+    var os = options.options();
+    RequestOptions.Builder builder = RequestOptions.DEFAULT.toBuilder();
+    if (os.getRequestConfig() != null) {
+      builder.setRequestConfig(os.getRequestConfig());
+    }
+    for (Header header : os.getHeaders()) {
+      builder.addHeader(header.getName(), header.getValue());
+    }
+    os.getParameters().forEach(builder::addParameter);
+    return builder.build();
+  }
+
+  public static Response performRequest(RestClient restClient, OpenSearchRestRequest request)
+      throws IOException {
+    return restClient.performRequest(toElasticsearchRequest(request));
+  }
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/client/shim/impl/Es8SearchClientShim.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/client/shim/impl/Es8SearchClientShim.java
@@ -4,6 +4,7 @@ import static com.linkedin.metadata.search.elasticsearch.client.shim.SearchClien
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._helpers.bulk.BulkIngester;
+import co.elastic.clients.elasticsearch._helpers.bulk.BulkListener;
 import co.elastic.clients.elasticsearch._types.Conflicts;
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import co.elastic.clients.elasticsearch._types.FieldValue;
@@ -75,9 +76,8 @@ import co.elastic.clients.json.JsonData;
 import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.LazyDeserializer;
 import co.elastic.clients.json.jackson.JacksonJsonpMapper;
-import co.elastic.clients.transport.DefaultTransportOptions;
 import co.elastic.clients.transport.TransportOptions;
-import co.elastic.clients.transport.http.HeaderMap;
+import co.elastic.clients.transport.rest_client.RestClientOptions;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -97,6 +97,7 @@ import com.linkedin.metadata.utils.elasticsearch.shim.KnnSearchResponse;
 import com.linkedin.metadata.utils.elasticsearch.shim.SemanticIndexSpec;
 import com.linkedin.metadata.utils.metrics.MetricUtils;
 import java.io.IOException;
+import java.io.Reader;
 import java.io.StringReader;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -118,7 +119,6 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.http.Header;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpStatus;
 import org.apache.http.auth.AuthScope;
@@ -140,6 +140,7 @@ import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
 import org.apache.http.nio.reactor.IOReactorException;
 import org.apache.http.nio.reactor.IOReactorExceptionHandler;
 import org.apache.http.ssl.SSLContexts;
+import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.opensearch.action.DocWriteRequest;
@@ -1479,12 +1480,10 @@ public class Es8SearchClientShim extends AbstractBulkProcessorShim<BulkIngester<
   @Nonnull
   @Override
   public RawResponse performLowLevelRequest(Request request) throws IOException {
-    org.elasticsearch.client.Request esRequest =
-        new org.elasticsearch.client.Request(request.getMethod(), request.getEndpoint());
-    esRequest.addParameters(request.getParameters());
-    esRequest.setEntity(request.getEntity());
-    org.elasticsearch.client.Response esResponse =
-        ((RestClientTransport) client._transport()).restClient().performRequest(esRequest);
+    Response esResponse =
+        ElasticsearchRestClientAdapter.performRequest(
+            ((RestClientTransport) client._transport()).restClient(),
+            new OpenSearchRestRequest(request));
 
     return new RawResponse(
         esResponse.getRequestLine(),
@@ -1617,8 +1616,7 @@ public class Es8SearchClientShim extends AbstractBulkProcessorShim<BulkIngester<
       int threadCount) {
     Supplier<BulkIngester<?>> processorSupplier =
         () -> {
-          co.elastic.clients.elasticsearch._helpers.bulk.BulkListener<Object> esBulkListener =
-              new Es8BulkListener(metricUtils);
+          BulkListener<Object> esBulkListener = new Es8BulkListener(metricUtils);
 
           final Refresh refresh;
           switch (writeRequestRefreshPolicy) {
@@ -1775,15 +1773,20 @@ public class Es8SearchClientShim extends AbstractBulkProcessorShim<BulkIngester<
     if (RequestOptions.DEFAULT.equals(requestOptions)) {
       return client;
     }
-    HeaderMap headerMap =
-        new HeaderMap(
-            requestOptions.getHeaders().stream()
-                .collect(Collectors.toMap(Header::getName, Header::getValue)));
     TransportOptions transportOptions =
-        new DefaultTransportOptions(headerMap, Collections.emptyMap(), null);
+        new RestClientOptions(
+            ElasticsearchRestClientAdapter.toElasticsearchRequestOptions(
+                new OpenSearchRestRequestOptions(requestOptions)),
+            false);
     return client.withTransportOptions(transportOptions);
   }
 
+  /**
+   * Maps OpenSearch {@link RequestOptions} (shim API) to Elasticsearch {@link
+   * org.elasticsearch.client.RequestOptions} so per-request {@link
+   * org.apache.http.client.config.RequestConfig} (e.g. socket timeout for bulk-by-scroll) is
+   * honored by the ES Java API client.
+   */
   private Query convertQuery(org.opensearch.index.query.QueryBuilder osQuery) {
     if (osQuery == null) {
       return null;
@@ -1968,7 +1971,7 @@ public class Es8SearchClientShim extends AbstractBulkProcessorShim<BulkIngester<
     return document;
   }
 
-  private java.io.Reader toJsonReader(Map<String, Object> body) {
+  private Reader toJsonReader(Map<String, Object> body) {
     try {
       return new StringReader(objectMapper.writeValueAsString(body));
     } catch (JsonProcessingException e) {

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/client/shim/impl/OpenSearchRestRequest.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/client/shim/impl/OpenSearchRestRequest.java
@@ -1,0 +1,9 @@
+package com.linkedin.metadata.search.elasticsearch.client.shim.impl;
+
+import org.opensearch.client.Request;
+
+/**
+ * Holds an OpenSearch REST {@link Request} so adapters avoid simple-name clashes with Elasticsearch
+ * REST types.
+ */
+public record OpenSearchRestRequest(Request request) {}

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/client/shim/impl/OpenSearchRestRequestOptions.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/client/shim/impl/OpenSearchRestRequestOptions.java
@@ -1,0 +1,9 @@
+package com.linkedin.metadata.search.elasticsearch.client.shim.impl;
+
+import org.opensearch.client.RequestOptions;
+
+/**
+ * Holds OpenSearch {@link RequestOptions} so adapters avoid clashes with Elasticsearch REST {@code
+ * RequestOptions}.
+ */
+public record OpenSearchRestRequestOptions(RequestOptions options) {}

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/update/ESBulkProcessor.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/update/ESBulkProcessor.java
@@ -46,6 +46,15 @@ public class ESBulkProcessor implements Closeable {
   @Builder.Default private Long retryInterval = 1L;
   @Builder.Default private Integer threadCount = 1; // Default to single processor
   @Builder.Default private TimeValue defaultTimeout = TimeValue.timeValueMinutes(1);
+
+  /**
+   * HTTP {@link RequestOptions} for by-query operations (delete/update-by-query, async submit,
+   * etc.). Same tuning for GMS and MAE ({@code
+   * elasticsearch.bulkProcessor.slowByQueryOperationTimeoutSeconds}); MAE-specific RestClient
+   * settings are configured separately on {@link SearchClientShim}.
+   */
+  @Builder.Default @Nonnull private RequestOptions byQueryRequestOptions = RequestOptions.DEFAULT;
+
   @Getter private final WriteRequest.RefreshPolicy writeRequestRefreshPolicy;
 
   private final MetricUtils metricUtils;
@@ -60,6 +69,7 @@ public class ESBulkProcessor implements Closeable {
       Long retryInterval,
       Integer threadCount,
       TimeValue defaultTimeout,
+      @Nonnull RequestOptions byQueryRequestOptions,
       WriteRequest.RefreshPolicy writeRequestRefreshPolicy,
       MetricUtils metricUtils) {
     this.searchClient = searchClient;
@@ -71,6 +81,7 @@ public class ESBulkProcessor implements Closeable {
     this.retryInterval = retryInterval;
     this.threadCount = threadCount;
     this.defaultTimeout = defaultTimeout;
+    this.byQueryRequestOptions = byQueryRequestOptions;
     this.writeRequestRefreshPolicy = writeRequestRefreshPolicy;
     if (async) {
       searchClient.generateAsyncBulkProcessor(
@@ -127,14 +138,13 @@ public class ESBulkProcessor implements Closeable {
 
   public Optional<BulkByScrollResponse> updateByQuery(
       Script script, QueryBuilder queryBuilder, String... indices) {
-    // Create an UpdateByQueryRequest
     UpdateByQueryRequest updateByQuery = new UpdateByQueryRequest(indices);
     updateByQuery.setQuery(queryBuilder);
     updateByQuery.setScript(script);
 
     try {
       final BulkByScrollResponse updateResponse =
-          searchClient.updateByQuery(updateByQuery, RequestOptions.DEFAULT);
+          searchClient.updateByQuery(updateByQuery, byQueryRequestOptions);
       if (metricUtils != null)
         metricUtils.increment(this.getClass(), ES_WRITES_METRIC, updateResponse.getTotal());
       return Optional.of(updateResponse);
@@ -161,12 +171,10 @@ public class ESBulkProcessor implements Closeable {
 
     try {
       if (!batchDelete) {
-        // flush pending writes
         searchClient.flushBulkProcessor();
       }
-      // perform delete after local flush
       final BulkByScrollResponse deleteResponse =
-          searchClient.deleteByQuery(deleteByQueryRequest, RequestOptions.DEFAULT);
+          searchClient.deleteByQuery(deleteByQueryRequest, byQueryRequestOptions);
       if (metricUtils != null)
         metricUtils.increment(this.getClass(), ES_WRITES_METRIC, deleteResponse.getTotal());
       return Optional.of(deleteResponse);
@@ -195,14 +203,12 @@ public class ESBulkProcessor implements Closeable {
     if (timeout != null) {
       deleteByQueryRequest.setTimeout(timeout);
     }
-    // count the number of conflicts, but do not abort the operation
     deleteByQueryRequest.setConflicts("proceed");
     deleteByQueryRequest.indices(indices);
     try {
-      // flush pending writes
       searchClient.flushBulkProcessor();
       String resp =
-          searchClient.submitDeleteByQueryTask(deleteByQueryRequest, RequestOptions.DEFAULT);
+          searchClient.submitDeleteByQueryTask(deleteByQueryRequest, byQueryRequestOptions);
       if (metricUtils != null) metricUtils.increment(this.getClass(), ES_BATCHES_METRIC, 1);
       return Optional.of(resp);
     } catch (Exception e) {
@@ -217,7 +223,7 @@ public class ESBulkProcessor implements Closeable {
 
   @Override
   public void close() throws IOException {
-    flush(); // Make sure pending operations are flushed
+    flush();
     searchClient.closeBulkProcessor();
   }
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
@@ -597,6 +597,7 @@ public class PropertiesCollectorConfigurationTest extends AbstractTestNGSpringCo
           "elasticsearch.bulkProcessor.refreshPolicy",
           "elasticsearch.bulkProcessor.requestsLimit",
           "elasticsearch.bulkProcessor.sizeLimit",
+          "elasticsearch.bulkProcessor.slowByQueryOperationTimeoutSeconds",
           "elasticsearch.bulkProcessor.threadCount",
           "elasticsearch.dataNodeCount",
           "elasticsearch.bulkProcessor.retryInterval",
@@ -996,6 +997,10 @@ public class PropertiesCollectorConfigurationTest extends AbstractTestNGSpringCo
           "elasticsearch.entityIndex.semanticSearch.models.nomic_embed_text.spaceType",
           "elasticsearch.entityIndex.semanticSearch.models.nomic_embed_text.efConstruction",
           "elasticsearch.entityIndex.semanticSearch.models.nomic_embed_text.m",
+          // MAE consumer (shared YAML; active when MAE_CONSUMER_ENABLED=true)
+          "maeConsumer.enabled",
+          "maeConsumer.elasticsearch.socketTimeoutMs",
+          "maeConsumer.elasticsearch.connectionRequestTimeoutMs",
           // Metadata Change Log configuration
           "metadataChangeLog.consumer.batch.enabled",
           "metadataChangeLog.consumer.batch.size",

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/elasticsearch/ElasticsearchConnectorFactory.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/elasticsearch/ElasticsearchConnectorFactory.java
@@ -15,7 +15,7 @@ import org.springframework.context.annotation.Configuration;
 public class ElasticsearchConnectorFactory {
   @Autowired
   @Qualifier("elasticSearchBulkProcessor")
-  private ESBulkProcessor bulkProcessor;
+  private ESBulkProcessor elasticSearchBulkProcessor;
 
   @Value("${elasticsearch.bulkProcessor.numRetries}")
   private Integer numRetries;
@@ -23,6 +23,6 @@ public class ElasticsearchConnectorFactory {
   @Bean(name = "elasticsearchConnector")
   @Nonnull
   public ElasticsearchConnector createInstance() {
-    return new ElasticsearchConnector(bulkProcessor, numRetries);
+    return new ElasticsearchConnector(elasticSearchBulkProcessor, numRetries);
   }
 }

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/DataHubAppConfiguration.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/DataHubAppConfiguration.java
@@ -55,6 +55,12 @@ public class DataHubAppConfiguration {
   /** ElasticSearch configurations */
   private ElasticSearchConfiguration elasticSearch;
 
+  /**
+   * MAE consumer Elasticsearch tuning ({@code maeConsumer.*}); active when {@code
+   * MAE_CONSUMER_ENABLED=true}.
+   */
+  private MaeConsumerConfiguration maeConsumer;
+
   /** Search Service configurations */
   private SearchServiceConfiguration searchService;
 

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/MaeConsumerConfiguration.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/MaeConsumerConfiguration.java
@@ -1,0 +1,36 @@
+package com.linkedin.metadata.config;
+
+import lombok.Data;
+
+/**
+ * Elasticsearch tuning for {@code metadata-jobs/mae-consumer-job} and embedded MAE in GMS. Defaults
+ * and env-backed placeholders live only in {@code application.yaml} ({@code maeConsumer.*}). Covers
+ * MAE-specific <strong>RestClient</strong> timeouts only ({@code socketTimeoutMs}, {@code
+ * connectionRequestTimeoutMs}); OpenSearch by-query {@code RequestOptions} use {@code
+ * elasticsearch.bulkProcessor.slowByQueryOperationTimeoutSeconds} (same for GMS and MAE). Integer
+ * fields {@code >= 0} override {@code elasticsearch.*}; {@code -1} defers to global Elasticsearch
+ * client settings.
+ */
+@Data
+public class MaeConsumerConfiguration {
+
+  /**
+   * Mirrors {@code MAE_CONSUMER_ENABLED}; when true, {@code maeConsumer.elasticsearch} RestClient
+   * timeouts merge with {@code elasticsearch.*} on the shared {@code SearchClientShim}.
+   */
+  private Boolean enabled;
+
+  private Elasticsearch elasticsearch;
+
+  @Data
+  public static class Elasticsearch {
+    /** RestClient socket timeout (ms); {@code -1} uses {@code elasticsearch.socketTimeout}. */
+    private Integer socketTimeoutMs;
+
+    /**
+     * Connection-pool checkout timeout (ms); {@code -1} uses {@code
+     * elasticsearch.connectionRequestTimeout}.
+     */
+    private Integer connectionRequestTimeoutMs;
+  }
+}

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/search/BulkProcessorConfiguration.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/search/BulkProcessorConfiguration.java
@@ -13,4 +13,12 @@ import lombok.extern.slf4j.Slf4j;
 @NoArgsConstructor
 public class BulkProcessorConfiguration {
   private int numRetries;
+
+  /**
+   * Socket timeout in seconds for OpenSearch {@code RequestOptions} on by-query class operations
+   * (delete/update-by-query, etc.). Same value for GMS and MAE processes; MAE-only tuning applies
+   * to RestClient ({@code maeConsumer.elasticsearch.*}), not this setting. Not used for
+   * system-update build-indices / reindex flows—those use {@link BuildIndicesConfiguration}.
+   */
+  private int slowByQueryOperationTimeoutSeconds;
 }

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -370,6 +370,13 @@ cassandra:
   keyspace: ${CASSANDRA_KEYSPACE:datahub}
   useSsl: ${CASSANDRA_USE_SSL:false}
 
+# MAE consumer (standalone or embedded in GMS): separate ES HTTP tuning from interactive defaults.
+maeConsumer:
+  enabled: ${MAE_CONSUMER_ENABLED:false}
+  elasticsearch:
+    socketTimeoutMs: ${MAE_ELASTICSEARCH_SOCKET_TIMEOUT:120000}
+    connectionRequestTimeoutMs: ${MAE_ELASTICSEARCH_CONNECTION_REQUEST_TIMEOUT:10000}
+
 elasticsearch:
   host: ${ELASTICSEARCH_HOST:localhost}
   port: ${ELASTICSEARCH_PORT:9200}
@@ -495,6 +502,9 @@ elasticsearch:
     retryInterval: ${ES_BULK_RETRY_INTERVAL:1}
     refreshPolicy: ${ES_BULK_REFRESH_POLICY:NONE}
     enableBatchDelete: ${ES_BULK_ENABLE_BATCH_DELETE:false}
+    # By-query HTTP socket timeout (seconds) for delete/update-by-query RequestOptions (DEFAULT tuning).
+    # Distinct from elasticsearch.buildIndices.slowOperationTimeoutSeconds (system-update / ESIndexBuilder jobs).
+    slowByQueryOperationTimeoutSeconds: ${ELASTICSEARCH_BULK_BY_QUERY_SLOW_OPERATION_TIMEOUT_SECONDS:180}
   index:
     prefix: ${INDEX_PREFIX:}
     numShards: ${ELASTICSEARCH_NUM_SHARDS_PER_INDEX:${elasticsearch.dataNodeCount}}

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/search/ElasticSearchBulkProcessorFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/search/ElasticSearchBulkProcessorFactory.java
@@ -4,15 +4,15 @@ import com.linkedin.metadata.search.elasticsearch.update.ESBulkProcessor;
 import com.linkedin.metadata.utils.elasticsearch.SearchClientShim;
 import com.linkedin.metadata.utils.metrics.MetricUtils;
 import javax.annotation.Nonnull;
-import lombok.extern.slf4j.Slf4j;
+import org.apache.http.client.config.RequestConfig;
 import org.opensearch.action.support.WriteRequest;
+import org.opensearch.client.RequestOptions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-@Slf4j
 @Configuration
 public class ElasticSearchBulkProcessorFactory {
   @Autowired
@@ -43,9 +43,13 @@ public class ElasticSearchBulkProcessorFactory {
   @Value("${elasticsearch.threadCount}")
   private Integer threadCount;
 
+  @Value("${elasticsearch.bulkProcessor.slowByQueryOperationTimeoutSeconds}")
+  private int slowByQueryOperationTimeoutSeconds;
+
   @Bean(name = "elasticSearchBulkProcessor")
   @Nonnull
   protected ESBulkProcessor getInstance(MetricUtils metricUtils) {
+    RequestOptions byQueryOpts = buildByQueryRequestOptions(slowByQueryOperationTimeoutSeconds);
     return ESBulkProcessor.builder(searchClient, metricUtils)
         .async(async)
         .bulkFlushPeriod(bulkFlushPeriod)
@@ -54,7 +58,19 @@ public class ElasticSearchBulkProcessorFactory {
         .numRetries(numRetries)
         .threadCount(threadCount)
         .batchDelete(enableBatchDelete)
+        .byQueryRequestOptions(byQueryOpts)
         .writeRequestRefreshPolicy(WriteRequest.RefreshPolicy.valueOf(refreshPolicy))
         .build();
+  }
+
+  @Nonnull
+  static RequestOptions buildByQueryRequestOptions(int slowOperationTimeoutSeconds) {
+    int socketTimeoutMs = Math.max(1, slowOperationTimeoutSeconds) * 1000;
+    RequestConfig baseConfig = RequestOptions.DEFAULT.getRequestConfig();
+    RequestConfig requestConfig =
+        baseConfig != null
+            ? RequestConfig.copy(baseConfig).setSocketTimeout(socketTimeoutMs).build()
+            : RequestConfig.custom().setSocketTimeout(socketTimeoutMs).build();
+    return RequestOptions.DEFAULT.toBuilder().setRequestConfig(requestConfig).build();
   }
 }

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/search/SearchClientShimFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/search/SearchClientShimFactory.java
@@ -3,6 +3,7 @@ package com.linkedin.gms.factory.search;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.gms.factory.common.ElasticsearchSSLContextFactory;
 import com.linkedin.gms.factory.config.ConfigurationProvider;
+import com.linkedin.metadata.config.MaeConsumerConfiguration;
 import com.linkedin.metadata.config.search.ElasticSearchConfiguration;
 import com.linkedin.metadata.search.elasticsearch.client.shim.SearchClientShimUtil;
 import com.linkedin.metadata.search.elasticsearch.client.shim.SearchClientShimUtil.ShimConfigurationBuilder;
@@ -43,14 +44,74 @@ public class SearchClientShimFactory {
   private SSLContext elasticSearchSSLContext;
 
   /**
-   * Create the SearchClientShim bean. This can be configured to either: 1. Auto-detect the search
-   * engine type by connecting to the cluster 2. Use a specific engine type as configured in
-   * properties
+   * Create the SearchClientShim bean. This can be configured to either: (1) auto-detect the search
+   * engine type by connecting to the cluster, or (2) use a specific engine type from properties.
+   *
+   * <p>Single process-wide shim: uses {@code elasticsearch.*} timeouts, merged with {@code
+   * maeConsumer.elasticsearch.*} via {@code Math.max(global, mae)} when {@code
+   * maeConsumer.enabled=true} so MAE indexing and GMS share one client.
    */
   @Bean(name = "searchClientShim")
   @Nonnull
   public SearchClientShim<?> createSearchClientShim(ObjectMapper objectMapper) throws IOException {
     ElasticSearchConfiguration esConfig = configurationProvider.getElasticSearch();
+    MaeConsumerConfiguration mae = configurationProvider.getMaeConsumer();
+    int socketMs = mergeRestClientSocketTimeoutMs(esConfig.getSocketTimeout(), mae);
+    int connMs =
+        mergeRestClientConnectionRequestTimeoutMs(esConfig.getConnectionRequestTimeout(), mae);
+    if (Boolean.TRUE.equals(mae != null ? mae.getEnabled() : null)
+        && mae.getElasticsearch() != null) {
+      log.info(
+          "searchClientShim: merged MAE RestClient timeouts socketTimeoutMs={} connectionRequestTimeoutMs={}",
+          socketMs,
+          connMs);
+    }
+    return buildSearchClientShim(objectMapper, esConfig, socketMs, connMs);
+  }
+
+  /**
+   * Combines {@code elasticsearch.socketTimeout} with optional MAE {@code socketTimeoutMs} when
+   * {@code maeConsumer.enabled=true}. Package-private for unit tests.
+   */
+  static int mergeRestClientSocketTimeoutMs(
+      int elasticsearchSocketMs, MaeConsumerConfiguration mae) {
+    int result = elasticsearchSocketMs;
+    if (Boolean.TRUE.equals(mae != null ? mae.getEnabled() : null)
+        && mae != null
+        && mae.getElasticsearch() != null) {
+      Integer so = mae.getElasticsearch().getSocketTimeoutMs();
+      if (so != null && so >= 0) {
+        result = Math.max(result, so);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Combines {@code elasticsearch.connectionRequestTimeout} with optional MAE {@code
+   * connectionRequestTimeoutMs} when {@code maeConsumer.enabled=true}. Package-private for unit
+   * tests.
+   */
+  static int mergeRestClientConnectionRequestTimeoutMs(
+      int elasticsearchConnectionRequestTimeoutMs, MaeConsumerConfiguration mae) {
+    int result = elasticsearchConnectionRequestTimeoutMs;
+    if (Boolean.TRUE.equals(mae != null ? mae.getEnabled() : null)
+        && mae != null
+        && mae.getElasticsearch() != null) {
+      Integer cr = mae.getElasticsearch().getConnectionRequestTimeoutMs();
+      if (cr != null && cr >= 0) {
+        result = Math.max(result, cr);
+      }
+    }
+    return result;
+  }
+
+  private SearchClientShim<?> buildSearchClientShim(
+      ObjectMapper objectMapper,
+      ElasticSearchConfiguration esConfig,
+      int socketTimeoutMs,
+      int connectionRequestTimeoutMs)
+      throws IOException {
 
     // Build the shim configuration from DataHub configuration
     ShimConfigurationBuilder configBuilder =
@@ -63,8 +124,8 @@ public class SearchClientShimFactory {
             .withPathPrefix(esConfig.getPathPrefix())
             .withAwsIamAuth(esConfig.isOpensearchUseAwsIamAuth(), esConfig.getRegion())
             .withThreadCount(esConfig.getThreadCount())
-            .withConnectionRequestTimeout(esConfig.getConnectionRequestTimeout())
-            .withSocketTimeout(esConfig.getSocketTimeout());
+            .withConnectionRequestTimeout(connectionRequestTimeoutMs)
+            .withSocketTimeout(socketTimeoutMs);
 
     // Determine how to create the shim
     SearchClientShim<?> shim;

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/search/ElasticSearchBulkProcessorFactoryTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/search/ElasticSearchBulkProcessorFactoryTest.java
@@ -3,14 +3,13 @@ package com.linkedin.gms.factory.search;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
-import com.linkedin.gms.factory.config.ConfigurationProvider;
 import com.linkedin.metadata.search.elasticsearch.update.ESBulkProcessor;
 import com.linkedin.metadata.utils.elasticsearch.SearchClientShim;
 import com.linkedin.metadata.utils.metrics.MetricUtils;
 import org.mockito.Answers;
 import org.opensearch.action.support.WriteRequest;
+import org.opensearch.client.RequestOptions;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -19,7 +18,6 @@ import org.testng.annotations.Test;
 
 @TestPropertySource(locations = "classpath:/application.yaml")
 @SpringBootTest(classes = {ElasticSearchBulkProcessorFactory.class})
-@EnableConfigurationProperties(ConfigurationProvider.class)
 public class ElasticSearchBulkProcessorFactoryTest extends AbstractTestNGSpringContextTests {
   @Autowired ESBulkProcessor test;
 
@@ -32,5 +30,12 @@ public class ElasticSearchBulkProcessorFactoryTest extends AbstractTestNGSpringC
   void testInjection() {
     assertNotNull(test);
     assertEquals(WriteRequest.RefreshPolicy.NONE, test.getWriteRequestRefreshPolicy());
+  }
+
+  @Test
+  void byQueryRequestOptionsUsesConfiguredSocketTimeoutMs() {
+    RequestOptions opts = ElasticSearchBulkProcessorFactory.buildByQueryRequestOptions(180);
+    assertNotNull(opts.getRequestConfig());
+    assertEquals(180_000, opts.getRequestConfig().getSocketTimeout());
   }
 }

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/search/SearchClientShimFactoryMaeTimeoutMergeTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/search/SearchClientShimFactoryMaeTimeoutMergeTest.java
@@ -1,0 +1,103 @@
+package com.linkedin.gms.factory.search;
+
+import static org.testng.Assert.assertEquals;
+
+import com.linkedin.metadata.config.MaeConsumerConfiguration;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/** Unit tests for MAE / global RestClient timeout merge in {@link SearchClientShimFactory}. */
+public class SearchClientShimFactoryMaeTimeoutMergeTest {
+
+  @Test
+  public void socketWhenMaeNull_usesElasticsearch() {
+    assertEquals(SearchClientShimFactory.mergeRestClientSocketTimeoutMs(30_000, null), 30_000);
+  }
+
+  @Test
+  public void socketWhenMaeDisabled_usesElasticsearch() {
+    MaeConsumerConfiguration mae = new MaeConsumerConfiguration();
+    mae.setEnabled(false);
+    mae.setElasticsearch(mel(60_000, 10_000));
+    assertEquals(SearchClientShimFactory.mergeRestClientSocketTimeoutMs(30_000, mae), 30_000);
+  }
+
+  @Test
+  public void socketWhenMaeEnabledButNestedElasticsearchNull_usesElasticsearch() {
+    MaeConsumerConfiguration mae = new MaeConsumerConfiguration();
+    mae.setEnabled(true);
+    mae.setElasticsearch(null);
+    assertEquals(SearchClientShimFactory.mergeRestClientSocketTimeoutMs(30_000, mae), 30_000);
+  }
+
+  @Test
+  public void socketWhenOverrideHigher_takesMax() {
+    MaeConsumerConfiguration mae = maeEnabled(mel(90_000, null));
+    assertEquals(SearchClientShimFactory.mergeRestClientSocketTimeoutMs(30_000, mae), 90_000);
+  }
+
+  @Test
+  public void socketWhenOverrideLower_keepsElasticsearch() {
+    MaeConsumerConfiguration mae = maeEnabled(mel(10_000, null));
+    assertEquals(SearchClientShimFactory.mergeRestClientSocketTimeoutMs(30_000, mae), 30_000);
+  }
+
+  @Test
+  public void socketWhenOverrideNull_usesElasticsearch() {
+    MaeConsumerConfiguration.Elasticsearch mel = new MaeConsumerConfiguration.Elasticsearch();
+    mel.setSocketTimeoutMs(null);
+    mel.setConnectionRequestTimeoutMs(5_000);
+    assertEquals(
+        SearchClientShimFactory.mergeRestClientSocketTimeoutMs(30_000, maeEnabled(mel)), 30_000);
+  }
+
+  @Test
+  public void socketWhenOverrideNegative_ignored() {
+    // -1 defers to global per maeConsumer docs; non-negative values participate in Math.max
+    MaeConsumerConfiguration mae = maeEnabled(mel(-1, 5_000));
+    assertEquals(SearchClientShimFactory.mergeRestClientSocketTimeoutMs(30_000, mae), 30_000);
+  }
+
+  @Test
+  public void connectionWhenMaeNull_usesElasticsearch() {
+    assertEquals(
+        SearchClientShimFactory.mergeRestClientConnectionRequestTimeoutMs(5_000, null), 5_000);
+  }
+
+  @Test
+  public void connectionOverrideHigher_takesMax() {
+    MaeConsumerConfiguration mae = maeEnabled(mel(null, 20_000));
+    assertEquals(
+        SearchClientShimFactory.mergeRestClientConnectionRequestTimeoutMs(5_000, mae), 20_000);
+  }
+
+  @DataProvider
+  public Object[][] enabledNotTrueCases() {
+    return new Object[][] {
+      {null}, {Boolean.FALSE},
+    };
+  }
+
+  @Test(dataProvider = "enabledNotTrueCases")
+  public void socketWhenMaeNotExplicitlyEnabled_noMerge(Boolean enabled) {
+    MaeConsumerConfiguration mae = new MaeConsumerConfiguration();
+    mae.setEnabled(enabled);
+    mae.setElasticsearch(mel(999_000, 999_000));
+    assertEquals(SearchClientShimFactory.mergeRestClientSocketTimeoutMs(30_000, mae), 30_000);
+  }
+
+  private static MaeConsumerConfiguration.Elasticsearch mel(
+      Integer socketTimeoutMs, Integer connectionRequestTimeoutMs) {
+    MaeConsumerConfiguration.Elasticsearch mel = new MaeConsumerConfiguration.Elasticsearch();
+    mel.setSocketTimeoutMs(socketTimeoutMs);
+    mel.setConnectionRequestTimeoutMs(connectionRequestTimeoutMs);
+    return mel;
+  }
+
+  private static MaeConsumerConfiguration maeEnabled(MaeConsumerConfiguration.Elasticsearch mel) {
+    MaeConsumerConfiguration mae = new MaeConsumerConfiguration();
+    mae.setEnabled(true);
+    mae.setElasticsearch(mel);
+    return mae;
+  }
+}

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/search/SearchClientShimFactorySemanticGateTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/search/SearchClientShimFactorySemanticGateTest.java
@@ -70,6 +70,12 @@ public class SearchClientShimFactorySemanticGateTest {
     SearchClientShimFactory.assertCompatModeNotSemanticEnabled(es8Shim, true);
   }
 
+  @Test
+  public void factoryAllowsNonEs7CompatibilityShimWhenSemanticSearchEnabled() {
+    SearchClientShim<?> plainShim = mock(SearchClientShim.class);
+    SearchClientShimFactory.assertCompatModeNotSemanticEnabled(plainShim, true);
+  }
+
   // ---------------------------------------------------------------------------
   // Version-gate tests for Es8SearchClientShim.assertSemanticSearchSupported()
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This change aligns **OpenSearch/Elasticsearch by-query** behavior (delete-by-query, update-by-query) for **GMS and the MAE consumer** by using a single configured socket timeout on `ESBulkProcessor` via `elasticsearch.bulkProcessor.slowByQueryOperationTimeoutSeconds` (and `ELASTICSEARCH_BULK_BY_QUERY_SLOW_OPERATION_TIMEOUT_SECONDS`).

**MAE-specific** tuning is limited to **RestClient** settings: when `maeConsumer.enabled` is true, `maeConsumer.elasticsearch.socketTimeoutMs` and `connectionRequestTimeoutMs` are merged with the global `elasticsearch.*` values using `Math.max` in `SearchClientShimFactory`, so GMS and MAE share one shim with higher timeouts when MAE asks for them.

## What changed

- **ESBulkProcessor**: one `byQueryRequestOptions` built from `slowByQueryOperationTimeoutSeconds`; no separate MAE by-query path.
- **ElasticSearchBulkProcessorFactory**: builds shared `RequestOptions` for by-query; factory test updated.
- **SearchClientShimFactory**: MAE RestClient timeout merge extracted into testable `mergeRestClientSocketTimeoutMs` / `mergeRestClientConnectionRequestTimeoutMs`; preserves semantic-search / ES8 startup checks and related comments.
- **Configuration**: `BulkProcessorConfiguration.slowByQueryOperationTimeoutSeconds`; new `MaeConsumerConfiguration` wired in `DataHubAppConfiguration` and `application.yaml`.
- **MAE job**: `ElasticsearchConnectorFactory` continues to use the shared bulk processor bean.
- **metadata-io**: small Es8/shim-related adjustments; adds `ElasticsearchRestClientAdapter`, `OpenSearchRestRequest`, `OpenSearchRestRequestOptions` where needed for the shim layer.
- **Docs**: `docs/deploy/environment-vars.md` (bulk by-query env + MAE RestClient vars); MAE Docker README/env hints.
- **Tests**: `SearchClientShimFactoryMaeTimeoutMergeTest` (merge rules); `SearchClientShimFactorySemanticGateTest` (non–ES7-compat shim + semantic); `PropertiesCollectorConfigurationTest` / `ElasticSearchBulkProcessorFactoryTest` updates.

## Notes for reviewers

- By-query timeout is **shared** across processes; MAE-only knobs are **RestClient** timeouts under `maeConsumer.elasticsearch.*`, not a second bulk by-query configuration.
- If operators previously set MAE-specific by-query timeouts, they should map to `ELASTICSEARCH_BULK_BY_QUERY_SLOW_OPERATION_TIMEOUT_SECONDS` (or the YAML equivalent) and use MAE env vars only for client/socket pool behavior.