### PR TITLE
feat(ingest/fabric-onelake): extract query usage from queryinsights

### DIFF
--- a/metadata-ingestion/docs/sources/fabric-onelake/README.md
+++ b/metadata-ingestion/docs/sources/fabric-onelake/README.md
@@ -2,7 +2,7 @@
 
 Microsoft Fabric OneLake is a storage and lakehouse platform. Learn more in the [official Microsoft Fabric OneLake documentation](https://learn.microsoft.com/fabric/onelake/onelake-overview).
 
-The DataHub integration for Microsoft Fabric OneLake covers workspace, lakehouse, and warehouse containers, table datasets with schema metadata, and view datasets with view definitions and view-to-table lineage parsed from the view SQL. It also captures stateful deletion detection.
+The DataHub integration for Microsoft Fabric OneLake covers workspace, lakehouse, and warehouse containers, table datasets with schema metadata, and view datasets with view definitions and view-to-table lineage parsed from the view SQL. It also extracts query usage statistics from the SQL Analytics Endpoint's `queryinsights` views, and captures stateful deletion detection.
 
 ## Concept Mapping
 

--- a/metadata-ingestion/docs/sources/fabric-onelake/fabric-onelake_post.md
+++ b/metadata-ingestion/docs/sources/fabric-onelake/fabric-onelake_post.md
@@ -266,6 +266,61 @@ source:
 3. **Schema**: Column metadata is reused from the same `INFORMATION_SCHEMA.COLUMNS` query that powers table schema extraction — no extra queries per view.
 4. **Lineage**: View definitions are passed to the SQL parsing aggregator to derive view → upstream table lineage. View URNs and upstream table URNs are resolved within the same workspace and item.
 
+#### Usage Statistics
+
+The connector extracts query usage statistics from each Lakehouse and Warehouse by reading the [`queryinsights.exec_requests_history`](https://learn.microsoft.com/en-us/fabric/data-warehouse/query-insights) view on the SQL Analytics Endpoint. Each captured query is parsed by the SQL parsing aggregator and emitted as:
+
+- `datasetUsageStatistics` aspects — query counts, distinct user counts, top users, top fields, and (when enabled) top SQL queries, bucketed by the configured window.
+- `operation` aspects — per-query operation events (insert, update, delete, etc.) when `usage.include_operational_stats` is enabled.
+
+##### Prerequisites
+
+Usage extraction reuses the SQL Analytics Endpoint connection used by [Schema Extraction](#schema-extraction). The same ODBC driver and permissions apply, plus:
+
+- `sql_endpoint.enabled` must be `true` — `queryinsights` views live on the SQL Analytics Endpoint, so the connector cannot read them otherwise. The configuration validator will reject `usage.include_usage_statistics=true` if the endpoint is not enabled.
+- The authenticated identity needs `SELECT` access on `queryinsights.exec_requests_history`. The view returns rows visible to the calling principal under Fabric's standard query-history visibility rules.
+- Microsoft Fabric retains query insights data for **30 days**. Older history cannot be backfilled, so configure `usage.start_time` accordingly.
+
+##### Configuration
+
+```yaml
+source:
+  type: fabric-onelake
+  config:
+    # Usage extraction is enabled by default. Set to false to skip query usage.
+    usage:
+      include_usage_statistics: true
+
+      # When true, the SQL filter excludes rows where status != 'Succeeded'
+      # (canceled / failed queries are skipped at the source).
+      skip_failed_queries: true
+
+      # Optional: emit per-query operation aspects in addition to aggregated
+      # datasetUsageStatistics. Defaults to true (inherited from BaseUsageConfig).
+      include_operational_stats: true
+
+      # Optional: include top SQL queries in the usage payload.
+      include_top_n_queries: true
+      top_n_queries: 10
+
+      # Optional: window the connector queries from queryinsights. Defaults to
+      # the standard BaseUsageConfig "last bucket" window. Fabric retains
+      # queryinsights for 30 days.
+      bucket_duration: DAY
+      # start_time: "2026-04-01T00:00:00Z"
+      # end_time:   "2026-05-01T00:00:00Z"
+
+    # Usage extraction depends on the SQL Analytics Endpoint.
+    extract_schema:
+      enabled: true
+    sql_endpoint:
+      enabled: true
+```
+
+All standard `BaseUsageConfig` fields (`bucket_duration`, `start_time`, `end_time`, `top_n_queries`, `format_sql_queries`, `include_top_n_queries`, `include_operational_stats`, `user_email_pattern`, etc.) are supported under the `usage` block.
+
+When stateful ingestion is enabled, the usage time window is checkpointed only after a successful run, so a partial or failed run won't silently skip the next window.
+
 #### Schemas-Enabled vs Schemas-Disabled Lakehouses
 
 The connector automatically handles both schemas-enabled and schemas-disabled lakehouses:
@@ -304,6 +359,8 @@ Module behavior is constrained by source APIs, permissions, and metadata exposed
   - Table count limits in very large databases
 - **Graceful Degradation**: If schema extraction fails for a table, the table will still be ingested without column metadata (no ingestion failure)
 - **View Extraction Requires SQL Endpoint**: Views are only discovered through the SQL Analytics Endpoint. If `sql_endpoint.enabled` is `false`, or if the endpoint is unreachable for a given Lakehouse/Warehouse, views in that item will not be ingested.
+- **Usage Statistics Retention**: Fabric `queryinsights` retains query history for only **30 days**. Older usage cannot be backfilled, regardless of the configured `usage.start_time`.
+- **Usage Statistics Requires SQL Endpoint**: Usage extraction reads `queryinsights.exec_requests_history` over the SQL Analytics Endpoint. If `sql_endpoint.enabled` is `false`, the configuration validator will reject `usage.include_usage_statistics=true`. If the endpoint is unreachable for a specific Lakehouse/Warehouse, usage for that item is skipped without failing the run.
 
 ### Troubleshooting
 

--- a/metadata-ingestion/docs/sources/fabric-onelake/fabric-onelake_post.md
+++ b/metadata-ingestion/docs/sources/fabric-onelake/fabric-onelake_post.md
@@ -273,13 +273,7 @@ The connector extracts query usage statistics from each Lakehouse and Warehouse 
 - `datasetUsageStatistics` aspects — query counts, distinct user counts, top users, top fields, and (when enabled) top SQL queries, bucketed by the configured window.
 - `operation` aspects — per-query operation events (insert, update, delete, etc.) when `usage.include_operational_stats` is enabled.
 
-##### Prerequisites
-
-Usage extraction reuses the SQL Analytics Endpoint connection used by [Schema Extraction](#schema-extraction). The same ODBC driver and permissions apply, plus:
-
-- `sql_endpoint.enabled` must be `true` — `queryinsights` views live on the SQL Analytics Endpoint, so the connector cannot read them otherwise. The configuration validator will reject `usage.include_usage_statistics=true` if the endpoint is not enabled.
-- The authenticated identity needs `SELECT` access on `queryinsights.exec_requests_history`. The view returns rows visible to the calling principal under Fabric's standard query-history visibility rules.
-- Microsoft Fabric retains query insights data for **30 days**. Older history cannot be backfilled, so configure `usage.start_time` accordingly.
+See [Query Usage Statistics](#query-usage-statistics) under Prerequisites for the required workspace role (Contributor or higher) and ODBC setup.
 
 ##### Configuration
 

--- a/metadata-ingestion/docs/sources/fabric-onelake/fabric-onelake_pre.md
+++ b/metadata-ingestion/docs/sources/fabric-onelake/fabric-onelake_pre.md
@@ -16,6 +16,7 @@ The `fabric-onelake` module ingests metadata from Fabric Onelake into DataHub. I
 - Table datasets with proper subtypes
 - View datasets with view definitions captured from the SQL Analytics endpoint
 - View-to-table lineage parsed from view definitions
+- Query usage statistics and operation aspects derived from `queryinsights.exec_requests_history`
 - Automatic detection and handling of schemas-enabled and schemas-disabled lakehouses
 - Pattern-based filtering for workspaces, lakehouses, warehouses, tables, and views
 - Stateful ingestion for stale entity removal

--- a/metadata-ingestion/docs/sources/fabric-onelake/fabric-onelake_pre.md
+++ b/metadata-ingestion/docs/sources/fabric-onelake/fabric-onelake_pre.md
@@ -223,3 +223,11 @@ Reading view definitions (needed for view-to-table lineage) requires `VIEW DEFIN
 If neither is acceptable for your environment, set `extract_views: false` to skip view ingestion. Views will still appear without definitions if you ingest them at Viewer level, but lineage will be missing.
 
 References: [Fabric Warehouse roles and permissions](https://learn.microsoft.com/en-us/fabric/data-warehouse/share-warehouse-manage-permissions), [Lakehouse workspace roles](https://learn.microsoft.com/en-us/fabric/data-engineering/workspace-roles-lakehouse).
+
+#### Query Usage Statistics
+
+Usage extraction reads [`queryinsights.exec_requests_history`](https://learn.microsoft.com/en-us/fabric/data-warehouse/query-insights) over the SQL Analytics Endpoint. It reuses the ODBC setup from [SQL Analytics Endpoint Setup](#sql-analytics-endpoint-setup), so `sql_endpoint.enabled` must be `true` — the configuration validator rejects `usage.include_usage_statistics=true` otherwise.
+
+**Required role.** Visibility into `queryinsights` is **scoped per workspace**. The ingesting identity (service principal, managed identity, or user) needs **Contributor or higher** on each workspace whose Lakehouses/Warehouses you want usage for. The workspace **Viewer** role used for table ingestion is _not_ sufficient: per [Microsoft's docs](https://learn.microsoft.com/en-us/fabric/data-warehouse/query-insights), `queryinsights` requires _"contributor or higher permissions"_ on a Premium-capacity workspace, and full query text — needed for SQL parsing and column-level usage — is only exposed to Admin, Member, and Contributor roles.
+
+**Retention and latency.** Fabric retains `queryinsights` for **30 days only** — older history cannot be backfilled, so configure `usage.start_time` accordingly. Newly executed queries can take up to 15 minutes to appear, increasing under concurrency. System queries and queries from outside a user's context are not surfaced.

--- a/metadata-ingestion/docs/sources/fabric-onelake/fabric-onelake_recipe.yml
+++ b/metadata-ingestion/docs/sources/fabric-onelake/fabric-onelake_recipe.yml
@@ -76,6 +76,19 @@ source:
     #   trust_server_certificate: "no"  # Trust server certificate (default: "no")
     #   query_timeout: 30  # Timeout for SQL queries in seconds (default: 30)
 
+    # Optional: Query usage extraction. Reads queryinsights.exec_requests_history
+    # on each Lakehouse/Warehouse SQL Analytics Endpoint. Requires sql_endpoint.enabled=true.
+    # Fabric retains queryinsights for 30 days.
+    # usage:
+    #   include_usage_statistics: true   # Master toggle (default: true)
+    #   skip_failed_queries: true        # Filter rows where status != 'Succeeded' (default: true)
+    #   include_operational_stats: true  # Emit per-query operation aspects (default: true)
+    #   include_top_n_queries: true
+    #   top_n_queries: 10
+    #   bucket_duration: DAY
+    #   # start_time: "2026-04-01T00:00:00Z"
+    #   # end_time:   "2026-05-01T00:00:00Z"
+
 sink:
   type: datahub-rest
   config:

--- a/metadata-ingestion/src/datahub/ingestion/autogenerated/connector_registry/datahub.json
+++ b/metadata-ingestion/src/datahub/ingestion/autogenerated/connector_registry/datahub.json
@@ -1317,6 +1317,12 @@
           "supported": true
         },
         {
+          "capability": "USAGE_STATS",
+          "description": "Extracted from queryinsights.exec_requests_history (30-day retention) when `usage.include_usage_statistics` is enabled. Column-level usage is derived via SQL parsing of the query text.",
+          "subtype_modifier": null,
+          "supported": true
+        },
+        {
           "capability": "DELETION_DETECTION",
           "description": "Enabled by default via stateful ingestion",
           "subtype_modifier": null,

--- a/metadata-ingestion/src/datahub/ingestion/autogenerated/connector_registry/datahub.json
+++ b/metadata-ingestion/src/datahub/ingestion/autogenerated/connector_registry/datahub.json
@@ -1329,6 +1329,12 @@
           "supported": true
         },
         {
+          "capability": "OPERATION_CAPTURE",
+          "description": "Optionally enabled via `usage.include_usage_statistics` and `usage.include_operational_stats`",
+          "subtype_modifier": null,
+          "supported": true
+        },
+        {
           "capability": "PLATFORM_INSTANCE",
           "description": "Enabled by default",
           "subtype_modifier": null,

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/client.py
@@ -37,10 +37,10 @@ def _parse_table_name(full_name: str) -> tuple[str, str]:
         schema_name, table_name = full_name.rsplit(".", 1)
     else:
         from datahub.ingestion.source.fabric.onelake.constants import (
-            DEFAULT_SCHEMA_SCHEMALESS_LAKEHOUSE,
+            FABRIC_SQL_DEFAULT_SCHEMA,
         )
 
-        schema_name = DEFAULT_SCHEMA_SCHEMALESS_LAKEHOUSE
+        schema_name = FABRIC_SQL_DEFAULT_SCHEMA
         table_name = full_name
     return schema_name, table_name
 

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/config.py
@@ -17,6 +17,7 @@ from datahub.ingestion.source.state.stale_entity_removal_handler import (
 from datahub.ingestion.source.state.stateful_ingestion_base import (
     StatefulIngestionConfigBase,
 )
+from datahub.ingestion.source.usage.usage_common import BaseUsageConfig
 
 
 class ExtractSchemaConfig(ConfigModel):
@@ -73,6 +74,31 @@ class SqlEndpointConfig(ConfigModel):
         description="Timeout for SQL queries in seconds",
         ge=1,
         le=300,
+    )
+
+
+class FabricUsageConfig(BaseUsageConfig):
+    """Usage tracking configuration for Fabric OneLake.
+
+    Retention is 30 days per Microsoft Fabric documentation:
+    https://learn.microsoft.com/en-us/fabric/data-warehouse/query-insights
+    """
+
+    include_usage_statistics: bool = Field(
+        default=True,
+        description=(
+            "Master toggle for Fabric usage extraction. When False, no "
+            "`datasetUsageStatistics` or `operation` aspects are emitted from "
+            "queryinsights, regardless of `include_operational_stats`."
+        ),
+    )
+
+    skip_failed_queries: bool = Field(
+        default=True,
+        description=(
+            "When True, the SQL filter excludes rows where status != 'Succeeded' "
+            "(canceled / failed queries are skipped at the source)."
+        ),
     )
 
 
@@ -208,6 +234,16 @@ class FabricOneLakeSourceConfig(
         ),
     )
 
+    # Usage tracking
+    usage: FabricUsageConfig = Field(
+        default=FabricUsageConfig(),
+        description=(
+            "Usage tracking configuration. Reads `queryinsights.exec_requests_history` "
+            "on each Lakehouse/Warehouse SQL Analytics Endpoint. Requires "
+            "`extract_schema.enabled=True` and a configured `sql_endpoint`."
+        ),
+    )
+
     @model_validator(mode="after")
     def validate_sql_endpoint_dependencies(self):
         """sql_endpoint must be configured when any feature that uses it is enabled.
@@ -229,5 +265,20 @@ class FabricOneLakeSourceConfig(
                 "when extract_schema.enabled=True with "
                 "method='sql_analytics_endpoint'. "
                 "Both features query the SQL Analytics Endpoint."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_usage_extraction_prerequisites(self):
+        """Usage requires the SQL Analytics Endpoint — queryinsights lives there."""
+        if self.usage.include_usage_statistics and (
+            self.sql_endpoint is None or not self.sql_endpoint.enabled
+        ):
+            raise ValueError(
+                "usage.include_usage_statistics=True requires a configured and "
+                "enabled sql_endpoint, because usage is read from "
+                "queryinsights.exec_requests_history on the SQL Analytics Endpoint. "
+                "Either set usage.include_usage_statistics=False to disable usage "
+                "extraction, or configure sql_endpoint with enabled=True."
             )
         return self

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/config.py
@@ -239,8 +239,8 @@ class FabricOneLakeSourceConfig(
         default=FabricUsageConfig(),
         description=(
             "Usage tracking configuration. Reads `queryinsights.exec_requests_history` "
-            "on each Lakehouse/Warehouse SQL Analytics Endpoint. Requires "
-            "`extract_schema.enabled=True` and a configured `sql_endpoint`."
+            "on each Lakehouse/Warehouse SQL Analytics Endpoint. Requires a "
+            "configured and enabled `sql_endpoint`."
         ),
     )
 
@@ -248,37 +248,34 @@ class FabricOneLakeSourceConfig(
     def validate_sql_endpoint_dependencies(self):
         """sql_endpoint must be configured when any feature that uses it is enabled.
 
-        Both view discovery (INFORMATION_SCHEMA.VIEWS) and column-level schema
-        extraction (INFORMATION_SCHEMA.COLUMNS) go through the SQL Analytics
-        Endpoint, but they are otherwise independent — a user may enable either
-        one without the other.
+        View discovery (INFORMATION_SCHEMA.VIEWS), column-level schema extraction
+        (INFORMATION_SCHEMA.COLUMNS), and usage statistics
+        (queryinsights.exec_requests_history) all go through the SQL Analytics
+        Endpoint but are otherwise independent.
         """
-        needs_sql_endpoint = self.extract_views or (
+        sql_endpoint_enabled = (
+            self.sql_endpoint is not None and self.sql_endpoint.enabled
+        )
+        if sql_endpoint_enabled:
+            return self
+
+        requiring_features = []
+        if self.extract_views:
+            requiring_features.append("extract_views=True")
+        if (
             self.extract_schema.enabled
             and self.extract_schema.method == "sql_analytics_endpoint"
-        )
-        if needs_sql_endpoint and (
-            self.sql_endpoint is None or not self.sql_endpoint.enabled
         ):
-            raise ValueError(
-                "sql_endpoint.enabled must be True when extract_views=True or "
-                "when extract_schema.enabled=True with "
-                "method='sql_analytics_endpoint'. "
-                "Both features query the SQL Analytics Endpoint."
+            requiring_features.append(
+                "extract_schema with method='sql_analytics_endpoint'"
             )
-        return self
+        if self.usage.include_usage_statistics:
+            requiring_features.append("usage.include_usage_statistics=True")
 
-    @model_validator(mode="after")
-    def validate_usage_extraction_prerequisites(self):
-        """Usage requires the SQL Analytics Endpoint — queryinsights lives there."""
-        if self.usage.include_usage_statistics and (
-            self.sql_endpoint is None or not self.sql_endpoint.enabled
-        ):
+        if requiring_features:
             raise ValueError(
-                "usage.include_usage_statistics=True requires a configured and "
-                "enabled sql_endpoint, because usage is read from "
-                "queryinsights.exec_requests_history on the SQL Analytics Endpoint. "
-                "Either set usage.include_usage_statistics=False to disable usage "
-                "extraction, or configure sql_endpoint with enabled=True."
+                f"sql_endpoint must be configured with enabled=True when any of "
+                f"the following are set: {', '.join(requiring_features)}. "
+                f"These features all query the SQL Analytics Endpoint."
             )
         return self

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/config.py
@@ -101,6 +101,16 @@ class FabricUsageConfig(BaseUsageConfig):
         ),
     )
 
+    include_queries: bool = Field(
+        default=True,
+        description=(
+            "If enabled, emit a `Query` entity for each unique parsed queryinsights "
+            "row so the SQL becomes a first-class, searchable asset in DataHub "
+            "(visible on the Queries tab and as standalone Query pages). "
+            "Requires `include_usage_statistics=True`."
+        ),
+    )
+
 
 class FabricOneLakeSourceConfig(
     StatefulIngestionConfigBase,
@@ -236,7 +246,7 @@ class FabricOneLakeSourceConfig(
 
     # Usage tracking
     usage: FabricUsageConfig = Field(
-        default=FabricUsageConfig(),
+        default_factory=FabricUsageConfig,
         description=(
             "Usage tracking configuration. Reads `queryinsights.exec_requests_history` "
             "on each Lakehouse/Warehouse SQL Analytics Endpoint. Requires a "

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/constants.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/constants.py
@@ -1,5 +1,7 @@
 """Constants for Fabric OneLake ingestion."""
 
-# Default schema for schemas-disabled Fabric Lakehouses
-# Fabric Lakehouses without explicit schemas use "dbo" as the default schema
-DEFAULT_SCHEMA_SCHEMALESS_LAKEHOUSE = "dbo"
+# Default T-SQL schema for the Fabric SQL layer. Applies to:
+#   * schemas-disabled Lakehouses (catalog returns no schema_name → fall back to dbo)
+#   * unqualified table refs in observed queries (parser default for dataset URN resolution)
+# Fabric Warehouse and Lakehouse SQL Analytics endpoints both use dbo.
+FABRIC_SQL_DEFAULT_SCHEMA = "dbo"

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/models.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/models.py
@@ -117,10 +117,10 @@ class FabricQueryInsightsRow:
     Reference: https://learn.microsoft.com/en-us/sql/relational-databases/system-views/queryinsights-exec-requests-history-transact-sql?view=fabric
     """
 
-    start_time: Optional[datetime]
-    statement_type: Optional[str]
+    start_time: datetime
+    statement_type: str
+    status: str
+    command: str
     login_name: Optional[str]
     row_count: Optional[int]
-    status: Optional[str]
     query_hash: Optional[str]
-    command: Optional[str]

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/models.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/models.py
@@ -7,6 +7,7 @@ References:
 """
 
 from dataclasses import dataclass
+from datetime import datetime
 from typing import List, Literal, Optional
 
 
@@ -107,3 +108,19 @@ class FabricTableSchema:
 
     table: FabricTable
     columns: List[FabricColumn]
+
+
+@dataclass
+class FabricQueryInsightsRow:
+    """A single row from `queryinsights.exec_requests_history`.
+
+    Reference: https://learn.microsoft.com/en-us/sql/relational-databases/system-views/queryinsights-exec-requests-history-transact-sql?view=fabric
+    """
+
+    start_time: Optional[datetime]
+    statement_type: Optional[str]
+    login_name: Optional[str]
+    row_count: Optional[int]
+    status: Optional[str]
+    query_hash: Optional[str]
+    command: Optional[str]

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/models.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/models.py
@@ -123,4 +123,3 @@ class FabricQueryInsightsRow:
     command: str
     login_name: Optional[str]
     row_count: Optional[int]
-    query_hash: Optional[str]

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/report.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import TYPE_CHECKING, Optional
 
 from datahub.ingestion.source.fabric.common.report import FabricClientReport
 from datahub.ingestion.source.state.stale_entity_removal_handler import (
     StaleEntityRemovalSourceReport,
 )
-from datahub.utilities.lossy_collections import LossyList
+from datahub.utilities.lossy_collections import LossyDict, LossyList
+from datahub.utilities.stats_collections import TopKDict
 
 if TYPE_CHECKING:
     from datahub.ingestion.source.fabric.onelake.schema_report import (
@@ -67,6 +69,21 @@ class FabricOneLakeSourceReport(StaleEntityRemovalSourceReport):
 
     # SQL parsing aggregator report (lineage / view parsing metrics)
     sql_aggregator: Optional["SqlAggregatorReport"] = None
+
+    num_usage_queries_fetched: int = 0
+    num_usage_queries_skipped: TopKDict[str, int] = field(default_factory=TopKDict)
+    usage_extraction_per_item_sec: LossyDict[str, float] = field(
+        default_factory=LossyDict
+    )
+    usage_start_time: Optional[datetime] = None
+    usage_end_time: Optional[datetime] = None
+    usage_run_skipped: bool = False
+
+    def report_usage_query_skipped(self, reason: str) -> None:
+        """Record a queryinsights row that was skipped before reaching the aggregator."""
+        self.num_usage_queries_skipped[reason] = (
+            self.num_usage_queries_skipped.get(reason, 0) + 1
+        )
 
     def report_workspace_scanned(self) -> None:
         """Increment workspaces scanned counter."""

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/schema_client.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/schema_client.py
@@ -123,7 +123,7 @@ class SchemaExtractionClient(Protocol):
         start_time: datetime,
         end_time: datetime,
         skip_failed_queries: bool,
-        batch_size: int = 1000,
+        fetch_chunk_size: int = 1000,
     ) -> Iterator[FabricQueryInsightsRow]:
         """Stream rows from queryinsights.exec_requests_history within a time window.
 
@@ -133,7 +133,8 @@ class SchemaExtractionClient(Protocol):
             start_time: Inclusive lower bound on `start_time` column
             end_time: Exclusive upper bound on `start_time` column
             skip_failed_queries: When True, filter `status = 'Succeeded'` at the source
-            batch_size: Server-side fetch size
+            fetch_chunk_size: Python-side `cursor.fetchmany()` chunk size — tunes. Narrow the time
+                window if a single run's result set is too large to process.
 
         Yields:
             One `FabricQueryInsightsRow` per matching row, ordered by `start_time`.
@@ -468,23 +469,17 @@ class SqlAnalyticsEndpointClient:
                     )
                 return columns_by_table
         except SQLAlchemyError as e:
-            error_msg = str(e)
             logger.warning(
                 f"Failed to extract schema for all tables "
-                f"in workspace {workspace_id}, item {item_id}: {error_msg}"
+                f"in workspace {workspace_id}, item {item_id}: {e}",
+                exc_info=True,
             )
-            if self.report:
-                self.report.failures += 1
-            # Re-raise the exception
             raise
         except Exception as e:
             logger.error(
                 f"Unexpected error extracting schema for all tables: {e}",
                 exc_info=True,
             )
-            if self.report:
-                self.report.failures += 1
-            # Re-raise the exception
             raise
 
     def get_all_views(
@@ -538,21 +533,17 @@ class SqlAnalyticsEndpointClient:
                     )
                 return views
         except SQLAlchemyError as e:
-            error_msg = str(e)
             logger.warning(
                 f"Failed to discover views "
-                f"in workspace {workspace_id}, item {item_id}: {error_msg}"
+                f"in workspace {workspace_id}, item {item_id}: {e}",
+                exc_info=True,
             )
-            if self.report:
-                self.report.failures += 1
             raise
         except Exception as e:
             logger.error(
                 f"Unexpected error discovering views: {e}",
                 exc_info=True,
             )
-            if self.report:
-                self.report.failures += 1
             raise
 
     def stream_usage_history(
@@ -562,13 +553,9 @@ class SqlAnalyticsEndpointClient:
         start_time: datetime,
         end_time: datetime,
         skip_failed_queries: bool,
-        batch_size: int = 1000,
+        fetch_chunk_size: int = 1000,
     ) -> Iterator[FabricQueryInsightsRow]:
         """Stream queryinsights.exec_requests_history rows for a single item.
-
-        Note: pyodbc / ODBC 18 buffer the full result set client-side, so peak
-        memory scales with total rows in the window, not `batch_size`. Narrow
-        the window if needed.
 
         Reference: https://learn.microsoft.com/en-us/sql/relational-databases/system-views/queryinsights-exec-requests-history-transact-sql?view=fabric
         """
@@ -579,7 +566,6 @@ class SqlAnalyticsEndpointClient:
                 login_name,
                 row_count,
                 status,
-                query_hash,
                 command
             FROM queryinsights.exec_requests_history
             WHERE start_time >= :start_time AND start_time < :end_time
@@ -603,39 +589,31 @@ class SqlAnalyticsEndpointClient:
                     query, {"start_time": sql_start, "end_time": sql_end}
                 )
                 while True:
-                    batch = cursor.fetchmany(batch_size)
+                    batch = cursor.fetchmany(fetch_chunk_size)
                     if not batch:
                         break
                     for row in batch:
                         row_mapping = row._mapping
-                        # query_hash surfaces from pyodbc as binary(8); coerce to str at the
-                        # boundary so consumers don't have to think about its wire type.
-                        raw_hash = row_mapping["query_hash"]
                         yield FabricQueryInsightsRow(
                             start_time=row_mapping["start_time"],
                             statement_type=row_mapping["statement_type"],
                             login_name=row_mapping["login_name"],
                             row_count=row_mapping["row_count"],
                             status=row_mapping["status"],
-                            query_hash=str(raw_hash) if raw_hash is not None else None,
                             command=row_mapping["command"],
                         )
         except SQLAlchemyError as e:
-            error_msg = str(e)
             logger.warning(
                 f"Failed to stream queryinsights.exec_requests_history "
-                f"in workspace {workspace_id}, item {item_id}: {error_msg}"
+                f"in workspace {workspace_id}, item {item_id}: {e}",
+                exc_info=True,
             )
-            if self.report:
-                self.report.failures += 1
             raise
         except Exception as e:
             logger.error(
                 f"Unexpected error streaming usage history: {e}",
                 exc_info=True,
             )
-            if self.report:
-                self.report.failures += 1
             raise
 
     def _get_engine(self, workspace_id: str, item_id: str, endpoint_url: str) -> Engine:

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/schema_client.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/schema_client.py
@@ -3,7 +3,7 @@
 import logging
 import re
 import struct
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import (
     TYPE_CHECKING,
     Dict,
@@ -595,9 +595,15 @@ class SqlAnalyticsEndpointClient:
         sql += " ORDER BY start_time"
         query = text(sql)
 
+        # Bind as naive UTC so pyodbc → ODBC 18 emits a datetime2 parameter
+        # directly, matching the column type. Passing tz-aware datetimes works
+        # but relies on the driver's implicit datetimeoffset → datetime2
+        # coercion, which has varied across driver versions.
+        sql_start = start_time.astimezone(timezone.utc).replace(tzinfo=None)
+        sql_end = end_time.astimezone(timezone.utc).replace(tzinfo=None)
         with engine.connect() as connection:
             cursor = connection.execute(
-                query, {"start_time": start_time, "end_time": end_time}
+                query, {"start_time": sql_start, "end_time": sql_end}
             )
             while True:
                 batch = cursor.fetchmany(batch_size)

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/schema_client.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/schema_client.py
@@ -3,7 +3,16 @@
 import logging
 import re
 import struct
-from typing import TYPE_CHECKING, Dict, List, Optional, Protocol, Tuple
+from datetime import datetime
+from typing import (
+    TYPE_CHECKING,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Protocol,
+    Tuple,
+)
 
 from sqlalchemy import bindparam, create_engine, text
 from sqlalchemy.engine import Engine
@@ -18,7 +27,11 @@ from datahub.ingestion.source.fabric.common.auth import (
     FabricAuthHelper,
 )
 from datahub.ingestion.source.fabric.onelake.config import SqlEndpointConfig
-from datahub.ingestion.source.fabric.onelake.models import FabricColumn, FabricView
+from datahub.ingestion.source.fabric.onelake.models import (
+    FabricColumn,
+    FabricQueryInsightsRow,
+    FabricView,
+)
 from datahub.ingestion.source.fabric.onelake.schema_report import (
     SqlAnalyticsEndpointReport,
 )
@@ -100,6 +113,30 @@ class SchemaExtractionClient(Protocol):
 
         Returns:
             List of FabricView objects with name, schema, and optional definition
+        """
+        ...
+
+    def stream_usage_history(
+        self,
+        workspace_id: str,
+        item_id: str,
+        start_time: datetime,
+        end_time: datetime,
+        skip_failed_queries: bool,
+        batch_size: int = 1000,
+    ) -> Iterator[FabricQueryInsightsRow]:
+        """Stream rows from queryinsights.exec_requests_history within a time window.
+
+        Args:
+            workspace_id: Workspace GUID (used for engine cache key)
+            item_id: Lakehouse / Warehouse GUID (used for engine cache key)
+            start_time: Inclusive lower bound on `start_time` column
+            end_time: Exclusive upper bound on `start_time` column
+            skip_failed_queries: When True, filter `status = 'Succeeded'` at the source
+            batch_size: Server-side fetch size
+
+        Yields:
+            One `FabricQueryInsightsRow` per matching row, ordered by `start_time`.
         """
         ...
 
@@ -517,6 +554,69 @@ class SqlAnalyticsEndpointClient:
             if self.report:
                 self.report.failures += 1
             raise
+
+    def stream_usage_history(
+        self,
+        workspace_id: str,
+        item_id: str,
+        start_time: datetime,
+        end_time: datetime,
+        skip_failed_queries: bool,
+        batch_size: int = 1000,
+    ) -> Iterator[FabricQueryInsightsRow]:
+        """Stream queryinsights.exec_requests_history rows for a single item.
+
+        Reuses the same engine cache (`_get_engine`) as schema and view extraction so
+        the SQLAlchemy connection pool is shared across all read paths for an item.
+
+        Filters `start_time` server-side so we never hold more than `batch_size` rows
+        in memory regardless of workspace size. The view itself is scoped to the
+        connected lakehouse / warehouse — cross-database queries appear in the
+        connecting context's view, so per-item querying is the correct unit.
+
+        Reference: https://learn.microsoft.com/en-us/sql/relational-databases/system-views/queryinsights-exec-requests-history-transact-sql?view=fabric
+        """
+        engine = self._get_engine(workspace_id, item_id, self.endpoint_url)
+
+        sql = """
+            SELECT
+                start_time,
+                statement_type,
+                login_name,
+                row_count,
+                status,
+                query_hash,
+                command
+            FROM queryinsights.exec_requests_history
+            WHERE start_time >= :start_time AND start_time < :end_time
+        """
+        if skip_failed_queries:
+            sql += " AND status = 'Succeeded'"
+        sql += " ORDER BY start_time"
+        query = text(sql)
+
+        with engine.connect() as connection:
+            cursor = connection.execute(
+                query, {"start_time": start_time, "end_time": end_time}
+            )
+            while True:
+                batch = cursor.fetchmany(batch_size)
+                if not batch:
+                    break
+                for row in batch:
+                    row_mapping = row._mapping
+                    # query_hash surfaces from pyodbc as binary(8); coerce to str at the
+                    # boundary so consumers don't have to think about its wire type.
+                    raw_hash = row_mapping["query_hash"]
+                    yield FabricQueryInsightsRow(
+                        start_time=row_mapping["start_time"],
+                        statement_type=row_mapping["statement_type"],
+                        login_name=row_mapping["login_name"],
+                        row_count=row_mapping["row_count"],
+                        status=row_mapping["status"],
+                        query_hash=str(raw_hash) if raw_hash is not None else None,
+                        command=row_mapping["command"],
+                    )
 
     def _get_engine(self, workspace_id: str, item_id: str, endpoint_url: str) -> Engine:
         """Get or create SQLAlchemy engine for a workspace/item combination.

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/schema_client.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/schema_client.py
@@ -566,18 +566,12 @@ class SqlAnalyticsEndpointClient:
     ) -> Iterator[FabricQueryInsightsRow]:
         """Stream queryinsights.exec_requests_history rows for a single item.
 
-        Reuses the same engine cache (`_get_engine`) as schema and view extraction so
-        the SQLAlchemy connection pool is shared across all read paths for an item.
-
-        Filters `start_time` server-side so we never hold more than `batch_size` rows
-        in memory regardless of workspace size. The view itself is scoped to the
-        connected lakehouse / warehouse — cross-database queries appear in the
-        connecting context's view, so per-item querying is the correct unit.
+        Note: pyodbc / ODBC 18 buffer the full result set client-side, so peak
+        memory scales with total rows in the window, not `batch_size`. Narrow
+        the window if needed.
 
         Reference: https://learn.microsoft.com/en-us/sql/relational-databases/system-views/queryinsights-exec-requests-history-transact-sql?view=fabric
         """
-        engine = self._get_engine(workspace_id, item_id, self.endpoint_url)
-
         sql = """
             SELECT
                 start_time,
@@ -601,28 +595,48 @@ class SqlAnalyticsEndpointClient:
         # coercion, which has varied across driver versions.
         sql_start = start_time.astimezone(timezone.utc).replace(tzinfo=None)
         sql_end = end_time.astimezone(timezone.utc).replace(tzinfo=None)
-        with engine.connect() as connection:
-            cursor = connection.execute(
-                query, {"start_time": sql_start, "end_time": sql_end}
+
+        try:
+            engine = self._get_engine(workspace_id, item_id, self.endpoint_url)
+            with engine.connect() as connection:
+                cursor = connection.execute(
+                    query, {"start_time": sql_start, "end_time": sql_end}
+                )
+                while True:
+                    batch = cursor.fetchmany(batch_size)
+                    if not batch:
+                        break
+                    for row in batch:
+                        row_mapping = row._mapping
+                        # query_hash surfaces from pyodbc as binary(8); coerce to str at the
+                        # boundary so consumers don't have to think about its wire type.
+                        raw_hash = row_mapping["query_hash"]
+                        yield FabricQueryInsightsRow(
+                            start_time=row_mapping["start_time"],
+                            statement_type=row_mapping["statement_type"],
+                            login_name=row_mapping["login_name"],
+                            row_count=row_mapping["row_count"],
+                            status=row_mapping["status"],
+                            query_hash=str(raw_hash) if raw_hash is not None else None,
+                            command=row_mapping["command"],
+                        )
+        except SQLAlchemyError as e:
+            error_msg = str(e)
+            logger.warning(
+                f"Failed to stream queryinsights.exec_requests_history "
+                f"in workspace {workspace_id}, item {item_id}: {error_msg}"
             )
-            while True:
-                batch = cursor.fetchmany(batch_size)
-                if not batch:
-                    break
-                for row in batch:
-                    row_mapping = row._mapping
-                    # query_hash surfaces from pyodbc as binary(8); coerce to str at the
-                    # boundary so consumers don't have to think about its wire type.
-                    raw_hash = row_mapping["query_hash"]
-                    yield FabricQueryInsightsRow(
-                        start_time=row_mapping["start_time"],
-                        statement_type=row_mapping["statement_type"],
-                        login_name=row_mapping["login_name"],
-                        row_count=row_mapping["row_count"],
-                        status=row_mapping["status"],
-                        query_hash=str(raw_hash) if raw_hash is not None else None,
-                        command=row_mapping["command"],
-                    )
+            if self.report:
+                self.report.failures += 1
+            raise
+        except Exception as e:
+            logger.error(
+                f"Unexpected error streaming usage history: {e}",
+                exc_info=True,
+            )
+            if self.report:
+                self.report.failures += 1
+            raise
 
     def _get_engine(self, workspace_id: str, item_id: str, endpoint_url: str) -> Engine:
         """Get or create SQLAlchemy engine for a workspace/item combination.

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/source.py
@@ -155,6 +155,10 @@ class WarehouseSchemaKey(WarehouseKey):
     "`usage.include_usage_statistics` is enabled. Column-level usage is derived "
     "via SQL parsing of the query text.",
 )
+@capability(
+    SourceCapability.OPERATION_CAPTURE,
+    "Optionally enabled via `usage.include_usage_statistics` and `usage.include_operational_stats`",
+)
 class FabricOneLakeSource(StatefulIngestionSourceBase):
     """Extracts metadata from Microsoft Fabric OneLake."""
 
@@ -186,14 +190,15 @@ class FabricOneLakeSource(StatefulIngestionSourceBase):
         # aspects. Constructed unconditionally so view lineage works regardless of
         # the usage toggle; usage flags below decide what gets emitted.
         usage_enabled = config.usage.include_usage_statistics
+        queries_enabled = usage_enabled and config.usage.include_queries
         self.aggregator = SqlParsingAggregator(
             platform=PLATFORM,
             platform_instance=config.platform_instance,
             env=config.env,
             graph=ctx.graph,
             generate_lineage=True,
-            generate_queries=False,
-            generate_query_subject_fields=False,
+            generate_queries=queries_enabled,
+            generate_query_subject_fields=queries_enabled,
             generate_usage_statistics=usage_enabled,
             generate_operations=usage_enabled
             and config.usage.include_operational_stats,
@@ -330,7 +335,7 @@ class FabricOneLakeSource(StatefulIngestionSourceBase):
             aggregator_drain_succeeded = True
             logger.info(f"SQL aggregator drained: emitted {emitted} MCPs")
         except Exception as e:
-            self.report.report_warning(
+            self.report.report_failure(
                 title="Failed to Generate Lineage / Usage",
                 message="Error draining SQL aggregator for lineage and usage.",
                 context=f"mcps_emitted_before_failure={emitted}",

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/source.py
@@ -49,7 +49,7 @@ from datahub.ingestion.source.fabric.common.urn_generator import (
 from datahub.ingestion.source.fabric.onelake.client import OneLakeClient
 from datahub.ingestion.source.fabric.onelake.config import FabricOneLakeSourceConfig
 from datahub.ingestion.source.fabric.onelake.constants import (
-    DEFAULT_SCHEMA_SCHEMALESS_LAKEHOUSE,
+    FABRIC_SQL_DEFAULT_SCHEMA,
 )
 from datahub.ingestion.source.fabric.onelake.models import (
     FabricColumn,
@@ -222,6 +222,9 @@ class FabricOneLakeSource(StatefulIngestionSourceBase):
             redundant_run_skip_handler=self.redundant_usage_run_skip_handler,
         )
 
+        # Resolved at the start of get_workunits_internal(); see comment there.
+        self._skip_usage_run: bool = False
+
     @classmethod
     def create(cls, config_dict: dict, ctx: PipelineContext) -> "FabricOneLakeSource":
         config = FabricOneLakeSourceConfig.model_validate(config_dict)
@@ -253,6 +256,12 @@ class FabricOneLakeSource(StatefulIngestionSourceBase):
     def get_workunits_internal(self) -> Iterable[Union[MetadataWorkUnit, Entity]]:
         """Generate workunits for all Fabric OneLake resources."""
         logger.info("Starting Fabric OneLake ingestion")
+
+        # Resolve the skip-run decision once per ingestion.
+        self._skip_usage_run = (
+            self.config.usage.include_usage_statistics
+            and self.usage_extractor.should_skip_run()
+        )
 
         try:
             # List all workspaces
@@ -292,13 +301,10 @@ class FabricOneLakeSource(StatefulIngestionSourceBase):
                 exc=e,
             )
 
-        # aggregator can resolve cross-item view→table references. When
-        # usage extraction is on, this same drain emits datasetUsageStatistics
-        # and operation aspects from the parsed queryinsights rows.
+        # Drain the aggregator. Emits view lineage and (when usage is enabled)
+        # datasetUsageStatistics / operation aspects. Deferred to the end so
+        # cross-item view→table references resolve.
         aggregator_drain_succeeded = False
-        # Emit lineage / view-parsing workunits accumulated by the
-        # aggregator across all workspaces. Deferred to the end so the
-        # aggregator can resolve cross-item view→table references.
         emitted = 0
         try:
             for mcp in self.aggregator.gen_metadata():
@@ -529,9 +535,14 @@ class FabricOneLakeSource(StatefulIngestionSourceBase):
         """
         if not self.config.usage.include_usage_statistics:
             return
-        if schema_client is None:
+        if self._skip_usage_run:
             return
-        if self.usage_extractor.should_skip_run():
+        if schema_client is None:
+            self.report.report_usage_query_skipped("no_sql_endpoint_for_item")
+            logger.info(
+                f"Skipping usage extraction for item {item_id} "
+                f"({item_display_name}): SQL Analytics Endpoint unavailable."
+            )
             return
         self.usage_extractor.extract(
             workspace_id=workspace_id,
@@ -565,7 +576,7 @@ class FabricOneLakeSource(StatefulIngestionSourceBase):
                 normalized_schema = (
                     table.schema_name
                     if table.schema_name
-                    else DEFAULT_SCHEMA_SCHEMALESS_LAKEHOUSE
+                    else FABRIC_SQL_DEFAULT_SCHEMA
                 )
 
                 # Filter tables
@@ -634,7 +645,7 @@ class FabricOneLakeSource(StatefulIngestionSourceBase):
 
         Args:
             schema_map: Dictionary mapping (schema_name, table_name) to list of columns
-            schema_name: Schema name (always non-empty, defaults to DEFAULT_SCHEMA_SCHEMALESS_LAKEHOUSE for schemas-disabled lakehouses)
+            schema_name: Schema name (always non-empty, defaults to FABRIC_SQL_DEFAULT_SCHEMA for schemas-disabled lakehouses)
             table_name: Table name
 
         Returns:
@@ -867,9 +878,7 @@ class FabricOneLakeSource(StatefulIngestionSourceBase):
         views_by_schema: dict[str, list[FabricView]] = defaultdict(list)
         for view in views:
             normalized_schema = (
-                view.schema_name
-                if view.schema_name
-                else DEFAULT_SCHEMA_SCHEMALESS_LAKEHOUSE
+                view.schema_name if view.schema_name else FABRIC_SQL_DEFAULT_SCHEMA
             )
 
             view_full_name = f"{normalized_schema}.{view.name}"

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/source.py
@@ -263,6 +263,19 @@ class FabricOneLakeSource(StatefulIngestionSourceBase):
             and self.usage_extractor.should_skip_run()
         )
 
+        if self.config.usage.include_usage_statistics:
+            if self._skip_usage_run:
+                logger.info(
+                    "Usage extraction skipped: configured window already covered "
+                    "by a previous successful run."
+                )
+            else:
+                logger.info(
+                    f"Usage extraction enabled, window="
+                    f"[{self.usage_extractor.start_time.isoformat()} -> "
+                    f"{self.usage_extractor.end_time.isoformat()}]"
+                )
+
         try:
             # List all workspaces
             workspaces = list(self.client.list_workspaces())
@@ -304,6 +317,10 @@ class FabricOneLakeSource(StatefulIngestionSourceBase):
         # Drain the aggregator. Emits view lineage and (when usage is enabled)
         # datasetUsageStatistics / operation aspects. Deferred to the end so
         # cross-item view→table references resolve.
+        logger.info(
+            "Draining SQL aggregator (view lineage"
+            f"{', usage' if self.config.usage.include_usage_statistics and not self._skip_usage_run else ''})"
+        )
         aggregator_drain_succeeded = False
         emitted = 0
         try:
@@ -311,6 +328,7 @@ class FabricOneLakeSource(StatefulIngestionSourceBase):
                 yield mcp.as_workunit()
                 emitted += 1
             aggregator_drain_succeeded = True
+            logger.info(f"SQL aggregator drained: emitted {emitted} MCPs")
         except Exception as e:
             self.report.report_warning(
                 title="Failed to Generate Lineage / Usage",
@@ -724,10 +742,15 @@ class FabricOneLakeSource(StatefulIngestionSourceBase):
         item_type: Literal["Lakehouse", "Warehouse"],
         item_display_name: str,
     ) -> Optional["SchemaExtractionClient"]:
-        """Create a SQL Analytics Endpoint client, shared by column-schema and
-        view extraction. Returns None on failure; both features skip this item.
+        """Create a SQL Analytics Endpoint client, shared by column-schema,
+        view extraction, and usage statistics. Returns None on failure; all
+        three features skip this item.
         """
-        needs_endpoint = self.config.extract_schema.enabled or self.config.extract_views
+        needs_endpoint = (
+            self.config.extract_schema.enabled
+            or self.config.extract_views
+            or self.config.usage.include_usage_statistics
+        )
         if not (needs_endpoint and self.config.sql_endpoint):
             return None
 
@@ -753,16 +776,16 @@ class FabricOneLakeSource(StatefulIngestionSourceBase):
             error_msg = str(e)
             logger.warning(
                 f"Failed to initialize SQL Analytics Endpoint for item {item_id}: "
-                f"{error_msg}. Both column-schema and view extraction will be "
-                "skipped for this item.",
+                f"{error_msg}. If enabled, column-schema, view extraction, and "
+                "usage statistics will be skipped for this item.",
                 exc_info=True,
             )
             self.report.report_warning(
                 title="SQL Analytics Endpoint Initialization Failed",
                 message=(
                     "Failed to initialize the SQL Analytics Endpoint client. "
-                    "Both column-schema and view extraction will be skipped for "
-                    "this item."
+                    "If enabled, column-schema, view extraction, and usage "
+                    "statistics will be skipped for this item."
                 ),
                 context=f"item_id={item_id}, item_type={item_type}, error={error_msg}",
                 exc=e,

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/source.py
@@ -63,6 +63,10 @@ from datahub.ingestion.source.fabric.onelake.report import (
     FabricOneLakeClientReport,
     FabricOneLakeSourceReport,
 )
+from datahub.ingestion.source.fabric.onelake.usage import FabricUsageExtractor
+from datahub.ingestion.source.state.redundant_run_skip_handler import (
+    RedundantUsageRunSkipHandler,
+)
 from datahub.ingestion.source.state.stale_entity_removal_handler import (
     StaleEntityRemovalHandler,
 )
@@ -145,6 +149,12 @@ class WarehouseSchemaKey(WarehouseKey):
     SourceCapability.LINEAGE_FINE,
     "Extracted from view definitions via SQL parsing when `extract_views` is enabled",
 )
+@capability(
+    SourceCapability.USAGE_STATS,
+    "Extracted from queryinsights.exec_requests_history (30-day retention) when "
+    "`usage.include_usage_statistics` is enabled. Column-level usage is derived "
+    "via SQL parsing of the query text.",
+)
 class FabricOneLakeSource(StatefulIngestionSourceBase):
     """Extracts metadata from Microsoft Fabric OneLake."""
 
@@ -171,7 +181,11 @@ class FabricOneLakeSource(StatefulIngestionSourceBase):
         # Link client report to source report for reporting
         self.report.client_report = self.client_report
 
-        # SQL parsing aggregator for view lineage.
+        # SQL parsing aggregator. Drives view lineage and (when usage is enabled)
+        # the parsing of observed queries from queryinsights into usage and operation
+        # aspects. Constructed unconditionally so view lineage works regardless of
+        # the usage toggle; usage flags below decide what gets emitted.
+        usage_enabled = config.usage.include_usage_statistics
         self.aggregator = SqlParsingAggregator(
             platform=PLATFORM,
             platform_instance=config.platform_instance,
@@ -180,11 +194,33 @@ class FabricOneLakeSource(StatefulIngestionSourceBase):
             generate_lineage=True,
             generate_queries=False,
             generate_query_subject_fields=False,
-            generate_usage_statistics=False,
-            generate_operations=False,
+            generate_usage_statistics=usage_enabled,
+            generate_operations=usage_enabled
+            and config.usage.include_operational_stats,
+            usage_config=config.usage if usage_enabled else None,
             eager_graph_load=False,
         )
         self.report.sql_aggregator = self.aggregator.report
+
+        # Stateful skip-handler for the usage time window. None when stateful
+        # ingestion is not configured; the extractor handles that gracefully.
+        self.redundant_usage_run_skip_handler: Optional[RedundantUsageRunSkipHandler]
+        if config.stateful_ingestion is not None and config.stateful_ingestion.enabled:
+            self.redundant_usage_run_skip_handler = RedundantUsageRunSkipHandler(
+                source=self,
+                config=config,
+                pipeline_name=ctx.pipeline_name,
+                run_id=ctx.run_id,
+            )
+        else:
+            self.redundant_usage_run_skip_handler = None
+
+        self.usage_extractor = FabricUsageExtractor(
+            config=config.usage,
+            aggregator=self.aggregator,
+            report=self.report,
+            redundant_run_skip_handler=self.redundant_usage_run_skip_handler,
+        )
 
     @classmethod
     def create(cls, config_dict: dict, ctx: PipelineContext) -> "FabricOneLakeSource":
@@ -256,6 +292,10 @@ class FabricOneLakeSource(StatefulIngestionSourceBase):
                 exc=e,
             )
 
+        # aggregator can resolve cross-item view→table references. When
+        # usage extraction is on, this same drain emits datasetUsageStatistics
+        # and operation aspects from the parsed queryinsights rows.
+        aggregator_drain_succeeded = False
         # Emit lineage / view-parsing workunits accumulated by the
         # aggregator across all workspaces. Deferred to the end so the
         # aggregator can resolve cross-item view→table references.
@@ -264,13 +304,23 @@ class FabricOneLakeSource(StatefulIngestionSourceBase):
             for mcp in self.aggregator.gen_metadata():
                 yield mcp.as_workunit()
                 emitted += 1
+            aggregator_drain_succeeded = True
         except Exception as e:
             self.report.report_warning(
-                title="Failed to Generate View Lineage",
-                message="Error draining SQL aggregator for view lineage.",
+                title="Failed to Generate Lineage / Usage",
+                message="Error draining SQL aggregator for lineage and usage.",
                 context=f"mcps_emitted_before_failure={emitted}",
                 exc=e,
             )
+
+        # Update the usage checkpoint only after a successful drain so a partial
+        # run doesn't mark the window as covered.
+        if (
+            aggregator_drain_succeeded
+            and self.config.usage.include_usage_statistics
+            and not self.report.usage_run_skipped
+        ):
+            self.usage_extractor.update_state_on_success()
 
     def _create_workspace_container(
         self, workspace: FabricWorkspace
@@ -398,6 +448,10 @@ class FabricOneLakeSource(StatefulIngestionSourceBase):
                 emitted_schemas=emitted_schemas,
             )
 
+        self._extract_item_usage(
+            workspace.id, lakehouse.id, lakehouse.name, schema_client
+        )
+
     def _process_warehouse(
         self, workspace: FabricWorkspace, warehouse: FabricWarehouse
     ) -> Iterable[Union[Container, Dataset]]:
@@ -454,6 +508,37 @@ class FabricOneLakeSource(StatefulIngestionSourceBase):
                 schema_map=schema_map,
                 emitted_schemas=emitted_schemas,
             )
+
+        self._extract_item_usage(
+            workspace.id, warehouse.id, warehouse.name, schema_client
+        )
+
+    def _extract_item_usage(
+        self,
+        workspace_id: str,
+        item_id: str,
+        item_display_name: str,
+        schema_client: Optional["SchemaExtractionClient"],
+    ) -> None:
+        """Stream queryinsights rows for one item into the aggregator.
+
+        No-op when usage is disabled, when this run was already covered by a
+        previous successful run, or when schema extraction failed for this item
+        (we share the same SQL endpoint connection). Per-item extraction
+        failures are caught inside the extractor.
+        """
+        if not self.config.usage.include_usage_statistics:
+            return
+        if schema_client is None:
+            return
+        if self.usage_extractor.should_skip_run():
+            return
+        self.usage_extractor.extract(
+            workspace_id=workspace_id,
+            item_id=item_id,
+            item_display_name=item_display_name,
+            schema_client=schema_client,
+        )
 
     def _process_item_tables(
         self,

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/usage.py
@@ -16,10 +16,11 @@ from __future__ import annotations
 import logging
 import time
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Optional
 
 from datahub.emitter.mce_builder import make_user_urn
 from datahub.ingestion.source.fabric.onelake.config import FabricUsageConfig
+from datahub.ingestion.source.fabric.onelake.constants import FABRIC_SQL_DEFAULT_SCHEMA
 from datahub.ingestion.source.fabric.onelake.models import FabricQueryInsightsRow
 from datahub.ingestion.source.fabric.onelake.report import FabricOneLakeSourceReport
 from datahub.ingestion.source.state.redundant_run_skip_handler import (
@@ -40,7 +41,7 @@ logger = logging.getLogger(__name__)
 
 
 class FabricUsageExtractor:
-    """Streams queryinsights rows for a single item into the shared aggregator."""
+    """Streams queryinsights rows into the shared SQL parsing aggregator."""
 
     def __init__(
         self,
@@ -146,7 +147,7 @@ class FabricUsageExtractor:
         item_id: str,
         item_display_name: str,
     ) -> None:
-        if not row.command or not row.command.strip():
+        if not row.command.strip():
             self.report.report_usage_query_skipped("empty_command")
             return
 
@@ -160,16 +161,15 @@ class FabricUsageExtractor:
             return
 
         timestamp = self._normalize_timestamp(row.start_time)
-        if timestamp is None:
-            self.report.report_usage_query_skipped("missing_start_time")
-            return
 
         # The view-lineage path uses default_db=f"{workspace_id}.{item_id}" so the
         # synthetic SQL parser identifier matches the URN we generate for tables.
         # Observed queries must use the same identifier so the parser resolves
         # `<schema>.<table>` references to the same dataset URNs.
         default_db = f"{workspace_id}.{item_id}"
-        default_schema: Optional[str] = None
+        # Unqualified table refs (e.g. `SELECT * FROM customers`) resolve to the
+        # T-SQL default schema on Fabric Warehouse / Lakehouse SQL endpoints.
+        default_schema = FABRIC_SQL_DEFAULT_SCHEMA
 
         user = (
             CorpUserUrn.from_string(make_user_urn(login_name)) if login_name else None
@@ -196,17 +196,13 @@ class FabricUsageExtractor:
         self.report.num_usage_queries_fetched += 1
 
     @staticmethod
-    def _normalize_timestamp(value: Any) -> Optional[datetime]:
+    def _normalize_timestamp(value: datetime) -> datetime:
         """Coerce queryinsights timestamps to timezone-aware UTC.
 
         `start_time` from queryinsights is `datetime2` and surfaces as a naive
         datetime via pyodbc. The aggregator expects timezone-aware timestamps
         for bucket boundary comparisons against the (UTC-aware) usage config.
         """
-        if value is None:
-            return None
-        if isinstance(value, datetime):
-            if value.tzinfo is None:
-                return value.replace(tzinfo=timezone.utc)
-            return value.astimezone(timezone.utc)
-        return None
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/usage.py
@@ -115,6 +115,11 @@ class FabricUsageExtractor:
         item_key = f"{workspace_id}/{item_id}"
         started_at = time.monotonic()
 
+        logger.info(
+            f"Starting usage extraction for item='{item_display_name}' "
+            f"workspace_id={workspace_id} item_id={item_id}"
+        )
+
         try:
             row_iter = schema_client.stream_usage_history(
                 workspace_id=workspace_id,
@@ -125,7 +130,12 @@ class FabricUsageExtractor:
             )
             for row in row_iter:
                 self._handle_row(row, workspace_id, item_id, item_display_name)
+            logger.info(f"Finished usage extraction for item='{item_display_name}'")
         except Exception as e:
+            logger.warning(
+                f"Failed usage extraction for item='{item_display_name}' "
+                f"workspace_id={workspace_id} item_id={item_id}: {e}"
+            )
             self.report.report_warning(
                 title="Failed to Extract Usage",
                 message=(

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/usage.py
@@ -91,6 +91,11 @@ class FabricUsageExtractor:
         Use the resolved (`self.start_time` / `self.end_time`) — not the raw
         config window — so we don't over-claim coverage when the skip handler
         narrowed the window to only the uncovered portion.
+
+        Note: the handler internally refuses to advance the checkpoint if any
+        per-item `extract()` reported failure via `report_current_run_status`.
+        So this is a no-op unless every item succeeded; the next run then
+        retries the same window.
         """
         if self.redundant_run_skip_handler:
             self.redundant_run_skip_handler.update_state(
@@ -145,6 +150,14 @@ class FabricUsageExtractor:
                 context=f"workspace_id={workspace_id}, item_id={item_id}",
                 exc=e,
             )
+            # Mark this item's step as failed so the skip handler refuses to advance
+            # the usage checkpoint. Otherwise a window where every item failed would
+            # be permanently marked as covered, and the missed rows are unrecoverable
+            # past queryinsights' 30-day retention.
+            if self.redundant_run_skip_handler:
+                self.redundant_run_skip_handler.report_current_run_status(
+                    f"usage-extraction-{workspace_id}/{item_id}", False
+                )
         finally:
             self.report.usage_extraction_per_item_sec[item_key] = round(
                 time.monotonic() - started_at, 3
@@ -191,7 +204,6 @@ class FabricUsageExtractor:
             user=user,
             default_db=default_db,
             default_schema=default_schema,
-            query_hash=row.query_hash,
             extra_info={
                 "fabric_workspace_id": workspace_id,
                 "fabric_item_id": item_id,

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/usage.py
@@ -85,11 +85,16 @@ class FabricUsageExtractor:
         return False
 
     def update_state_on_success(self) -> None:
-        """Persist the resolved time window so future runs can short-circuit."""
+        """Persist the resolved time window so future runs can short-circuit.
+
+        Use the resolved (`self.start_time` / `self.end_time`) — not the raw
+        config window — so we don't over-claim coverage when the skip handler
+        narrowed the window to only the uncovered portion.
+        """
         if self.redundant_run_skip_handler:
             self.redundant_run_skip_handler.update_state(
-                self.config.start_time,
-                self.config.end_time,
+                self.start_time,
+                self.end_time,
                 self.config.bucket_duration,
             )
 

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/usage.py
@@ -1,0 +1,207 @@
+"""Fabric OneLake usage / operation extractor.
+
+Reads `queryinsights.exec_requests_history` from each Lakehouse / Warehouse
+SQL Analytics Endpoint and feeds the rows into a `SqlParsingAggregator`. The
+aggregator parses each query via sqlglot and emits `datasetUsageStatistics`
+and `operation` aspects through the same `gen_metadata()` drain that already
+emits view lineage.
+
+Reference:
+- https://learn.microsoft.com/en-us/fabric/data-warehouse/query-insights
+- https://learn.microsoft.com/en-us/sql/relational-databases/system-views/queryinsights-exec-requests-history-transact-sql?view=fabric
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, Optional
+
+from datahub.emitter.mce_builder import make_user_urn
+from datahub.ingestion.source.fabric.onelake.config import FabricUsageConfig
+from datahub.ingestion.source.fabric.onelake.models import FabricQueryInsightsRow
+from datahub.ingestion.source.fabric.onelake.report import FabricOneLakeSourceReport
+from datahub.ingestion.source.state.redundant_run_skip_handler import (
+    RedundantUsageRunSkipHandler,
+)
+from datahub.metadata.urns import CorpUserUrn
+from datahub.sql_parsing.sql_parsing_aggregator import (
+    ObservedQuery,
+    SqlParsingAggregator,
+)
+
+if TYPE_CHECKING:
+    from datahub.ingestion.source.fabric.onelake.schema_client import (
+        SchemaExtractionClient,
+    )
+
+logger = logging.getLogger(__name__)
+
+
+class FabricUsageExtractor:
+    """Streams queryinsights rows for a single item into the shared aggregator."""
+
+    def __init__(
+        self,
+        config: FabricUsageConfig,
+        aggregator: SqlParsingAggregator,
+        report: FabricOneLakeSourceReport,
+        redundant_run_skip_handler: Optional[RedundantUsageRunSkipHandler] = None,
+    ):
+        self.config = config
+        self.aggregator = aggregator
+        self.report = report
+        self.redundant_run_skip_handler = redundant_run_skip_handler
+
+        self.start_time, self.end_time = self._resolve_time_window()
+        self.report.usage_start_time = self.start_time
+        self.report.usage_end_time = self.end_time
+
+    def _resolve_time_window(self) -> tuple[datetime, datetime]:
+        if self.redundant_run_skip_handler:
+            return self.redundant_run_skip_handler.suggest_run_time_window(
+                self.config.start_time, self.config.end_time
+            )
+        return self.config.start_time, self.config.end_time
+
+    def should_skip_run(self) -> bool:
+        """Whether this run's time window was fully covered by a previous successful run."""
+        if not self.redundant_run_skip_handler:
+            return False
+        if self.redundant_run_skip_handler.should_skip_this_run(
+            cur_start_time=self.config.start_time,
+            cur_end_time=self.config.end_time,
+        ):
+            self.report.usage_run_skipped = True
+            self.report.info(
+                title="Usage extraction skipped",
+                message=(
+                    "Usage extraction skipped because the configured time window was "
+                    "fully covered by a previous successful run."
+                ),
+            )
+            return True
+        return False
+
+    def update_state_on_success(self) -> None:
+        """Persist the resolved time window so future runs can short-circuit."""
+        if self.redundant_run_skip_handler:
+            self.redundant_run_skip_handler.update_state(
+                self.config.start_time,
+                self.config.end_time,
+                self.config.bucket_duration,
+            )
+
+    def extract(
+        self,
+        workspace_id: str,
+        item_id: str,
+        item_display_name: str,
+        schema_client: "SchemaExtractionClient",
+    ) -> None:
+        """Stream this item's queryinsights rows into the aggregator.
+
+        Returns nothing — the aggregator's internal state holds the parsed queries
+        and the source drains it via `gen_metadata()` after all items are processed.
+        Per-item exceptions are caught here so one bad item doesn't poison the run.
+        """
+        item_key = f"{workspace_id}/{item_id}"
+        started_at = time.monotonic()
+
+        try:
+            row_iter = schema_client.stream_usage_history(
+                workspace_id=workspace_id,
+                item_id=item_id,
+                start_time=self.start_time,
+                end_time=self.end_time,
+                skip_failed_queries=self.config.skip_failed_queries,
+            )
+            for row in row_iter:
+                self._handle_row(row, workspace_id, item_id, item_display_name)
+        except Exception as e:
+            self.report.report_warning(
+                title="Failed to Extract Usage",
+                message=(
+                    "Error reading queryinsights.exec_requests_history. "
+                    "Usage stats for this item will be skipped."
+                ),
+                context=f"workspace_id={workspace_id}, item_id={item_id}",
+                exc=e,
+            )
+        finally:
+            self.report.usage_extraction_per_item_sec[item_key] = round(
+                time.monotonic() - started_at, 3
+            )
+
+    def _handle_row(
+        self,
+        row: FabricQueryInsightsRow,
+        workspace_id: str,
+        item_id: str,
+        item_display_name: str,
+    ) -> None:
+        if not row.command or not row.command.strip():
+            self.report.report_usage_query_skipped("empty_command")
+            return
+
+        # Entra UPNs are case-insensitive by Microsoft spec, but pyodbc preserves the
+        # case Fabric sent. Lowercase here so the resulting CorpUserUrn matches the
+        # lowercased URNs that Azure AD / Okta / Google identity sources produce.
+        login_name = row.login_name.lower() if row.login_name else None
+
+        if login_name and not self.config.user_email_pattern.allowed(login_name):
+            self.report.report_usage_query_skipped("user_filtered")
+            return
+
+        timestamp = self._normalize_timestamp(row.start_time)
+        if timestamp is None:
+            self.report.report_usage_query_skipped("missing_start_time")
+            return
+
+        # The view-lineage path uses default_db=f"{workspace_id}.{item_id}" so the
+        # synthetic SQL parser identifier matches the URN we generate for tables.
+        # Observed queries must use the same identifier so the parser resolves
+        # `<schema>.<table>` references to the same dataset URNs.
+        default_db = f"{workspace_id}.{item_id}"
+        default_schema: Optional[str] = None
+
+        user = (
+            CorpUserUrn.from_string(make_user_urn(login_name)) if login_name else None
+        )
+
+        observed = ObservedQuery(
+            query=row.command,
+            timestamp=timestamp,
+            user=user,
+            default_db=default_db,
+            default_schema=default_schema,
+            query_hash=row.query_hash,
+            extra_info={
+                "fabric_workspace_id": workspace_id,
+                "fabric_item_id": item_id,
+                "fabric_item_name": item_display_name,
+                "statement_type": row.statement_type,
+                "row_count": row.row_count,
+                "status": row.status,
+            },
+        )
+
+        self.aggregator.add_observed_query(observed)
+        self.report.num_usage_queries_fetched += 1
+
+    @staticmethod
+    def _normalize_timestamp(value: Any) -> Optional[datetime]:
+        """Coerce queryinsights timestamps to timezone-aware UTC.
+
+        `start_time` from queryinsights is `datetime2` and surfaces as a naive
+        datetime via pyodbc. The aggregator expects timezone-aware timestamps
+        for bucket boundary comparisons against the (UTC-aware) usage config.
+        """
+        if value is None:
+            return None
+        if isinstance(value, datetime):
+            if value.tzinfo is None:
+                return value.replace(tzinfo=timezone.utc)
+            return value.astimezone(timezone.utc)
+        return None

--- a/metadata-ingestion/tests/integration/fabric/fabric_onelake/golden/test_fabric_onelake_lakehouse_with_views_golden.json
+++ b/metadata-ingestion/tests/integration/fabric/fabric_onelake/golden/test_fabric_onelake_lakehouse_with_views_golden.json
@@ -429,7 +429,8 @@
                         "actor": "urn:li:corpuser:_ingestion"
                     },
                     "dataset": "urn:li:dataset:(urn:li:dataPlatform:fabric-onelake,ws-123.lh-456.dbo.customers,PROD)",
-                    "type": "VIEW"
+                    "type": "VIEW",
+                    "query": "urn:li:query:view_b11da4266e24de154bd688e0ac7b1e2a8917ecd10adbd69af017548856aa2f32"
                 }
             ],
             "fineGrainedLineages": [
@@ -443,7 +444,8 @@
                         "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:fabric-onelake,ws-123.lh-456.dbo.v_active_customers,PROD),customer_id)"
                     ],
                     "transformOperation": "COPY: [customers].[customer_id] AS [customer_id]",
-                    "confidenceScore": 0.2
+                    "confidenceScore": 0.2,
+                    "query": "urn:li:query:view_b11da4266e24de154bd688e0ac7b1e2a8917ecd10adbd69af017548856aa2f32"
                 },
                 {
                     "upstreamType": "FIELD_SET",
@@ -455,14 +457,15 @@
                         "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:fabric-onelake,ws-123.lh-456.dbo.v_active_customers,PROD),name)"
                     ],
                     "transformOperation": "COPY: [customers].[name] AS [name]",
-                    "confidenceScore": 0.2
+                    "confidenceScore": 0.2,
+                    "query": "urn:li:query:view_b11da4266e24de154bd688e0ac7b1e2a8917ecd10adbd69af017548856aa2f32"
                 }
             ]
         }
     },
     "systemMetadata": {
         "lastObserved": 1705320000000,
-        "runId": "fabric-onelake-2024_01_15-12_00_00-d56xql",
+        "runId": "fabric-onelake-2024_01_15-12_00_00-gluc5b",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -496,6 +499,35 @@
     }
 },
 {
+    "entityType": "query",
+    "entityUrn": "urn:li:query:view_b11da4266e24de154bd688e0ac7b1e2a8917ecd10adbd69af017548856aa2f32",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "SELECT\n  customer_id,\n  name\nFROM dbo.customers\nWHERE\n  active = 1",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:_ingestion"
+            },
+            "lastModified": {
+                "time": 1705320000000,
+                "actor": "urn:li:corpuser:_ingestion"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1705320000000,
+        "runId": "fabric-onelake-2024_01_15-12_00_00-gluc5b",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
     "entityType": "container",
     "entityUrn": "urn:li:container:4cd19b5ecd3323c3e546bc983a6befb1",
     "changeType": "UPSERT",
@@ -508,6 +540,57 @@
     "systemMetadata": {
         "lastObserved": 1705300200000,
         "runId": "fabric-onelake-2024_01_15-12_00_00-sro6ea",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:view_b11da4266e24de154bd688e0ac7b1e2a8917ecd10adbd69af017548856aa2f32",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:fabric-onelake,ws-123.lh-456.dbo.customers,PROD)"
+                },
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:fabric-onelake,ws-123.lh-456.dbo.v_active_customers,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:fabric-onelake,ws-123.lh-456.dbo.customers,PROD),customer_id)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:fabric-onelake,ws-123.lh-456.dbo.customers,PROD),name)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:fabric-onelake,ws-123.lh-456.dbo.v_active_customers,PROD),customer_id)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:fabric-onelake,ws-123.lh-456.dbo.v_active_customers,PROD),name)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1705320000000,
+        "runId": "fabric-onelake-2024_01_15-12_00_00-gluc5b",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:view_b11da4266e24de154bd688e0ac7b1e2a8917ecd10adbd69af017548856aa2f32",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:fabric-onelake"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1705320000000,
+        "runId": "fabric-onelake-2024_01_15-12_00_00-gluc5b",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -556,6 +639,22 @@
     "systemMetadata": {
         "lastObserved": 1705300200000,
         "runId": "fabric-onelake-2024_01_15-12_00_00-sro6ea",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:view_b11da4266e24de154bd688e0ac7b1e2a8917ecd10adbd69af017548856aa2f32",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1705320000000,
+        "runId": "fabric-onelake-2024_01_15-12_00_00-gluc5b",
         "lastRunId": "no-run-id-provided"
     }
 }

--- a/metadata-ingestion/tests/integration/fabric/fabric_onelake/golden/test_fabric_onelake_warehouse_with_views_golden.json
+++ b/metadata-ingestion/tests/integration/fabric/fabric_onelake/golden/test_fabric_onelake_warehouse_with_views_golden.json
@@ -429,7 +429,8 @@
                         "actor": "urn:li:corpuser:_ingestion"
                     },
                     "dataset": "urn:li:dataset:(urn:li:dataPlatform:fabric-onelake,ws-123.wh-789.dbo.orders,PROD)",
-                    "type": "VIEW"
+                    "type": "VIEW",
+                    "query": "urn:li:query:view_972e9f2df7c33923f9dcc02bea208d4e581e8e0cc403f997d93524a62b0bbf95"
                 }
             ],
             "fineGrainedLineages": [
@@ -443,7 +444,8 @@
                         "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:fabric-onelake,ws-123.wh-789.dbo.v_total_orders,PROD),order_id)"
                     ],
                     "transformOperation": "COPY: [orders].[order_id] AS [order_id]",
-                    "confidenceScore": 0.2
+                    "confidenceScore": 0.2,
+                    "query": "urn:li:query:view_972e9f2df7c33923f9dcc02bea208d4e581e8e0cc403f997d93524a62b0bbf95"
                 },
                 {
                     "upstreamType": "FIELD_SET",
@@ -455,14 +457,15 @@
                         "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:fabric-onelake,ws-123.wh-789.dbo.v_total_orders,PROD),total)"
                     ],
                     "transformOperation": "SQL: SUM([orders].[amount]) AS [total]",
-                    "confidenceScore": 0.2
+                    "confidenceScore": 0.2,
+                    "query": "urn:li:query:view_972e9f2df7c33923f9dcc02bea208d4e581e8e0cc403f997d93524a62b0bbf95"
                 }
             ]
         }
     },
     "systemMetadata": {
         "lastObserved": 1705320000000,
-        "runId": "fabric-onelake-2024_01_15-12_00_00-e59scd",
+        "runId": "fabric-onelake-2024_01_15-12_00_00-ya8ozm",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -496,6 +499,35 @@
     }
 },
 {
+    "entityType": "query",
+    "entityUrn": "urn:li:query:view_972e9f2df7c33923f9dcc02bea208d4e581e8e0cc403f997d93524a62b0bbf95",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "SELECT\n  order_id,\n  SUM(amount) AS total\nFROM dbo.orders\nGROUP BY\n  order_id",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:_ingestion"
+            },
+            "lastModified": {
+                "time": 1705320000000,
+                "actor": "urn:li:corpuser:_ingestion"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1705320000000,
+        "runId": "fabric-onelake-2024_01_15-12_00_00-ya8ozm",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
     "entityType": "container",
     "entityUrn": "urn:li:container:202f2856c351aeedc2c982f30dd90de4",
     "changeType": "UPSERT",
@@ -508,6 +540,57 @@
     "systemMetadata": {
         "lastObserved": 1705320000000,
         "runId": "fabric-onelake-2024_01_15-12_00_00-e59scd",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:view_972e9f2df7c33923f9dcc02bea208d4e581e8e0cc403f997d93524a62b0bbf95",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:fabric-onelake,ws-123.wh-789.dbo.orders,PROD)"
+                },
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:fabric-onelake,ws-123.wh-789.dbo.v_total_orders,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:fabric-onelake,ws-123.wh-789.dbo.orders,PROD),amount)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:fabric-onelake,ws-123.wh-789.dbo.orders,PROD),order_id)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:fabric-onelake,ws-123.wh-789.dbo.v_total_orders,PROD),order_id)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:fabric-onelake,ws-123.wh-789.dbo.v_total_orders,PROD),total)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1705320000000,
+        "runId": "fabric-onelake-2024_01_15-12_00_00-ya8ozm",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:view_972e9f2df7c33923f9dcc02bea208d4e581e8e0cc403f997d93524a62b0bbf95",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:fabric-onelake"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1705320000000,
+        "runId": "fabric-onelake-2024_01_15-12_00_00-ya8ozm",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -556,6 +639,22 @@
     "systemMetadata": {
         "lastObserved": 1705320000000,
         "runId": "fabric-onelake-2024_01_15-12_00_00-e59scd",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:view_972e9f2df7c33923f9dcc02bea208d4e581e8e0cc403f997d93524a62b0bbf95",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1705320000000,
+        "runId": "fabric-onelake-2024_01_15-12_00_00-ya8ozm",
         "lastRunId": "no-run-id-provided"
     }
 }

--- a/metadata-ingestion/tests/integration/fabric/fabric_onelake/golden/test_fabric_onelake_with_usage_statistics_golden.json
+++ b/metadata-ingestion/tests/integration/fabric/fabric_onelake/golden/test_fabric_onelake_with_usage_statistics_golden.json
@@ -1,0 +1,535 @@
+[
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:7db4f4e3c5968c90bc8c6ece02025fb1",
+    "changeType": "UPSERT",
+    "aspectName": "containerProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "platform": "fabric",
+                "env": "PROD",
+                "workspace_id": "ws-123"
+            },
+            "name": "Test Workspace",
+            "qualifiedName": "ws-123",
+            "env": "PROD"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1705320000000,
+        "runId": "fabric-onelake-2024_01_15-12_00_00-964bf0",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:7db4f4e3c5968c90bc8c6ece02025fb1",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:fabric"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1705320000000,
+        "runId": "fabric-onelake-2024_01_15-12_00_00-964bf0",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:7db4f4e3c5968c90bc8c6ece02025fb1",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Fabric Workspace"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1705320000000,
+        "runId": "fabric-onelake-2024_01_15-12_00_00-964bf0",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:7db4f4e3c5968c90bc8c6ece02025fb1",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1705320000000,
+        "runId": "fabric-onelake-2024_01_15-12_00_00-964bf0",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:4cd19b5ecd3323c3e546bc983a6befb1",
+    "changeType": "UPSERT",
+    "aspectName": "containerProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "platform": "fabric-onelake",
+                "env": "PROD",
+                "workspace_id": "ws-123",
+                "lakehouse_id": "lh-456"
+            },
+            "name": "Test Lakehouse",
+            "qualifiedName": "ws-123.lh-456",
+            "env": "PROD"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1705320000000,
+        "runId": "fabric-onelake-2024_01_15-12_00_00-964bf0",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:4cd19b5ecd3323c3e546bc983a6befb1",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:fabric-onelake"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1705320000000,
+        "runId": "fabric-onelake-2024_01_15-12_00_00-964bf0",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:4cd19b5ecd3323c3e546bc983a6befb1",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:7db4f4e3c5968c90bc8c6ece02025fb1"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1705320000000,
+        "runId": "fabric-onelake-2024_01_15-12_00_00-964bf0",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:4cd19b5ecd3323c3e546bc983a6befb1",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Fabric Lakehouse"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1705320000000,
+        "runId": "fabric-onelake-2024_01_15-12_00_00-964bf0",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:4cd19b5ecd3323c3e546bc983a6befb1",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:7db4f4e3c5968c90bc8c6ece02025fb1",
+                    "urn": "urn:li:container:7db4f4e3c5968c90bc8c6ece02025fb1"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1705320000000,
+        "runId": "fabric-onelake-2024_01_15-12_00_00-964bf0",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:ebf61ea16adf27fdb96dbbb043307e36",
+    "changeType": "UPSERT",
+    "aspectName": "containerProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "platform": "fabric-onelake",
+                "env": "PROD",
+                "workspace_id": "ws-123",
+                "lakehouse_id": "lh-456",
+                "schema_name": "dbo"
+            },
+            "name": "dbo",
+            "qualifiedName": "ws-123.lh-456.dbo",
+            "env": "PROD"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1705320000000,
+        "runId": "fabric-onelake-2024_01_15-12_00_00-964bf0",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:ebf61ea16adf27fdb96dbbb043307e36",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:fabric-onelake"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1705320000000,
+        "runId": "fabric-onelake-2024_01_15-12_00_00-964bf0",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:ebf61ea16adf27fdb96dbbb043307e36",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:4cd19b5ecd3323c3e546bc983a6befb1"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1705320000000,
+        "runId": "fabric-onelake-2024_01_15-12_00_00-964bf0",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:ebf61ea16adf27fdb96dbbb043307e36",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Fabric Schema"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1705320000000,
+        "runId": "fabric-onelake-2024_01_15-12_00_00-964bf0",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:ebf61ea16adf27fdb96dbbb043307e36",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:7db4f4e3c5968c90bc8c6ece02025fb1",
+                    "urn": "urn:li:container:7db4f4e3c5968c90bc8c6ece02025fb1"
+                },
+                {
+                    "id": "urn:li:container:4cd19b5ecd3323c3e546bc983a6befb1",
+                    "urn": "urn:li:container:4cd19b5ecd3323c3e546bc983a6befb1"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1705320000000,
+        "runId": "fabric-onelake-2024_01_15-12_00_00-964bf0",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:fabric-onelake,ws-123.lh-456.dbo.customers,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:fabric-onelake"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1705320000000,
+        "runId": "fabric-onelake-2024_01_15-12_00_00-964bf0",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:fabric-onelake,ws-123.lh-456.dbo.customers,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "",
+            "platform": "urn:li:dataPlatform:fabric-onelake",
+            "version": 0,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.Schemaless": {}
+            },
+            "fields": [
+                {
+                    "fieldPath": "customer_id",
+                    "nullable": false,
+                    "description": "",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NumberType": {}
+                        }
+                    },
+                    "nativeDataType": "int",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "email",
+                    "nullable": false,
+                    "description": "",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "varchar",
+                    "recursive": false,
+                    "isPartOfKey": false
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1705320000000,
+        "runId": "fabric-onelake-2024_01_15-12_00_00-964bf0",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:fabric-onelake,ws-123.lh-456.dbo.customers,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "name": "customers",
+            "tags": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1705320000000,
+        "runId": "fabric-onelake-2024_01_15-12_00_00-964bf0",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:fabric-onelake,ws-123.lh-456.dbo.customers,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:ebf61ea16adf27fdb96dbbb043307e36"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1705320000000,
+        "runId": "fabric-onelake-2024_01_15-12_00_00-964bf0",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:fabric-onelake,ws-123.lh-456.dbo.customers,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Table"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1705320000000,
+        "runId": "fabric-onelake-2024_01_15-12_00_00-964bf0",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:fabric-onelake,ws-123.lh-456.dbo.customers,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1705276800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "uniqueUserCount": 1,
+            "totalSqlQueries": 1,
+            "topSqlQueries": [
+                "SELECT\n  customer_id,\n  email\nFROM dbo.customers\nWHERE\n  customer_id > 0"
+            ],
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:alice@example.com",
+                    "count": 1,
+                    "userEmail": "alice@example.com"
+                }
+            ],
+            "fieldCounts": [
+                {
+                    "fieldPath": "customer_id",
+                    "count": 1
+                },
+                {
+                    "fieldPath": "email",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1705320000000,
+        "runId": "fabric-onelake-2024_01_15-12_00_00-964bf0",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:fabric-onelake,ws-123.lh-456.dbo.customers,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:7db4f4e3c5968c90bc8c6ece02025fb1",
+                    "urn": "urn:li:container:7db4f4e3c5968c90bc8c6ece02025fb1"
+                },
+                {
+                    "id": "urn:li:container:4cd19b5ecd3323c3e546bc983a6befb1",
+                    "urn": "urn:li:container:4cd19b5ecd3323c3e546bc983a6befb1"
+                },
+                {
+                    "id": "urn:li:container:ebf61ea16adf27fdb96dbbb043307e36",
+                    "urn": "urn:li:container:ebf61ea16adf27fdb96dbbb043307e36"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1705320000000,
+        "runId": "fabric-onelake-2024_01_15-12_00_00-964bf0",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:4cd19b5ecd3323c3e546bc983a6befb1",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1705320000000,
+        "runId": "fabric-onelake-2024_01_15-12_00_00-964bf0",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:7db4f4e3c5968c90bc8c6ece02025fb1",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1705320000000,
+        "runId": "fabric-onelake-2024_01_15-12_00_00-964bf0",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:ebf61ea16adf27fdb96dbbb043307e36",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1705320000000,
+        "runId": "fabric-onelake-2024_01_15-12_00_00-964bf0",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:fabric-onelake,ws-123.lh-456.dbo.customers,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1705320000000,
+        "runId": "fabric-onelake-2024_01_15-12_00_00-964bf0",
+        "lastRunId": "no-run-id-provided"
+    }
+}
+]

--- a/metadata-ingestion/tests/integration/fabric/fabric_onelake/test_fabric_onelake_source.py
+++ b/metadata-ingestion/tests/integration/fabric/fabric_onelake/test_fabric_onelake_source.py
@@ -376,6 +376,7 @@ def test_fabric_onelake_warehouse_with_views(pytestconfig: pytest.Config) -> Non
     finally:
         Path(output_file).unlink(missing_ok=True)
 
+
 @time_machine.travel(FROZEN_TIME, tick=False)
 @pytest.mark.integration
 def test_fabric_onelake_with_usage_statistics(pytestconfig: pytest.Config) -> None:
@@ -449,8 +450,13 @@ def test_fabric_onelake_with_usage_statistics(pytestconfig: pytest.Config) -> No
             ),
             patch.object(
                 FabricOneLakeSource,
-                "_create_schema_client_and_map",
-                return_value=(mock_schema_client, schema_map),
+                "_create_schema_client",
+                return_value=mock_schema_client,
+            ),
+            patch.object(
+                FabricOneLakeSource,
+                "_fetch_schema_map",
+                return_value=schema_map,
             ),
         ):
             pipeline = Pipeline.create(

--- a/metadata-ingestion/tests/integration/fabric/fabric_onelake/test_fabric_onelake_source.py
+++ b/metadata-ingestion/tests/integration/fabric/fabric_onelake/test_fabric_onelake_source.py
@@ -411,7 +411,6 @@ def test_fabric_onelake_with_usage_statistics(pytestconfig: pytest.Config) -> No
             login_name="alice@example.com",
             row_count=42,
             status="Succeeded",
-            query_hash="abc123",
             command="SELECT customer_id, email FROM dbo.customers WHERE customer_id > 0",
         ),
     ]
@@ -499,6 +498,131 @@ def test_fabric_onelake_with_usage_statistics(pytestconfig: pytest.Config) -> No
                 pytestconfig,
                 output_path=output_file,
                 golden_path=str(golden_path),
+            )
+
+    finally:
+        Path(output_file).unlink(missing_ok=True)
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+@pytest.mark.integration
+def test_fabric_onelake_dml_emits_operation_aspect() -> None:
+    """A DML query (INSERT) should produce an `operation` aspect for the target table."""
+    table = FabricTable(
+        name="customers",
+        schema_name="dbo",
+        item_id="lh-456",
+        workspace_id="ws-123",
+    )
+    schema_map = {
+        ("dbo", "customers"): [
+            FabricColumn(name="customer_id", data_type="int", is_nullable=False),
+            FabricColumn(name="email", data_type="varchar", is_nullable=True),
+        ],
+    }
+
+    query_ts = FROZEN_TIME - timedelta(hours=2)
+    usage_rows = [
+        FabricQueryInsightsRow(
+            start_time=query_ts,
+            statement_type="INSERT",
+            login_name="alice@example.com",
+            row_count=1,
+            status="Succeeded",
+            command=(
+                "INSERT INTO dbo.customers (customer_id, email) "
+                "VALUES (1, 'foo@bar.com')"
+            ),
+        ),
+    ]
+
+    mock_schema_client = MagicMock()
+    mock_schema_client.get_all_views.return_value = []
+    mock_schema_client.stream_usage_history.return_value = iter(usage_rows)
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
+        output_file = tmp.name
+
+    try:
+        with (
+            patch.object(
+                OneLakeClient,
+                "list_workspaces",
+                return_value=[FabricWorkspace(id="ws-123", name="Test Workspace")],
+            ),
+            patch.object(
+                OneLakeClient,
+                "list_lakehouses",
+                return_value=[
+                    FabricLakehouse(
+                        id="lh-456",
+                        name="Test Lakehouse",
+                        workspace_id="ws-123",
+                        type="Lakehouse",
+                    )
+                ],
+            ),
+            patch.object(OneLakeClient, "list_warehouses", return_value=[]),
+            patch.object(
+                OneLakeClient,
+                "list_lakehouse_tables",
+                return_value=[table],
+            ),
+            patch.object(
+                FabricOneLakeSource,
+                "_create_schema_client",
+                return_value=mock_schema_client,
+            ),
+            patch.object(
+                FabricOneLakeSource,
+                "_fetch_schema_map",
+                return_value=schema_map,
+            ),
+        ):
+            pipeline = Pipeline.create(
+                {
+                    "source": {
+                        "type": "fabric-onelake",
+                        "config": {
+                            "credential": {
+                                "authentication_method": "service_principal",
+                                "client_id": "test-client",
+                                "client_secret": "test-secret",
+                                "tenant_id": "test-tenant",
+                            },
+                            "usage": {
+                                "include_usage_statistics": True,
+                                "include_operational_stats": True,
+                            },
+                        },
+                    },
+                    "sink": {
+                        "type": "file",
+                        "config": {"filename": output_file},
+                    },
+                }
+            )
+
+            pipeline.run()
+            pipeline.raise_from_status()
+
+            with Path(output_file).open() as f:
+                events = json.load(f)
+
+            operation_events = [
+                event for event in events if event.get("aspectName") == "operation"
+            ]
+            assert operation_events, (
+                "Expected at least one `operation` aspect for the INSERT query; "
+                "got none. This means the generate_operations path is not "
+                "actually wired up for DML queries."
+            )
+            # Operation must target the customers dataset (parser resolves
+            # `dbo.customers` via default_db=<workspace>.<item> and default_schema=dbo).
+            target_urns = {event.get("entityUrn") for event in operation_events}
+            assert any("customers" in (urn or "") for urn in target_urns), (
+                f"Operation aspects emitted but none target the customers "
+                f"dataset; got entityUrns={target_urns!r}"
             )
 
     finally:

--- a/metadata-ingestion/tests/integration/fabric/fabric_onelake/test_fabric_onelake_source.py
+++ b/metadata-ingestion/tests/integration/fabric/fabric_onelake/test_fabric_onelake_source.py
@@ -6,7 +6,7 @@ produces the expected metadata events.
 
 import json
 import tempfile
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -18,6 +18,7 @@ from datahub.ingestion.source.fabric.onelake.client import OneLakeClient
 from datahub.ingestion.source.fabric.onelake.models import (
     FabricColumn,
     FabricLakehouse,
+    FabricQueryInsightsRow,
     FabricTable,
     FabricView,
     FabricWarehouse,
@@ -365,6 +366,128 @@ def test_fabric_onelake_warehouse_with_views(pytestconfig: pytest.Config) -> Non
                 Path(__file__).parent
                 / "golden"
                 / "test_fabric_onelake_warehouse_with_views_golden.json"
+            )
+            mce_helpers.check_golden_file(
+                pytestconfig,
+                output_path=output_file,
+                golden_path=str(golden_path),
+            )
+
+    finally:
+        Path(output_file).unlink(missing_ok=True)
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+@pytest.mark.integration
+def test_fabric_onelake_with_usage_statistics(pytestconfig: pytest.Config) -> None:
+    """Usage extraction emits datasetUsageStatistics for queried tables.
+
+    Patches `stream_usage_history` to yield a small set of queryinsights rows
+    (a SELECT against `customers`) and verifies the SQL aggregator drains
+    `datasetUsageStatistics` aspects through the pipeline. The query's
+    `default_db` matches the URN scheme `<workspace_id>.<item_id>` so the
+    parser resolves `dbo.customers` to the same dataset URN we emit.
+    """
+    table = FabricTable(
+        name="customers",
+        schema_name="dbo",
+        item_id="lh-456",
+        workspace_id="ws-123",
+    )
+    schema_map = {
+        ("dbo", "customers"): [
+            FabricColumn(name="customer_id", data_type="int", is_nullable=False),
+            FabricColumn(name="email", data_type="varchar", is_nullable=True),
+        ],
+    }
+
+    # Pick a timestamp comfortably inside the default usage window
+    # (default end_time = FROZEN_TIME, default start_time = FROZEN_TIME - 1 day floored to UTC midnight).
+    query_ts = FROZEN_TIME - timedelta(hours=2)
+    usage_rows = [
+        FabricQueryInsightsRow(
+            start_time=query_ts,
+            statement_type="SELECT",
+            login_name="alice@example.com",
+            row_count=42,
+            status="Succeeded",
+            query_hash="abc123",
+            command="SELECT customer_id, email FROM dbo.customers WHERE customer_id > 0",
+        ),
+    ]
+
+    mock_schema_client = MagicMock()
+    mock_schema_client.get_all_views.return_value = []
+    mock_schema_client.stream_usage_history.return_value = iter(usage_rows)
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
+        output_file = tmp.name
+
+    try:
+        with (
+            patch.object(
+                OneLakeClient,
+                "list_workspaces",
+                return_value=[FabricWorkspace(id="ws-123", name="Test Workspace")],
+            ),
+            patch.object(
+                OneLakeClient,
+                "list_lakehouses",
+                return_value=[
+                    FabricLakehouse(
+                        id="lh-456",
+                        name="Test Lakehouse",
+                        workspace_id="ws-123",
+                        type="Lakehouse",
+                    )
+                ],
+            ),
+            patch.object(OneLakeClient, "list_warehouses", return_value=[]),
+            patch.object(
+                OneLakeClient,
+                "list_lakehouse_tables",
+                return_value=[table],
+            ),
+            patch.object(
+                FabricOneLakeSource,
+                "_create_schema_client_and_map",
+                return_value=(mock_schema_client, schema_map),
+            ),
+        ):
+            pipeline = Pipeline.create(
+                {
+                    "source": {
+                        "type": "fabric-onelake",
+                        "config": {
+                            "credential": {
+                                "authentication_method": "service_principal",
+                                "client_id": "test-client",
+                                "client_secret": "test-secret",
+                                "tenant_id": "test-tenant",
+                            },
+                            "usage": {
+                                "include_usage_statistics": True,
+                                "include_operational_stats": True,
+                            },
+                        },
+                    },
+                    "sink": {
+                        "type": "file",
+                        "config": {"filename": output_file},
+                    },
+                }
+            )
+
+            pipeline.run()
+            pipeline.raise_from_status()
+
+            assert isinstance(pipeline.source, FabricOneLakeSource)
+            assert pipeline.source.report.num_usage_queries_fetched == 1
+            assert mock_schema_client.stream_usage_history.called
+
+            golden_path = (
+                Path(__file__).parent
+                / "golden"
+                / "test_fabric_onelake_with_usage_statistics_golden.json"
             )
             mce_helpers.check_golden_file(
                 pytestconfig,

--- a/metadata-ingestion/tests/unit/fabric_onelake/test_config.py
+++ b/metadata-ingestion/tests/unit/fabric_onelake/test_config.py
@@ -10,7 +10,12 @@ from datahub.ingestion.source.azure.azure_auth import (
     AzureAuthenticationMethod,
     AzureCredentialConfig,
 )
-from datahub.ingestion.source.fabric.onelake.config import FabricOneLakeSourceConfig
+from datahub.ingestion.source.fabric.onelake.config import (
+    ExtractSchemaConfig,
+    FabricOneLakeSourceConfig,
+    FabricUsageConfig,
+    SqlEndpointConfig,
+)
 
 
 class TestFabricOneLakeSourceConfig:
@@ -119,3 +124,60 @@ class TestFabricOneLakeSourceConfig:
         assert config.extract_lakehouses is False
         assert config.extract_warehouses is False
         assert config.extract_schemas is False
+
+
+class TestSqlEndpointDependencyValidator:
+    """Tests for `validate_sql_endpoint_dependencies`.
+
+    The validator guards three SQL-endpoint-dependent features (view discovery,
+    column-schema extraction, usage statistics) so users get a clear config-time
+    error instead of a runtime failure.
+    """
+
+    def test_default_config_is_valid(self) -> None:
+        """Defaults enable view/schema/usage features and a default sql_endpoint, so they must agree."""
+        config = FabricOneLakeSourceConfig(credential=AzureCredentialConfig())
+        assert config.sql_endpoint is not None and config.sql_endpoint.enabled
+
+    def test_passes_when_all_sql_endpoint_features_disabled(self) -> None:
+        """When none of the SQL-endpoint features are on, sql_endpoint=None must be allowed."""
+        config = FabricOneLakeSourceConfig(
+            credential=AzureCredentialConfig(),
+            extract_views=False,
+            extract_schema=ExtractSchemaConfig(enabled=False),
+            usage=FabricUsageConfig(include_usage_statistics=False),
+            sql_endpoint=None,
+        )
+        assert config.sql_endpoint is None
+
+    def test_extract_views_requires_enabled_sql_endpoint(self) -> None:
+        with pytest.raises(ValidationError, match="extract_views=True"):
+            FabricOneLakeSourceConfig(
+                credential=AzureCredentialConfig(),
+                extract_views=True,
+                extract_schema=ExtractSchemaConfig(enabled=False),
+                usage=FabricUsageConfig(include_usage_statistics=False),
+                sql_endpoint=SqlEndpointConfig(enabled=False),
+            )
+
+    def test_extract_schema_requires_enabled_sql_endpoint(self) -> None:
+        with pytest.raises(ValidationError, match="extract_schema"):
+            FabricOneLakeSourceConfig(
+                credential=AzureCredentialConfig(),
+                extract_views=False,
+                extract_schema=ExtractSchemaConfig(
+                    enabled=True, method="sql_analytics_endpoint"
+                ),
+                usage=FabricUsageConfig(include_usage_statistics=False),
+                sql_endpoint=SqlEndpointConfig(enabled=False),
+            )
+
+    def test_usage_requires_enabled_sql_endpoint(self) -> None:
+        with pytest.raises(ValidationError, match="usage.include_usage_statistics"):
+            FabricOneLakeSourceConfig(
+                credential=AzureCredentialConfig(),
+                extract_views=False,
+                extract_schema=ExtractSchemaConfig(enabled=False),
+                usage=FabricUsageConfig(include_usage_statistics=True),
+                sql_endpoint=SqlEndpointConfig(enabled=False),
+            )

--- a/metadata-ingestion/tests/unit/fabric_onelake/test_schema_client.py
+++ b/metadata-ingestion/tests/unit/fabric_onelake/test_schema_client.py
@@ -331,8 +331,6 @@ class TestSqlAnalyticsEndpointClient:
         mock_engine.connect.return_value = mock_connection
         mock_create_engine.return_value = mock_engine
 
-        mock_report.failures = 0
-
         client = SqlAnalyticsEndpointClient(
             auth_helper=mock_auth_helper,
             config=sql_endpoint_config,
@@ -343,7 +341,6 @@ class TestSqlAnalyticsEndpointClient:
 
         with pytest.raises(SQLAlchemyError):
             client.get_all_views(workspace_id="ws-123", item_id="item-456")
-        assert mock_report.failures > 0
 
     def test_close(self, mock_auth_helper, sql_endpoint_config):
         """Test closing all engine connections."""

--- a/metadata-ingestion/tests/unit/fabric_onelake/test_usage.py
+++ b/metadata-ingestion/tests/unit/fabric_onelake/test_usage.py
@@ -35,7 +35,7 @@ def make_row(
 
 def make_extractor(
     config: FabricUsageConfig | None = None,
-    skip_handler=None,
+    skip_handler: MagicMock | None = None,
 ) -> tuple[FabricUsageExtractor, MagicMock, FabricOneLakeSourceReport]:
     """Build an extractor with a mock aggregator and real report."""
     config = config or FabricUsageConfig()

--- a/metadata-ingestion/tests/unit/fabric_onelake/test_usage.py
+++ b/metadata-ingestion/tests/unit/fabric_onelake/test_usage.py
@@ -29,7 +29,6 @@ def make_row(
         command=command,
         login_name=login_name,
         row_count=1,
-        query_hash="hash-1",
     )
 
 
@@ -181,6 +180,54 @@ def test_extract_swallows_stream_exception_and_warns() -> None:
     assert any(w.title == "Failed to Extract Usage" for w in report.warnings)
     # Timing is still recorded even when extraction fails.
     assert f"{WORKSPACE_ID}/{ITEM_ID}" in report.usage_extraction_per_item_sec
+
+
+def test_extract_failure_marks_skip_handler_step_failed() -> None:
+    """Per-item failures must call report_current_run_status(False) so the skip
+    handler refuses to advance the usage checkpoint — otherwise a window where
+    every item failed would be permanently marked as covered.
+    """
+    skip_handler = MagicMock()
+    skip_handler.suggest_run_time_window.return_value = (
+        FabricUsageConfig().start_time,
+        FabricUsageConfig().end_time,
+    )
+    extractor, _, _ = make_extractor(skip_handler=skip_handler)
+
+    schema_client = MagicMock()
+    schema_client.stream_usage_history.side_effect = RuntimeError("endpoint down")
+
+    extractor.extract(
+        workspace_id=WORKSPACE_ID,
+        item_id=ITEM_ID,
+        item_display_name=ITEM_DISPLAY_NAME,
+        schema_client=schema_client,
+    )
+
+    skip_handler.report_current_run_status.assert_called_once_with(
+        f"usage-extraction-{WORKSPACE_ID}/{ITEM_ID}", False
+    )
+
+
+def test_extract_happy_path_does_not_mark_skip_handler_step_failed() -> None:
+    skip_handler = MagicMock()
+    skip_handler.suggest_run_time_window.return_value = (
+        FabricUsageConfig().start_time,
+        FabricUsageConfig().end_time,
+    )
+    extractor, _, _ = make_extractor(skip_handler=skip_handler)
+
+    schema_client = MagicMock()
+    schema_client.stream_usage_history.return_value = iter([make_row()])
+
+    extractor.extract(
+        workspace_id=WORKSPACE_ID,
+        item_id=ITEM_ID,
+        item_display_name=ITEM_DISPLAY_NAME,
+        schema_client=schema_client,
+    )
+
+    skip_handler.report_current_run_status.assert_not_called()
 
 
 def test_extract_partial_failure_keeps_already_processed_rows() -> None:

--- a/metadata-ingestion/tests/unit/fabric_onelake/test_usage.py
+++ b/metadata-ingestion/tests/unit/fabric_onelake/test_usage.py
@@ -1,0 +1,297 @@
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from datahub.configuration.common import AllowDenyPattern
+from datahub.ingestion.source.fabric.onelake.config import FabricUsageConfig
+from datahub.ingestion.source.fabric.onelake.models import FabricQueryInsightsRow
+from datahub.ingestion.source.fabric.onelake.report import FabricOneLakeSourceReport
+from datahub.ingestion.source.fabric.onelake.usage import FabricUsageExtractor
+from datahub.sql_parsing.sql_parsing_aggregator import ObservedQuery
+
+WORKSPACE_ID = "ws-123"
+ITEM_ID = "lh-456"
+ITEM_DISPLAY_NAME = "Test Lakehouse"
+QUERY_TS = datetime(2026, 5, 11, 10, 0, 0, tzinfo=timezone.utc)
+
+
+def make_row(
+    command: str = "SELECT * FROM dbo.customers",
+    login_name: str | None = "alice@example.com",
+    start_time: datetime | None = None,
+    status: str = "Succeeded",
+) -> FabricQueryInsightsRow:
+    return FabricQueryInsightsRow(
+        start_time=start_time or QUERY_TS,
+        statement_type="SELECT",
+        status=status,
+        command=command,
+        login_name=login_name,
+        row_count=1,
+        query_hash="hash-1",
+    )
+
+
+def make_extractor(
+    config: FabricUsageConfig | None = None,
+    skip_handler=None,
+) -> tuple[FabricUsageExtractor, MagicMock, FabricOneLakeSourceReport]:
+    """Build an extractor with a mock aggregator and real report."""
+    config = config or FabricUsageConfig()
+    aggregator = MagicMock()
+    report = FabricOneLakeSourceReport()
+    extractor = FabricUsageExtractor(
+        config=config,
+        aggregator=aggregator,
+        report=report,
+        redundant_run_skip_handler=skip_handler,
+    )
+    return extractor, aggregator, report
+
+
+def test_resolve_time_window_no_skip_handler_uses_config_window() -> None:
+    extractor, _, report = make_extractor()
+    assert extractor.start_time == extractor.config.start_time
+    assert extractor.end_time == extractor.config.end_time
+    assert report.usage_start_time == extractor.start_time
+    assert report.usage_end_time == extractor.end_time
+
+
+def test_resolve_time_window_skip_handler_narrows_window() -> None:
+    narrowed_start = QUERY_TS - timedelta(hours=2)
+    narrowed_end = QUERY_TS
+    skip_handler = MagicMock()
+    skip_handler.suggest_run_time_window.return_value = (narrowed_start, narrowed_end)
+
+    extractor, _, report = make_extractor(skip_handler=skip_handler)
+
+    assert extractor.start_time == narrowed_start
+    assert extractor.end_time == narrowed_end
+    assert report.usage_start_time == narrowed_start
+    assert report.usage_end_time == narrowed_end
+    skip_handler.suggest_run_time_window.assert_called_once()
+
+
+def test_should_skip_run_returns_false_without_handler() -> None:
+    extractor, _, report = make_extractor()
+    assert extractor.should_skip_run() is False
+    assert report.usage_run_skipped is False
+
+
+def test_should_skip_run_returns_false_when_handler_says_run() -> None:
+    skip_handler = MagicMock()
+    skip_handler.suggest_run_time_window.return_value = (
+        FabricUsageConfig().start_time,
+        FabricUsageConfig().end_time,
+    )
+    skip_handler.should_skip_this_run.return_value = False
+
+    extractor, _, report = make_extractor(skip_handler=skip_handler)
+    assert extractor.should_skip_run() is False
+    assert report.usage_run_skipped is False
+
+
+def test_should_skip_run_returns_true_when_handler_says_skip() -> None:
+    skip_handler = MagicMock()
+    skip_handler.suggest_run_time_window.return_value = (
+        FabricUsageConfig().start_time,
+        FabricUsageConfig().end_time,
+    )
+    skip_handler.should_skip_this_run.return_value = True
+
+    extractor, _, report = make_extractor(skip_handler=skip_handler)
+    assert extractor.should_skip_run() is True
+    assert report.usage_run_skipped is True
+
+
+def test_update_state_on_success_persists_resolved_window() -> None:
+    narrowed_start = QUERY_TS - timedelta(hours=2)
+    narrowed_end = QUERY_TS
+    skip_handler = MagicMock()
+    skip_handler.suggest_run_time_window.return_value = (narrowed_start, narrowed_end)
+
+    extractor, _, _ = make_extractor(skip_handler=skip_handler)
+    extractor.update_state_on_success()
+
+    skip_handler.update_state.assert_called_once_with(
+        narrowed_start,
+        narrowed_end,
+        extractor.config.bucket_duration,
+    )
+
+
+def test_extract_happy_path_feeds_aggregator() -> None:
+    extractor, aggregator, report = make_extractor()
+    rows = [make_row(), make_row(command="SELECT 1")]
+
+    schema_client = MagicMock()
+    schema_client.stream_usage_history.return_value = iter(rows)
+
+    extractor.extract(
+        workspace_id=WORKSPACE_ID,
+        item_id=ITEM_ID,
+        item_display_name=ITEM_DISPLAY_NAME,
+        schema_client=schema_client,
+    )
+
+    assert aggregator.add_observed_query.call_count == 2
+    assert report.num_usage_queries_fetched == 2
+    assert f"{WORKSPACE_ID}/{ITEM_ID}" in report.usage_extraction_per_item_sec
+
+
+def test_extract_passes_resolved_window_and_skip_flag_to_client() -> None:
+    config = FabricUsageConfig(skip_failed_queries=False)
+    extractor, _, _ = make_extractor(config=config)
+
+    schema_client = MagicMock()
+    schema_client.stream_usage_history.return_value = iter([])
+
+    extractor.extract(
+        workspace_id=WORKSPACE_ID,
+        item_id=ITEM_ID,
+        item_display_name=ITEM_DISPLAY_NAME,
+        schema_client=schema_client,
+    )
+
+    schema_client.stream_usage_history.assert_called_once_with(
+        workspace_id=WORKSPACE_ID,
+        item_id=ITEM_ID,
+        start_time=extractor.start_time,
+        end_time=extractor.end_time,
+        skip_failed_queries=False,
+    )
+
+
+def test_extract_swallows_stream_exception_and_warns() -> None:
+    extractor, aggregator, report = make_extractor()
+
+    schema_client = MagicMock()
+    schema_client.stream_usage_history.side_effect = RuntimeError("connection lost")
+
+    # Must not raise — per-item failures don't poison the run.
+    extractor.extract(
+        workspace_id=WORKSPACE_ID,
+        item_id=ITEM_ID,
+        item_display_name=ITEM_DISPLAY_NAME,
+        schema_client=schema_client,
+    )
+
+    aggregator.add_observed_query.assert_not_called()
+    assert any(w.title == "Failed to Extract Usage" for w in report.warnings)
+    # Timing is still recorded even when extraction fails.
+    assert f"{WORKSPACE_ID}/{ITEM_ID}" in report.usage_extraction_per_item_sec
+
+
+def test_extract_partial_failure_keeps_already_processed_rows() -> None:
+    """A mid-stream failure should still leave prior rows in the aggregator."""
+    extractor, aggregator, report = make_extractor()
+
+    def failing_iter():
+        yield make_row(command="SELECT 1")
+        yield make_row(command="SELECT 2")
+        raise RuntimeError("stream broke")
+
+    schema_client = MagicMock()
+    schema_client.stream_usage_history.return_value = failing_iter()
+
+    extractor.extract(
+        workspace_id=WORKSPACE_ID,
+        item_id=ITEM_ID,
+        item_display_name=ITEM_DISPLAY_NAME,
+        schema_client=schema_client,
+    )
+
+    assert aggregator.add_observed_query.call_count == 2
+    assert report.num_usage_queries_fetched == 2
+    assert any(w.title == "Failed to Extract Usage" for w in report.warnings)
+
+
+@pytest.mark.parametrize("command", ["", "   ", "\n\t"])
+def test_handle_row_skips_empty_command(command: str) -> None:
+    extractor, aggregator, report = make_extractor()
+    extractor._handle_row(
+        make_row(command=command), WORKSPACE_ID, ITEM_ID, ITEM_DISPLAY_NAME
+    )
+
+    aggregator.add_observed_query.assert_not_called()
+    assert report.num_usage_queries_skipped.get("empty_command") == 1
+
+
+def test_handle_row_skips_user_filtered_by_email_pattern() -> None:
+    config = FabricUsageConfig(
+        user_email_pattern=AllowDenyPattern(deny=["bot@example.com"]),
+    )
+    extractor, aggregator, report = make_extractor(config=config)
+
+    extractor._handle_row(
+        make_row(login_name="bot@example.com"),
+        WORKSPACE_ID,
+        ITEM_ID,
+        ITEM_DISPLAY_NAME,
+    )
+
+    aggregator.add_observed_query.assert_not_called()
+    assert report.num_usage_queries_skipped.get("user_filtered") == 1
+
+
+def test_handle_row_lowercases_login_name_in_user_urn() -> None:
+    extractor, aggregator, _ = make_extractor()
+    extractor._handle_row(
+        make_row(login_name="Alice@Example.COM"),
+        WORKSPACE_ID,
+        ITEM_ID,
+        ITEM_DISPLAY_NAME,
+    )
+
+    aggregator.add_observed_query.assert_called_once()
+    observed: ObservedQuery = aggregator.add_observed_query.call_args[0][0]
+    assert observed.user is not None
+    assert "alice@example.com" in str(observed.user)
+
+
+def test_handle_row_no_login_name_emits_query_without_user() -> None:
+    extractor, aggregator, _ = make_extractor()
+    extractor._handle_row(
+        make_row(login_name=None),
+        WORKSPACE_ID,
+        ITEM_ID,
+        ITEM_DISPLAY_NAME,
+    )
+
+    aggregator.add_observed_query.assert_called_once()
+    observed: ObservedQuery = aggregator.add_observed_query.call_args[0][0]
+    assert observed.user is None
+
+
+def test_handle_row_sets_default_db_to_workspace_item() -> None:
+    """default_db must match the URN scheme `<workspace_id>.<item_id>` so
+    sqlglot resolves `<schema>.<table>` references to the dataset URNs we emit.
+    """
+    extractor, aggregator, _ = make_extractor()
+    extractor._handle_row(make_row(), WORKSPACE_ID, ITEM_ID, ITEM_DISPLAY_NAME)
+
+    observed: ObservedQuery = aggregator.add_observed_query.call_args[0][0]
+    assert observed.default_db == f"{WORKSPACE_ID}.{ITEM_ID}"
+    assert observed.default_schema == "dbo"
+
+
+def test_normalize_timestamp_naive_treated_as_utc() -> None:
+    naive = datetime(2026, 5, 11, 10, 0, 0)
+    result = FabricUsageExtractor._normalize_timestamp(naive)
+    assert result.tzinfo is timezone.utc
+    assert result == datetime(2026, 5, 11, 10, 0, 0, tzinfo=timezone.utc)
+
+
+def test_normalize_timestamp_non_utc_converted_to_utc() -> None:
+    ist = timezone(timedelta(hours=5, minutes=30))
+    aware = datetime(2026, 5, 11, 15, 30, 0, tzinfo=ist)
+    result = FabricUsageExtractor._normalize_timestamp(aware)
+    assert result.tzinfo == timezone.utc
+    # 15:30 IST == 10:00 UTC
+    assert result == datetime(2026, 5, 11, 10, 0, 0, tzinfo=timezone.utc)
+
+
+def test_normalize_timestamp_already_utc_returns_utc() -> None:
+    aware = datetime(2026, 5, 11, 10, 0, 0, tzinfo=timezone.utc)
+    assert FabricUsageExtractor._normalize_timestamp(aware) == aware


### PR DESCRIPTION
## Summary

Adds usage statistics extraction for the Fabric OneLake source by streaming query history from `queryinsights.exec_requests_history` on each Lakehouse/Warehouse SQL Analytics Endpoint and feeding it into the existing `SqlParsingAggregator`.

- New `FabricUsageExtractor` runs per Lakehouse/Warehouse over the same SQL endpoint connection used for schema extraction.
- New `FabricUsageConfig` (extends `BaseUsageConfig`) with:
  - `include_usage_statistics` — master toggle (default `True`).
  - `skip_failed_queries` — server-side filter on `status = 'Succeeded'` (default `True`).
- The aggregator is now constructed unconditionally; the usage flags decide whether `generate_usage_statistics` / `generate_operations` are turned on, so view lineage continues to work when usage is disabled. Operational stats follow the standard `include_operational_stats` flag from `BaseUsageConfig`.
- Stateful redundant-run handling via `RedundantUsageRunSkipHandler`. The window checkpoint is only advanced after a successful aggregator drain, so a partial/failed run doesn't mark the window as covered.
- New `USAGE_STATS` source capability declaration on `FabricOneLakeSource`.
- Validator: `usage.include_usage_statistics=True` requires `sql_endpoint.enabled=True`, since `queryinsights` lives on the SQL Analytics Endpoint. Note: Fabric retains query insights for 30 days.

