### PR TITLE
ci(lint): use default runner for smoke-test-lint to prevent OOM

### DIFF
--- a/.github/workflows/lint-jobs.yml
+++ b/.github/workflows/lint-jobs.yml
@@ -28,6 +28,7 @@ jobs:
       smoke-test-cypress: ${{ steps.filter.outputs.smoke-test-cypress == 'true' || steps.filter.outputs.lint-job == 'true' }}
       playwright-e2e: ${{ steps.filter.outputs.playwright-e2e == 'true' || steps.filter.outputs.lint-job == 'true' }}
       small-runner: ${{ steps.runners.outputs.small-runner }}
+      default-runner: ${{ steps.runners.outputs.default-runner }}
       default-gh-runner: ${{ steps.runners.outputs.default-gh-runner }}
     steps:
       - uses: acryldata/sane-checkout-action@186e92cc5948a9c3e1cc7a96eaff9f776f3fc8e3 # v7
@@ -151,7 +152,7 @@ jobs:
 
   smoke-test-lint:
     name: Lint on smoke tests
-    runs-on: ${{ needs.setup.outputs.small-runner }}
+    runs-on: ${{ needs.setup.outputs.default-runner }}
     needs: setup
     if: ${{ needs.setup.outputs.smoke-test-python == 'true' || needs.setup.outputs.smoke-test-cypress == 'true' }}
     env:

--- a/.github/workflows/lint-jobs.yml
+++ b/.github/workflows/lint-jobs.yml
@@ -27,7 +27,6 @@ jobs:
       smoke-test-python: ${{ steps.filter.outputs.smoke-test-python == 'true' || steps.filter.outputs.lint-job == 'true' }}
       smoke-test-cypress: ${{ steps.filter.outputs.smoke-test-cypress == 'true' || steps.filter.outputs.lint-job == 'true' }}
       playwright-e2e: ${{ steps.filter.outputs.playwright-e2e == 'true' || steps.filter.outputs.lint-job == 'true' }}
-      small-runner: ${{ steps.runners.outputs.small-runner }}
       default-runner: ${{ steps.runners.outputs.default-runner }}
       default-gh-runner: ${{ steps.runners.outputs.default-gh-runner }}
     steps:


### PR DESCRIPTION
## Summary
- Upgrades the `smoke-test-lint` job runner from `small-runner` (`depot-ubuntu-24.04-small`) to `default-runner` (`depot-ubuntu-24.04`) to prevent OOM failures
- Exposes `default-runner` as a setup job output so it can be referenced by lint jobs

## Test plan
- [ ] Verify `smoke-test-lint` job completes without OOM on the next PR run

🤖 Generated with [Claude Code](https://claude.com/claude-code)