### PR TITLE
feat(search): add browse sidebar sort menu

### DIFF
--- a/datahub-web-react/src/app/searchV2/sidebar/BrowseContext.tsx
+++ b/datahub-web-react/src/app/searchV2/sidebar/BrowseContext.tsx
@@ -13,6 +13,7 @@ import {
     PLATFORM_FILTER_NAME,
 } from '@app/searchV2/utils/constants';
 import { useEntityRegistry } from '@app/useEntityRegistry';
+import { getBrowseResultGroupLabel } from '@app/searchV2/sidebar/browseSortUtils';
 
 import { AggregationMetadata, BrowseResultGroupV2, EntityType, FacetFilterInput, FilterOperator } from '@types';
 
@@ -127,8 +128,7 @@ export const useBrowseResultGroup = () => {
 export const useBrowseDisplayName = () => {
     const entityRegistry = useEntityRegistry();
     const browseResultGroup = useBrowseResultGroup();
-    const { entity } = browseResultGroup;
-    return entity ? entityRegistry.getDisplayName(entity.type, entity) : browseResultGroup.name;
+    return getBrowseResultGroupLabel(browseResultGroup, entityRegistry);
 };
 
 export const useBrowsePath = () => {

--- a/datahub-web-react/src/app/searchV2/sidebar/BrowseSidebar.tsx
+++ b/datahub-web-react/src/app/searchV2/sidebar/BrowseSidebar.tsx
@@ -1,12 +1,19 @@
-import { Button } from '@components';
+import { Button, Dropdown } from '@components';
 import { ArrowLineLeft } from '@phosphor-icons/react/dist/csr/ArrowLineLeft';
 import { ArrowLineRight } from '@phosphor-icons/react/dist/csr/ArrowLineRight';
-import { Divider, Typography } from 'antd';
+import { Check } from '@phosphor-icons/react/dist/csr/Check';
+import { Divider, MenuProps, Typography } from 'antd';
 import React, { useCallback, useState } from 'react';
 import styled from 'styled-components';
 
 import { SEARCH_RESULTS_BROWSE_SIDEBAR_ID } from '@app/onboarding/config/SearchOnboardingConfig';
 import { useIsPlatformBrowseMode } from '@app/searchV2/sidebar/BrowseContext';
+import {
+    BrowseSortOrder,
+    BrowseSortProvider,
+    useBrowseSortOrder,
+    useSetBrowseSortOrder,
+} from '@app/searchV2/sidebar/BrowseSortContext';
 import EntityBrowse from '@app/searchV2/sidebar/EntityBrowse';
 import PlatformBrowse from '@app/searchV2/sidebar/PlatformBrowse';
 import { ProfileSidebarResizer } from '@src/app/entityV2/shared/containers/profile/sidebar/ProfileSidebarResizer';
@@ -59,10 +66,17 @@ const StyledSidebar = styled.div`
 const Controls = styled.div<{ isCollapsed: boolean }>`
     display: flex;
     align-items: center;
-    justify-content: ${(props) => (props.isCollapsed ? 'center' : 'space-between')};
+    justify-content: ${(props) => (props.isCollapsed ? 'center' : 'flex-start')};
+    gap: ${(props) => (props.isCollapsed ? '0' : '8px')};
     height: 52px;
     padding: 16px 12px;
     overflow: hidden;
+`;
+
+const HeaderActions = styled.div`
+    display: flex;
+    align-items: center;
+    margin-left: auto;
 `;
 
 const NavigateTitle = styled(Typography.Title)<{ isClosed: boolean }>`
@@ -76,6 +90,43 @@ const NavigateTitle = styled(Typography.Title)<{ isClosed: boolean }>`
         font-weight: bold;
         color: ${(props) => props.theme.colors.textSecondary};
     }
+`;
+
+const SortButton = styled.button<{ $isOpen: boolean }>`
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    padding: 0;
+    border: none;
+    border-radius: 999px;
+    background-color: ${(props) => (props.$isOpen ? props.theme.colors.bgSurface : 'transparent')};
+    color: ${(props) => props.theme.colors.icon};
+    cursor: pointer;
+
+    &:hover {
+        background-color: ${(props) => props.theme.colors.bgSurface};
+    }
+
+    &:focus-visible {
+        outline: 2px solid ${(props) => props.theme.colors.primary};
+        outline-offset: 2px;
+    }
+`;
+
+const SortTrigger = styled.span`
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+`;
+
+const MenuLabel = styled.span`
+    display: inline-flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    gap: 12px;
 `;
 
 const ThinDivider = styled(Divider)`
@@ -100,7 +151,87 @@ type Props = {
     visible: boolean;
 };
 
-const BrowseSidebar = ({ visible }: Props) => {
+const SORT_MENU_ITEMS: Array<{ key: BrowseSortOrder; label: string }> = [
+    { key: BrowseSortOrder.ALPHABETICAL_ASC, label: 'Alphabetical (A-Z)' },
+    { key: BrowseSortOrder.ALPHABETICAL_DESC, label: 'Alphabetical (Z-A)' },
+    { key: BrowseSortOrder.RECENTLY_USED, label: 'Recently Used' },
+];
+
+const SortIcon = () => (
+    <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true" fill="none">
+        <path d="M2 3h10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+        <path d="M2 7h7" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+        <path d="M2 11h4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+);
+
+const BrowseSidebarControls = ({ isClosed, onToggleCollapse }: { isClosed: boolean; onToggleCollapse: () => void }) => {
+    const sortOrder = useBrowseSortOrder();
+    const setSortOrder = useSetBrowseSortOrder();
+    const [isSortMenuOpen, setIsSortMenuOpen] = useState(false);
+
+    const sortMenu: MenuProps = {
+        selectable: true,
+        selectedKeys: [sortOrder],
+        onClick: ({ key }) => {
+            setSortOrder(key as BrowseSortOrder);
+            setIsSortMenuOpen(false);
+        },
+        items: SORT_MENU_ITEMS.map((item) => ({
+            key: item.key,
+            label: (
+                <MenuLabel>
+                    <span>{item.label}</span>
+                    {sortOrder === item.key ? <Check size={14} weight="bold" /> : null}
+                </MenuLabel>
+            ),
+        })),
+    };
+
+    return (
+        <Controls isCollapsed={isClosed}>
+            {!isClosed ? (
+                <NavigateTitle level={5} isClosed={isClosed}>
+                    Navigate
+                </NavigateTitle>
+            ) : null}
+            {!isClosed ? (
+                <Dropdown
+                    open={isSortMenuOpen}
+                    onOpenChange={setIsSortMenuOpen}
+                    menu={sortMenu}
+                    placement="bottomRight"
+                >
+                    <SortTrigger>
+                        <SortButton
+                            type="button"
+                            aria-label="Change browse sort order"
+                            aria-haspopup="menu"
+                            aria-expanded={isSortMenuOpen}
+                            data-testid="browse-sort-toggle"
+                            $isOpen={isSortMenuOpen}
+                        >
+                            <SortIcon />
+                        </SortButton>
+                    </SortTrigger>
+                </Dropdown>
+            ) : null}
+            <HeaderActions>
+                <Button
+                    variant="text"
+                    color="gray"
+                    size="lg"
+                    isCircle
+                    icon={{ icon: isClosed ? ArrowLineRight : ArrowLineLeft }}
+                    isActive={!isClosed}
+                    onClick={onToggleCollapse}
+                />
+            </HeaderActions>
+        </Controls>
+    );
+};
+
+const BrowseSidebarContent = ({ visible }: Props) => {
     const isPlatformBrowseMode = useIsPlatformBrowseMode();
     const [isClosed, setIsClosed] = useState(false);
     const [isHidden, setIsHidden] = useState(false);
@@ -124,22 +255,7 @@ const BrowseSidebar = ({ visible }: Props) => {
                 $isShowNavBarRedesign={isShowNavBarRedesign}
                 id="browse-v2"
             >
-                <Controls isCollapsed={isClosed}>
-                    {!isClosed ? (
-                        <NavigateTitle level={5} isClosed={isClosed}>
-                            Navigate
-                        </NavigateTitle>
-                    ) : null}
-                    <Button
-                        variant="text"
-                        color="gray"
-                        size="lg"
-                        isCircle
-                        icon={{ icon: isClosed ? ArrowLineRight : ArrowLineLeft }}
-                        isActive={!isClosed}
-                        onClick={() => setIsClosed(!isClosed)}
-                    />
-                </Controls>
+                <BrowseSidebarControls isClosed={isClosed} onToggleCollapse={() => setIsClosed(!isClosed)} />
                 <StyledSidebar id={SEARCH_RESULTS_BROWSE_SIDEBAR_ID}>
                     <ThinDivider />
                     <SidebarBody>
@@ -167,6 +283,14 @@ const BrowseSidebar = ({ visible }: Props) => {
                 />
             )}
         </>
+    );
+};
+
+const BrowseSidebar = ({ visible }: Props) => {
+    return (
+        <BrowseSortProvider>
+            <BrowseSidebarContent visible={visible} />
+        </BrowseSortProvider>
     );
 };
 

--- a/datahub-web-react/src/app/searchV2/sidebar/BrowseSortContext.tsx
+++ b/datahub-web-react/src/app/searchV2/sidebar/BrowseSortContext.tsx
@@ -1,0 +1,49 @@
+import React, { ReactNode, createContext, useContext, useMemo, useState } from 'react';
+
+export enum BrowseSortOrder {
+    ALPHABETICAL_ASC = 'ALPHABETICAL_ASC',
+    ALPHABETICAL_DESC = 'ALPHABETICAL_DESC',
+    RECENTLY_USED = 'RECENTLY_USED',
+}
+
+type BrowseSortContextValue = {
+    sortOrder: BrowseSortOrder;
+    setSortOrder: React.Dispatch<React.SetStateAction<BrowseSortOrder>>;
+};
+
+const BrowseSortContext = createContext<BrowseSortContextValue | null>(null);
+
+type Props = {
+    children: ReactNode;
+    initialSortOrder?: BrowseSortOrder;
+};
+
+export const BrowseSortProvider = ({
+    children,
+    initialSortOrder = BrowseSortOrder.ALPHABETICAL_ASC,
+}: Props) => {
+    const [sortOrder, setSortOrder] = useState(initialSortOrder);
+    const value = useMemo(() => ({ sortOrder, setSortOrder }), [sortOrder]);
+
+    return <BrowseSortContext.Provider value={value}>{children}</BrowseSortContext.Provider>;
+};
+
+export const useBrowseSortOrder = () => {
+    const context = useContext(BrowseSortContext);
+
+    if (!context) {
+        throw new Error(`${useBrowseSortOrder.name} must be used under a ${BrowseSortProvider.name}`);
+    }
+
+    return context.sortOrder;
+};
+
+export const useSetBrowseSortOrder = () => {
+    const context = useContext(BrowseSortContext);
+
+    if (!context) {
+        throw new Error(`${useSetBrowseSortOrder.name} must be used under a ${BrowseSortProvider.name}`);
+    }
+
+    return context.setSortOrder;
+};

--- a/datahub-web-react/src/app/searchV2/sidebar/__tests__/BrowseSidebarSort.test.tsx
+++ b/datahub-web-react/src/app/searchV2/sidebar/__tests__/BrowseSidebarSort.test.tsx
@@ -1,0 +1,66 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import BrowseSidebar from '@app/searchV2/sidebar/BrowseSidebar';
+import { BrowseProvider } from '@app/searchV2/sidebar/BrowseContext';
+import { useBrowseSortOrder } from '@app/searchV2/sidebar/BrowseSortContext';
+import { sortBrowseResultGroups } from '@app/searchV2/sidebar/browseSortUtils';
+import TestPageContainer from '@utils/test-utils/TestPageContainer';
+
+vi.mock('@app/searchV2/useSearchAndBrowseVersion', () => ({
+    useIsPlatformBrowseV2: () => false,
+}));
+
+vi.mock('@app/searchV2/sidebar/PlatformBrowse', () => ({
+    default: () => null,
+}));
+
+vi.mock('@app/searchV2/sidebar/EntityBrowse', () => ({
+    default: () => {
+        const sortOrder = useBrowseSortOrder();
+        const groups = sortBrowseResultGroups(
+            [
+                { name: 'c-folder', count: 1, hasSubGroups: false, entity: null },
+                { name: 'a-folder', count: 1, hasSubGroups: false, entity: null },
+                { name: 'b-folder', count: 1, hasSubGroups: false, entity: null },
+            ],
+            sortOrder,
+            {
+                getDisplayName: () => '',
+            } as any,
+        );
+
+        return (
+            <div data-testid="browse-order">
+                {groups.map((group) => group.name).join(', ')}
+            </div>
+        );
+    },
+}));
+
+function renderSidebar() {
+    return render(
+        <TestPageContainer>
+            <BrowseProvider>
+                <BrowseSidebar visible />
+            </BrowseProvider>
+        </TestPageContainer>,
+    );
+}
+
+describe('BrowseSidebar sort toggle', () => {
+    it('renders A-Z by default and lets users switch between sort modes', async () => {
+        renderSidebar();
+
+        expect(screen.getByTestId('browse-order')).toHaveTextContent('a-folder, b-folder, c-folder');
+
+        fireEvent.click(screen.getByTestId('browse-sort-toggle'));
+        fireEvent.click(await screen.findByText('Alphabetical (Z-A)'));
+        expect(screen.getByTestId('browse-order')).toHaveTextContent('c-folder, b-folder, a-folder');
+
+        fireEvent.click(screen.getByTestId('browse-sort-toggle'));
+        fireEvent.click(await screen.findByText('Recently Used'));
+        expect(screen.getByTestId('browse-order')).toHaveTextContent('c-folder, a-folder, b-folder');
+    });
+});

--- a/datahub-web-react/src/app/searchV2/sidebar/__tests__/browseSortUtils.test.ts
+++ b/datahub-web-react/src/app/searchV2/sidebar/__tests__/browseSortUtils.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { BrowseSortOrder } from '@app/searchV2/sidebar/BrowseSortContext';
+import { getBrowseResultGroupLabel, sortBrowseResultGroups } from '@app/searchV2/sidebar/browseSortUtils';
+import type { EntityRegistry } from '@src/entityRegistryContext';
+import type { BrowseResultGroupV2 } from '@types';
+import { EntityType } from '@types';
+
+const mockEntityRegistry = {
+    getDisplayName: vi.fn((type, entity) => {
+        if (type === EntityType.Container) {
+            return entity.properties?.name ?? entity.urn;
+        }
+
+        return entity.name ?? entity.urn;
+    }),
+} as unknown as EntityRegistry;
+
+function buildGroup(name: string, entityName?: string): BrowseResultGroupV2 {
+    return {
+        name,
+        count: 1,
+        hasSubGroups: false,
+        entity: entityName
+            ? ({
+                  urn: `urn:li:container:${entityName}`,
+                  type: EntityType.Container,
+                  properties: { name: entityName },
+              } as any)
+            : null,
+    };
+}
+
+describe('browseSortUtils', () => {
+    it('uses the entity display name when a browse group has an entity', () => {
+        expect(getBrowseResultGroupLabel(buildGroup('ignored-name', 'Visible Label'), mockEntityRegistry)).toBe(
+            'Visible Label',
+        );
+    });
+
+    it('falls back to the raw browse group name when no entity exists', () => {
+        expect(getBrowseResultGroupLabel(buildGroup('plain-folder'), mockEntityRegistry)).toBe('plain-folder');
+    });
+
+    it('sorts browse groups A-Z using the visible label', () => {
+        const sorted = sortBrowseResultGroups(
+            [buildGroup('z-folder'), buildGroup('internal-b', 'Beta'), buildGroup('a-folder')],
+            BrowseSortOrder.ALPHABETICAL_ASC,
+            mockEntityRegistry,
+        );
+
+        expect(sorted.map((group) => getBrowseResultGroupLabel(group, mockEntityRegistry))).toEqual([
+            'a-folder',
+            'Beta',
+            'z-folder',
+        ]);
+    });
+
+    it('sorts browse groups Z-A using the visible label', () => {
+        const sorted = sortBrowseResultGroups(
+            [buildGroup('z-folder'), buildGroup('internal-b', 'Beta'), buildGroup('a-folder')],
+            BrowseSortOrder.ALPHABETICAL_DESC,
+            mockEntityRegistry,
+        );
+
+        expect(sorted.map((group) => getBrowseResultGroupLabel(group, mockEntityRegistry))).toEqual([
+            'z-folder',
+            'Beta',
+            'a-folder',
+        ]);
+    });
+
+    it('preserves backend order for Recently Used', () => {
+        const original = [buildGroup('c-folder'), buildGroup('a-folder'), buildGroup('b-folder')];
+
+        const sorted = sortBrowseResultGroups(original, BrowseSortOrder.RECENTLY_USED, mockEntityRegistry);
+
+        expect(sorted.map((group) => group.name)).toEqual(['c-folder', 'a-folder', 'b-folder']);
+    });
+});

--- a/datahub-web-react/src/app/searchV2/sidebar/browseSortUtils.ts
+++ b/datahub-web-react/src/app/searchV2/sidebar/browseSortUtils.ts
@@ -1,0 +1,28 @@
+import type { EntityRegistry } from '@src/entityRegistryContext';
+import type { BrowseResultGroupV2 } from '@types';
+
+import { BrowseSortOrder } from '@app/searchV2/sidebar/BrowseSortContext';
+
+export function getBrowseResultGroupLabel(group: BrowseResultGroupV2, entityRegistry: EntityRegistry): string {
+    return group.entity ? entityRegistry.getDisplayName(group.entity.type, group.entity) : group.name;
+}
+
+export function sortBrowseResultGroups(
+    groups: BrowseResultGroupV2[],
+    sortOrder: BrowseSortOrder,
+    entityRegistry: EntityRegistry,
+) {
+    if (sortOrder === BrowseSortOrder.RECENTLY_USED) {
+        return groups;
+    }
+
+    const direction = sortOrder === BrowseSortOrder.ALPHABETICAL_DESC ? -1 : 1;
+
+    return [...groups].sort((firstGroup, secondGroup) => {
+        return (
+            getBrowseResultGroupLabel(firstGroup, entityRegistry).localeCompare(
+                getBrowseResultGroupLabel(secondGroup, entityRegistry),
+            ) * direction
+        );
+    });
+}

--- a/datahub-web-react/src/app/searchV2/sidebar/useBrowsePagination.tsx
+++ b/datahub-web-react/src/app/searchV2/sidebar/useBrowsePagination.tsx
@@ -1,9 +1,12 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 
 import { useBrowsePath, useEntityType } from '@app/searchV2/sidebar/BrowseContext';
+import { useBrowseSortOrder } from '@app/searchV2/sidebar/BrowseSortContext';
+import { sortBrowseResultGroups } from '@app/searchV2/sidebar/browseSortUtils';
 import { BROWSE_LOAD_MORE_MARGIN, BROWSE_PAGE_SIZE } from '@app/searchV2/sidebar/constants';
 import { useSidebarFilters } from '@app/searchV2/sidebar/useSidebarFilters';
 import useIntersect from '@app/shared/useIntersect';
+import { useEntityRegistry } from '@app/useEntityRegistry';
 
 import { GetBrowseResultsV2Query, useGetBrowseResultsV2Query } from '@graphql/browseV2.generated';
 
@@ -15,7 +18,9 @@ const useBrowsePagination = ({ skip }: Props) => {
     const initializing = useRef(true);
     const type = useEntityType();
     const path = useBrowsePath();
+    const entityRegistry = useEntityRegistry();
     const sidebarFilters = useSidebarFilters();
+    const sortOrder = useBrowseSortOrder();
     const [startToBrowseMap, setStartToBrowseMap] = useState<Record<number, GetBrowseResultsV2Query | undefined>>({});
     const startList = useMemo(
         () =>
@@ -24,10 +29,10 @@ const useBrowsePagination = ({ skip }: Props) => {
                 .sort((a, b) => a - b),
         [startToBrowseMap],
     );
-    const groups = useMemo(
-        () => startList.flatMap((start) => startToBrowseMap[start]?.browseV2?.groups ?? []),
-        [startList, startToBrowseMap],
-    );
+    const groups = useMemo(() => {
+        const flattenedGroups = startList.flatMap((start) => startToBrowseMap[start]?.browseV2?.groups ?? []);
+        return sortBrowseResultGroups(flattenedGroups, sortOrder, entityRegistry);
+    }, [entityRegistry, sortOrder, startList, startToBrowseMap]);
     const latestStart = startList.length ? startList[startList.length - 1] : -1;
     const latestData = latestStart >= 0 ? startToBrowseMap[latestStart] : null;
     const total = latestData?.browseV2?.total ?? -1;


### PR DESCRIPTION
## Summary

Adds a sort menu to the Search V2 browse sidebar so users can control how browse path groups are ordered in the `Navigate` panel.

This change introduces:
- `Alphabetical (A-Z)`
- `Alphabetical (Z-A)`
- `Recently Used`

The selected sort mode is applied in the frontend browse sidebar only. No backend or schema changes were made.

## Related Issue

Closes #16171

## What Changed

- Added a sort control to the Search V2 browse sidebar header next to the collapse control
- Added shared sidebar sort state for browse ordering
- Centralized browse group sorting in the browse pagination/data flow
- Reused the same visible-label logic for both rendering and sorting
- Added frontend regression coverage for:
  - A-Z ordering
  - Z-A ordering
  - Recently Used preserving backend order
  - sidebar sort menu behavior

| Sorted size-wise by default | Sorting options |
|---|---|
| <img width="266" height="346" alt="Screenshot 1" src="https://github.com/user-attachments/assets/4b7b3c02-c335-4e82-a0fb-bd5cdfa42d35" /> | <img width="266" height="346" alt="Screenshot 2" src="https://github.com/user-attachments/assets/82c4ad52-fe91-41dc-949e-061b7c7a6e2e" /> |

## Testing

Tests added/updated:
- browse sort utility tests
- browse sidebar sort menu test

Note:
- Full local Gradle verification was blocked in this environment because the installed Java versions did not match the repo’s Gradle/runtime requirements.
- After switching to the correct running frontend/runtime, the UI change was confirmed visually.

## Docs

No docs update needed. This is a small UI enhancement and does not introduce a new documented feature flow, breaking change, or migration requirement.
