### PR TITLE
fix(ingest/kafka-connect,sql-parsing): surface CLL failures and recover from partial bulk-fetch misses

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/common.py
@@ -999,9 +999,21 @@ class BaseConnector:
                 return fine_grained_lineages
 
         except Exception as e:
-            logger.debug(
-                f"Failed to extract fine-grained lineage for "
-                f"{source_dataset} → {target_dataset}: {e}"
+            # Surface as a structured warning so per-collection failures show up in the
+            # ingestion report. Asset-level lineage is unaffected (the caller still
+            # appends the KafkaConnectLineage entry; only fine_grained_lineages is None).
+            self.report.warning(
+                title="Failed to extract column-level lineage",
+                message=(
+                    "An error occurred while resolving schema for column-level "
+                    "lineage. Asset-level lineage is unaffected."
+                ),
+                context=(
+                    f"connector={self.connector_manifest.name}, "
+                    f"source_platform={source_platform}, source={source_dataset}, "
+                    f"target={target_dataset}, error_type={type(e).__name__}"
+                ),
+                exc=e,
             )
 
         return None

--- a/metadata-ingestion/src/datahub/sql_parsing/schema_resolver_provider.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/schema_resolver_provider.py
@@ -59,11 +59,16 @@ class SchemaResolverProvider:
         env: str,
     ) -> SchemaResolver:
         """Return a bulk-initialized SchemaResolver, cached per (platform, platform_instance, env)."""
+        # Pass the graph through so that resolve_table() can fall back to a targeted
+        # per-URN fetch when the bulk pre-population missed an entry (e.g. transient
+        # GMS error mid-batch, pagination edge case, or filter mismatch). Already
+        # cached URNs short-circuit before any per-URN call is made, so this does not
+        # regress the bulk-fetch fast path.
         resolver = SchemaResolver(
             platform=platform,
             platform_instance=platform_instance,
             env=env,
-            graph=None,
+            graph=self._graph,
             report=self._report,
         )
         logger.info(f"Fetching schemas for platform {platform}, env {env}")

--- a/metadata-ingestion/tests/unit/test_kafka_connect.py
+++ b/metadata-ingestion/tests/unit/test_kafka_connect.py
@@ -939,6 +939,94 @@ class TestMongoSourceConnector:
         assert len(lineages) == 2
         assert all(lin.fine_grained_lineages is None for lin in lineages)
 
+    def test_mongo_source_asset_lineage_preserved_when_schema_missing(self) -> None:
+        """Asset-level lineage must survive a schema-resolver miss (URN absent from cache)."""
+        config = KafkaConnectSourceConfig(
+            connect_uri="http://test:8083",
+            cluster_name="test",
+            use_schema_resolver=True,
+            schema_resolver_finegrained_lineage=True,
+        )
+        report = KafkaConnectSourceReport()
+
+        manifest = ConnectorManifest(
+            name="mongo-source-connector",
+            type="source",
+            config={
+                "connector.class": "com.mongodb.kafka.connect.MongoSourceConnector",
+                "topic.prefix": "prod.mongo",
+            },
+            tasks=[],
+            topic_names=["prod.mongo.mydb.users"],
+        )
+
+        # Resolver returns the URN string but no schema (URN missing from DataHub cache).
+        mock_resolver = Mock()
+        mock_resolver.resolve_table.return_value = (
+            "urn:li:dataset:(urn:li:dataPlatform:mongodb,mydb.users,PROD)",
+            None,
+        )
+
+        connector = MongoSourceConnector(
+            connector_manifest=manifest,
+            config=config,
+            report=report,
+            schema_resolver=mock_resolver,
+        )
+
+        lineages = connector.extract_lineages()
+
+        # Asset-level lineage MUST be emitted even when CLL extraction has nothing to work with.
+        assert len(lineages) == 1
+        assert lineages[0].source_dataset == "mydb.users"
+        assert lineages[0].target_dataset == "prod.mongo.mydb.users"
+        assert lineages[0].fine_grained_lineages is None
+
+    def test_mongo_source_asset_lineage_preserved_when_resolver_raises(self) -> None:
+        """Exceptions in schema resolution must not block asset-level lineage."""
+        config = KafkaConnectSourceConfig(
+            connect_uri="http://test:8083",
+            cluster_name="test",
+            use_schema_resolver=True,
+            schema_resolver_finegrained_lineage=True,
+        )
+        report = KafkaConnectSourceReport()
+
+        manifest = ConnectorManifest(
+            name="mongo-source-connector",
+            type="source",
+            config={
+                "connector.class": "com.mongodb.kafka.connect.MongoSourceConnector",
+                "topic.prefix": "prod.mongo",
+            },
+            tasks=[],
+            topic_names=["prod.mongo.mydb.users"],
+        )
+
+        mock_resolver = Mock()
+        mock_resolver.resolve_table.side_effect = RuntimeError("simulated GMS hiccup")
+
+        connector = MongoSourceConnector(
+            connector_manifest=manifest,
+            config=config,
+            report=report,
+            schema_resolver=mock_resolver,
+        )
+
+        lineages = connector.extract_lineages()
+
+        # Asset-level lineage survives the exception.
+        assert len(lineages) == 1
+        assert lineages[0].source_dataset == "mydb.users"
+        assert lineages[0].fine_grained_lineages is None
+
+        # The CLL failure is surfaced as a structured warning, not silently dropped.
+        warnings = list(report.warnings)
+        assert len(warnings) == 1
+        assert any("mydb.users" in ctx for ctx in warnings[0].context), (
+            f"Expected warning context to include the failing table; got: {warnings[0].context}"
+        )
+
 
 class TestConfluentCloudConnectors:
     """Test Confluent Cloud connector compatibility with Platform connectors."""


### PR DESCRIPTION
## Summary

The kafka-connect MongoDB source connector and the shared `SchemaResolver` had two diagnostic blind spots that made per-collection lineage drops hard to investigate.

### 1. Silent CLL failures in `_extract_fine_grained_lineage`

Any exception inside `_extract_fine_grained_lineage` was swallowed at `logger.debug` level — no `report.warning`, no aggregation in the ingestion report. Per-collection schema-resolution failures (URN encoding edge cases, transform interactions, etc.) left no signal in the report.

This PR converts the broad `except Exception` into a structured `self.report.warning(...)` that names the connector, source/target, and exception type. Behavior is unchanged: `_extract_fine_grained_lineage` still returns `None` and the caller still appends asset-level lineage as before — only the visibility of the failure changes.

### 2. `SchemaResolverProvider` disabled per-URN fallback

`SchemaResolverProvider.get()` constructed `SchemaResolver` instances with `graph=None`, which disables the per-URN `get_entities()` fallback inside `SchemaResolver.resolve_table()`. When the bulk pre-population missed any URN — transient GMS error mid-batch, pagination edge case, filter mismatch — those entries were *permanently* absent from the cache for the rest of the ingestion run with no recovery path.

This PR passes `self._graph` through to the constructed resolver so the targeted per-URN fallback works again. The bulk-fetch fast path is preserved: cache hits short-circuit before any per-URN call is made, so populated URNs incur zero extra I/O.

### Tests

Adds two regression tests pinning the contract that asset-level lineage is emitted regardless of CLL outcome:

- `test_mongo_source_asset_lineage_preserved_when_schema_missing` — schema resolver returns `(urn, None)`; asset lineage is still emitted, `fine_grained_lineages is None`.
- `test_mongo_source_asset_lineage_preserved_when_resolver_raises` — schema resolver raises an exception; asset lineage is still emitted, a structured warning is reported with the failing source in context.

## Test plan

- [x] New unit tests pass.
- [x] Full `tests/unit/test_kafka_connect.py` (162) and `tests/unit/test_kafka_connect_schema_resolver.py` + `tests/unit/sdk/test_schema_resolver_cache.py` (29 combined) all pass.
- [x] `./gradlew :metadata-ingestion:lintFix` clean.