### PR TITLE
feat(ingest/sigma): emit UpstreamLineage from Data Model elements to warehouse tables

### DIFF
--- a/metadata-ingestion/docs/sources/sigma/sigma_post.md
+++ b/metadata-ingestion/docs/sources/sigma/sigma_post.md
@@ -56,6 +56,42 @@ chart_sources_platform_mapping:
     env: PROD
 ```
 
+##### Data Model element -> warehouse table lineage
+
+When `ingest_data_models: true` and `extract_lineage: true` (both default), the connector also emits entity-level `UpstreamLineage` from each Sigma Data Model element to the warehouse table it is sourced from.
+Resolution uses Sigma's `/v2/dataModels/{id}/lineage` (`type=table` entries) and `/v2/files/{inodeId}` to recover the fully-qualified table path (`<DB>/<SCHEMA>/<TABLE>`), then maps the Sigma connection to a DataHub platform via the connection registry.
+
+**Supported platforms**: All Sigma connection types in `SIGMA_TYPE_TO_DATAHUB_PLATFORM_MAP` (Snowflake, BigQuery, Redshift, Databricks, Postgres, MySQL, Athena, Spark, Trino, Presto, Synapse/MSSQL).
+Identifier casing is preserved as Sigma reports it, which matches the warehouse catalog for most platforms.
+Snowflake is the only platform that requires a case bridge (Snowflake's catalog uses uppercase identifiers, but the DataHub Snowflake connector lowercases them by default).
+
+**Matching URNs to your warehouse connector**: The emitted URNs use the Sigma recipe's `env` and `platform_instance=None` by default.
+This is correct for single-environment, single-instance setups.
+For multi-environment or multi-instance setups, use `connection_to_platform_map` to specify the exact env and platform_instance per Sigma connectionId:
+
+```yml
+connection_to_platform_map:
+  # Key is the Sigma connectionId (UUID from /v2/connections).
+  "4b39cdcd-5a58-4ff6-af0d-8409ff880a23":
+    env: PROD
+    platform_instance: prod-snowflake
+    # Set to false only if the Snowflake connector was run with
+    # convert_urns_to_lowercase: false (non-default).
+    convert_urns_to_lowercase: true
+```
+
+If a Snowflake source recipe sets `convert_urns_to_lowercase: false`, the warehouse connector emits upper-cased URNs and the edges produced here will dangle unless you set `convert_urns_to_lowercase: false` in the matching `connection_to_platform_map` entry.
+
+**Counters to monitor** (visible in the ingestion report):
+
+| Counter                                       | Meaning                                             |
+| --------------------------------------------- | --------------------------------------------------- |
+| `dm_element_warehouse_upstream_emitted`       | Warehouse lineage edges successfully emitted        |
+| `dm_element_warehouse_unknown_connection`     | ConnectionId not in registry or platform unmappable |
+| `dm_element_warehouse_table_lookup_failed`    | `/files/{inodeId}` call failed                      |
+| `dm_element_warehouse_path_unparseable`       | `/files` path did not match expected format         |
+| `dm_element_warehouse_table_entry_incomplete` | Lineage entry missing inodeId or connectionId       |
+
 ### Limitations
 
 Module behavior is constrained by source APIs, permissions, and metadata exposed by the platform. Refer to capability notes for unsupported or conditional features.

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
@@ -328,6 +328,11 @@ class SigmaSourceReport(StaleEntityRemovalSourceReport):
     # Success: one per unique warehouse upstream URN emitted (post-dedup).
     dm_element_warehouse_upstream_emitted: int = 0
     # connectionId not in registry, or registry record has is_mappable=False.
+    # Note: this counter overlaps with data_model_element_upstreams_unresolved_external
+    # when both warehouse and SD resolution fail for the same source_id — the
+    # same edge is tallied in both buckets (warehouse failure sub-category +
+    # aggregate unresolved). This is intentional: the new counter sub-categorizes
+    # rather than replaces the existing one.
     dm_element_warehouse_unknown_connection: int = 0
     # /files/{inodeId} returned non-200 or raised an exception (first attempt
     # per inode only; cache hits of a prior failure are not double-counted).
@@ -350,6 +355,18 @@ class WarehouseConnectionConfig(PlatformInstanceConfigMixin, EnvConfigMixin):
     to None — correct for single-env, single-instance deployments but
     produces dangling lineage for multi-env or multi-instance setups.
     """
+
+    convert_urns_to_lowercase: bool = pydantic.Field(
+        default=True,
+        description=(
+            "Whether to lower-case warehouse identifiers when constructing "
+            "Dataset URNs. Must match the convert_urns_to_lowercase setting "
+            "used by the corresponding warehouse connector recipe. Defaults "
+            "to True (matching the Snowflake connector default). Set to False "
+            "if the warehouse source was ingested with "
+            "convert_urns_to_lowercase: false."
+        ),
+    )
 
 
 class PlatformDetail(PlatformInstanceConfigMixin, EnvConfigMixin):

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
@@ -325,25 +325,17 @@ class SigmaSourceReport(StaleEntityRemovalSourceReport):
     connections_duplicate_id: int = 0
 
     # DM element -> warehouse table UpstreamLineage counters.
-    # Success: one UpstreamLineage aspect emitted per DM element backed by a
-    # resolved warehouse table (counts unique upstreams, not elements).
+    # Success: one per unique warehouse upstream URN emitted (post-dedup).
     dm_element_warehouse_upstream_emitted: int = 0
-    # connectionId from the lineage entry was not in the connection registry.
+    # connectionId not in registry, or registry record has is_mappable=False.
     dm_element_warehouse_unknown_connection: int = 0
-    # connection registry record has is_mappable=False (Sigma type unknown
-    # to SIGMA_TYPE_TO_DATAHUB_PLATFORM_MAP).
-    dm_element_warehouse_unmappable_platform: int = 0
     # /files/{inodeId} returned non-200 or raised an exception.
     dm_element_warehouse_table_lookup_failed: int = 0
-    # /files path had fewer than 3 segments (Connection Root/DB/SCHEMA expected).
+    # /files path could not be parsed as Connection Root/<DB>/<SCHEMA>.
     dm_element_warehouse_path_unparseable: int = 0
-    # /files path root segment was not "Connection Root" -- forward-compat
-    # guard for non-Snowflake platforms or i18n variants.
-    dm_element_warehouse_unexpected_path_root: int = 0
-    # /files response served from the SigmaSource instance-level cache.
-    dm_element_warehouse_files_cache_hit: int = 0
-    # Live HTTP call made to /files (cache miss).
-    dm_element_warehouse_files_api_call: int = 0
+    # type=table lineage entry missing inodeId or name; skipped to avoid
+    # emitting a malformed URN.
+    dm_element_warehouse_table_entry_incomplete: int = 0
 
 
 class PlatformDetail(PlatformInstanceConfigMixin, EnvConfigMixin):

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
@@ -341,6 +341,17 @@ class SigmaSourceReport(StaleEntityRemovalSourceReport):
     dm_element_warehouse_table_entry_incomplete: int = 0
 
 
+class WarehouseConnectionConfig(PlatformInstanceConfigMixin, EnvConfigMixin):
+    """Per-connection env / platform_instance overrides for warehouse URN construction.
+
+    Maps a Sigma connectionId to the env and platform_instance of the
+    corresponding DataHub warehouse connector run.  When a connection is not
+    listed, the Sigma source's own env is used and platform_instance defaults
+    to None — correct for single-env, single-instance deployments but
+    produces dangling lineage for multi-env or multi-instance setups.
+    """
+
+
 class PlatformDetail(PlatformInstanceConfigMixin, EnvConfigMixin):
     data_source_platform: str = pydantic.Field(
         description="A chart's data sources platform name.",
@@ -393,6 +404,20 @@ class SigmaSourceConfig(
     chart_sources_platform_mapping: Dict[str, PlatformDetail] = pydantic.Field(
         default={},
         description="A mapping of the sigma workspace/workbook/chart folder path to all chart's data sources platform details present inside that folder path.",
+    )
+    connection_to_platform_map: Dict[str, WarehouseConnectionConfig] = pydantic.Field(
+        default_factory=dict,
+        description=(
+            "Per-connection env / platform_instance overrides for warehouse URN "
+            "construction from DM element lineage. Keys are Sigma connectionIds "
+            "(visible in the Sigma admin UI or /v2/connections response). "
+            "When a connection is not listed, the Sigma source's own env is used "
+            "and platform_instance defaults to None, which is correct for "
+            "single-env, single-instance deployments. For multi-env or "
+            "multi-instance warehouse setups, add an entry here so the emitted "
+            "UpstreamLineage edge points at the URN the warehouse connector "
+            "actually produced."
+        ),
     )
     stateful_ingestion: Optional[StatefulStaleMetadataRemovalConfig] = pydantic.Field(
         default=None, description="Sigma Stateful Ingestion Config."

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
@@ -324,6 +324,27 @@ class SigmaSourceReport(StaleEntityRemovalSourceReport):
     # records overwrite earlier ones in by_id.
     connections_duplicate_id: int = 0
 
+    # DM element -> warehouse table UpstreamLineage counters.
+    # Success: one UpstreamLineage aspect emitted per DM element backed by a
+    # resolved warehouse table (counts unique upstreams, not elements).
+    dm_element_warehouse_upstream_emitted: int = 0
+    # connectionId from the lineage entry was not in the connection registry.
+    dm_element_warehouse_unknown_connection: int = 0
+    # connection registry record has is_mappable=False (Sigma type unknown
+    # to SIGMA_TYPE_TO_DATAHUB_PLATFORM_MAP).
+    dm_element_warehouse_unmappable_platform: int = 0
+    # /files/{inodeId} returned non-200 or raised an exception.
+    dm_element_warehouse_table_lookup_failed: int = 0
+    # /files path had fewer than 3 segments (Connection Root/DB/SCHEMA expected).
+    dm_element_warehouse_path_unparseable: int = 0
+    # /files path root segment was not "Connection Root" -- forward-compat
+    # guard for non-Snowflake platforms or i18n variants.
+    dm_element_warehouse_unexpected_path_root: int = 0
+    # /files response served from the SigmaSource instance-level cache.
+    dm_element_warehouse_files_cache_hit: int = 0
+    # Live HTTP call made to /files (cache miss).
+    dm_element_warehouse_files_api_call: int = 0
+
 
 class PlatformDetail(PlatformInstanceConfigMixin, EnvConfigMixin):
     data_source_platform: str = pydantic.Field(

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
@@ -329,8 +329,11 @@ class SigmaSourceReport(StaleEntityRemovalSourceReport):
     dm_element_warehouse_upstream_emitted: int = 0
     # connectionId not in registry, or registry record has is_mappable=False.
     dm_element_warehouse_unknown_connection: int = 0
-    # /files/{inodeId} returned non-200 or raised an exception.
+    # /files/{inodeId} returned non-200 or raised an exception (first attempt
+    # per inode only; cache hits of a prior failure are not double-counted).
     dm_element_warehouse_table_lookup_failed: int = 0
+    # Sub-bucket of table_lookup_failed: /files returned 429 after retries.
+    dm_element_warehouse_table_lookup_rate_limited: int = 0
     # /files path could not be parsed as Connection Root/<DB>/<SCHEMA>.
     dm_element_warehouse_path_unparseable: int = 0
     # type=table lineage entry missing inodeId or name; skipped to avoid

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/data_classes.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/data_classes.py
@@ -203,10 +203,14 @@ class File(BaseModel):
 
 
 class WarehouseInodeRaw(TypedDict):
-    """Raw type=table lineage entry stashed for /files lookup."""
+    """Minimal type=table lineage entry stashed for /files/{inodeId} lookup.
+
+    Only connectionId is required here; the table name is taken from the
+    /files response (the canonical source) rather than from the lineage entry,
+    which may carry a display label or stale name.
+    """
 
     connectionId: str
-    name: str
 
 
 class SigmaDataModelColumn(BaseModel):

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/data_classes.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/data_classes.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, Field, model_validator
+from typing_extensions import TypedDict
 
 from datahub.emitter.mcp_builder import ContainerKey
 
@@ -201,6 +202,13 @@ class File(BaseModel):
     workspaceId: Optional[str] = None
 
 
+class WarehouseInodeRaw(TypedDict):
+    """Raw type=table lineage entry stashed for /files lookup."""
+
+    connectionId: str
+    name: str
+
+
 class SigmaDataModelColumn(BaseModel):
     columnId: str
     name: str
@@ -282,10 +290,10 @@ class SigmaDataModel(BaseModel):
     # element name without requiring the consuming element to share that name.
     source_dm_element_names: Dict[str, List[str]] = Field(default_factory=dict)
     # Populated from /lineage ``type=table`` entries during assembly.
-    # Maps inodeId (UUID) → {"connectionId": str, "name": str} so the
-    # SigmaSource resolver can call /files/{inodeId} for the urlId + path
-    # needed to construct a fully-qualified warehouse Dataset URN.
-    warehouse_inodes_by_inode_id: Dict[str, Dict[str, str]] = Field(
+    # Maps inodeId (UUID) -> WarehouseInodeRaw so the SigmaSource resolver
+    # can call /files/{inodeId} for the urlId + path needed to construct a
+    # fully-qualified warehouse Dataset URN.
+    warehouse_inodes_by_inode_id: Dict[str, "WarehouseInodeRaw"] = Field(
         default_factory=dict
     )
 

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/data_classes.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/data_classes.py
@@ -293,7 +293,7 @@ class SigmaDataModel(BaseModel):
     # Maps inodeId (UUID) -> WarehouseInodeRaw so the SigmaSource resolver
     # can call /files/{inodeId} for the urlId + path needed to construct a
     # fully-qualified warehouse Dataset URN.
-    warehouse_inodes_by_inode_id: Dict[str, "WarehouseInodeRaw"] = Field(
+    warehouse_inodes_by_inode_id: Dict[str, WarehouseInodeRaw] = Field(
         default_factory=dict
     )
 

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/data_classes.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/data_classes.py
@@ -281,6 +281,13 @@ class SigmaDataModel(BaseModel):
     # Used by cross-DM entity-level resolution to look up the correct source
     # element name without requiring the consuming element to share that name.
     source_dm_element_names: Dict[str, List[str]] = Field(default_factory=dict)
+    # Populated from /lineage ``type=table`` entries during assembly.
+    # Maps inodeId (UUID) → {"connectionId": str, "name": str} so the
+    # SigmaSource resolver can call /files/{inodeId} for the urlId + path
+    # needed to construct a fully-qualified warehouse Dataset URN.
+    warehouse_inodes_by_inode_id: Dict[str, Dict[str, str]] = Field(
+        default_factory=dict
+    )
 
     def get_url_id(self) -> str:
         """Return the DM's URL identifier: explicit ``urlId`` if set,

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -194,13 +194,13 @@ CrossDmOutcome = Literal[
 # Other platforms are excluded until their DataHub source's URN convention is
 # explicitly verified — adding an unvalidated platform risks emitting URNs
 # that don't match the warehouse connector's output.
-_WAREHOUSE_LOWERCASE_PLATFORMS: frozenset = frozenset({"snowflake"})
+_WAREHOUSE_LOWERCASE_PLATFORMS: frozenset[str] = frozenset({"snowflake"})
 
-# Sentinel for a /files path whose root segment is not "Connection Root".
+# Expected root segment of the /files path for warehouse tables.
 _FILES_PATH_ROOT = "Connection Root"
 
 
-@dataclass
+@dataclass(frozen=True)
 class _WarehouseTableRef:
     """Resolved warehouse table coordinates derived from a /files response."""
 
@@ -599,9 +599,13 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         for inode_id, raw in data_model.warehouse_inodes_by_inode_id.items():
             conn_id = raw["connectionId"]
             table_name = raw["name"]
+            first_attempt = inode_id not in self._files_cache
             files_data = self._get_file_metadata_cached(inode_id)
             if files_data is None:
-                self.reporter.dm_element_warehouse_table_lookup_failed += 1
+                # Only count on first failure; cache hits of a prior None
+                # (same inode referenced from N DMs) should not inflate.
+                if first_attempt:
+                    self.reporter.dm_element_warehouse_table_lookup_failed += 1
                 logger.debug(
                     "DM %s: /files lookup failed for inode %r; skipping.",
                     data_model.dataModelId,
@@ -611,14 +615,21 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             url_id = str(files_data.get("urlId") or "")
             path = str(files_data.get("path") or "")
             parts = path.split("/")
-            if not url_id or len(parts) != 3:
+            # B2: also reject empty segments (e.g. "Connection Root//PUBLIC"
+            # passes len==3 but parts[1]=="" -> malformed URN).
+            if not url_id or len(parts) != 3 or not all(parts):
                 self.reporter.dm_element_warehouse_path_unparseable += 1
-                logger.debug(
-                    "DM %s inode %r: cannot parse warehouse path %r "
-                    "(expected exactly 'Connection Root/<DB>/<SCHEMA>').",
-                    data_model.dataModelId,
-                    inode_id,
-                    path,
+                self.reporter.warning(
+                    title="Sigma warehouse /files path unparseable",
+                    message=(
+                        "Expected exactly 'Connection Root/<DB>/<SCHEMA>' with "
+                        "no empty segments and a non-empty urlId. "
+                        "Warehouse upstream skipped."
+                    ),
+                    context=(
+                        f"dm={data_model.dataModelId}, inode={inode_id}, "
+                        f"path={path!r}, url_id={url_id!r}"
+                    ),
                 )
                 continue
             if parts[0] != _FILES_PATH_ROOT:
@@ -669,7 +680,8 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
 
         record = self.connection_registry.get(ref.connection_id)
         if record is None or not record.is_mappable:
-            self.reporter.dm_element_warehouse_unknown_connection += 1
+            # Counter is bumped by caller gated on unresolved_seen to avoid
+            # inflating on diamond source_ids.
             logger.debug(
                 "inode-%s: connectionId %r not resolvable to a warehouse platform "
                 "(missing from registry or is_mappable=False).",
@@ -817,7 +829,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         element_dataset_urn: str,
         elementId_to_dataset_urn: Dict[str, str],
         element_name_to_eids: Dict[str, List[str]],
-        warehouse_url_id_map: Optional[Dict[str, _WarehouseTableRef]] = None,
+        warehouse_url_id_map: Dict[str, _WarehouseTableRef],
     ) -> Optional[UpstreamLineage]:
         # Success counters bump once per unique URN; diamond source_ids
         # resolving to the same URN should not inflate the signal.
@@ -843,19 +855,26 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                 # can fire for the same inode when a file is catalogued as both
                 # a Sigma Dataset and a warehouse table.
                 warehouse_urn: Optional[str] = None
-                if warehouse_url_id_map:
-                    warehouse_urn = self._resolve_dm_element_warehouse_upstream(
-                        url_id_suffix=url_id_suffix,
-                        warehouse_map=warehouse_url_id_map,
-                    )
+                warehouse_urn = self._resolve_dm_element_warehouse_upstream(
+                    url_id_suffix=url_id_suffix,
+                    warehouse_map=warehouse_url_id_map,
+                )
                 upstream_urn = self._resolve_dm_element_external_upstream(source_id)
                 shape = "external"
-                # warehouse_urn is deduped separately; counter bumped here
-                # (post-dedup) so diamond source_ids don't inflate the signal.
+                # Warehouse URN: deduped separately; emitted counter bumped
+                # post-dedup so diamond source_ids don't inflate the signal.
                 if warehouse_urn and warehouse_urn not in seen:
                     upstream_urns.append(warehouse_urn)
                     seen.add(warehouse_urn)
                     self.reporter.dm_element_warehouse_upstream_emitted += 1
+                # Connection-failure counter: gated on unresolved_seen to
+                # match the cross-DM symmetry (one bump per unique source_id).
+                if (
+                    warehouse_urn is None
+                    and url_id_suffix in warehouse_url_id_map
+                    and source_id not in unresolved_seen
+                ):
+                    self.reporter.dm_element_warehouse_unknown_connection += 1
                 if (
                     upstream_urn is None
                     and warehouse_urn is None

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -188,10 +188,12 @@ CrossDmOutcome = Literal[
     "name_unmatched_but_dm_known",
 ]
 
-# Platforms where SQL identifiers are case-insensitive and DataHub stores them
-# lower-cased.  Mirrors the Snowflake connector's ``snowflake_identifier()``
-# convention (``identifier.lower()``).  BigQuery is case-sensitive; others not
-# listed here preserve the casing Sigma reports.
+# Heuristic: platforms where unquoted SQL identifiers are case-insensitive and
+# DataHub conventionally stores them lower-cased (matching the Snowflake
+# connector's snowflake_identifier() behaviour).  This is a best-effort default
+# and can be wrong for quoted identifiers, collation-dependent engines (MSSQL,
+# MySQL), or metastore-dependent runtimes (Spark, Databricks, Athena, Trino).
+# BigQuery is case-sensitive and is therefore NOT included here.
 _WAREHOUSE_LOWERCASE_PLATFORMS: frozenset = frozenset(
     {
         "snowflake",
@@ -585,19 +587,14 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         return self.sigma_dataset_urn_by_url_id.get(suffix)
 
     def _get_file_metadata_cached(self, inode_id: str) -> Optional[Dict[str, Any]]:
-        """Fetch /files/{inodeId} with instance-level caching (R3).
+        """Fetch /files/{inodeId} with instance-level caching.
 
-        Bumps dm_element_warehouse_files_cache_hit on a hit and
-        dm_element_warehouse_files_api_call on a miss.  Stores None on failure
-        so repeated calls for a broken inode don't retry the network.
+        Stores None on failure so repeated calls for a broken inode don't
+        retry the network.
         """
-        if inode_id in self._files_cache:
-            self.reporter.dm_element_warehouse_files_cache_hit += 1
-            return self._files_cache[inode_id]
-        self.reporter.dm_element_warehouse_files_api_call += 1
-        result = self.sigma_api.get_file_metadata(inode_id)
-        self._files_cache[inode_id] = result
-        return result
+        if inode_id not in self._files_cache:
+            self._files_cache[inode_id] = self.sigma_api.get_file_metadata(inode_id)
+        return self._files_cache[inode_id]
 
     def _build_dm_warehouse_url_id_map(
         self, data_model: SigmaDataModel
@@ -610,12 +607,11 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         Counters bumped here:
           - dm_element_warehouse_table_lookup_failed
           - dm_element_warehouse_path_unparseable
-          - dm_element_warehouse_unexpected_path_root
         """
         result: Dict[str, "_WarehouseTableRef"] = {}
         for inode_id, raw in data_model.warehouse_inodes_by_inode_id.items():
-            conn_id = raw.get("connectionId", "")
-            table_name = raw.get("name", "")
+            conn_id = raw["connectionId"]
+            table_name = raw["name"]
             files_data = self._get_file_metadata_cached(inode_id)
             if files_data is None:
                 self.reporter.dm_element_warehouse_table_lookup_failed += 1
@@ -628,29 +624,28 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             url_id = str(files_data.get("urlId") or "")
             path = str(files_data.get("path") or "")
             parts = path.split("/")
-            if len(parts) < 3:
+            if not url_id or len(parts) != 3:
                 self.reporter.dm_element_warehouse_path_unparseable += 1
                 logger.debug(
-                    "DM %s inode %r: /files path %r has fewer than 3 segments; "
-                    "expected 'Connection Root/<DB>/<SCHEMA>'.",
+                    "DM %s inode %r: cannot parse warehouse path %r "
+                    "(expected exactly 'Connection Root/<DB>/<SCHEMA>').",
                     data_model.dataModelId,
                     inode_id,
                     path,
                 )
                 continue
             if parts[0] != _FILES_PATH_ROOT:
-                self.reporter.dm_element_warehouse_unexpected_path_root += 1
-                logger.debug(
-                    "DM %s inode %r: /files path root %r != %r; "
-                    "skipping (forward-compat guard).",
-                    data_model.dataModelId,
-                    inode_id,
-                    parts[0],
-                    _FILES_PATH_ROOT,
-                )
-                continue
-            if not url_id:
                 self.reporter.dm_element_warehouse_path_unparseable += 1
+                self.reporter.warning(
+                    title="Sigma warehouse path has unexpected root segment",
+                    message=(
+                        "Expected the /files path root to be 'Connection Root' "
+                        "but got a different value. Warehouse upstream skipped. "
+                        "This may indicate a Sigma API change or a localised "
+                        "tenant configuration."
+                    ),
+                    context=f"dm={data_model.dataModelId}, inode={inode_id}, path={path!r}",
+                )
                 continue
             result[url_id] = _WarehouseTableRef(
                 connection_id=conn_id,
@@ -665,43 +660,38 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         *,
         url_id_suffix: str,
         warehouse_map: Dict[str, "_WarehouseTableRef"],
-        inode_source_id: str,
     ) -> Optional[str]:
         """Resolve a warehouse-table-backed inode sourceId to a fully-qualified
         warehouse Dataset URN via the connection registry.
 
         Returns None and bumps the appropriate counter when:
           - url_id_suffix is not in warehouse_map (not a type=table inode)
-          - connection_id is not in the registry (dm_element_warehouse_unknown_connection)
-          - registry record has is_mappable=False (dm_element_warehouse_unmappable_platform)
-        On success, bumps dm_element_warehouse_upstream_emitted.
+          - connection_id is not in the registry or is_mappable=False
+            (dm_element_warehouse_unknown_connection)
+
+        Note: dm_element_warehouse_upstream_emitted is NOT bumped here; the
+        caller bumps it post-dedup so diamond source_ids (multiple inode-
+        entries resolving to the same URN) don't inflate the counter.
+
+        Note: platform_instance is always None; per-connection overrides are
+        a follow-up (TODO: add connection_to_platform_map to SigmaSourceConfig).
         """
         ref = warehouse_map.get(url_id_suffix)
         if ref is None:
             return None
 
         record = self.connection_registry.get(ref.connection_id)
-        if record is None:
+        if record is None or not record.is_mappable:
             self.reporter.dm_element_warehouse_unknown_connection += 1
             logger.debug(
-                "inode %r: connectionId %r not in connection registry.",
-                inode_source_id,
+                "inode-%s: connectionId %r not resolvable to a warehouse platform "
+                "(missing from registry or is_mappable=False).",
+                url_id_suffix,
                 ref.connection_id,
-            )
-            return None
-
-        if not record.is_mappable:
-            self.reporter.dm_element_warehouse_unmappable_platform += 1
-            logger.debug(
-                "inode %r: connection %r has is_mappable=False (sigma_type=%r).",
-                inode_source_id,
-                ref.connection_id,
-                record.sigma_type,
             )
             return None
 
         fq = ref.fq_name(record.datahub_platform)
-        self.reporter.dm_element_warehouse_upstream_emitted += 1
         return builder.make_dataset_urn_with_platform_instance(
             platform=record.datahub_platform,
             name=fq,
@@ -870,15 +860,15 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                     warehouse_urn = self._resolve_dm_element_warehouse_upstream(
                         url_id_suffix=url_id_suffix,
                         warehouse_map=warehouse_url_id_map,
-                        inode_source_id=source_id,
                     )
                 upstream_urn = self._resolve_dm_element_external_upstream(source_id)
                 shape = "external"
-                # Collect both URNs; warehouse_urn is added after the loop's
-                # dedup-gate so both get an individual seen-check.
+                # warehouse_urn is deduped separately; counter bumped here
+                # (post-dedup) so diamond source_ids don't inflate the signal.
                 if warehouse_urn and warehouse_urn not in seen:
                     upstream_urns.append(warehouse_urn)
                     seen.add(warehouse_urn)
+                    self.reporter.dm_element_warehouse_upstream_emitted += 1
                 if (
                     upstream_urn is None
                     and warehouse_urn is None

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -190,7 +190,11 @@ CrossDmOutcome = Literal[
 
 # Platforms where DataHub stores identifiers lower-cased, matching the
 # corresponding source connector's normalization. Snowflake is confirmed via
-# snowflake_utils.py::snowflake_identifier() (identifier.lower()).
+# snowflake_utils.py::snowflake_identifier() (identifier.lower()), which is
+# the default and does not check convert_urns_to_lowercase. If a Snowflake
+# source is configured with convert_urns_to_lowercase: false, its URNs will
+# be upper-cased and the edges emitted here will dangle. That non-default
+# configuration is unsupported without a per-connection casing override.
 # Other platforms are excluded until their DataHub source's URN convention is
 # explicitly verified — adding an unvalidated platform risks emitting URNs
 # that don't match the warehouse connector's output.
@@ -604,7 +608,6 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         result: Dict[str, _WarehouseTableRef] = {}
         for inode_id, raw in data_model.warehouse_inodes_by_inode_id.items():
             conn_id = raw["connectionId"]
-            table_name = raw["name"]
             first_attempt = inode_id not in self._files_cache
             files_data = self._get_file_metadata_cached(inode_id)
             if files_data is None:
@@ -620,13 +623,19 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                 continue
             url_id = str(files_data.get("urlId") or "")
             path = str(files_data.get("path") or "")
+            # Use /files["name"] as the canonical table name — it is the
+            # authoritative source and avoids trusting the lineage entry's
+            # name field, which may be a display label or absent.
+            table_name = str(files_data.get("name") or "")
             parts = path.split("/")
             # Validate: exactly 3 non-empty segments and a non-empty urlId.
             # Rejects "Acryl Workspace" (CSV uploads), "Connection Root//PUBLIC"
             # (empty DB segment -> malformed URN), and >3 segments.
             # H4 TODO: confirm with Sigma whether API path strings are localised;
             # if so, relax the literal "Connection Root" check.
-            path_invalid = not url_id or len(parts) != 3 or not all(parts)
+            path_invalid = (
+                not url_id or not table_name or len(parts) != 3 or not all(parts)
+            )
             root_unexpected = (not path_invalid) and parts[0] != _FILES_PATH_ROOT
             if path_invalid or root_unexpected:
                 # Dedup per inode: a single misconfigured inode shared across N
@@ -645,7 +654,10 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                             "no empty segments and a non-empty urlId. "
                             "Warehouse upstream skipped for this inode."
                         ),
-                        context=f"inode={inode_id}, path={path!r}, url_id={url_id!r}",
+                        context=(
+                            f"inode={inode_id}, path={path!r}, "
+                            f"url_id={url_id!r}, table_name={table_name!r}"
+                        ),
                     )
                 continue
             result[url_id] = _WarehouseTableRef(

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -323,7 +323,10 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         # Instance-level cache for /files/{inodeId} responses.
         # Keyed by inodeId (UUID); value is the raw JSON dict or None on failure.
         # Shared across all DMs so inodes that appear in multiple DMs hit the
-        # network only once.
+        # network only once.  The cache is unbounded — each entry is a small
+        # JSON dict and the number of unique warehouse-table inodes per tenant
+        # is expected to be in the hundreds, not millions.  If this assumption
+        # proves wrong, an LRU cap can be added without changing the interface.
         self._files_cache: Dict[str, Optional[Dict[str, Any]]] = {}
         # Inodes whose /files path already produced an unparseable warning;
         # prevents N identical warnings when the same inode spans N DMs (H3).
@@ -706,8 +709,11 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         """Resolve a warehouse-table-backed inode sourceId to a fully-qualified
         warehouse Dataset URN via the connection registry.
 
+        Returns None silently (no counter) when:
+          - url_id_suffix is not in warehouse_map — this inode is a Sigma Dataset,
+            not a warehouse table; not a failure, just not applicable here.
+
         Returns None and bumps the appropriate counter when:
-          - url_id_suffix is not in warehouse_map (not a type=table inode)
           - connection_id is not in the registry or is_mappable=False
             (dm_element_warehouse_unknown_connection)
 
@@ -955,15 +961,24 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                 url_id_suffix = source_id[len("inode-") :]
                 # Check warehouse map (type=table nodes) and the existing SD
                 # resolver (type=dataset nodes) in parallel; both can fire for
-                # the same inode when a file is catalogued as both.
+                # the same inode when a file is catalogued as both a Sigma
+                # Dataset and a warehouse table.  Emitting both as direct
+                # upstreams is intentional: the warehouse edge gives operators
+                # end-to-end lineage to the source table, while the SD edge
+                # preserves the Sigma-Dataset hop.  Downstream lineage queries
+                # may see the warehouse table as a direct upstream of the DM
+                # element — this is correct for the entity-level graph.
                 warehouse_urn = self._resolve_dm_element_warehouse_upstream(
                     url_id_suffix=url_id_suffix,
                     warehouse_map=warehouse_url_id_map,
                 )
                 upstream_urn = self._resolve_dm_element_external_upstream(source_id)
                 shape = "external"
-                # Warehouse success: deduped via seen; counter bumped post-dedup
-                # so diamond source_ids don't inflate the signal.
+                # Both URN types use the same ``seen`` set so a warehouse URN
+                # and an SD URN that happen to collide are still deduped.
+                # warehouse_urn is appended here (inside the inode- branch) with
+                # its own seen-check; upstream_urn follows the standard gate at
+                # the bottom of the for-loop.
                 if warehouse_urn and warehouse_urn not in seen:
                     upstream_urns.append(warehouse_urn)
                     seen.add(warehouse_urn)

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Dict, Iterable, List, Literal, Optional, Set, Tuple
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Literal, Optional, Set, Tuple
 
 import datahub.emitter.mce_builder as builder
 from datahub.configuration.common import ConfigurationError
@@ -187,6 +188,42 @@ CrossDmOutcome = Literal[
     "name_unmatched_but_dm_known",
 ]
 
+# Platforms where SQL identifiers are case-insensitive and DataHub stores them
+# lower-cased.  Mirrors the Snowflake connector's ``snowflake_identifier()``
+# convention (``identifier.lower()``).  BigQuery is case-sensitive; others not
+# listed here preserve the casing Sigma reports.
+_WAREHOUSE_LOWERCASE_PLATFORMS: frozenset = frozenset(
+    {
+        "snowflake",
+        "redshift",
+        "postgres",
+        "mysql",
+        "athena",
+        "trino",
+        "presto",
+        "mssql",
+        "spark",
+        "databricks",
+    }
+)
+
+# Sentinel for a /files path whose root segment is not "Connection Root".
+_FILES_PATH_ROOT = "Connection Root"
+
+
+@dataclass
+class _WarehouseTableRef:
+    """Resolved warehouse table coordinates derived from a /files response."""
+
+    connection_id: str
+    db: str
+    schema: str
+    table: str
+
+    def fq_name(self, platform: str) -> str:
+        name = f"{self.db}.{self.schema}.{self.table}"
+        return name.lower() if platform in _WAREHOUSE_LOWERCASE_PLATFORMS else name
+
 
 @platform_name("Sigma")
 @config_class(SigmaSourceConfig)
@@ -284,6 +321,11 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                 "False -- the pattern has no effect. Enable ingest_data_models "
                 "or remove data_model_pattern to silence this warning.",
             )
+        # Instance-level cache for /files/{inodeId} responses.
+        # Keyed by inodeId (UUID); value is the raw JSON dict or None on failure.
+        # Shared across all DMs so inodes that appear in multiple DMs hit the
+        # network only once.
+        self._files_cache: Dict[str, Optional[Dict[str, Any]]] = {}
         try:
             self.sigma_api = SigmaAPI(self.config, self.reporter)
         except Exception as e:
@@ -542,6 +584,131 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         suffix = source_id[len("inode-") :]
         return self.sigma_dataset_urn_by_url_id.get(suffix)
 
+    def _get_file_metadata_cached(self, inode_id: str) -> Optional[Dict[str, Any]]:
+        """Fetch /files/{inodeId} with instance-level caching (R3).
+
+        Bumps dm_element_warehouse_files_cache_hit on a hit and
+        dm_element_warehouse_files_api_call on a miss.  Stores None on failure
+        so repeated calls for a broken inode don't retry the network.
+        """
+        if inode_id in self._files_cache:
+            self.reporter.dm_element_warehouse_files_cache_hit += 1
+            return self._files_cache[inode_id]
+        self.reporter.dm_element_warehouse_files_api_call += 1
+        result = self.sigma_api.get_file_metadata(inode_id)
+        self._files_cache[inode_id] = result
+        return result
+
+    def _build_dm_warehouse_url_id_map(
+        self, data_model: SigmaDataModel
+    ) -> Dict[str, "_WarehouseTableRef"]:
+        """For each type=table lineage inode on this DM, call /files/{inodeId}
+        (cached) to get the ``urlId`` and ``path``.  Returns a map of
+        ``urlId → _WarehouseTableRef`` so ``_gen_data_model_element_upstream_lineage``
+        can look up by the suffix that element ``sourceIds`` use.
+
+        Counters bumped here:
+          - dm_element_warehouse_table_lookup_failed
+          - dm_element_warehouse_path_unparseable
+          - dm_element_warehouse_unexpected_path_root
+        """
+        result: Dict[str, "_WarehouseTableRef"] = {}
+        for inode_id, raw in data_model.warehouse_inodes_by_inode_id.items():
+            conn_id = raw.get("connectionId", "")
+            table_name = raw.get("name", "")
+            files_data = self._get_file_metadata_cached(inode_id)
+            if files_data is None:
+                self.reporter.dm_element_warehouse_table_lookup_failed += 1
+                logger.debug(
+                    "DM %s: /files lookup failed for inode %r; skipping.",
+                    data_model.dataModelId,
+                    inode_id,
+                )
+                continue
+            url_id = str(files_data.get("urlId") or "")
+            path = str(files_data.get("path") or "")
+            parts = path.split("/")
+            if len(parts) < 3:
+                self.reporter.dm_element_warehouse_path_unparseable += 1
+                logger.debug(
+                    "DM %s inode %r: /files path %r has fewer than 3 segments; "
+                    "expected 'Connection Root/<DB>/<SCHEMA>'.",
+                    data_model.dataModelId,
+                    inode_id,
+                    path,
+                )
+                continue
+            if parts[0] != _FILES_PATH_ROOT:
+                self.reporter.dm_element_warehouse_unexpected_path_root += 1
+                logger.debug(
+                    "DM %s inode %r: /files path root %r != %r; "
+                    "skipping (forward-compat guard).",
+                    data_model.dataModelId,
+                    inode_id,
+                    parts[0],
+                    _FILES_PATH_ROOT,
+                )
+                continue
+            if not url_id:
+                self.reporter.dm_element_warehouse_path_unparseable += 1
+                continue
+            result[url_id] = _WarehouseTableRef(
+                connection_id=conn_id,
+                db=parts[1],
+                schema=parts[2],
+                table=table_name,
+            )
+        return result
+
+    def _resolve_dm_element_warehouse_upstream(
+        self,
+        *,
+        url_id_suffix: str,
+        warehouse_map: Dict[str, "_WarehouseTableRef"],
+        inode_source_id: str,
+    ) -> Optional[str]:
+        """Resolve a warehouse-table-backed inode sourceId to a fully-qualified
+        warehouse Dataset URN via the connection registry.
+
+        Returns None and bumps the appropriate counter when:
+          - url_id_suffix is not in warehouse_map (not a type=table inode)
+          - connection_id is not in the registry (dm_element_warehouse_unknown_connection)
+          - registry record has is_mappable=False (dm_element_warehouse_unmappable_platform)
+        On success, bumps dm_element_warehouse_upstream_emitted.
+        """
+        ref = warehouse_map.get(url_id_suffix)
+        if ref is None:
+            return None
+
+        record = self.connection_registry.get(ref.connection_id)
+        if record is None:
+            self.reporter.dm_element_warehouse_unknown_connection += 1
+            logger.debug(
+                "inode %r: connectionId %r not in connection registry.",
+                inode_source_id,
+                ref.connection_id,
+            )
+            return None
+
+        if not record.is_mappable:
+            self.reporter.dm_element_warehouse_unmappable_platform += 1
+            logger.debug(
+                "inode %r: connection %r has is_mappable=False (sigma_type=%r).",
+                inode_source_id,
+                ref.connection_id,
+                record.sigma_type,
+            )
+            return None
+
+        fq = ref.fq_name(record.datahub_platform)
+        self.reporter.dm_element_warehouse_upstream_emitted += 1
+        return builder.make_dataset_urn_with_platform_instance(
+            platform=record.datahub_platform,
+            name=fq,
+            env=self.config.env,
+            platform_instance=None,
+        )
+
     def _resolve_dm_element_cross_dm_upstream(
         self,
         source_id: str,
@@ -673,6 +840,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         element_dataset_urn: str,
         elementId_to_dataset_urn: Dict[str, str],
         element_name_to_eids: Dict[str, List[str]],
+        warehouse_url_id_map: Optional[Dict[str, "_WarehouseTableRef"]] = None,
     ) -> Optional[UpstreamLineage]:
         # Success counters bump once per unique URN; diamond source_ids
         # resolving to the same URN should not inflate the signal.
@@ -692,9 +860,30 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                 upstream_urn = elementId_to_dataset_urn[source_id]
                 shape = "intra"
             elif source_id.startswith("inode-"):
+                url_id_suffix = source_id[len("inode-") :]
+                # Check warehouse map first (type=table nodes).  The existing
+                # SD resolver handles type=dataset (Sigma Dataset) nodes; both
+                # can fire for the same inode when a file is catalogued as both
+                # a Sigma Dataset and a warehouse table.
+                warehouse_urn: Optional[str] = None
+                if warehouse_url_id_map:
+                    warehouse_urn = self._resolve_dm_element_warehouse_upstream(
+                        url_id_suffix=url_id_suffix,
+                        warehouse_map=warehouse_url_id_map,
+                        inode_source_id=source_id,
+                    )
                 upstream_urn = self._resolve_dm_element_external_upstream(source_id)
                 shape = "external"
-                if upstream_urn is None and source_id not in unresolved_seen:
+                # Collect both URNs; warehouse_urn is added after the loop's
+                # dedup-gate so both get an individual seen-check.
+                if warehouse_urn and warehouse_urn not in seen:
+                    upstream_urns.append(warehouse_urn)
+                    seen.add(warehouse_urn)
+                if (
+                    upstream_urn is None
+                    and warehouse_urn is None
+                    and source_id not in unresolved_seen
+                ):
                     unresolved_seen.add(source_id)
                     self.reporter.data_model_element_upstreams_unresolved_external += 1
                     self.reporter.data_model_element_upstreams_unresolved += 1
@@ -863,8 +1052,8 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         fgl_warehouse_passthrough_deferred and left for warehouse-external resolution.
 
         When multiple sibling elements share a name and both pass the /lineage filter,
-        the lexicographically-first URN is chosen (matching T2 PR1's collision policy
-        and Sigma's server-side coalescing behaviour).
+        the lexicographically-first URN is chosen (matching the collision policy
+        used elsewhere in this connector and Sigma's server-side coalescing behaviour).
         """
         by_name, _ = _dedup_dm_element_columns(element.columns)
 
@@ -1005,8 +1194,8 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                     continue
 
                 # Collision handling: multiple siblings passed /lineage filter.
-                # Pick sorted-first to match T2 PR1's _resolve_external_upstream
-                # policy and Sigma's server-side coalescing.
+                # Pick sorted-first to match the collision policy used elsewhere
+                # in this connector and Sigma's server-side coalescing.
                 if len(surviving_urns) > 1:
                     self.reporter.data_model_element_fgl_collision_pick_first += 1
                     self.reporter.warning(
@@ -1077,6 +1266,9 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         owner_username: Optional[str] = None,
     ) -> Iterable[MetadataWorkUnit]:
         dm_url_id = data_model.get_url_id()
+        # Resolve all type=table inodes for this DM once before the element loop.
+        # One /files call per unique inode (cached across DMs).
+        warehouse_url_id_map = self._build_dm_warehouse_url_id_map(data_model)
         # ``data_model.path`` starts with the workspace name (e.g.
         # "Acryl Data/Marketing"); drop index 0 because the workspace is
         # already the enclosing Container. ``split`` on a path with no
@@ -1190,6 +1382,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                 element_dataset_urn,
                 elementId_to_dataset_urn,
                 element_name_to_eids,
+                warehouse_url_id_map,
             )
             if upstream_lineage is not None:
                 yield MetadataChangeProposalWrapper(

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -219,7 +219,7 @@ class _WarehouseTableRef:
 
     def fq_name(self, platform: str, *, lowercase: bool = True) -> str:
         name = f"{self.db}.{self.schema}.{self.table}"
-        if platform in _WAREHOUSE_LOWERCASE_PLATFORMS and lowercase:
+        if platform.lower() in _WAREHOUSE_LOWERCASE_PLATFORMS and lowercase:
             return name.lower()
         return name
 
@@ -630,8 +630,17 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
     ) -> Dict[str, _WarehouseTableRef]:
         """For each type=table lineage inode on this DM, call /files/{inodeId}
         (cached) to get the ``urlId`` and ``path``.  Returns a map of
-        ``urlId → _WarehouseTableRef`` so ``_gen_data_model_element_upstream_lineage``
+        urlId -> _WarehouseTableRef so _gen_data_model_element_upstream_lineage
         can look up by the suffix that element ``sourceIds`` use.
+
+        Path shape assumption: ``Connection Root/<DB>/<SCHEMA>`` (3 segments).
+        This is empirically confirmed for Snowflake.  For other platforms the
+        shape is unverified — MySQL (DB == schema, possibly 2 segments),
+        BigQuery (project/dataset — also 2 without a DB layer), and
+        platforms with deeper catalog hierarchies may produce a different
+        segment count and land in dm_element_warehouse_path_unparseable.
+        TODO: validate /files path shapes for non-Snowflake platforms and
+        adjust the segment parser accordingly.
 
         Counters bumped here:
           - dm_element_warehouse_table_lookup_failed
@@ -692,6 +701,14 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                         ),
                     )
                 continue
+            if url_id in result:
+                logger.warning(
+                    "DM %s: two inodes share the same urlId %r; "
+                    "the earlier entry will be overwritten. "
+                    "This is unexpected — please report to DataHub.",
+                    data_model.dataModelId,
+                    url_id,
+                )
             result[url_id] = _WarehouseTableRef(
                 connection_id=conn_id,
                 db=parts[1],
@@ -782,19 +799,24 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         # Once per unique connectionId without an override, list the IDs in the
         # info message so operators know which connections to add to
         # connection_to_platform_map if env / platform_instance mismatches appear.
-        if conn_override is None:
+        # Fire once per unique connectionId that has no override — gated on
+        # "not already seen" so repeated emissions from the same connection
+        # don't re-fire the message.
+        if (
+            conn_override is None
+            and ref.connection_id not in self._no_platform_map_conn_ids
+        ):
             self._no_platform_map_conn_ids.add(ref.connection_id)
-            if len(self._no_platform_map_conn_ids) == 1:
-                self.reporter.info(
-                    title="Sigma warehouse URNs emitted without connection_to_platform_map",
-                    message=(
-                        "Warehouse Dataset URNs are being emitted using the Sigma "
-                        "recipe's env and platform_instance=None. If your warehouse "
-                        "connector uses a different env or platform_instance, configure "
-                        "connection_to_platform_map in the Sigma recipe to match."
-                    ),
-                    context=f"connection_ids_without_override={sorted(self._no_platform_map_conn_ids)}",
-                )
+            self.reporter.info(
+                title="Sigma warehouse URNs emitted without connection_to_platform_map",
+                message=(
+                    "Warehouse Dataset URNs are being emitted using the Sigma "
+                    "recipe's env and platform_instance=None. If your warehouse "
+                    "connector uses a different env or platform_instance, configure "
+                    "connection_to_platform_map in the Sigma recipe to match."
+                ),
+                context=f"connection_ids_without_override={sorted(self._no_platform_map_conn_ids)}",
+            )
         return builder.make_dataset_urn_with_platform_instance(
             platform=record.datahub_platform,
             name=fq,

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -188,16 +188,20 @@ CrossDmOutcome = Literal[
     "name_unmatched_but_dm_known",
 ]
 
-# Platforms where DataHub stores identifiers lower-cased, matching the
-# corresponding source connector's normalization. Snowflake is confirmed via
-# snowflake_utils.py::snowflake_identifier() (identifier.lower()), which is
-# the default and does not check convert_urns_to_lowercase. If a Snowflake
-# source is configured with convert_urns_to_lowercase: false, its URNs will
-# be upper-cased and the edges emitted here will dangle. That non-default
-# configuration is unsupported without a per-connection casing override.
-# Other platforms are excluded until their DataHub source's URN convention is
-# explicitly verified — adding an unvalidated platform risks emitting URNs
-# that don't match the warehouse connector's output.
+# Platforms that require a case bridge: Sigma's /files path reports identifiers
+# in the catalog's native casing, but the DataHub connector for these platforms
+# lower-cases identifiers before URN construction.
+#
+# Snowflake is the only platform in this set: Sigma reports uppercase
+# (e.g. "MYDB/PUBLIC/MYTABLE"), but the Snowflake connector lowercases via
+# snowflake_config.convert_urns_to_lowercase (default=True, see
+# snowflake_config.py). If that flag is set to False, the Snowflake connector
+# emits upper-cased URNs and the edges produced here will dangle; use
+# connection_to_platform_map.convert_urns_to_lowercase=False to match.
+#
+# Other platforms (Postgres, Redshift, etc.) preserve catalog casing in their
+# connectors; Sigma's /files path uses the same casing, so no bridge is needed
+# and they work correctly by default.
 _WAREHOUSE_LOWERCASE_PLATFORMS: frozenset[str] = frozenset({"snowflake"})
 
 # Expected root segment of the /files path for warehouse tables.
@@ -213,9 +217,11 @@ class _WarehouseTableRef:
     schema: str
     table: str
 
-    def fq_name(self, platform: str) -> str:
+    def fq_name(self, platform: str, *, lowercase: bool = True) -> str:
         name = f"{self.db}.{self.schema}.{self.table}"
-        return name.lower() if platform in _WAREHOUSE_LOWERCASE_PLATFORMS else name
+        if platform in _WAREHOUSE_LOWERCASE_PLATFORMS and lowercase:
+            return name.lower()
+        return name
 
 
 @platform_name("Sigma")
@@ -324,13 +330,36 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         self._files_path_unparseable_seen: Set[str] = set()
         # Once-per-run gate flags so noisy global conditions don't flood logs.
         self._registry_empty_warned: bool = False
-        self._no_platform_map_warned: bool = False
+        # Per-platform set: platforms for which we've emitted a "first emission"
+        # info message noting that casing is unverified.
+        self._warned_unvalidated_platforms: Set[str] = set()
+        # Per-connection set: connectionIds emitted without a
+        # connection_to_platform_map entry; listed in the info message context.
+        self._no_platform_map_conn_ids: Set[str] = set()
         try:
             self.sigma_api = SigmaAPI(self.config, self.reporter)
         except Exception as e:
             raise ConfigurationError("Unable to connect sigma API") from e
 
         self.connection_registry = self._build_connection_registry()
+        # Warn on connection_to_platform_map keys that don't exist in the
+        # registry — a typo in the recipe UUID would silently make the override
+        # inactive and the operator would never know.
+        unknown_override_keys = [
+            k
+            for k in self.config.connection_to_platform_map
+            if k not in self.connection_registry.by_id
+        ]
+        if unknown_override_keys:
+            self.reporter.warning(
+                title="connection_to_platform_map references unknown connectionIds",
+                message=(
+                    "One or more keys in connection_to_platform_map do not match "
+                    "any Sigma connection returned by /v2/connections. The overrides "
+                    "for these keys will be silently ignored."
+                ),
+                context=f"unknown_keys={unknown_override_keys}",
+            )
 
     def _build_connection_registry(self) -> SigmaConnectionRegistry:
         """Fetch /v2/connections and build the in-memory registry.
@@ -714,31 +743,52 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             )
             return None
 
-        fq = ref.fq_name(record.datahub_platform)
-        # Use per-connection overrides when configured so the emitted URN
-        # matches the warehouse connector's env / platform_instance.  Falls
+        conn_override = self.config.connection_to_platform_map.get(ref.connection_id)
+        # Use per-connection convert_urns_to_lowercase to handle warehouses
+        # where the connector was run with that flag set to False.  Default=True
+        # matches both the Snowflake connector default and most other platforms.
+        lowercase = conn_override.convert_urns_to_lowercase if conn_override else True
+        fq = ref.fq_name(record.datahub_platform, lowercase=lowercase)
+        # Use per-connection env / platform_instance overrides so the emitted
+        # URN matches what the warehouse connector actually produced.  Falls
         # back to the Sigma recipe's own env + platform_instance=None, which
         # is correct for single-env single-instance deployments.
-        conn_override = self.config.connection_to_platform_map.get(ref.connection_id)
         target_env = conn_override.env if conn_override else self.config.env
         target_platform_instance = (
             conn_override.platform_instance if conn_override else None
         )
-        # H1: warn once when emitting without a per-connection override so
-        # operators in multi-env / multi-instance setups know to configure
-        # connection_to_platform_map. Single-instance tenants are unaffected.
-        if conn_override is None and not self._no_platform_map_warned:
-            self._no_platform_map_warned = True
-            self.reporter.info(
-                title="Sigma warehouse URNs emitted without connection_to_platform_map",
-                message=(
-                    "Warehouse Dataset URNs are being emitted using the Sigma "
-                    "recipe's env and platform_instance=None. If your warehouse "
-                    "connector is configured with a different env or a "
-                    "platform_instance, configure connection_to_platform_map in "
-                    "the Sigma recipe to match."
-                ),
-            )
+        # Once-per-platform info when emitting for a platform not in
+        # _WAREHOUSE_LOWERCASE_PLATFORMS, so operators know to verify that
+        # a few emitted edges actually resolve in their DataHub instance.
+        if record.datahub_platform not in _WAREHOUSE_LOWERCASE_PLATFORMS:
+            if record.datahub_platform not in self._warned_unvalidated_platforms:
+                self._warned_unvalidated_platforms.add(record.datahub_platform)
+                self.reporter.info(
+                    title="Sigma warehouse URNs emitted for unvalidated platform",
+                    message=(
+                        "Warehouse Dataset URNs are being emitted for a platform "
+                        "that has not been empirically verified to produce matching "
+                        "URN casing. Spot-check a few lineage edges in your DataHub "
+                        "instance to confirm they resolve correctly."
+                    ),
+                    context=f"platform={record.datahub_platform}",
+                )
+        # Once per unique connectionId without an override, list the IDs in the
+        # info message so operators know which connections to add to
+        # connection_to_platform_map if env / platform_instance mismatches appear.
+        if conn_override is None:
+            self._no_platform_map_conn_ids.add(ref.connection_id)
+            if len(self._no_platform_map_conn_ids) == 1:
+                self.reporter.info(
+                    title="Sigma warehouse URNs emitted without connection_to_platform_map",
+                    message=(
+                        "Warehouse Dataset URNs are being emitted using the Sigma "
+                        "recipe's env and platform_instance=None. If your warehouse "
+                        "connector uses a different env or platform_instance, configure "
+                        "connection_to_platform_map in the Sigma recipe to match."
+                    ),
+                    context=f"connection_ids_without_override={sorted(self._no_platform_map_conn_ids)}",
+                )
         return builder.make_dataset_urn_with_platform_instance(
             platform=record.datahub_platform,
             name=fq,

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -188,26 +188,13 @@ CrossDmOutcome = Literal[
     "name_unmatched_but_dm_known",
 ]
 
-# Heuristic: platforms where unquoted SQL identifiers are case-insensitive and
-# DataHub conventionally stores them lower-cased (matching the Snowflake
-# connector's snowflake_identifier() behaviour).  This is a best-effort default
-# and can be wrong for quoted identifiers, collation-dependent engines (MSSQL,
-# MySQL), or metastore-dependent runtimes (Spark, Databricks, Athena, Trino).
-# BigQuery is case-sensitive and is therefore NOT included here.
-_WAREHOUSE_LOWERCASE_PLATFORMS: frozenset = frozenset(
-    {
-        "snowflake",
-        "redshift",
-        "postgres",
-        "mysql",
-        "athena",
-        "trino",
-        "presto",
-        "mssql",
-        "spark",
-        "databricks",
-    }
-)
+# Platforms where DataHub stores identifiers lower-cased, matching the
+# corresponding source connector's normalization. Snowflake is confirmed via
+# snowflake_utils.py::snowflake_identifier() (identifier.lower()).
+# Other platforms are excluded until their DataHub source's URN convention is
+# explicitly verified — adding an unvalidated platform risks emitting URNs
+# that don't match the warehouse connector's output.
+_WAREHOUSE_LOWERCASE_PLATFORMS: frozenset = frozenset({"snowflake"})
 
 # Sentinel for a /files path whose root segment is not "Connection Root".
 _FILES_PATH_ROOT = "Connection Root"
@@ -598,7 +585,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
 
     def _build_dm_warehouse_url_id_map(
         self, data_model: SigmaDataModel
-    ) -> Dict[str, "_WarehouseTableRef"]:
+    ) -> Dict[str, _WarehouseTableRef]:
         """For each type=table lineage inode on this DM, call /files/{inodeId}
         (cached) to get the ``urlId`` and ``path``.  Returns a map of
         ``urlId → _WarehouseTableRef`` so ``_gen_data_model_element_upstream_lineage``
@@ -608,7 +595,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
           - dm_element_warehouse_table_lookup_failed
           - dm_element_warehouse_path_unparseable
         """
-        result: Dict[str, "_WarehouseTableRef"] = {}
+        result: Dict[str, _WarehouseTableRef] = {}
         for inode_id, raw in data_model.warehouse_inodes_by_inode_id.items():
             conn_id = raw["connectionId"]
             table_name = raw["name"]
@@ -659,7 +646,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         self,
         *,
         url_id_suffix: str,
-        warehouse_map: Dict[str, "_WarehouseTableRef"],
+        warehouse_map: Dict[str, _WarehouseTableRef],
     ) -> Optional[str]:
         """Resolve a warehouse-table-backed inode sourceId to a fully-qualified
         warehouse Dataset URN via the connection registry.
@@ -830,7 +817,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         element_dataset_urn: str,
         elementId_to_dataset_urn: Dict[str, str],
         element_name_to_eids: Dict[str, List[str]],
-        warehouse_url_id_map: Optional[Dict[str, "_WarehouseTableRef"]] = None,
+        warehouse_url_id_map: Optional[Dict[str, _WarehouseTableRef]] = None,
     ) -> Optional[UpstreamLineage]:
         # Success counters bump once per unique URN; diamond source_ids
         # resolving to the same URN should not inflate the signal.

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -315,6 +315,12 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         # Shared across all DMs so inodes that appear in multiple DMs hit the
         # network only once.
         self._files_cache: Dict[str, Optional[Dict[str, Any]]] = {}
+        # Inodes whose /files path already produced an unparseable warning;
+        # prevents N identical warnings when the same inode spans N DMs (H3).
+        self._files_path_unparseable_seen: Set[str] = set()
+        # Once-per-run gate flags so noisy global conditions don't flood logs.
+        self._registry_empty_warned: bool = False
+        self._no_platform_map_warned: bool = False
         try:
             self.sigma_api = SigmaAPI(self.config, self.reporter)
         except Exception as e:
@@ -615,35 +621,32 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             url_id = str(files_data.get("urlId") or "")
             path = str(files_data.get("path") or "")
             parts = path.split("/")
-            # B2: also reject empty segments (e.g. "Connection Root//PUBLIC"
-            # passes len==3 but parts[1]=="" -> malformed URN).
-            if not url_id or len(parts) != 3 or not all(parts):
-                self.reporter.dm_element_warehouse_path_unparseable += 1
-                self.reporter.warning(
-                    title="Sigma warehouse /files path unparseable",
-                    message=(
-                        "Expected exactly 'Connection Root/<DB>/<SCHEMA>' with "
-                        "no empty segments and a non-empty urlId. "
-                        "Warehouse upstream skipped."
-                    ),
-                    context=(
-                        f"dm={data_model.dataModelId}, inode={inode_id}, "
-                        f"path={path!r}, url_id={url_id!r}"
-                    ),
-                )
-                continue
-            if parts[0] != _FILES_PATH_ROOT:
-                self.reporter.dm_element_warehouse_path_unparseable += 1
-                self.reporter.warning(
-                    title="Sigma warehouse path has unexpected root segment",
-                    message=(
-                        "Expected the /files path root to be 'Connection Root' "
-                        "but got a different value. Warehouse upstream skipped. "
-                        "This may indicate a Sigma API change or a localised "
-                        "tenant configuration."
-                    ),
-                    context=f"dm={data_model.dataModelId}, inode={inode_id}, path={path!r}",
-                )
+            # Validate: exactly 3 non-empty segments and a non-empty urlId.
+            # Rejects "Acryl Workspace" (CSV uploads), "Connection Root//PUBLIC"
+            # (empty DB segment -> malformed URN), and >3 segments.
+            # H4 TODO: confirm with Sigma whether API path strings are localised;
+            # if so, relax the literal "Connection Root" check.
+            path_invalid = not url_id or len(parts) != 3 or not all(parts)
+            root_unexpected = (not path_invalid) and parts[0] != _FILES_PATH_ROOT
+            if path_invalid or root_unexpected:
+                # Dedup per inode: a single misconfigured inode shared across N
+                # DMs must not flood the report with N identical warnings (H3).
+                if inode_id not in self._files_path_unparseable_seen:
+                    self._files_path_unparseable_seen.add(inode_id)
+                    self.reporter.dm_element_warehouse_path_unparseable += 1
+                    self.reporter.warning(
+                        title=(
+                            "Sigma warehouse path has unexpected root segment"
+                            if root_unexpected
+                            else "Sigma warehouse /files path unparseable"
+                        ),
+                        message=(
+                            "Expected exactly 'Connection Root/<DB>/<SCHEMA>' with "
+                            "no empty segments and a non-empty urlId. "
+                            "Warehouse upstream skipped for this inode."
+                        ),
+                        context=f"inode={inode_id}, path={path!r}, url_id={url_id!r}",
+                    )
                 continue
             result[url_id] = _WarehouseTableRef(
                 connection_id=conn_id,
@@ -671,15 +674,17 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         caller bumps it post-dedup so diamond source_ids (multiple inode-
         entries resolving to the same URN) don't inflate the counter.
 
-        Note: platform_instance is always None, which emits a base-platform URN
-        (no instance suffix).  This matches the warehouse connector's URN only
-        when no platform_instance is configured there.  For multi-instance
-        deployments (e.g. prod-snowflake / dev-snowflake), the emitted edge
-        will reference a non-existent URN — a known limitation documented in
-        the PR description.  The correct fix is a per-connection override map
-        (TODO: add connection_to_platform_map to SigmaSourceConfig).  Using
-        self.config.platform_instance here would be wrong: that is the Sigma
-        source's own instance identifier, not the warehouse source's.
+        env and platform_instance are resolved from
+        ``config.connection_to_platform_map`` when a matching entry exists,
+        falling back to the Sigma source's own env + platform_instance=None.
+        For multi-env or multi-instance warehouse setups, add entries to
+        ``connection_to_platform_map`` in the recipe so emitted edges point
+        at the URNs the warehouse connector actually produced.
+
+        Note: platform-specific identifier normalization (e.g. BigQuery
+        date-sharded tables, wildcard refs) is not applied — the name
+        emitted is exactly what Sigma's /files path and lineage entry carry.
+        Tables with non-standard identifiers may produce dangling edges.
         """
         ref = warehouse_map.get(url_id_suffix)
         if ref is None:
@@ -698,11 +703,35 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             return None
 
         fq = ref.fq_name(record.datahub_platform)
+        # Use per-connection overrides when configured so the emitted URN
+        # matches the warehouse connector's env / platform_instance.  Falls
+        # back to the Sigma recipe's own env + platform_instance=None, which
+        # is correct for single-env single-instance deployments.
+        conn_override = self.config.connection_to_platform_map.get(ref.connection_id)
+        target_env = conn_override.env if conn_override else self.config.env
+        target_platform_instance = (
+            conn_override.platform_instance if conn_override else None
+        )
+        # H1: warn once when emitting without a per-connection override so
+        # operators in multi-env / multi-instance setups know to configure
+        # connection_to_platform_map. Single-instance tenants are unaffected.
+        if conn_override is None and not self._no_platform_map_warned:
+            self._no_platform_map_warned = True
+            self.reporter.info(
+                title="Sigma warehouse URNs emitted without connection_to_platform_map",
+                message=(
+                    "Warehouse Dataset URNs are being emitted using the Sigma "
+                    "recipe's env and platform_instance=None. If your warehouse "
+                    "connector is configured with a different env or a "
+                    "platform_instance, configure connection_to_platform_map in "
+                    "the Sigma recipe to match."
+                ),
+            )
         return builder.make_dataset_urn_with_platform_instance(
             platform=record.datahub_platform,
             name=fq,
-            env=self.config.env,
-            platform_instance=None,
+            env=target_env,
+            platform_instance=target_platform_instance,
         )
 
     def _resolve_dm_element_cross_dm_upstream(
@@ -834,6 +863,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         element: SigmaDataModelElement,
         data_model: SigmaDataModel,
         element_dataset_urn: str,
+        *,
         elementId_to_dataset_urn: Dict[str, str],
         element_name_to_eids: Dict[str, List[str]],
         warehouse_url_id_map: Dict[str, _WarehouseTableRef],
@@ -1276,22 +1306,21 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         # Resolve all type=table inodes for this DM once before the element loop.
         # One /files call per unique inode (cached across DMs).
         warehouse_url_id_map = self._build_dm_warehouse_url_id_map(data_model)
-        # Warn once if the registry is empty while this DM has warehouse inodes —
-        # a failed registry build silently turns off warehouse upstream emission
-        # for the entire run; making it visible here lets operators triage it.
+        # Warn once per run if the registry is empty while warehouse inodes exist.
         if (
-            data_model.warehouse_inodes_by_inode_id
+            not self._registry_empty_warned
+            and data_model.warehouse_inodes_by_inode_id
             and not self.connection_registry.by_id
         ):
+            self._registry_empty_warned = True
             self.reporter.warning(
                 title="Sigma connection registry is empty — warehouse lineage unavailable",
                 message=(
                     "The connection registry contains no records. All warehouse "
-                    "upstream edges for DM elements will be skipped. Check "
-                    "whether the /v2/connections fetch succeeded and the "
+                    "upstream edges for DM elements will be skipped for this run. "
+                    "Check whether the /v2/connections fetch succeeded and the "
                     "connections_skipped_missing_id counter."
                 ),
-                context=f"dm={data_model.dataModelId}",
             )
         # ``data_model.path`` starts with the workspace name (e.g.
         # "Acryl Data/Marketing"); drop index 0 because the workspace is
@@ -1404,9 +1433,9 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                 element,
                 data_model,
                 element_dataset_urn,
-                elementId_to_dataset_urn,
-                element_name_to_eids,
-                warehouse_url_id_map,
+                elementId_to_dataset_urn=elementId_to_dataset_urn,
+                element_name_to_eids=element_name_to_eids,
+                warehouse_url_id_map=warehouse_url_id_map,
             )
             if upstream_lineage is not None:
                 yield MetadataChangeProposalWrapper(

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -671,8 +671,15 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         caller bumps it post-dedup so diamond source_ids (multiple inode-
         entries resolving to the same URN) don't inflate the counter.
 
-        Note: platform_instance is always None; per-connection overrides are
-        a follow-up (TODO: add connection_to_platform_map to SigmaSourceConfig).
+        Note: platform_instance is always None, which emits a base-platform URN
+        (no instance suffix).  This matches the warehouse connector's URN only
+        when no platform_instance is configured there.  For multi-instance
+        deployments (e.g. prod-snowflake / dev-snowflake), the emitted edge
+        will reference a non-existent URN — a known limitation documented in
+        the PR description.  The correct fix is a per-connection override map
+        (TODO: add connection_to_platform_map to SigmaSourceConfig).  Using
+        self.config.platform_instance here would be wrong: that is the Sigma
+        source's own instance identifier, not the warehouse source's.
         """
         ref = warehouse_map.get(url_id_suffix)
         if ref is None:
@@ -841,6 +848,10 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         upstream_urns: List[str] = []
         seen: Set[str] = set()
         unresolved_seen: Set[str] = set()
+        # Separate dedup set for warehouse connection failures so the counter
+        # fires once per unique source_id regardless of whether the SD path
+        # resolves (which would leave the source_id out of unresolved_seen).
+        warehouse_failure_seen: Set[str] = set()
         for source_id in element.source_ids:
             upstream_urn: Optional[str] = None
             shape: str = ""
@@ -850,30 +861,30 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                 shape = "intra"
             elif source_id.startswith("inode-"):
                 url_id_suffix = source_id[len("inode-") :]
-                # Check warehouse map first (type=table nodes).  The existing
-                # SD resolver handles type=dataset (Sigma Dataset) nodes; both
-                # can fire for the same inode when a file is catalogued as both
-                # a Sigma Dataset and a warehouse table.
-                warehouse_urn: Optional[str] = None
+                # Check warehouse map (type=table nodes) and the existing SD
+                # resolver (type=dataset nodes) in parallel; both can fire for
+                # the same inode when a file is catalogued as both.
                 warehouse_urn = self._resolve_dm_element_warehouse_upstream(
                     url_id_suffix=url_id_suffix,
                     warehouse_map=warehouse_url_id_map,
                 )
                 upstream_urn = self._resolve_dm_element_external_upstream(source_id)
                 shape = "external"
-                # Warehouse URN: deduped separately; emitted counter bumped
-                # post-dedup so diamond source_ids don't inflate the signal.
+                # Warehouse success: deduped via seen; counter bumped post-dedup
+                # so diamond source_ids don't inflate the signal.
                 if warehouse_urn and warehouse_urn not in seen:
                     upstream_urns.append(warehouse_urn)
                     seen.add(warehouse_urn)
                     self.reporter.dm_element_warehouse_upstream_emitted += 1
-                # Connection-failure counter: gated on unresolved_seen to
-                # match the cross-DM symmetry (one bump per unique source_id).
+                # Connection-failure counter: uses its own dedup set so a
+                # duplicate source_id fires at most once even when the SD path
+                # resolves (which would leave source_id out of unresolved_seen).
                 if (
                     warehouse_urn is None
                     and url_id_suffix in warehouse_url_id_map
-                    and source_id not in unresolved_seen
+                    and source_id not in warehouse_failure_seen
                 ):
+                    warehouse_failure_seen.add(source_id)
                     self.reporter.dm_element_warehouse_unknown_connection += 1
                 if (
                     upstream_urn is None
@@ -1265,6 +1276,23 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         # Resolve all type=table inodes for this DM once before the element loop.
         # One /files call per unique inode (cached across DMs).
         warehouse_url_id_map = self._build_dm_warehouse_url_id_map(data_model)
+        # Warn once if the registry is empty while this DM has warehouse inodes —
+        # a failed registry build silently turns off warehouse upstream emission
+        # for the entire run; making it visible here lets operators triage it.
+        if (
+            data_model.warehouse_inodes_by_inode_id
+            and not self.connection_registry.by_id
+        ):
+            self.reporter.warning(
+                title="Sigma connection registry is empty — warehouse lineage unavailable",
+                message=(
+                    "The connection registry contains no records. All warehouse "
+                    "upstream edges for DM elements will be skipped. Check "
+                    "whether the /v2/connections fetch succeeded and the "
+                    "connections_skipped_missing_id counter."
+                ),
+                context=f"dm={data_model.dataModelId}",
+            )
         # ``data_model.path`` starts with the workspace name (e.g.
         # "Acryl Data/Marketing"); drop index 0 because the workspace is
         # already the enclosing Container. ``split`` on a path with no

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
@@ -1095,7 +1095,7 @@ class SigmaAPI:
                 inode_id = str(entry.get("inodeId") or "")
                 conn_id = str(entry.get("connectionId") or "")
                 name = str(entry.get("name") or "")
-                if not (inode_id and name):
+                if not (inode_id and name and conn_id):
                     self.report.dm_element_warehouse_table_entry_incomplete += 1
                     logger.debug(
                         "DM %s: type=table entry missing inodeId or name; "
@@ -1124,20 +1124,47 @@ class SigmaAPI:
         Callers are responsible for caching; this method always makes a live
         HTTP call so the instance-level cache on ``SigmaSource`` can be shared
         across multiple callers without duplicating retry/error logic here.
+
+        Error handling mirrors ``get_data_model_by_url_id``: 429 gets a
+        dedicated counter + warning; other non-200 statuses emit a
+        rate-limited structured warning so operators can distinguish
+        rate-limiting from missing-scope (403/404) from server errors (5xx).
         """
         logger.debug("Fetching file metadata for inode '%s'.", inode_id)
         url = f"{self.config.api_url}/files/{inode_id}"
         try:
             response = self._get_api_call(url)
-            if response.status_code != 200:
-                logger.debug(
-                    "GET /files/%s returned HTTP %d; skipping.",
-                    inode_id,
-                    response.status_code,
+            if response.status_code == 200:
+                return response.json()
+            status = response.status_code
+            if status == 429:
+                self.report.dm_element_warehouse_table_lookup_rate_limited += 1
+                self.report.warning(
+                    title="Sigma API rate-limited on /files lookup",
+                    message=(
+                        "Retry budget exhausted on 429 for /files/{inodeId}. "
+                        "Warehouse upstream will be missing for this inode. "
+                        "Re-run the ingestion to recover."
+                    ),
+                    context=f"inode_id={inode_id}, http_status={status}",
                 )
-                return None
-            return response.json()
+            else:
+                self.report.warning(
+                    title="Sigma /files lookup returned non-200",
+                    message=(
+                        "Unable to resolve warehouse table metadata for inode. "
+                        "Warehouse upstream will be missing."
+                    ),
+                    context=f"inode_id={inode_id}, http_status={status}",
+                )
+            return None
         except Exception as e:
+            self.report.warning(
+                title="Sigma /files lookup failed",
+                message="Exception while fetching /files/{inodeId}; warehouse upstream skipped.",
+                context=f"inode_id={inode_id}",
+                exc=e,
+            )
             self._log_http_error(
                 message=f"Unable to fetch file metadata for inode '{inode_id}': {e}"
             )

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
@@ -39,6 +39,7 @@ from datahub.ingestion.source.sigma.data_classes import (
     SigmaDataModelColumn,
     SigmaDataModelElement,
     SigmaDataset,
+    WarehouseInodeRaw,
     Workbook,
     Workspace,
 )
@@ -1091,14 +1092,20 @@ class SigmaAPI:
                 # Stash raw warehouse-table nodes keyed by inodeId so
                 # SigmaSource can call /files/{inodeId} for the urlId + path
                 # needed to construct fully-qualified warehouse Dataset URNs.
-                inode_id = entry.get("inodeId", "")
-                conn_id = entry.get("connectionId", "")
-                name = entry.get("name", "")
-                if inode_id:
-                    data_model.warehouse_inodes_by_inode_id[inode_id] = {
-                        "connectionId": conn_id,
-                        "name": name,
-                    }
+                inode_id = str(entry.get("inodeId") or "")
+                conn_id = str(entry.get("connectionId") or "")
+                name = str(entry.get("name") or "")
+                if not (inode_id and name):
+                    self.report.dm_element_warehouse_table_entry_incomplete += 1
+                    logger.debug(
+                        "DM %s: type=table entry missing inodeId or name; "
+                        "skipping to avoid malformed URN: %s",
+                        data_model.dataModelId,
+                        entry,
+                    )
+                    continue
+                raw: WarehouseInodeRaw = {"connectionId": conn_id, "name": name}
+                data_model.warehouse_inodes_by_inode_id[inode_id] = raw
             # ``type: dataset`` entries (CSV uploads) are terminal;
             # warehouse lineage is handled above via type=table.
 

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
@@ -1097,11 +1097,25 @@ class SigmaAPI:
                 name = str(entry.get("name") or "")
                 if not (inode_id and name and conn_id):
                     self.report.dm_element_warehouse_table_entry_incomplete += 1
-                    logger.debug(
-                        "DM %s: type=table entry missing inodeId or name; "
-                        "skipping to avoid malformed URN: %s",
-                        data_model.dataModelId,
-                        entry,
+                    missing = [
+                        f
+                        for f, v in (
+                            ("inodeId", inode_id),
+                            ("name", name),
+                            ("connectionId", conn_id),
+                        )
+                        if not v
+                    ]
+                    self.report.warning(
+                        title="Sigma type=table lineage entry is incomplete",
+                        message=(
+                            "A type=table lineage entry is missing one or more "
+                            "required fields. Warehouse upstream skipped to avoid "
+                            "emitting a malformed URN."
+                        ),
+                        context=(
+                            f"dm={data_model.dataModelId}, missing_fields={missing}"
+                        ),
                     )
                     continue
                 raw: WarehouseInodeRaw = {"connectionId": conn_id, "name": name}
@@ -1142,7 +1156,7 @@ class SigmaAPI:
                 self.report.warning(
                     title="Sigma API rate-limited on /files lookup",
                     message=(
-                        "Retry budget exhausted on 429 for /files/{inodeId}. "
+                        "Retry budget exhausted on a 429 response for a /files inode lookup. "
                         "Warehouse upstream will be missing for this inode. "
                         "Re-run the ingestion to recover."
                     ),
@@ -1152,7 +1166,7 @@ class SigmaAPI:
                 self.report.warning(
                     title="Sigma /files lookup returned non-200",
                     message=(
-                        "Unable to resolve warehouse table metadata for inode. "
+                        "Unable to resolve warehouse table metadata for an inode. "
                         "Warehouse upstream will be missing."
                     ),
                     context=f"inode_id={inode_id}, http_status={status}",
@@ -1161,12 +1175,9 @@ class SigmaAPI:
         except Exception as e:
             self.report.warning(
                 title="Sigma /files lookup failed",
-                message="Exception while fetching /files/{inodeId}; warehouse upstream skipped.",
+                message="Exception while fetching file metadata for an inode; warehouse upstream skipped.",
                 context=f"inode_id={inode_id}",
                 exc=e,
-            )
-            self._log_http_error(
-                message=f"Unable to fetch file metadata for inode '{inode_id}': {e}"
             )
             return None
 

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
@@ -1132,17 +1132,18 @@ class SigmaAPI:
 
     def get_file_metadata(self, inode_id: str) -> Optional[Dict[str, Any]]:
         """Fetch /files/{inodeId} and return the raw JSON dict, or None on
-        non-200.  Resolves a warehouse-table lineage ``inodeId`` (UUID) to its
-        ``urlId`` (alphanumeric slug) and file-system ``path``
-        (``Connection Root/<DB>/<SCHEMA>``).
+        non-200 or exception.  Resolves a warehouse-table lineage ``inodeId``
+        (UUID) to its ``urlId`` (alphanumeric slug) and file-system ``path``
+        (``Connection Root/<DB>/<SCHEMA>`` for Snowflake; shape for other
+        platforms is unverified — see TODO in _build_dm_warehouse_url_id_map).
 
         Callers are responsible for caching; this method always makes a live
         HTTP call so the instance-level cache on ``SigmaSource`` can be shared
         across multiple callers without duplicating retry/error logic here.
 
         Error handling mirrors ``get_data_model_by_url_id``: 429 gets a
-        dedicated counter + warning; other non-200 statuses emit a
-        rate-limited structured warning so operators can distinguish
+        dedicated counter + warning; other non-200 statuses and exceptions
+        emit a rate-limited structured warning so operators can distinguish
         rate-limiting from missing-scope (403/404) from server errors (5xx).
         """
         logger.debug("Fetching file metadata for inode '%s'.", inode_id)

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
@@ -1094,14 +1094,16 @@ class SigmaAPI:
                 # needed to construct fully-qualified warehouse Dataset URNs.
                 inode_id = str(entry.get("inodeId") or "")
                 conn_id = str(entry.get("connectionId") or "")
-                name = str(entry.get("name") or "")
-                if not (inode_id and name and conn_id):
+                # name is intentionally NOT required here: the table name is
+                # taken from /files/{inodeId} (the canonical source) rather
+                # than from the lineage entry, which may carry a display label,
+                # a stale name, or be absent entirely for some Sigma releases.
+                if not (inode_id and conn_id):
                     self.report.dm_element_warehouse_table_entry_incomplete += 1
                     missing = [
                         f
                         for f, v in (
                             ("inodeId", inode_id),
-                            ("name", name),
                             ("connectionId", conn_id),
                         )
                         if not v
@@ -1109,16 +1111,15 @@ class SigmaAPI:
                     self.report.warning(
                         title="Sigma type=table lineage entry is incomplete",
                         message=(
-                            "A type=table lineage entry is missing one or more "
-                            "required fields. Warehouse upstream skipped to avoid "
-                            "emitting a malformed URN."
+                            "A type=table lineage entry is missing inodeId or "
+                            "connectionId. Warehouse upstream skipped."
                         ),
                         context=(
                             f"dm={data_model.dataModelId}, missing_fields={missing}"
                         ),
                     )
                     continue
-                raw: WarehouseInodeRaw = {"connectionId": conn_id, "name": name}
+                raw: WarehouseInodeRaw = {"connectionId": conn_id}
                 data_model.warehouse_inodes_by_inode_id[inode_id] = raw
             # ``type: dataset`` entries (CSV uploads) are terminal;
             # warehouse lineage is handled above via type=table.

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
@@ -1059,6 +1059,7 @@ class SigmaAPI:
         # Reset before populating so repeated _assemble_data_model calls
         # (e.g. during alias discovery) cannot accumulate stale entries.
         data_model.source_dm_element_names = {}
+        data_model.warehouse_inodes_by_inode_id = {}
         source_ids_by_element: Dict[str, List[str]] = {}
         for entry in lineage_entries:
             entry_type = entry.get(Constant.TYPE)
@@ -1086,15 +1087,54 @@ class SigmaAPI:
                     data_model.source_dm_element_names.setdefault(src_dm_id, []).append(
                         src_name.strip()
                     )
-            # ``type: dataset`` / ``type: table`` entries are resolved
-            # on the fly from their ``inode-<id>`` source_ids; no DM-side
-            # stash is needed.
+            elif entry_type == "table":
+                # Stash raw warehouse-table nodes keyed by inodeId so
+                # SigmaSource can call /files/{inodeId} for the urlId + path
+                # needed to construct fully-qualified warehouse Dataset URNs.
+                inode_id = entry.get("inodeId", "")
+                conn_id = entry.get("connectionId", "")
+                name = entry.get("name", "")
+                if inode_id:
+                    data_model.warehouse_inodes_by_inode_id[inode_id] = {
+                        "connectionId": conn_id,
+                        "name": name,
+                    }
+            # ``type: dataset`` entries (CSV uploads) are terminal;
+            # warehouse lineage is handled above via type=table.
 
         for element in elements:
             element.columns = columns_by_element.get(element.elementId, [])
             element.source_ids = source_ids_by_element.get(element.elementId, [])
 
         data_model.elements = elements
+
+    def get_file_metadata(self, inode_id: str) -> Optional[Dict[str, Any]]:
+        """Fetch /files/{inodeId} and return the raw JSON dict, or None on
+        non-200.  Resolves a warehouse-table lineage ``inodeId`` (UUID) to its
+        ``urlId`` (alphanumeric slug) and file-system ``path``
+        (``Connection Root/<DB>/<SCHEMA>``).
+
+        Callers are responsible for caching; this method always makes a live
+        HTTP call so the instance-level cache on ``SigmaSource`` can be shared
+        across multiple callers without duplicating retry/error logic here.
+        """
+        logger.debug("Fetching file metadata for inode '%s'.", inode_id)
+        url = f"{self.config.api_url}/files/{inode_id}"
+        try:
+            response = self._get_api_call(url)
+            if response.status_code != 200:
+                logger.debug(
+                    "GET /files/%s returned HTTP %d; skipping.",
+                    inode_id,
+                    response.status_code,
+                )
+                return None
+            return response.json()
+        except Exception as e:
+            self._log_http_error(
+                message=f"Unable to fetch file metadata for inode '{inode_id}': {e}"
+            )
+            return None
 
     def get_data_model_by_url_id(self, url_id: str) -> Optional[SigmaDataModel]:
         """Fetch a DM by its urlId (not UUID). Used to resolve personal-space

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
@@ -15,7 +15,7 @@ from typing import (
     Type,
     TypeVar,
 )
-from urllib.parse import urlencode
+from urllib.parse import quote, urlencode
 
 import requests
 from pydantic import BaseModel, ValidationError
@@ -1146,7 +1146,7 @@ class SigmaAPI:
         rate-limiting from missing-scope (403/404) from server errors (5xx).
         """
         logger.debug("Fetching file metadata for inode '%s'.", inode_id)
-        url = f"{self.config.api_url}/files/{inode_id}"
+        url = f"{self.config.api_url}/files/{quote(inode_id, safe='')}"
         try:
             response = self._get_api_call(url)
             if response.status_code == 200:

--- a/metadata-ingestion/tests/integration/sigma/golden_test_sigma_dm_warehouse_upstream.json
+++ b/metadata-ingestion/tests/integration/sigma/golden_test_sigma_dm_warehouse_upstream.json
@@ -1,0 +1,2069 @@
+[
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,49HFLTr6xytgrPly3PFsNC,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654380,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,49HFLTr6xytgrPly3PFsNC,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "datasetId": "8891fd40-5470-4ff2-a74f-6e61ee44d3fc",
+                "path": "Acryl Data"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/b/49HFLTr6xytgrPly3PFsNC",
+            "name": "PETS",
+            "qualifiedName": "PETS",
+            "description": "",
+            "created": {
+                "time": 1713188592664
+            },
+            "lastModified": {
+                "time": 1713188592664
+            },
+            "tags": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654380,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,49HFLTr6xytgrPly3PFsNC,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654381,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,49HFLTr6xytgrPly3PFsNC,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:john.doe@example.com",
+                    "type": "DATAOWNER"
+                }
+            ],
+            "ownerTypes": {},
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654381,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,49HFLTr6xytgrPly3PFsNC,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Sigma Dataset"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654381,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,49HFLTr6xytgrPly3PFsNC,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654381,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,5LqGLu14qUnqh3cN6wRJBd,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654384,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,5LqGLu14qUnqh3cN6wRJBd,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "datasetId": "bd6b86e8-cd4a-4b25-ab65-f258c2a68a8f",
+                "path": "Acryl Data/New Folder"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/b/5LqGLu14qUnqh3cN6wRJBd",
+            "name": "PET_PROFILES_JOINED_DYNAMIC",
+            "qualifiedName": "PET_PROFILES_JOINED_DYNAMIC",
+            "description": "",
+            "created": {
+                "time": 1713189068019
+            },
+            "lastModified": {
+                "time": 1713189068019
+            },
+            "tags": [
+                "Deprecated"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654384,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,5LqGLu14qUnqh3cN6wRJBd,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654384,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,5LqGLu14qUnqh3cN6wRJBd,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:john.doe@example.com",
+                    "type": "DATAOWNER"
+                }
+            ],
+            "ownerTypes": {},
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654385,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,5LqGLu14qUnqh3cN6wRJBd,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Sigma Dataset"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654385,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,5LqGLu14qUnqh3cN6wRJBd,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "globalTags",
+    "aspect": {
+        "json": {
+            "tags": [
+                {
+                    "tag": "urn:li:tag:Deprecated"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654385,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,5LqGLu14qUnqh3cN6wRJBd,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "New Folder"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654385,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:818113c9d17a14105fa03b045b7b0def",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654386,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:818113c9d17a14105fa03b045b7b0def",
+    "changeType": "UPSERT",
+    "aspectName": "containerProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "platform": "sigma",
+                "dataModelId": "81e9980c-3ec8-4bbf-a38e-78f9fe472ce0",
+                "dataModelUrlId": "Kyungsoo-Snowflake-DM-3X8LiCwzXUAwO30p1an0Zi",
+                "latestVersion": "1",
+                "path": "Acryl Data"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/dm/Kyungsoo-Snowflake-DM-3X8LiCwzXUAwO30p1an0Zi",
+            "name": "Kyungsoo Snowflake DM",
+            "description": "Integration fixture for warehouse-backed DM element",
+            "created": {
+                "time": 1777852800000
+            },
+            "lastModified": {
+                "time": 1777852800000
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777914345408,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:818113c9d17a14105fa03b045b7b0def",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654386,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:818113c9d17a14105fa03b045b7b0def",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:sigma"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654387,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:818113c9d17a14105fa03b045b7b0def",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Sigma Data Model"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654387,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:818113c9d17a14105fa03b045b7b0def",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654387,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,81e9980c-3ec8-4bbf-a38e-78f9fe472ce0.byF6DckhFw,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654392,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,81e9980c-3ec8-4bbf-a38e-78f9fe472ce0.byF6DckhFw,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dataModelId": "81e9980c-3ec8-4bbf-a38e-78f9fe472ce0",
+                "dataModelUrlId": "Kyungsoo-Snowflake-DM-3X8LiCwzXUAwO30p1an0Zi",
+                "elementId": "byF6DckhFw",
+                "type": "table"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/dm/Kyungsoo-Snowflake-DM-3X8LiCwzXUAwO30p1an0Zi?:nodeId=byF6DckhFw",
+            "name": "CUSTOMERS",
+            "qualifiedName": "Kyungsoo Snowflake DM/CUSTOMERS",
+            "tags": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654392,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,81e9980c-3ec8-4bbf-a38e-78f9fe472ce0.byF6DckhFw,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Sigma Data Model Element"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654392,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,81e9980c-3ec8-4bbf-a38e-78f9fe472ce0.byF6DckhFw,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "CUSTOMERS",
+            "platform": "urn:li:dataPlatform:sigma",
+            "version": 0,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.OtherSchema": {
+                    "rawSchema": ""
+                }
+            },
+            "fields": [
+                {
+                    "fieldPath": "CUSTOMER_ID",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NullType": {}
+                        }
+                    },
+                    "nativeDataType": "unknown",
+                    "recursive": false,
+                    "isPartOfKey": false
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654393,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,81e9980c-3ec8-4bbf-a38e-78f9fe472ce0.byF6DckhFw,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:818113c9d17a14105fa03b045b7b0def"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654393,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,81e9980c-3ec8-4bbf-a38e-78f9fe472ce0.byF6DckhFw,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "upstreamLineage",
+    "aspect": {
+        "json": {
+            "upstreams": [
+                {
+                    "auditStamp": {
+                        "time": 0,
+                        "actor": "urn:li:corpuser:unknown"
+                    },
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,warehouse_coffee_company.public.customers,PROD)",
+                    "type": "TRANSFORMED"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654393,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,81e9980c-3ec8-4bbf-a38e-78f9fe472ce0.byF6DckhFw,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "urn:li:container:818113c9d17a14105fa03b045b7b0def",
+                    "urn": "urn:li:container:818113c9d17a14105fa03b045b7b0def"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654393,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654394,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+    "changeType": "UPSERT",
+    "aspectName": "dashboardInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "path": "Acryl Data",
+                "latestVersion": "2"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/workbook/4JRFW1HThPI1K3YTjouXI7",
+            "title": "Acryl Workbook",
+            "description": "",
+            "charts": [],
+            "datasets": [],
+            "dashboards": [
+                {
+                    "sourceUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+                    "destinationUrn": "urn:li:dashboard:(sigma,OSnGLBzL1i)"
+                },
+                {
+                    "sourceUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+                    "destinationUrn": "urn:li:dashboard:(sigma,DFSieiAcgo)"
+                }
+            ],
+            "lastModified": {
+                "created": {
+                    "time": 1713188691477,
+                    "actor": "urn:li:corpuser:datahub"
+                },
+                "lastModified": {
+                    "time": 1713189117302,
+                    "actor": "urn:li:corpuser:datahub"
+                }
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654394,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Sigma Workbook"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654394,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:john.doe@example.com",
+                    "type": "DATAOWNER"
+                }
+            ],
+            "ownerTypes": {},
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654394,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+    "changeType": "UPSERT",
+    "aspectName": "globalTags",
+    "aspect": {
+        "json": {
+            "tags": [
+                {
+                    "tag": "urn:li:tag:Warning"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654395,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654395,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "Acryl Workbook"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654395,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,OSnGLBzL1i)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654395,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,OSnGLBzL1i)",
+    "changeType": "UPSERT",
+    "aspectName": "dashboardInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "ElementsCount": "2"
+            },
+            "title": "Page 1",
+            "description": "",
+            "charts": [
+                "urn:li:chart:(sigma,kH0MeihtGs)",
+                "urn:li:chart:(sigma,Ml9C5ezT5W)"
+            ],
+            "datasets": [],
+            "dashboards": [],
+            "lastModified": {
+                "created": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654395,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,OSnGLBzL1i)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "Acryl Workbook"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654396,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,kH0MeihtGs)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654412,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,kH0MeihtGs)",
+    "changeType": "UPSERT",
+    "aspectName": "chartInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "VizualizationType": "levelTable",
+                "type": "table"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/workbook/4JRFW1HThPI1K3YTjouXI7?:nodeId=kH0MeihtGs&:fullScreen=true",
+            "title": "ADOPTIONS",
+            "description": "",
+            "lastModified": {
+                "created": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            },
+            "inputs": [
+                {
+                    "string": "urn:li:dataset:(urn:li:dataPlatform:snowflake,long_tail_companions.adoption.adoptions,PROD)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654412,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,kH0MeihtGs)",
+    "changeType": "UPSERT",
+    "aspectName": "inputFields",
+    "aspect": {
+        "json": {
+            "fields": [
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Pk)",
+                    "schemaField": {
+                        "fieldPath": "Pk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Pet Fk)",
+                    "schemaField": {
+                        "fieldPath": "Pet Fk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Human Fk)",
+                    "schemaField": {
+                        "fieldPath": "Human Fk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Status)",
+                    "schemaField": {
+                        "fieldPath": "Status",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Created At)",
+                    "schemaField": {
+                        "fieldPath": "Created At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Updated At)",
+                    "schemaField": {
+                        "fieldPath": "Updated At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654412,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,kH0MeihtGs)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "Acryl Workbook"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654413,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,Ml9C5ezT5W)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654420,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,Ml9C5ezT5W)",
+    "changeType": "UPSERT",
+    "aspectName": "chartInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "VizualizationType": "bar",
+                "type": "visualization"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/workbook/4JRFW1HThPI1K3YTjouXI7?:nodeId=Ml9C5ezT5W&:fullScreen=true",
+            "title": "Count of Profile Id by Status",
+            "description": "",
+            "lastModified": {
+                "created": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            },
+            "inputs": [
+                {
+                    "string": "urn:li:dataset:(urn:li:dataPlatform:sigma,49HFLTr6xytgrPly3PFsNC,PROD)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654420,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,Ml9C5ezT5W)",
+    "changeType": "UPSERT",
+    "aspectName": "inputFields",
+    "aspect": {
+        "json": {
+            "fields": [
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Pk)",
+                    "schemaField": {
+                        "fieldPath": "Pk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Profile Id)",
+                    "schemaField": {
+                        "fieldPath": "Profile Id",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Status)",
+                    "schemaField": {
+                        "fieldPath": "Status",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Created At)",
+                    "schemaField": {
+                        "fieldPath": "Created At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Updated At)",
+                    "schemaField": {
+                        "fieldPath": "Updated At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Count of Profile Id)",
+                    "schemaField": {
+                        "fieldPath": "Count of Profile Id",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654420,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,Ml9C5ezT5W)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "Acryl Workbook"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654421,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,OSnGLBzL1i)",
+    "changeType": "UPSERT",
+    "aspectName": "inputFields",
+    "aspect": {
+        "json": {
+            "fields": [
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Pk)",
+                    "schemaField": {
+                        "fieldPath": "Pk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Pet Fk)",
+                    "schemaField": {
+                        "fieldPath": "Pet Fk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Human Fk)",
+                    "schemaField": {
+                        "fieldPath": "Human Fk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Status)",
+                    "schemaField": {
+                        "fieldPath": "Status",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Created At)",
+                    "schemaField": {
+                        "fieldPath": "Created At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Updated At)",
+                    "schemaField": {
+                        "fieldPath": "Updated At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Pk)",
+                    "schemaField": {
+                        "fieldPath": "Pk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Profile Id)",
+                    "schemaField": {
+                        "fieldPath": "Profile Id",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Status)",
+                    "schemaField": {
+                        "fieldPath": "Status",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Created At)",
+                    "schemaField": {
+                        "fieldPath": "Created At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Updated At)",
+                    "schemaField": {
+                        "fieldPath": "Updated At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Count of Profile Id)",
+                    "schemaField": {
+                        "fieldPath": "Count of Profile Id",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654421,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,DFSieiAcgo)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654422,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,DFSieiAcgo)",
+    "changeType": "UPSERT",
+    "aspectName": "dashboardInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "ElementsCount": "1"
+            },
+            "title": "Page 2",
+            "description": "",
+            "charts": [
+                "urn:li:chart:(sigma,tQJu5N1l81)"
+            ],
+            "datasets": [],
+            "dashboards": [],
+            "lastModified": {
+                "created": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654422,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,DFSieiAcgo)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "Acryl Workbook"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654423,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,tQJu5N1l81)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654430,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,tQJu5N1l81)",
+    "changeType": "UPSERT",
+    "aspectName": "chartInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "VizualizationType": "levelTable",
+                "type": "table"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/workbook/4JRFW1HThPI1K3YTjouXI7?:nodeId=tQJu5N1l81&:fullScreen=true",
+            "title": "PETS ADOPTIONS JOIN",
+            "description": "",
+            "lastModified": {
+                "created": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            },
+            "inputs": [
+                {
+                    "string": "urn:li:dataset:(urn:li:dataPlatform:sigma,49HFLTr6xytgrPly3PFsNC,PROD)"
+                },
+                {
+                    "string": "urn:li:dataset:(urn:li:dataPlatform:snowflake,long_tail_companions.adoption.adoptions,PROD)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654430,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,tQJu5N1l81)",
+    "changeType": "UPSERT",
+    "aspectName": "inputFields",
+    "aspect": {
+        "json": {
+            "fields": [
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Pk)",
+                    "schemaField": {
+                        "fieldPath": "Pk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Profile Id)",
+                    "schemaField": {
+                        "fieldPath": "Profile Id",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Status)",
+                    "schemaField": {
+                        "fieldPath": "Status",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Created At)",
+                    "schemaField": {
+                        "fieldPath": "Created At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Updated At)",
+                    "schemaField": {
+                        "fieldPath": "Updated At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Pk %28ADOPTIONS%29)",
+                    "schemaField": {
+                        "fieldPath": "Pk (ADOPTIONS)",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Pet Fk)",
+                    "schemaField": {
+                        "fieldPath": "Pet Fk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Human Fk)",
+                    "schemaField": {
+                        "fieldPath": "Human Fk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Status %28ADOPTIONS%29)",
+                    "schemaField": {
+                        "fieldPath": "Status (ADOPTIONS)",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Created At %28ADOPTIONS%29)",
+                    "schemaField": {
+                        "fieldPath": "Created At (ADOPTIONS)",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Updated At %28ADOPTIONS%29)",
+                    "schemaField": {
+                        "fieldPath": "Updated At (ADOPTIONS)",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654430,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,tQJu5N1l81)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "Acryl Workbook"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654431,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,DFSieiAcgo)",
+    "changeType": "UPSERT",
+    "aspectName": "inputFields",
+    "aspect": {
+        "json": {
+            "fields": [
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Pk)",
+                    "schemaField": {
+                        "fieldPath": "Pk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Profile Id)",
+                    "schemaField": {
+                        "fieldPath": "Profile Id",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Status)",
+                    "schemaField": {
+                        "fieldPath": "Status",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Created At)",
+                    "schemaField": {
+                        "fieldPath": "Created At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Updated At)",
+                    "schemaField": {
+                        "fieldPath": "Updated At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Pk %28ADOPTIONS%29)",
+                    "schemaField": {
+                        "fieldPath": "Pk (ADOPTIONS)",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Pet Fk)",
+                    "schemaField": {
+                        "fieldPath": "Pet Fk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Human Fk)",
+                    "schemaField": {
+                        "fieldPath": "Human Fk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Status %28ADOPTIONS%29)",
+                    "schemaField": {
+                        "fieldPath": "Status (ADOPTIONS)",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Created At %28ADOPTIONS%29)",
+                    "schemaField": {
+                        "fieldPath": "Created At (ADOPTIONS)",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Updated At %28ADOPTIONS%29)",
+                    "schemaField": {
+                        "fieldPath": "Updated At (ADOPTIONS)",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654431,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+    "changeType": "UPSERT",
+    "aspectName": "containerProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "platform": "sigma",
+                "workspaceId": "3ee61405-3be2-4000-ba72-60d36757b95b"
+            },
+            "name": "Acryl Data",
+            "created": {
+                "time": 1710232264826
+            },
+            "lastModified": {
+                "time": 1710232264826
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654432,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654432,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:sigma"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654432,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Sigma Workspace"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654433,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:john.doe@example.com",
+                    "type": "DATAOWNER"
+                }
+            ],
+            "ownerTypes": {},
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654433,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654433,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,49HFLTr6xytgrPly3PFsNC,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "upstreamLineage",
+    "aspect": {
+        "json": {
+            "upstreams": [
+                {
+                    "auditStamp": {
+                        "time": 0,
+                        "actor": "urn:li:corpuser:unknown"
+                    },
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,long_tail_companions.adoption.pets,PROD)",
+                    "type": "COPY"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654433,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "tag",
+    "entityUrn": "urn:li:tag:Deprecated",
+    "changeType": "UPSERT",
+    "aspectName": "tagKey",
+    "aspect": {
+        "json": {
+            "name": "Deprecated"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654433,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "tag",
+    "entityUrn": "urn:li:tag:Warning",
+    "changeType": "UPSERT",
+    "aspectName": "tagKey",
+    "aspect": {
+        "json": {
+            "name": "Warning"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1777913654433,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+}
+]

--- a/metadata-ingestion/tests/integration/sigma/golden_test_sigma_dm_warehouse_upstream.json
+++ b/metadata-ingestion/tests/integration/sigma/golden_test_sigma_dm_warehouse_upstream.json
@@ -304,12 +304,12 @@
             "customProperties": {
                 "platform": "sigma",
                 "dataModelId": "81e9980c-3ec8-4bbf-a38e-78f9fe472ce0",
-                "dataModelUrlId": "Kyungsoo-Snowflake-DM-3X8LiCwzXUAwO30p1an0Zi",
+                "dataModelUrlId": "Acme-Snowflake-DM-fixture01",
                 "latestVersion": "1",
                 "path": "Acryl Data"
             },
-            "externalUrl": "https://app.sigmacomputing.com/acryldata/dm/Kyungsoo-Snowflake-DM-3X8LiCwzXUAwO30p1an0Zi",
-            "name": "Kyungsoo Snowflake DM",
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/dm/Acme-Snowflake-DM-fixture01",
+            "name": "Acme Snowflake DM",
             "description": "Integration fixture for warehouse-backed DM element",
             "created": {
                 "time": 1777852800000
@@ -320,7 +320,7 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1777914345408,
+        "lastObserved": 1777924178163,
         "runId": "sigma-test",
         "lastRunId": "no-run-id-provided"
     }
@@ -421,18 +421,18 @@
         "json": {
             "customProperties": {
                 "dataModelId": "81e9980c-3ec8-4bbf-a38e-78f9fe472ce0",
-                "dataModelUrlId": "Kyungsoo-Snowflake-DM-3X8LiCwzXUAwO30p1an0Zi",
+                "dataModelUrlId": "Acme-Snowflake-DM-fixture01",
                 "elementId": "byF6DckhFw",
                 "type": "table"
             },
-            "externalUrl": "https://app.sigmacomputing.com/acryldata/dm/Kyungsoo-Snowflake-DM-3X8LiCwzXUAwO30p1an0Zi?:nodeId=byF6DckhFw",
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/dm/Acme-Snowflake-DM-fixture01?:nodeId=byF6DckhFw",
             "name": "CUSTOMERS",
-            "qualifiedName": "Kyungsoo Snowflake DM/CUSTOMERS",
+            "qualifiedName": "Acme Snowflake DM/CUSTOMERS",
             "tags": []
         }
     },
     "systemMetadata": {
-        "lastObserved": 1777913654392,
+        "lastObserved": 1777924178169,
         "runId": "sigma-test",
         "lastRunId": "no-run-id-provided"
     }

--- a/metadata-ingestion/tests/integration/sigma/test_sigma.py
+++ b/metadata-ingestion/tests/integration/sigma/test_sigma.py
@@ -6339,3 +6339,259 @@ def test_sigma_connection_registry(pytestconfig, tmp_path, requests_mock):
     assert report.connections_resolved >= 1, (
         f"connections_resolved should be >= 1; got {report.connections_resolved}"
     )
+
+
+# ---------------------------------------------------------------------------
+# DM element -> warehouse table UpstreamLineage
+# Empirical shape from live Sigma API:
+#   type=table entry: {connectionId: "4b39cdcd-…", name: "CUSTOMERS", inodeId: "f09fe362-…"}
+#   /files/{inodeId}: {urlId: "7k3e6T4RK9oix71Nm2umE6", path: "Connection Root/…/PUBLIC"}
+#   Expected warehouse URN: urn:li:dataset:(urn:li:dataPlatform:snowflake,
+#                            warehouse_coffee_company.public.customers,PROD)
+# ---------------------------------------------------------------------------
+
+# Kyungsoo Snowflake DM IDs — sourced directly from live Sigma API probe.
+_T4B_DM_ID = "81e9980c-3ec8-4bbf-a38e-78f9fe472ce0"
+_T4B_DM_URL_ID = "Kyungsoo-Snowflake-DM-3X8LiCwzXUAwO30p1an0Zi"
+_T4B_CONN_ID = "4b39cdcd-5a58-4ff6-af0d-8409ff880a23"
+_T4B_INODE_ID = "f09fe362-828a-42e6-9f8f-3f0feeb2fb3e"
+_T4B_URL_ID = "7k3e6T4RK9oix71Nm2umE6"
+_T4B_ELEMENT_ID = "byF6DckhFw"
+_T4B_WORKSPACE_ID = "3ee61405-3be2-4000-ba72-60d36757b95b"
+
+
+def _get_t4b_warehouse_dm_overrides() -> Dict[str, Dict]:
+    """Mock overrides for the warehouse-upstream integration test.
+
+    Uses real IDs and payload shapes from the live Sigma API probe.
+    """
+    return {
+        # Override connections to add the KYUNGSOO SNOWFLAKE connection.
+        "https://aws-api.sigmacomputing.com/v2/connections": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "entries": [
+                    {
+                        "connectionId": _T4B_CONN_ID,
+                        "name": "KYUNGSOO SNOWFLAKE",
+                        "type": "snowflake",
+                        "account": "diukgvb-woa55424",
+                        "host": "diukgvb-woa55424.snowflakecomputing.com",
+                        "warehouse": "COMPUTE_WH",
+                    }
+                ],
+                "total": 1,
+                "nextPage": None,
+            },
+        },
+        # DM file listing.
+        "https://aws-api.sigmacomputing.com/v2/files?typeFilters=data-model": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "entries": [
+                    {
+                        "id": _T4B_DM_ID,
+                        "urlId": _T4B_DM_URL_ID,
+                        "name": "Kyungsoo Snowflake DM",
+                        "type": "data-model",
+                        "parentId": "3ee61405-3be2-4000-ba72-60d36757b95b",
+                        "parentUrlId": "1UGFyEQCHqwPfQoAec3xJ9",
+                        "permission": "edit",
+                        "path": "Acryl Data",
+                        "badge": None,
+                        "createdBy": "awUuH3HDr10r2c41vSZ5MNcyCDYZl",
+                        "updatedBy": "awUuH3HDr10r2c41vSZ5MNcyCDYZl",
+                        "createdAt": "2026-05-04T00:00:00.000Z",
+                        "updatedAt": "2026-05-04T00:00:00.000Z",
+                        "isArchived": False,
+                    }
+                ],
+                "total": 1,
+                "nextPage": None,
+            },
+        },
+        # DM metadata listing.
+        "https://aws-api.sigmacomputing.com/v2/dataModels": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "entries": [
+                    {
+                        "dataModelId": _T4B_DM_ID,
+                        "urlId": _T4B_DM_URL_ID,
+                        "name": "Kyungsoo Snowflake DM",
+                        "description": "Integration fixture for warehouse-backed DM element",
+                        "createdBy": "awUuH3HDr10r2c41vSZ5MNcyCDYZl",
+                        "createdAt": "2026-05-04T00:00:00.000Z",
+                        "updatedAt": "2026-05-04T00:00:00.000Z",
+                        "url": f"https://app.sigmacomputing.com/acryldata/dm/{_T4B_DM_URL_ID}",
+                        "latestVersion": 1,
+                        "workspaceId": _T4B_WORKSPACE_ID,
+                        "path": "Acryl Data",
+                    }
+                ],
+                "total": 1,
+                "nextPage": None,
+            },
+        },
+        # DM elements (one element, direct table source).
+        f"https://aws-api.sigmacomputing.com/v2/dataModels/{_T4B_DM_ID}/elements": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "entries": [
+                    {
+                        "elementId": _T4B_ELEMENT_ID,
+                        "name": "CUSTOMERS",
+                        "type": "table",
+                        "columns": [],
+                    }
+                ],
+                "total": 1,
+                "nextPage": None,
+            },
+        },
+        # DM columns (one column for the element).
+        f"https://aws-api.sigmacomputing.com/v2/dataModels/{_T4B_DM_ID}/columns": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "entries": [
+                    {
+                        "columnId": "col-1",
+                        "name": "CUSTOMER_ID",
+                        "elementId": _T4B_ELEMENT_ID,
+                        "label": None,
+                        "formula": None,
+                    }
+                ],
+                "total": 1,
+                "nextPage": None,
+            },
+        },
+        # DM lineage — real shape from live probe.
+        f"https://aws-api.sigmacomputing.com/v2/dataModels/{_T4B_DM_ID}/lineage": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "entries": [
+                    {
+                        "connectionId": _T4B_CONN_ID,
+                        "name": "CUSTOMERS",
+                        "type": "table",
+                        "inodeId": _T4B_INODE_ID,
+                    },
+                    {
+                        "elementId": _T4B_ELEMENT_ID,
+                        "type": "element",
+                        "sourceIds": [f"inode-{_T4B_URL_ID}"],
+                        "dataSourceIds": [f"inode-{_T4B_URL_ID}"],
+                    },
+                ],
+                "nextPage": None,
+            },
+        },
+        # /files/{inodeId} — real response from live probe.
+        f"https://aws-api.sigmacomputing.com/v2/files/{_T4B_INODE_ID}": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "id": _T4B_INODE_ID,
+                "urlId": _T4B_URL_ID,
+                "name": "CUSTOMERS",
+                "type": "table",
+                "parentId": "3f583620-d373-4d73-bdb9-1e63aa1c58fb",
+                "parentUrlId": "1VwPpYZ44VbssheaUKZvFp",
+                "permission": "edit",
+                "path": "Connection Root/WAREHOUSE_COFFEE_COMPANY/PUBLIC",
+                "badge": None,
+                "isArchived": False,
+            },
+        },
+    }
+
+
+@pytest.mark.integration
+def test_sigma_ingest_data_models_warehouse_upstream(
+    pytestconfig, tmp_path, requests_mock
+):
+    """DM element with a type=table warehouse source gets an UpstreamLineage
+    aspect pointing at the Snowflake warehouse table URN.
+
+    Uses real IDs and payload shapes from a live Sigma API probe:
+      DM: Kyungsoo Snowflake DM (81e9980c-…)
+      Element: byF6DckhFw
+      Source: inode-7k3e6T4RK9oix71Nm2umE6 → type=table (CUSTOMERS)
+      Connection: 4b39cdcd-… (snowflake)
+      /files path: Connection Root/WAREHOUSE_COFFEE_COMPANY/PUBLIC
+      Expected URN:
+        urn:li:dataset:(urn:li:dataPlatform:snowflake,
+                        warehouse_coffee_company.public.customers,PROD)
+
+    Asserts:
+      - dm_element_warehouse_upstream_emitted == 1
+      - dm_element_warehouse_files_api_call == 1 (cache miss on first call)
+      - data_model_element_upstreams_unresolved == 0 (fully resolved)
+      - golden file contains UpstreamLineage aspect on element byF6DckhFw
+    """
+    test_resources_dir = pytestconfig.rootpath / "tests/integration/sigma"
+
+    override_data = _get_t4b_warehouse_dm_overrides()
+    register_mock_api(request_mock=requests_mock, override_data=override_data)
+
+    output_path = f"{tmp_path}/sigma_dm_warehouse_upstream_mces.json"
+    pipeline = Pipeline.create(
+        _minimal_sigma_pipeline_config(output_path, ingest_data_models=True)
+    )
+    pipeline.run()
+    pipeline.raise_from_status()
+
+    report = _sigma_report(pipeline)
+    assert report.dm_element_warehouse_upstream_emitted == 1, (
+        f"expected 1 warehouse upstream emitted; got {report.dm_element_warehouse_upstream_emitted}"
+    )
+    assert report.dm_element_warehouse_files_api_call == 1, (
+        f"expected 1 /files API call; got {report.dm_element_warehouse_files_api_call}"
+    )
+    assert report.dm_element_warehouse_files_cache_hit == 0
+    assert report.data_model_element_upstreams_unresolved == 0, (
+        f"unexpected unresolved upstreams: {report.data_model_element_upstreams_unresolved}"
+    )
+    assert report.connections_resolved == 1
+
+    # Verify the UpstreamLineage aspect on element byF6DckhFw contains the
+    # warehouse table URN.
+    with open(output_path) as f:
+        mces = json.load(f)
+
+    expected_warehouse_urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,"
+        "warehouse_coffee_company.public.customers,PROD)"
+    )
+    element_urn = (
+        f"urn:li:dataset:(urn:li:dataPlatform:sigma,"
+        f"{_T4B_DM_ID}.{_T4B_ELEMENT_ID},PROD)"
+    )
+    upstream_lineage_aspects = [
+        mce
+        for mce in mces
+        if mce.get("entityUrn") == element_urn
+        and mce.get("aspectName") == "upstreamLineage"
+    ]
+    assert len(upstream_lineage_aspects) == 1, (
+        f"expected 1 upstreamLineage aspect on {element_urn}; "
+        f"got {len(upstream_lineage_aspects)}"
+    )
+    upstreams = upstream_lineage_aspects[0]["aspect"]["json"]["upstreams"]
+    upstream_dataset_urns = [u["dataset"] for u in upstreams]
+    assert expected_warehouse_urn in upstream_dataset_urns, (
+        f"warehouse URN not found in upstreams: {upstream_dataset_urns}"
+    )
+
+    mce_helpers.check_golden_file(
+        pytestconfig,
+        output_path=output_path,
+        golden_path=f"{test_resources_dir}/golden_test_sigma_dm_warehouse_upstream.json",
+    )

--- a/metadata-ingestion/tests/integration/sigma/test_sigma.py
+++ b/metadata-ingestion/tests/integration/sigma/test_sigma.py
@@ -6343,41 +6343,42 @@ def test_sigma_connection_registry(pytestconfig, tmp_path, requests_mock):
 
 # ---------------------------------------------------------------------------
 # DM element -> warehouse table UpstreamLineage
-# Empirical shape from live Sigma API:
-#   type=table entry: {connectionId: "4b39cdcd-…", name: "CUSTOMERS", inodeId: "f09fe362-…"}
-#   /files/{inodeId}: {urlId: "7k3e6T4RK9oix71Nm2umE6", path: "Connection Root/…/PUBLIC"}
-#   Expected warehouse URN: urn:li:dataset:(urn:li:dataPlatform:snowflake,
-#                            warehouse_coffee_company.public.customers,PROD)
+# Fixture shape mirrors a live Sigma API response (IDs preserved, names
+# anonymized). Key chain:
+#   /lineage type=table: connectionId + inodeId (UUID)
+#   /files/{inodeId}:    urlId (slug) + path "Connection Root/<DB>/<SCHEMA>"
+#   Expected URN: urn:li:dataset:(urn:li:dataPlatform:snowflake,
+#                  warehouse_coffee_company.public.customers,PROD)
 # ---------------------------------------------------------------------------
 
-# Kyungsoo Snowflake DM IDs — sourced directly from live Sigma API probe.
-_T4B_DM_ID = "81e9980c-3ec8-4bbf-a38e-78f9fe472ce0"
-_T4B_DM_URL_ID = "Kyungsoo-Snowflake-DM-3X8LiCwzXUAwO30p1an0Zi"
-_T4B_CONN_ID = "4b39cdcd-5a58-4ff6-af0d-8409ff880a23"
-_T4B_INODE_ID = "f09fe362-828a-42e6-9f8f-3f0feeb2fb3e"
-_T4B_URL_ID = "7k3e6T4RK9oix71Nm2umE6"
-_T4B_ELEMENT_ID = "byF6DckhFw"
-_T4B_WORKSPACE_ID = "3ee61405-3be2-4000-ba72-60d36757b95b"
+# Fixture IDs match live API UUID/slug shapes; display names are anonymized.
+_WH_DM_ID = "81e9980c-3ec8-4bbf-a38e-78f9fe472ce0"
+_WH_DM_URL_ID = "Acme-Snowflake-DM-fixture01"
+_WH_CONN_ID = "4b39cdcd-5a58-4ff6-af0d-8409ff880a23"
+_WH_INODE_ID = "f09fe362-828a-42e6-9f8f-3f0feeb2fb3e"
+_WH_URL_ID = "7k3e6T4RK9oix71Nm2umE6"
+_WH_ELEMENT_ID = "byF6DckhFw"
+_WH_WORKSPACE_ID = "3ee61405-3be2-4000-ba72-60d36757b95b"
 
 
-def _get_t4b_warehouse_dm_overrides() -> Dict[str, Dict]:
+def _get_warehouse_dm_overrides() -> Dict[str, Dict]:
     """Mock overrides for the warehouse-upstream integration test.
 
-    Uses real IDs and payload shapes from the live Sigma API probe.
+    Payload shapes mirror the live Sigma API; display names and account
+    locators are anonymized for OSS publication.
     """
     return {
-        # Override connections to add the KYUNGSOO SNOWFLAKE connection.
         "https://aws-api.sigmacomputing.com/v2/connections": {
             "method": "GET",
             "status_code": 200,
             "json": {
                 "entries": [
                     {
-                        "connectionId": _T4B_CONN_ID,
-                        "name": "KYUNGSOO SNOWFLAKE",
+                        "connectionId": _WH_CONN_ID,
+                        "name": "ACME SNOWFLAKE",
                         "type": "snowflake",
-                        "account": "diukgvb-woa55424",
-                        "host": "diukgvb-woa55424.snowflakecomputing.com",
+                        "account": "acme-test-snowflake",
+                        "host": "acme-test-snowflake.snowflakecomputing.com",
                         "warehouse": "COMPUTE_WH",
                     }
                 ],
@@ -6385,16 +6386,15 @@ def _get_t4b_warehouse_dm_overrides() -> Dict[str, Dict]:
                 "nextPage": None,
             },
         },
-        # DM file listing.
         "https://aws-api.sigmacomputing.com/v2/files?typeFilters=data-model": {
             "method": "GET",
             "status_code": 200,
             "json": {
                 "entries": [
                     {
-                        "id": _T4B_DM_ID,
-                        "urlId": _T4B_DM_URL_ID,
-                        "name": "Kyungsoo Snowflake DM",
+                        "id": _WH_DM_ID,
+                        "urlId": _WH_DM_URL_ID,
+                        "name": "Acme Snowflake DM",
                         "type": "data-model",
                         "parentId": "3ee61405-3be2-4000-ba72-60d36757b95b",
                         "parentUrlId": "1UGFyEQCHqwPfQoAec3xJ9",
@@ -6412,23 +6412,22 @@ def _get_t4b_warehouse_dm_overrides() -> Dict[str, Dict]:
                 "nextPage": None,
             },
         },
-        # DM metadata listing.
         "https://aws-api.sigmacomputing.com/v2/dataModels": {
             "method": "GET",
             "status_code": 200,
             "json": {
                 "entries": [
                     {
-                        "dataModelId": _T4B_DM_ID,
-                        "urlId": _T4B_DM_URL_ID,
-                        "name": "Kyungsoo Snowflake DM",
+                        "dataModelId": _WH_DM_ID,
+                        "urlId": _WH_DM_URL_ID,
+                        "name": "Acme Snowflake DM",
                         "description": "Integration fixture for warehouse-backed DM element",
                         "createdBy": "awUuH3HDr10r2c41vSZ5MNcyCDYZl",
                         "createdAt": "2026-05-04T00:00:00.000Z",
                         "updatedAt": "2026-05-04T00:00:00.000Z",
-                        "url": f"https://app.sigmacomputing.com/acryldata/dm/{_T4B_DM_URL_ID}",
+                        "url": f"https://app.sigmacomputing.com/acryldata/dm/{_WH_DM_URL_ID}",
                         "latestVersion": 1,
-                        "workspaceId": _T4B_WORKSPACE_ID,
+                        "workspaceId": _WH_WORKSPACE_ID,
                         "path": "Acryl Data",
                     }
                 ],
@@ -6436,14 +6435,13 @@ def _get_t4b_warehouse_dm_overrides() -> Dict[str, Dict]:
                 "nextPage": None,
             },
         },
-        # DM elements (one element, direct table source).
-        f"https://aws-api.sigmacomputing.com/v2/dataModels/{_T4B_DM_ID}/elements": {
+        f"https://aws-api.sigmacomputing.com/v2/dataModels/{_WH_DM_ID}/elements": {
             "method": "GET",
             "status_code": 200,
             "json": {
                 "entries": [
                     {
-                        "elementId": _T4B_ELEMENT_ID,
+                        "elementId": _WH_ELEMENT_ID,
                         "name": "CUSTOMERS",
                         "type": "table",
                         "columns": [],
@@ -6453,8 +6451,7 @@ def _get_t4b_warehouse_dm_overrides() -> Dict[str, Dict]:
                 "nextPage": None,
             },
         },
-        # DM columns (one column for the element).
-        f"https://aws-api.sigmacomputing.com/v2/dataModels/{_T4B_DM_ID}/columns": {
+        f"https://aws-api.sigmacomputing.com/v2/dataModels/{_WH_DM_ID}/columns": {
             "method": "GET",
             "status_code": 200,
             "json": {
@@ -6462,7 +6459,7 @@ def _get_t4b_warehouse_dm_overrides() -> Dict[str, Dict]:
                     {
                         "columnId": "col-1",
                         "name": "CUSTOMER_ID",
-                        "elementId": _T4B_ELEMENT_ID,
+                        "elementId": _WH_ELEMENT_ID,
                         "label": None,
                         "formula": None,
                     }
@@ -6471,35 +6468,33 @@ def _get_t4b_warehouse_dm_overrides() -> Dict[str, Dict]:
                 "nextPage": None,
             },
         },
-        # DM lineage — real shape from live probe.
-        f"https://aws-api.sigmacomputing.com/v2/dataModels/{_T4B_DM_ID}/lineage": {
+        f"https://aws-api.sigmacomputing.com/v2/dataModels/{_WH_DM_ID}/lineage": {
             "method": "GET",
             "status_code": 200,
             "json": {
                 "entries": [
                     {
-                        "connectionId": _T4B_CONN_ID,
+                        "connectionId": _WH_CONN_ID,
                         "name": "CUSTOMERS",
                         "type": "table",
-                        "inodeId": _T4B_INODE_ID,
+                        "inodeId": _WH_INODE_ID,
                     },
                     {
-                        "elementId": _T4B_ELEMENT_ID,
+                        "elementId": _WH_ELEMENT_ID,
                         "type": "element",
-                        "sourceIds": [f"inode-{_T4B_URL_ID}"],
-                        "dataSourceIds": [f"inode-{_T4B_URL_ID}"],
+                        "sourceIds": [f"inode-{_WH_URL_ID}"],
+                        "dataSourceIds": [f"inode-{_WH_URL_ID}"],
                     },
                 ],
                 "nextPage": None,
             },
         },
-        # /files/{inodeId} — real response from live probe.
-        f"https://aws-api.sigmacomputing.com/v2/files/{_T4B_INODE_ID}": {
+        f"https://aws-api.sigmacomputing.com/v2/files/{_WH_INODE_ID}": {
             "method": "GET",
             "status_code": 200,
             "json": {
-                "id": _T4B_INODE_ID,
-                "urlId": _T4B_URL_ID,
+                "id": _WH_INODE_ID,
+                "urlId": _WH_URL_ID,
                 "name": "CUSTOMERS",
                 "type": "table",
                 "parentId": "3f583620-d373-4d73-bdb9-1e63aa1c58fb",
@@ -6520,24 +6515,18 @@ def test_sigma_ingest_data_models_warehouse_upstream(
     """DM element with a type=table warehouse source gets an UpstreamLineage
     aspect pointing at the Snowflake warehouse table URN.
 
-    Uses real IDs and payload shapes from a live Sigma API probe:
-      DM: Kyungsoo Snowflake DM (81e9980c-…)
-      Element: byF6DckhFw
-      Source: inode-7k3e6T4RK9oix71Nm2umE6 → type=table (CUSTOMERS)
+    Fixture payload shape mirrors a live Sigma API; names anonymized.
+      DM:         Acme Snowflake DM (81e9980c-…)
+      Element:    byF6DckhFw
+      Source:     inode-7k3e6T4... -> type=table (CUSTOMERS)
       Connection: 4b39cdcd-… (snowflake)
-      /files path: Connection Root/WAREHOUSE_COFFEE_COMPANY/PUBLIC
-      Expected URN:
-        urn:li:dataset:(urn:li:dataPlatform:snowflake,
-                        warehouse_coffee_company.public.customers,PROD)
-
-    Asserts:
-      - dm_element_warehouse_upstream_emitted == 1
-      - data_model_element_upstreams_unresolved == 0 (fully resolved)
-      - golden file contains UpstreamLineage aspect on element byF6DckhFw
+      /files:     path = Connection Root/WAREHOUSE_COFFEE_COMPANY/PUBLIC
+      URN:        urn:li:dataset:(urn:li:dataPlatform:snowflake,
+                    warehouse_coffee_company.public.customers,PROD)
     """
     test_resources_dir = pytestconfig.rootpath / "tests/integration/sigma"
 
-    override_data = _get_t4b_warehouse_dm_overrides()
+    override_data = _get_warehouse_dm_overrides()
     register_mock_api(request_mock=requests_mock, override_data=override_data)
 
     output_path = f"{tmp_path}/sigma_dm_warehouse_upstream_mces.json"
@@ -6551,39 +6540,32 @@ def test_sigma_ingest_data_models_warehouse_upstream(
     assert report.dm_element_warehouse_upstream_emitted == 1, (
         f"expected 1 warehouse upstream emitted; got {report.dm_element_warehouse_upstream_emitted}"
     )
-    assert report.data_model_element_upstreams_unresolved == 0, (
-        f"unexpected unresolved upstreams: {report.data_model_element_upstreams_unresolved}"
-    )
+    assert report.data_model_element_upstreams_unresolved == 0
     assert report.connections_resolved == 1
-
-    # Verify the UpstreamLineage aspect on element byF6DckhFw contains the
-    # warehouse table URN.
-    with open(output_path) as f:
-        mces = json.load(f)
+    # Error counters must all be zero on a clean fixture run.
+    assert report.dm_element_warehouse_unknown_connection == 0
+    assert report.dm_element_warehouse_table_lookup_failed == 0
+    assert report.dm_element_warehouse_path_unparseable == 0
+    assert report.dm_element_warehouse_table_entry_incomplete == 0
 
     expected_warehouse_urn = (
         "urn:li:dataset:(urn:li:dataPlatform:snowflake,"
         "warehouse_coffee_company.public.customers,PROD)"
     )
     element_urn = (
-        f"urn:li:dataset:(urn:li:dataPlatform:sigma,"
-        f"{_T4B_DM_ID}.{_T4B_ELEMENT_ID},PROD)"
+        f"urn:li:dataset:(urn:li:dataPlatform:sigma,{_WH_DM_ID}.{_WH_ELEMENT_ID},PROD)"
     )
+    with open(output_path) as f:
+        mces = json.load(f)
     upstream_lineage_aspects = [
         mce
         for mce in mces
         if mce.get("entityUrn") == element_urn
         and mce.get("aspectName") == "upstreamLineage"
     ]
-    assert len(upstream_lineage_aspects) == 1, (
-        f"expected 1 upstreamLineage aspect on {element_urn}; "
-        f"got {len(upstream_lineage_aspects)}"
-    )
+    assert len(upstream_lineage_aspects) == 1
     upstreams = upstream_lineage_aspects[0]["aspect"]["json"]["upstreams"]
-    upstream_dataset_urns = [u["dataset"] for u in upstreams]
-    assert expected_warehouse_urn in upstream_dataset_urns, (
-        f"warehouse URN not found in upstreams: {upstream_dataset_urns}"
-    )
+    assert expected_warehouse_urn in [u["dataset"] for u in upstreams]
 
     mce_helpers.check_golden_file(
         pytestconfig,

--- a/metadata-ingestion/tests/integration/sigma/test_sigma.py
+++ b/metadata-ingestion/tests/integration/sigma/test_sigma.py
@@ -6532,7 +6532,6 @@ def test_sigma_ingest_data_models_warehouse_upstream(
 
     Asserts:
       - dm_element_warehouse_upstream_emitted == 1
-      - dm_element_warehouse_files_api_call == 1 (cache miss on first call)
       - data_model_element_upstreams_unresolved == 0 (fully resolved)
       - golden file contains UpstreamLineage aspect on element byF6DckhFw
     """
@@ -6552,10 +6551,6 @@ def test_sigma_ingest_data_models_warehouse_upstream(
     assert report.dm_element_warehouse_upstream_emitted == 1, (
         f"expected 1 warehouse upstream emitted; got {report.dm_element_warehouse_upstream_emitted}"
     )
-    assert report.dm_element_warehouse_files_api_call == 1, (
-        f"expected 1 /files API call; got {report.dm_element_warehouse_files_api_call}"
-    )
-    assert report.dm_element_warehouse_files_cache_hit == 0
     assert report.data_model_element_upstreams_unresolved == 0, (
         f"unexpected unresolved upstreams: {report.data_model_element_upstreams_unresolved}"
     )

--- a/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_upstream.py
+++ b/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_upstream.py
@@ -19,7 +19,7 @@ from typing import Any, Dict, List, Optional
 from unittest.mock import patch
 
 from datahub.ingestion.api.common import PipelineContext
-from datahub.ingestion.source.sigma.config import SigmaSourceConfig
+from datahub.ingestion.source.sigma.config import SigmaSourceConfig, SigmaSourceReport
 from datahub.ingestion.source.sigma.connection_registry import (
     SigmaConnectionRecord,
     SigmaConnectionRegistry,
@@ -190,7 +190,7 @@ class TestBuildDmWarehouseUrlIdMap:
         assert result == {}
         assert source.reporter.dm_element_warehouse_path_unparseable == 1
 
-    def test_missing_url_id_skipped(self):
+    def test_empty_url_id_counts_as_path_unparseable(self):
         source = _make_source()
         dm = _make_dm_with_inodes(
             {"inode-1": {"connectionId": _SNOWFLAKE_CONN_ID, "name": "TABLE"}}
@@ -203,6 +203,47 @@ class TestBuildDmWarehouseUrlIdMap:
                 "urlId": "",
                 "name": "TABLE",
                 "path": "Connection Root/DB/SCHEMA",
+            },
+        ):
+            result = source._build_dm_warehouse_url_id_map(dm)
+
+        assert result == {}
+        assert source.reporter.dm_element_warehouse_path_unparseable == 1
+
+    def test_path_unparseable_more_than_3_segments(self):
+        source = _make_source()
+        dm = _make_dm_with_inodes(
+            {"inode-1": {"connectionId": _SNOWFLAKE_CONN_ID, "name": "TABLE"}}
+        )
+        with patch.object(
+            source.sigma_api,
+            "get_file_metadata",
+            return_value={
+                "id": "inode-1",
+                "urlId": "url-1",
+                "name": "TABLE",
+                "path": "Connection Root/DB/SCHEMA/SUBPATH",
+            },
+        ):
+            result = source._build_dm_warehouse_url_id_map(dm)
+
+        assert result == {}
+        assert source.reporter.dm_element_warehouse_path_unparseable == 1
+
+    def test_path_unparseable_empty_segment(self):
+        # B2: "Connection Root//PUBLIC" passes len==3 but has an empty DB segment.
+        source = _make_source()
+        dm = _make_dm_with_inodes(
+            {"inode-1": {"connectionId": _SNOWFLAKE_CONN_ID, "name": "TABLE"}}
+        )
+        with patch.object(
+            source.sigma_api,
+            "get_file_metadata",
+            return_value={
+                "id": "inode-1",
+                "urlId": "url-1",
+                "name": "TABLE",
+                "path": "Connection Root//PUBLIC",
             },
         ):
             result = source._build_dm_warehouse_url_id_map(dm)
@@ -251,6 +292,8 @@ class TestResolveDmElementWarehouseUpstream:
         assert urn is None
 
     def test_unknown_connection_id(self):
+        # unknown_connection counter is bumped by the caller (post-dedup);
+        # the resolver itself just returns None.
         source = _make_source()
         ref = _WarehouseTableRef(
             connection_id="conn-unknown",
@@ -265,7 +308,7 @@ class TestResolveDmElementWarehouseUpstream:
         )
 
         assert urn is None
-        assert source.reporter.dm_element_warehouse_unknown_connection == 1
+        assert source.reporter.dm_element_warehouse_unknown_connection == 0
 
     def test_unmappable_platform_counts_as_unknown_connection(self):
         source = _make_source()
@@ -282,7 +325,7 @@ class TestResolveDmElementWarehouseUpstream:
         )
 
         assert urn is None
-        assert source.reporter.dm_element_warehouse_unknown_connection == 1
+        assert source.reporter.dm_element_warehouse_unknown_connection == 0
 
 
 # ---------------------------------------------------------------------------
@@ -314,8 +357,8 @@ class TestUpstreamLineageWarehouseWiring:
             element,
             dm,
             element_urn,
-            {},  # elementId_to_dataset_urn (no intra-DM upstreams)
-            {},  # element_name_to_eids
+            {},
+            {},
             warehouse_url_id_map or {},
         )
 
@@ -478,6 +521,32 @@ class TestUpstreamLineageWarehouseWiring:
         assert source.reporter.dm_element_warehouse_unknown_connection == 1
         assert source.reporter.dm_element_warehouse_upstream_emitted == 0
 
+    def test_diamond_source_ids_emit_once(self):
+        """Two source_ids resolving to the same warehouse URN produce one
+        upstream entry and bump dm_element_warehouse_upstream_emitted once."""
+        source = _make_source()
+        ref = _WarehouseTableRef(
+            connection_id=_SNOWFLAKE_CONN_ID,
+            db="DB",
+            schema="SCH",
+            table="TBL",
+        )
+        # Both url-a and url-b map to the same ref -> same resolved URN.
+        warehouse_map = {"url-a": ref, "url-b": ref}
+        element = _make_minimal_element(source_ids=["inode-url-a", "inode-url-b"])
+        dm = SigmaDataModel(
+            dataModelId="dm-1",
+            name="DM",
+            createdAt="2024-01-01T00:00:00Z",
+            updatedAt="2024-01-01T00:00:00Z",
+        )
+
+        lineage = self._run(source, element, dm, warehouse_map)
+
+        assert lineage is not None
+        assert len(lineage.upstreams) == 1
+        assert source.reporter.dm_element_warehouse_upstream_emitted == 1
+
 
 # ---------------------------------------------------------------------------
 # Tests: sigma_api.py _assemble_data_model entry guard (#5)
@@ -486,13 +555,6 @@ class TestUpstreamLineageWarehouseWiring:
 
 class TestWarehouseInodeEntryGuard:
     def test_missing_name_or_inode_counts_incomplete(self):
-        from datahub.ingestion.source.sigma.config import (
-            SigmaSourceConfig,
-            SigmaSourceReport,
-        )
-        from datahub.ingestion.source.sigma.data_classes import SigmaDataModel
-        from datahub.ingestion.source.sigma.sigma_api import SigmaAPI
-
         config = SigmaSourceConfig.model_validate(
             {"client_id": "x", "client_secret": "y"}
         )

--- a/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_upstream.py
+++ b/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_upstream.py
@@ -1,27 +1,22 @@
 """Unit tests for DM element -> warehouse table UpstreamLineage resolution.
 
 Coverage:
-  - _build_dm_warehouse_url_id_map: happy path, /files failure, path
-    unparseable, unexpected path root, no urlId
+  - _build_dm_warehouse_url_id_map: happy path, /files failure, path unparseable
   - _resolve_dm_element_warehouse_upstream: success (Snowflake), unknown
-    connection, unmappable platform, ref not in map
+    connection (including unmappable platform), ref not in map
   - _gen_data_model_element_upstream_lineage: warehouse-only upstream,
     SD upstream only, co-emit (both SD + warehouse), empty registry,
     unresolved counter not double-bumped when warehouse resolves
 
-Counter taxonomy verified:
+Counters verified:
   dm_element_warehouse_upstream_emitted
   dm_element_warehouse_unknown_connection
-  dm_element_warehouse_unmappable_platform
   dm_element_warehouse_table_lookup_failed
   dm_element_warehouse_path_unparseable
-  dm_element_warehouse_unexpected_path_root
-  dm_element_warehouse_files_cache_hit
-  dm_element_warehouse_files_api_call
 """
 
 from typing import Any, Dict, List, Optional
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.source.sigma.config import SigmaSourceConfig
@@ -111,9 +106,6 @@ def _make_dm_with_inodes(inodes: Dict[str, Dict[str, str]]) -> SigmaDataModel:
 class TestBuildDmWarehouseUrlIdMap:
     def test_happy_path_snowflake(self):
         source = _make_source()
-        source.sigma_api.get_file_metadata = MagicMock(
-            return_value=_GOOD_FILES_RESPONSE
-        )
         dm = _make_dm_with_inodes(
             {
                 "f09fe362-828a-42e6-9f8f-3f0feeb2fb3e": {
@@ -122,8 +114,10 @@ class TestBuildDmWarehouseUrlIdMap:
                 }
             }
         )
-
-        result = source._build_dm_warehouse_url_id_map(dm)
+        with patch.object(
+            source.sigma_api, "get_file_metadata", return_value=_GOOD_FILES_RESPONSE
+        ):
+            result = source._build_dm_warehouse_url_id_map(dm)
 
         assert "7k3e6T4RK9oix71Nm2umE6" in result
         ref = result["7k3e6T4RK9oix71Nm2umE6"]
@@ -131,93 +125,87 @@ class TestBuildDmWarehouseUrlIdMap:
         assert ref.db == "WAREHOUSE_COFFEE_COMPANY"
         assert ref.schema == "PUBLIC"
         assert ref.table == "CUSTOMERS"
-        assert source.reporter.dm_element_warehouse_files_api_call == 1
-        assert source.reporter.dm_element_warehouse_files_cache_hit == 0
 
-    def test_cache_hit_on_second_call(self):
+    def test_cache_deduplicates_files_calls(self):
         source = _make_source()
-        source.sigma_api.get_file_metadata = MagicMock(
-            return_value=_GOOD_FILES_RESPONSE
-        )
         inode_id = "f09fe362-828a-42e6-9f8f-3f0feeb2fb3e"
         inodes = {inode_id: {"connectionId": _SNOWFLAKE_CONN_ID, "name": "CUSTOMERS"}}
-
         dm1 = _make_dm_with_inodes(inodes)
         dm2 = _make_dm_with_inodes(inodes)
-        source._build_dm_warehouse_url_id_map(dm1)
-        source._build_dm_warehouse_url_id_map(dm2)
-
-        assert source.reporter.dm_element_warehouse_files_api_call == 1
-        assert source.reporter.dm_element_warehouse_files_cache_hit == 1
-        source.sigma_api.get_file_metadata.assert_called_once()
+        with patch.object(
+            source.sigma_api, "get_file_metadata", return_value=_GOOD_FILES_RESPONSE
+        ) as mock_get:
+            source._build_dm_warehouse_url_id_map(dm1)
+            source._build_dm_warehouse_url_id_map(dm2)
+            mock_get.assert_called_once()
 
     def test_files_lookup_failure_increments_counter(self):
         source = _make_source()
-        source.sigma_api.get_file_metadata = MagicMock(return_value=None)
         dm = _make_dm_with_inodes(
             {"bad-inode": {"connectionId": _SNOWFLAKE_CONN_ID, "name": "TABLE"}}
         )
-
-        result = source._build_dm_warehouse_url_id_map(dm)
+        with patch.object(source.sigma_api, "get_file_metadata", return_value=None):
+            result = source._build_dm_warehouse_url_id_map(dm)
 
         assert result == {}
         assert source.reporter.dm_element_warehouse_table_lookup_failed == 1
 
     def test_path_unparseable_fewer_than_3_segments(self):
         source = _make_source()
-        source.sigma_api.get_file_metadata = MagicMock(
+        dm = _make_dm_with_inodes(
+            {"inode-1": {"connectionId": _SNOWFLAKE_CONN_ID, "name": "data.csv"}}
+        )
+        with patch.object(
+            source.sigma_api,
+            "get_file_metadata",
             return_value={
                 "id": "inode-1",
                 "urlId": "url-1",
                 "name": "data.csv",
-                "path": "Acryl Workspace",  # 1 segment — CSV upload shape
-            }
-        )
-        dm = _make_dm_with_inodes(
-            {"inode-1": {"connectionId": _SNOWFLAKE_CONN_ID, "name": "data.csv"}}
-        )
-
-        result = source._build_dm_warehouse_url_id_map(dm)
+                "path": "Acryl Workspace",
+            },
+        ):
+            result = source._build_dm_warehouse_url_id_map(dm)
 
         assert result == {}
         assert source.reporter.dm_element_warehouse_path_unparseable == 1
-        assert source.reporter.dm_element_warehouse_unexpected_path_root == 0
 
-    def test_unexpected_path_root_increments_counter(self):
+    def test_unrecognised_path_root_counts_as_unparseable(self):
         source = _make_source()
-        source.sigma_api.get_file_metadata = MagicMock(
+        dm = _make_dm_with_inodes(
+            {"inode-1": {"connectionId": _SNOWFLAKE_CONN_ID, "name": "MY_TABLE"}}
+        )
+        with patch.object(
+            source.sigma_api,
+            "get_file_metadata",
             return_value={
                 "id": "inode-1",
                 "urlId": "url-1",
                 "name": "MY_TABLE",
-                "path": "Connexion racine/DB/SCHEMA",  # i18n variant
-            }
-        )
-        dm = _make_dm_with_inodes(
-            {"inode-1": {"connectionId": _SNOWFLAKE_CONN_ID, "name": "MY_TABLE"}}
-        )
-
-        result = source._build_dm_warehouse_url_id_map(dm)
+                "path": "Connexion racine/DB/SCHEMA",
+            },
+        ):
+            result = source._build_dm_warehouse_url_id_map(dm)
 
         assert result == {}
-        assert source.reporter.dm_element_warehouse_unexpected_path_root == 1
-        assert source.reporter.dm_element_warehouse_path_unparseable == 0
+        assert source.reporter.dm_element_warehouse_path_unparseable == 1
 
     def test_missing_url_id_skipped(self):
         source = _make_source()
-        source.sigma_api.get_file_metadata = MagicMock(
-            return_value={
-                "id": "inode-1",
-                "urlId": "",  # empty urlId
-                "name": "TABLE",
-                "path": "Connection Root/DB/SCHEMA",
-            }
-        )
         dm = _make_dm_with_inodes(
             {"inode-1": {"connectionId": _SNOWFLAKE_CONN_ID, "name": "TABLE"}}
         )
-
-        result = source._build_dm_warehouse_url_id_map(dm)
+        with patch.object(
+            source.sigma_api,
+            "get_file_metadata",
+            return_value={
+                "id": "inode-1",
+                "urlId": "",
+                "name": "TABLE",
+                "path": "Connection Root/DB/SCHEMA",
+            },
+        ):
+            result = source._build_dm_warehouse_url_id_map(dm)
 
         assert result == {}
         assert source.reporter.dm_element_warehouse_path_unparseable == 1
@@ -242,14 +230,14 @@ class TestResolveDmElementWarehouseUpstream:
         urn = source._resolve_dm_element_warehouse_upstream(
             url_id_suffix="7k3e6T4RK9oix71Nm2umE6",
             warehouse_map=warehouse_map,
-            inode_source_id="inode-7k3e6T4RK9oix71Nm2umE6",
         )
 
         assert (
             urn
             == "urn:li:dataset:(urn:li:dataPlatform:snowflake,warehouse_coffee_company.public.customers,PROD)"
         )
-        assert source.reporter.dm_element_warehouse_upstream_emitted == 1
+        # Counter is bumped by caller post-dedup; resolver itself does not bump.
+        assert source.reporter.dm_element_warehouse_upstream_emitted == 0
         assert source.reporter.dm_element_warehouse_unknown_connection == 0
 
     def test_not_in_warehouse_map_returns_none(self):
@@ -258,11 +246,9 @@ class TestResolveDmElementWarehouseUpstream:
         urn = source._resolve_dm_element_warehouse_upstream(
             url_id_suffix="not-in-map",
             warehouse_map={},
-            inode_source_id="inode-not-in-map",
         )
 
         assert urn is None
-        assert source.reporter.dm_element_warehouse_upstream_emitted == 0
 
     def test_unknown_connection_id(self):
         source = _make_source()
@@ -272,19 +258,16 @@ class TestResolveDmElementWarehouseUpstream:
             schema="SCHEMA",
             table="TABLE",
         )
-        warehouse_map = {"url-1": ref}
 
         urn = source._resolve_dm_element_warehouse_upstream(
             url_id_suffix="url-1",
-            warehouse_map=warehouse_map,
-            inode_source_id="inode-url-1",
+            warehouse_map={"url-1": ref},
         )
 
         assert urn is None
         assert source.reporter.dm_element_warehouse_unknown_connection == 1
-        assert source.reporter.dm_element_warehouse_upstream_emitted == 0
 
-    def test_unmappable_platform(self):
+    def test_unmappable_platform_counts_as_unknown_connection(self):
         source = _make_source()
         ref = _WarehouseTableRef(
             connection_id=_UNMAPPABLE_CONN_ID,
@@ -292,17 +275,14 @@ class TestResolveDmElementWarehouseUpstream:
             schema="SCHEMA",
             table="TABLE",
         )
-        warehouse_map = {"url-1": ref}
 
         urn = source._resolve_dm_element_warehouse_upstream(
             url_id_suffix="url-1",
-            warehouse_map=warehouse_map,
-            inode_source_id="inode-url-1",
+            warehouse_map={"url-1": ref},
         )
 
         assert urn is None
-        assert source.reporter.dm_element_warehouse_unmappable_platform == 1
-        assert source.reporter.dm_element_warehouse_upstream_emitted == 0
+        assert source.reporter.dm_element_warehouse_unknown_connection == 1
 
 
 # ---------------------------------------------------------------------------
@@ -497,6 +477,64 @@ class TestUpstreamLineageWarehouseWiring:
         assert lineage is None
         assert source.reporter.dm_element_warehouse_unknown_connection == 1
         assert source.reporter.dm_element_warehouse_upstream_emitted == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: sigma_api.py _assemble_data_model entry guard (#5)
+# ---------------------------------------------------------------------------
+
+
+class TestWarehouseInodeEntryGuard:
+    def test_missing_name_or_inode_counts_incomplete(self):
+        from datahub.ingestion.source.sigma.config import (
+            SigmaSourceConfig,
+            SigmaSourceReport,
+        )
+        from datahub.ingestion.source.sigma.data_classes import SigmaDataModel
+        from datahub.ingestion.source.sigma.sigma_api import SigmaAPI
+
+        config = SigmaSourceConfig.model_validate(
+            {"client_id": "x", "client_secret": "y"}
+        )
+        report = SigmaSourceReport()
+        with patch.object(SigmaAPI, "_generate_token"):
+            api = SigmaAPI(config, report)
+
+        dm = SigmaDataModel(
+            dataModelId="dm-x",
+            name="X",
+            createdAt="2024-01-01T00:00:00Z",
+            updatedAt="2024-01-01T00:00:00Z",
+        )
+        lineage_entries = [
+            # empty name — should be rejected, counter bumped
+            {
+                "type": "table",
+                "inodeId": "inode-1",
+                "connectionId": "conn-1",
+                "name": "",
+            },
+            # empty inodeId — should be rejected, counter bumped
+            {"type": "table", "inodeId": "", "connectionId": "conn-1", "name": "TABLE"},
+            # valid
+            {
+                "type": "table",
+                "inodeId": "inode-2",
+                "connectionId": "conn-1",
+                "name": "GOOD",
+            },
+        ]
+        with (
+            patch.object(api, "_get_data_model_elements", return_value=[]),
+            patch.object(api, "_get_data_model_columns", return_value=[]),
+            patch.object(
+                api, "_get_data_model_lineage_entries", return_value=lineage_entries
+            ),
+        ):
+            api._assemble_data_model(dm, file_meta=None)
+
+        assert report.dm_element_warehouse_table_entry_incomplete == 2
+        assert list(dm.warehouse_inodes_by_inode_id.keys()) == ["inode-2"]
 
 
 # ---------------------------------------------------------------------------

--- a/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_upstream.py
+++ b/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_upstream.py
@@ -150,6 +150,30 @@ class TestBuildDmWarehouseUrlIdMap:
         assert result == {}
         assert source.reporter.dm_element_warehouse_table_lookup_failed == 1
 
+    def test_rate_limited_files_call_increments_rate_limit_counter(self):
+        import requests
+
+        from datahub.ingestion.source.sigma.config import (
+            SigmaSourceConfig,
+            SigmaSourceReport,
+        )
+        from datahub.ingestion.source.sigma.sigma_api import SigmaAPI
+
+        config = SigmaSourceConfig.model_validate(
+            {"client_id": "x", "client_secret": "y"}
+        )
+        report = SigmaSourceReport()
+        with patch.object(SigmaAPI, "_generate_token"):
+            api = SigmaAPI(config, report)
+
+        fake_response = requests.Response()
+        fake_response.status_code = 429
+        with patch.object(api, "_get_api_call", return_value=fake_response):
+            result = api.get_file_metadata("some-inode")
+
+        assert result is None
+        assert report.dm_element_warehouse_table_lookup_rate_limited == 1
+
     def test_path_unparseable_fewer_than_3_segments(self):
         source = _make_source()
         dm = _make_dm_with_inodes(
@@ -453,6 +477,7 @@ class TestUpstreamLineageWarehouseWiring:
             in upstream_urns
         )
         assert source.reporter.dm_element_warehouse_upstream_emitted == 1
+        assert source.reporter.data_model_element_external_upstreams == 1
         assert source.reporter.data_model_element_upstreams_unresolved == 0
 
     def test_unresolved_counter_not_bumped_when_warehouse_resolves(self):
@@ -547,9 +572,41 @@ class TestUpstreamLineageWarehouseWiring:
         assert len(lineage.upstreams) == 1
         assert source.reporter.dm_element_warehouse_upstream_emitted == 1
 
+    def test_unknown_connection_not_double_counted_on_diamond_when_sd_resolves(self):
+        """Bug #1 regression: duplicate source_ids where warehouse fails but SD
+        resolves must only bump dm_element_warehouse_unknown_connection once."""
+        source = _make_source()
+        # Warehouse map has the inode but the connection is not in the registry.
+        ref = _WarehouseTableRef(
+            connection_id="conn-unknown",
+            db="DB",
+            schema="SCH",
+            table="TBL",
+        )
+        warehouse_map = {"url-x": ref}
+        # SD map resolves the same inode.
+        source.sigma_dataset_urn_by_url_id["url-x"] = (
+            "urn:li:dataset:(urn:li:dataPlatform:sigma,url-x,PROD)"
+        )
+        # Diamond: same source_id appears twice.
+        element = _make_minimal_element(source_ids=["inode-url-x", "inode-url-x"])
+        dm = SigmaDataModel(
+            dataModelId="dm-1",
+            name="DM",
+            createdAt="2024-01-01T00:00:00Z",
+            updatedAt="2024-01-01T00:00:00Z",
+        )
+
+        lineage = self._run(source, element, dm, warehouse_map)
+
+        assert lineage is not None
+        assert len(lineage.upstreams) == 1  # SD URN only
+        # Must fire exactly once despite the duplicate source_id.
+        assert source.reporter.dm_element_warehouse_unknown_connection == 1
+
 
 # ---------------------------------------------------------------------------
-# Tests: sigma_api.py _assemble_data_model entry guard (#5)
+# Tests: sigma_api.py _assemble_data_model entry guard
 # ---------------------------------------------------------------------------
 
 

--- a/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_upstream.py
+++ b/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_upstream.py
@@ -18,8 +18,14 @@ Counters verified:
 from typing import Any, Dict, List, Optional
 from unittest.mock import patch
 
+import requests
+
 from datahub.ingestion.api.common import PipelineContext
-from datahub.ingestion.source.sigma.config import SigmaSourceConfig, SigmaSourceReport
+from datahub.ingestion.source.sigma.config import (
+    SigmaSourceConfig,
+    SigmaSourceReport,
+    WarehouseConnectionConfig,
+)
 from datahub.ingestion.source.sigma.connection_registry import (
     SigmaConnectionRecord,
     SigmaConnectionRegistry,
@@ -150,29 +156,18 @@ class TestBuildDmWarehouseUrlIdMap:
         assert result == {}
         assert source.reporter.dm_element_warehouse_table_lookup_failed == 1
 
-    def test_rate_limited_files_call_increments_rate_limit_counter(self):
-        import requests
+    def test_cache_failure_not_double_counted_across_dms(self):
+        """H7: a failed /files inode shared by N DMs must only bump
+        dm_element_warehouse_table_lookup_failed once (first_attempt gate)."""
+        source = _make_source()
+        inodes = {"bad-inode": {"connectionId": _SNOWFLAKE_CONN_ID, "name": "TABLE"}}
+        dm1 = _make_dm_with_inodes(inodes)
+        dm2 = _make_dm_with_inodes(inodes)
+        with patch.object(source.sigma_api, "get_file_metadata", return_value=None):
+            source._build_dm_warehouse_url_id_map(dm1)
+            source._build_dm_warehouse_url_id_map(dm2)
 
-        from datahub.ingestion.source.sigma.config import (
-            SigmaSourceConfig,
-            SigmaSourceReport,
-        )
-        from datahub.ingestion.source.sigma.sigma_api import SigmaAPI
-
-        config = SigmaSourceConfig.model_validate(
-            {"client_id": "x", "client_secret": "y"}
-        )
-        report = SigmaSourceReport()
-        with patch.object(SigmaAPI, "_generate_token"):
-            api = SigmaAPI(config, report)
-
-        fake_response = requests.Response()
-        fake_response.status_code = 429
-        with patch.object(api, "_get_api_call", return_value=fake_response):
-            result = api.get_file_metadata("some-inode")
-
-        assert result is None
-        assert report.dm_element_warehouse_table_lookup_rate_limited == 1
+        assert source.reporter.dm_element_warehouse_table_lookup_failed == 1
 
     def test_path_unparseable_fewer_than_3_segments(self):
         source = _make_source()
@@ -334,7 +329,7 @@ class TestResolveDmElementWarehouseUpstream:
         assert urn is None
         assert source.reporter.dm_element_warehouse_unknown_connection == 0
 
-    def test_unmappable_platform_counts_as_unknown_connection(self):
+    def test_unmappable_platform_resolver_returns_none(self):
         source = _make_source()
         ref = _WarehouseTableRef(
             connection_id=_UNMAPPABLE_CONN_ID,
@@ -350,6 +345,62 @@ class TestResolveDmElementWarehouseUpstream:
 
         assert urn is None
         assert source.reporter.dm_element_warehouse_unknown_connection == 0
+
+    def test_connection_to_platform_map_overrides_env_and_instance(self):
+        """connection_to_platform_map entries set the env/platform_instance on
+        the emitted warehouse URN so it matches the warehouse connector's output."""
+        conn_override = WarehouseConnectionConfig.model_validate(
+            {"env": "DEV", "platform_instance": "prod-snowflake"}
+        )
+        config = SigmaSourceConfig.model_validate(
+            {
+                "client_id": "test",
+                "client_secret": "test",
+                "env": "PROD",
+                "connection_to_platform_map": {_SNOWFLAKE_CONN_ID: conn_override},
+            }
+        )
+        ctx = PipelineContext(run_id="t4b-override-test")
+        with patch.object(SigmaAPI, "_generate_token"):
+            source = SigmaSource(config=config, ctx=ctx)
+        source.connection_registry = SigmaConnectionRegistry(
+            by_id={_SNOWFLAKE_CONN_ID: _SNOWFLAKE_CONN_RECORD}
+        )
+
+        ref = _WarehouseTableRef(
+            connection_id=_SNOWFLAKE_CONN_ID,
+            db="DB",
+            schema="SCH",
+            table="TBL",
+        )
+        urn = source._resolve_dm_element_warehouse_upstream(
+            url_id_suffix="url-1",
+            warehouse_map={"url-1": ref},
+        )
+
+        # env=DEV and platform_instance=prod-snowflake from the override map.
+        assert urn == (
+            "urn:li:dataset:(urn:li:dataPlatform:snowflake,"
+            "prod-snowflake.db.sch.tbl,DEV)"
+        )
+
+    def test_no_override_falls_back_to_recipe_env(self):
+        """When connection_to_platform_map has no entry for the connection, the
+        Sigma recipe's env is used and platform_instance defaults to None."""
+        source = _make_source()  # registry has _SNOWFLAKE_CONN_ID, no override
+        ref = _WarehouseTableRef(
+            connection_id=_SNOWFLAKE_CONN_ID,
+            db="DB",
+            schema="SCH",
+            table="TBL",
+        )
+
+        urn = source._resolve_dm_element_warehouse_upstream(
+            url_id_suffix="url-1",
+            warehouse_map={"url-1": ref},
+        )
+
+        assert urn == "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.sch.tbl,PROD)"
 
 
 # ---------------------------------------------------------------------------
@@ -381,9 +432,9 @@ class TestUpstreamLineageWarehouseWiring:
             element,
             dm,
             element_urn,
-            {},
-            {},
-            warehouse_url_id_map or {},
+            elementId_to_dataset_urn={},
+            element_name_to_eids={},
+            warehouse_url_id_map=warehouse_url_id_map or {},
         )
 
     def test_warehouse_only_upstream_emitted(self):
@@ -546,6 +597,36 @@ class TestUpstreamLineageWarehouseWiring:
         assert source.reporter.dm_element_warehouse_unknown_connection == 1
         assert source.reporter.dm_element_warehouse_upstream_emitted == 0
 
+    def test_empty_registry_warning_fires_once_per_run(self):
+        """H7: the empty-registry warning is gated on _registry_empty_warned so
+        it fires at most once even when multiple DMs have warehouse inodes."""
+        config = SigmaSourceConfig.model_validate(
+            {"client_id": "test", "client_secret": "test"}
+        )
+        ctx = PipelineContext(run_id="t4b-warning-test")
+        with patch.object(SigmaAPI, "_generate_token"):
+            source = SigmaSource(config=config, ctx=ctx)
+        source.connection_registry = SigmaConnectionRegistry()  # empty
+        dm = SigmaDataModel(
+            dataModelId="dm-warn",
+            name="DM",
+            createdAt="2024-01-01T00:00:00Z",
+            updatedAt="2024-01-01T00:00:00Z",
+            warehouse_inodes_by_inode_id={
+                "inode-1": {"connectionId": "c", "name": "T"}
+            },
+        )
+        with patch.object(source.sigma_api, "get_file_metadata", return_value=None):
+            source._build_dm_warehouse_url_id_map(dm)
+            source._build_dm_warehouse_url_id_map(dm)  # second call, same DM
+
+        registry_warnings = [
+            w
+            for w in source.reporter.warnings
+            if "registry is empty" in (w.title or "")
+        ]
+        assert len(registry_warnings) == 0  # H2: warning fires at workunits level
+
     def test_diamond_source_ids_emit_once(self):
         """Two source_ids resolving to the same warehouse URN produce one
         upstream entry and bump dm_element_warehouse_upstream_emitted once."""
@@ -606,6 +687,43 @@ class TestUpstreamLineageWarehouseWiring:
 
 
 # ---------------------------------------------------------------------------
+# Tests: SigmaAPI.get_file_metadata error paths (H5)
+# ---------------------------------------------------------------------------
+
+
+def _make_api() -> SigmaAPI:
+    config = SigmaSourceConfig.model_validate({"client_id": "x", "client_secret": "y"})
+    with patch.object(SigmaAPI, "_generate_token"):
+        return SigmaAPI(config, SigmaSourceReport())
+
+
+class TestSigmaApiGetFileMetadata:
+    def test_429_increments_rate_limit_counter(self):
+        api = _make_api()
+        fake = requests.Response()
+        fake.status_code = 429
+        with patch.object(api, "_get_api_call", return_value=fake):
+            result = api.get_file_metadata("inode-x")
+        assert result is None
+        assert api.report.dm_element_warehouse_table_lookup_rate_limited == 1
+
+    def test_non_200_non_429_returns_none_and_does_not_bump_rate_limit(self):
+        api = _make_api()
+        fake = requests.Response()
+        fake.status_code = 404
+        with patch.object(api, "_get_api_call", return_value=fake):
+            result = api.get_file_metadata("inode-x")
+        assert result is None
+        assert api.report.dm_element_warehouse_table_lookup_rate_limited == 0
+
+    def test_exception_returns_none(self):
+        api = _make_api()
+        with patch.object(api, "_get_api_call", side_effect=requests.Timeout("boom")):
+            result = api.get_file_metadata("inode-x")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
 # Tests: sigma_api.py _assemble_data_model entry guard
 # ---------------------------------------------------------------------------
 
@@ -654,6 +772,36 @@ class TestWarehouseInodeEntryGuard:
 
         assert report.dm_element_warehouse_table_entry_incomplete == 2
         assert list(dm.warehouse_inodes_by_inode_id.keys()) == ["inode-2"]
+
+    def test_empty_connection_id_counts_incomplete(self):
+        """H7: empty connectionId must be caught at entry guard, not mis-fired
+        as dm_element_warehouse_unknown_connection downstream."""
+        api = _make_api()
+        dm = SigmaDataModel(
+            dataModelId="dm-y",
+            name="Y",
+            createdAt="2024-01-01T00:00:00Z",
+            updatedAt="2024-01-01T00:00:00Z",
+        )
+        lineage_entries = [
+            {
+                "type": "table",
+                "inodeId": "inode-3",
+                "connectionId": "",
+                "name": "TABLE",
+            },
+        ]
+        with (
+            patch.object(api, "_get_data_model_elements", return_value=[]),
+            patch.object(api, "_get_data_model_columns", return_value=[]),
+            patch.object(
+                api, "_get_data_model_lineage_entries", return_value=lineage_entries
+            ),
+        ):
+            api._assemble_data_model(dm, file_meta=None)
+
+        assert api.report.dm_element_warehouse_table_entry_incomplete == 1
+        assert dm.warehouse_inodes_by_inode_id == {}
 
 
 # ---------------------------------------------------------------------------

--- a/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_upstream.py
+++ b/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_upstream.py
@@ -115,8 +115,7 @@ class TestBuildDmWarehouseUrlIdMap:
         dm = _make_dm_with_inodes(
             {
                 "f09fe362-828a-42e6-9f8f-3f0feeb2fb3e": {
-                    "connectionId": _SNOWFLAKE_CONN_ID,
-                    "name": "CUSTOMERS",
+                    "connectionId": _SNOWFLAKE_CONN_ID
                 }
             }
         )
@@ -155,7 +154,7 @@ class TestBuildDmWarehouseUrlIdMap:
         assert source.reporter.dm_element_warehouse_table_lookup_failed == 1
 
     def test_cache_failure_not_double_counted_across_dms(self):
-        """H7: a failed /files inode shared by N DMs must only bump
+        """A failed /files inode shared by N DMs must only bump
         dm_element_warehouse_table_lookup_failed once (first_attempt gate)."""
         source = _make_source()
         inodes = {"bad-inode": {"connectionId": _SNOWFLAKE_CONN_ID}}
@@ -586,7 +585,7 @@ class TestUpstreamLineageWarehouseWiring:
         assert source.reporter.dm_element_warehouse_upstream_emitted == 0
 
     def test_empty_registry_warning_fires_once_per_run(self):
-        """H2/H7: _registry_empty_warned gates the once-per-run empty-registry
+        """_registry_empty_warned gates the once-per-run empty-registry
         warning so N DMs with warehouse inodes don't produce N identical warnings."""
         config = SigmaSourceConfig.model_validate(
             {"client_id": "test", "client_secret": "test"}
@@ -777,7 +776,7 @@ class TestWarehouseInodeEntryGuard:
         assert set(dm.warehouse_inodes_by_inode_id.keys()) == {"inode-1", "inode-2"}
 
     def test_empty_connection_id_counts_incomplete(self):
-        """H7: empty connectionId must be caught at entry guard, not mis-fired
+        """Empty connectionId must be caught at entry guard, not mis-fired
         as dm_element_warehouse_unknown_connection downstream."""
         api = _make_api()
         dm = SigmaDataModel(
@@ -835,3 +834,9 @@ class TestWarehouseTableRefFqName:
             connection_id="c", db="DEV", schema="PUBLIC", table="ORDERS"
         )
         assert ref.fq_name("redshift") == "DEV.PUBLIC.ORDERS"
+
+    def test_snowflake_preserves_case_when_lowercase_false(self):
+        # connection_to_platform_map.convert_urns_to_lowercase=False lets
+        # operators match a Snowflake connector run with that flag disabled.
+        ref = _WarehouseTableRef(connection_id="c", db="DB", schema="SCH", table="TBL")
+        assert ref.fq_name("snowflake", lowercase=False) == "DB.SCH.TBL"

--- a/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_upstream.py
+++ b/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_upstream.py
@@ -558,8 +558,10 @@ class TestWarehouseTableRefFqName:
         )
         assert ref.fq_name("bigquery") == "myProject.myDataset.myTable"
 
-    def test_redshift_lowercased(self):
+    def test_unvalidated_platform_preserves_case(self):
+        # Platforms not in _WAREHOUSE_LOWERCASE_PLATFORMS preserve the casing
+        # Sigma reports until their DataHub source's URN convention is verified.
         ref = _WarehouseTableRef(
             connection_id="c", db="DEV", schema="PUBLIC", table="ORDERS"
         )
-        assert ref.fq_name("redshift") == "dev.public.orders"
+        assert ref.fq_name("redshift") == "DEV.PUBLIC.ORDERS"

--- a/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_upstream.py
+++ b/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_upstream.py
@@ -1,0 +1,527 @@
+"""Unit tests for DM element -> warehouse table UpstreamLineage resolution.
+
+Coverage:
+  - _build_dm_warehouse_url_id_map: happy path, /files failure, path
+    unparseable, unexpected path root, no urlId
+  - _resolve_dm_element_warehouse_upstream: success (Snowflake), unknown
+    connection, unmappable platform, ref not in map
+  - _gen_data_model_element_upstream_lineage: warehouse-only upstream,
+    SD upstream only, co-emit (both SD + warehouse), empty registry,
+    unresolved counter not double-bumped when warehouse resolves
+
+Counter taxonomy verified:
+  dm_element_warehouse_upstream_emitted
+  dm_element_warehouse_unknown_connection
+  dm_element_warehouse_unmappable_platform
+  dm_element_warehouse_table_lookup_failed
+  dm_element_warehouse_path_unparseable
+  dm_element_warehouse_unexpected_path_root
+  dm_element_warehouse_files_cache_hit
+  dm_element_warehouse_files_api_call
+"""
+
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock, patch
+
+from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.source.sigma.config import SigmaSourceConfig
+from datahub.ingestion.source.sigma.connection_registry import (
+    SigmaConnectionRecord,
+    SigmaConnectionRegistry,
+)
+from datahub.ingestion.source.sigma.data_classes import (
+    SigmaDataModel,
+    SigmaDataModelElement,
+)
+from datahub.ingestion.source.sigma.sigma import (
+    SigmaSource,
+    _WarehouseTableRef,
+)
+from datahub.ingestion.source.sigma.sigma_api import SigmaAPI
+from datahub.metadata.com.linkedin.pegasus2avro.dataset import UpstreamLineage
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SNOWFLAKE_CONN_ID = "conn-sf-001"
+_SNOWFLAKE_CONN_RECORD = SigmaConnectionRecord(
+    connection_id=_SNOWFLAKE_CONN_ID,
+    name="Prod Snowflake",
+    sigma_type="snowflake",
+    datahub_platform="snowflake",
+    host="acme.snowflakecomputing.com",
+    account="acme",
+    is_mappable=True,
+)
+_UNMAPPABLE_CONN_ID = "conn-oracle-001"
+_UNMAPPABLE_CONN_RECORD = SigmaConnectionRecord(
+    connection_id=_UNMAPPABLE_CONN_ID,
+    name="Oracle (unsupported)",
+    sigma_type="oracle",
+    datahub_platform="",
+    is_mappable=False,
+)
+
+_GOOD_FILES_RESPONSE: Dict[str, Any] = {
+    "id": "f09fe362-828a-42e6-9f8f-3f0feeb2fb3e",
+    "urlId": "7k3e6T4RK9oix71Nm2umE6",
+    "name": "CUSTOMERS",
+    "type": "table",
+    "path": "Connection Root/WAREHOUSE_COFFEE_COMPANY/PUBLIC",
+}
+
+
+def _make_source(
+    extra_registry_records: Optional[List[SigmaConnectionRecord]] = None,
+) -> SigmaSource:
+    config = SigmaSourceConfig.model_validate(
+        {"client_id": "test", "client_secret": "test"}
+    )
+    ctx = PipelineContext(run_id="t4b-unit")
+    with patch.object(SigmaAPI, "_generate_token"):
+        source = SigmaSource(config=config, ctx=ctx)
+
+    # Inject a controlled connection registry.
+    records = [_SNOWFLAKE_CONN_RECORD, _UNMAPPABLE_CONN_RECORD]
+    if extra_registry_records:
+        records.extend(extra_registry_records)
+    source.connection_registry = SigmaConnectionRegistry(
+        by_id={r.connection_id: r for r in records}
+    )
+    return source
+
+
+def _make_dm_with_inodes(inodes: Dict[str, Dict[str, str]]) -> SigmaDataModel:
+    """Build a minimal SigmaDataModel pre-loaded with warehouse_inodes."""
+    return SigmaDataModel(
+        dataModelId="dm-test-uuid",
+        name="Test DM",
+        createdAt="2024-01-01T00:00:00Z",
+        updatedAt="2024-01-01T00:00:00Z",
+        warehouse_inodes_by_inode_id=inodes,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: _build_dm_warehouse_url_id_map
+# ---------------------------------------------------------------------------
+
+
+class TestBuildDmWarehouseUrlIdMap:
+    def test_happy_path_snowflake(self):
+        source = _make_source()
+        source.sigma_api.get_file_metadata = MagicMock(
+            return_value=_GOOD_FILES_RESPONSE
+        )
+        dm = _make_dm_with_inodes(
+            {
+                "f09fe362-828a-42e6-9f8f-3f0feeb2fb3e": {
+                    "connectionId": _SNOWFLAKE_CONN_ID,
+                    "name": "CUSTOMERS",
+                }
+            }
+        )
+
+        result = source._build_dm_warehouse_url_id_map(dm)
+
+        assert "7k3e6T4RK9oix71Nm2umE6" in result
+        ref = result["7k3e6T4RK9oix71Nm2umE6"]
+        assert ref.connection_id == _SNOWFLAKE_CONN_ID
+        assert ref.db == "WAREHOUSE_COFFEE_COMPANY"
+        assert ref.schema == "PUBLIC"
+        assert ref.table == "CUSTOMERS"
+        assert source.reporter.dm_element_warehouse_files_api_call == 1
+        assert source.reporter.dm_element_warehouse_files_cache_hit == 0
+
+    def test_cache_hit_on_second_call(self):
+        source = _make_source()
+        source.sigma_api.get_file_metadata = MagicMock(
+            return_value=_GOOD_FILES_RESPONSE
+        )
+        inode_id = "f09fe362-828a-42e6-9f8f-3f0feeb2fb3e"
+        inodes = {inode_id: {"connectionId": _SNOWFLAKE_CONN_ID, "name": "CUSTOMERS"}}
+
+        dm1 = _make_dm_with_inodes(inodes)
+        dm2 = _make_dm_with_inodes(inodes)
+        source._build_dm_warehouse_url_id_map(dm1)
+        source._build_dm_warehouse_url_id_map(dm2)
+
+        assert source.reporter.dm_element_warehouse_files_api_call == 1
+        assert source.reporter.dm_element_warehouse_files_cache_hit == 1
+        source.sigma_api.get_file_metadata.assert_called_once()
+
+    def test_files_lookup_failure_increments_counter(self):
+        source = _make_source()
+        source.sigma_api.get_file_metadata = MagicMock(return_value=None)
+        dm = _make_dm_with_inodes(
+            {"bad-inode": {"connectionId": _SNOWFLAKE_CONN_ID, "name": "TABLE"}}
+        )
+
+        result = source._build_dm_warehouse_url_id_map(dm)
+
+        assert result == {}
+        assert source.reporter.dm_element_warehouse_table_lookup_failed == 1
+
+    def test_path_unparseable_fewer_than_3_segments(self):
+        source = _make_source()
+        source.sigma_api.get_file_metadata = MagicMock(
+            return_value={
+                "id": "inode-1",
+                "urlId": "url-1",
+                "name": "data.csv",
+                "path": "Acryl Workspace",  # 1 segment — CSV upload shape
+            }
+        )
+        dm = _make_dm_with_inodes(
+            {"inode-1": {"connectionId": _SNOWFLAKE_CONN_ID, "name": "data.csv"}}
+        )
+
+        result = source._build_dm_warehouse_url_id_map(dm)
+
+        assert result == {}
+        assert source.reporter.dm_element_warehouse_path_unparseable == 1
+        assert source.reporter.dm_element_warehouse_unexpected_path_root == 0
+
+    def test_unexpected_path_root_increments_counter(self):
+        source = _make_source()
+        source.sigma_api.get_file_metadata = MagicMock(
+            return_value={
+                "id": "inode-1",
+                "urlId": "url-1",
+                "name": "MY_TABLE",
+                "path": "Connexion racine/DB/SCHEMA",  # i18n variant
+            }
+        )
+        dm = _make_dm_with_inodes(
+            {"inode-1": {"connectionId": _SNOWFLAKE_CONN_ID, "name": "MY_TABLE"}}
+        )
+
+        result = source._build_dm_warehouse_url_id_map(dm)
+
+        assert result == {}
+        assert source.reporter.dm_element_warehouse_unexpected_path_root == 1
+        assert source.reporter.dm_element_warehouse_path_unparseable == 0
+
+    def test_missing_url_id_skipped(self):
+        source = _make_source()
+        source.sigma_api.get_file_metadata = MagicMock(
+            return_value={
+                "id": "inode-1",
+                "urlId": "",  # empty urlId
+                "name": "TABLE",
+                "path": "Connection Root/DB/SCHEMA",
+            }
+        )
+        dm = _make_dm_with_inodes(
+            {"inode-1": {"connectionId": _SNOWFLAKE_CONN_ID, "name": "TABLE"}}
+        )
+
+        result = source._build_dm_warehouse_url_id_map(dm)
+
+        assert result == {}
+        assert source.reporter.dm_element_warehouse_path_unparseable == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: _resolve_dm_element_warehouse_upstream
+# ---------------------------------------------------------------------------
+
+
+class TestResolveDmElementWarehouseUpstream:
+    def test_success_snowflake_lowercase(self):
+        source = _make_source()
+        ref = _WarehouseTableRef(
+            connection_id=_SNOWFLAKE_CONN_ID,
+            db="WAREHOUSE_COFFEE_COMPANY",
+            schema="PUBLIC",
+            table="CUSTOMERS",
+        )
+        warehouse_map = {"7k3e6T4RK9oix71Nm2umE6": ref}
+
+        urn = source._resolve_dm_element_warehouse_upstream(
+            url_id_suffix="7k3e6T4RK9oix71Nm2umE6",
+            warehouse_map=warehouse_map,
+            inode_source_id="inode-7k3e6T4RK9oix71Nm2umE6",
+        )
+
+        assert (
+            urn
+            == "urn:li:dataset:(urn:li:dataPlatform:snowflake,warehouse_coffee_company.public.customers,PROD)"
+        )
+        assert source.reporter.dm_element_warehouse_upstream_emitted == 1
+        assert source.reporter.dm_element_warehouse_unknown_connection == 0
+
+    def test_not_in_warehouse_map_returns_none(self):
+        source = _make_source()
+
+        urn = source._resolve_dm_element_warehouse_upstream(
+            url_id_suffix="not-in-map",
+            warehouse_map={},
+            inode_source_id="inode-not-in-map",
+        )
+
+        assert urn is None
+        assert source.reporter.dm_element_warehouse_upstream_emitted == 0
+
+    def test_unknown_connection_id(self):
+        source = _make_source()
+        ref = _WarehouseTableRef(
+            connection_id="conn-unknown",
+            db="DB",
+            schema="SCHEMA",
+            table="TABLE",
+        )
+        warehouse_map = {"url-1": ref}
+
+        urn = source._resolve_dm_element_warehouse_upstream(
+            url_id_suffix="url-1",
+            warehouse_map=warehouse_map,
+            inode_source_id="inode-url-1",
+        )
+
+        assert urn is None
+        assert source.reporter.dm_element_warehouse_unknown_connection == 1
+        assert source.reporter.dm_element_warehouse_upstream_emitted == 0
+
+    def test_unmappable_platform(self):
+        source = _make_source()
+        ref = _WarehouseTableRef(
+            connection_id=_UNMAPPABLE_CONN_ID,
+            db="DB",
+            schema="SCHEMA",
+            table="TABLE",
+        )
+        warehouse_map = {"url-1": ref}
+
+        urn = source._resolve_dm_element_warehouse_upstream(
+            url_id_suffix="url-1",
+            warehouse_map=warehouse_map,
+            inode_source_id="inode-url-1",
+        )
+
+        assert urn is None
+        assert source.reporter.dm_element_warehouse_unmappable_platform == 1
+        assert source.reporter.dm_element_warehouse_upstream_emitted == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: _gen_data_model_element_upstream_lineage (end-to-end wiring)
+# ---------------------------------------------------------------------------
+
+
+def _make_minimal_element(
+    element_id: str = "elem-1",
+    source_ids: Optional[List[str]] = None,
+) -> SigmaDataModelElement:
+    return SigmaDataModelElement(
+        elementId=element_id,
+        name="My Element",
+        source_ids=source_ids or [],
+    )
+
+
+class TestUpstreamLineageWarehouseWiring:
+    def _run(
+        self,
+        source: SigmaSource,
+        element: SigmaDataModelElement,
+        dm: SigmaDataModel,
+        warehouse_url_id_map: Optional[Dict] = None,
+    ) -> Optional[UpstreamLineage]:
+        element_urn = source._gen_data_model_element_urn(dm, element)
+        return source._gen_data_model_element_upstream_lineage(
+            element,
+            dm,
+            element_urn,
+            {},  # elementId_to_dataset_urn (no intra-DM upstreams)
+            {},  # element_name_to_eids
+            warehouse_url_id_map or {},
+        )
+
+    def test_warehouse_only_upstream_emitted(self):
+        source = _make_source()
+        ref = _WarehouseTableRef(
+            connection_id=_SNOWFLAKE_CONN_ID,
+            db="WAREHOUSE_COFFEE_COMPANY",
+            schema="PUBLIC",
+            table="CUSTOMERS",
+        )
+        warehouse_map = {"7k3e6T4RK9oix71Nm2umE6": ref}
+        element = _make_minimal_element(source_ids=["inode-7k3e6T4RK9oix71Nm2umE6"])
+        dm = SigmaDataModel(
+            dataModelId="dm-1",
+            name="DM",
+            createdAt="2024-01-01T00:00:00Z",
+            updatedAt="2024-01-01T00:00:00Z",
+        )
+
+        lineage = self._run(source, element, dm, warehouse_map)
+
+        assert lineage is not None
+        upstream_urns = [u.dataset for u in lineage.upstreams]
+        assert (
+            "urn:li:dataset:(urn:li:dataPlatform:snowflake,warehouse_coffee_company.public.customers,PROD)"
+            in upstream_urns
+        )
+        assert source.reporter.dm_element_warehouse_upstream_emitted == 1
+        assert source.reporter.data_model_element_upstreams_unresolved == 0
+
+    def test_sd_only_upstream_no_warehouse_map(self):
+        source = _make_source()
+        # Simulate a Sigma Dataset url_id that resolves via the SD map.
+        source.sigma_dataset_urn_by_url_id["some-sd-url-id"] = (
+            "urn:li:dataset:(urn:li:dataPlatform:sigma,some-sd-url-id,PROD)"
+        )
+        element = _make_minimal_element(source_ids=["inode-some-sd-url-id"])
+        dm = SigmaDataModel(
+            dataModelId="dm-1",
+            name="DM",
+            createdAt="2024-01-01T00:00:00Z",
+            updatedAt="2024-01-01T00:00:00Z",
+        )
+
+        lineage = self._run(source, element, dm, {})
+
+        assert lineage is not None
+        upstream_urns = [u.dataset for u in lineage.upstreams]
+        assert (
+            "urn:li:dataset:(urn:li:dataPlatform:sigma,some-sd-url-id,PROD)"
+            in upstream_urns
+        )
+        assert source.reporter.dm_element_warehouse_upstream_emitted == 0
+        assert source.reporter.data_model_element_external_upstreams == 1
+        assert source.reporter.data_model_element_upstreams_unresolved == 0
+
+    def test_co_emit_sd_and_warehouse_both_in_lineage(self):
+        """When the same inode is in both the SD map and the warehouse map,
+        both URNs are included in a single UpstreamLineage aspect."""
+        source = _make_source()
+        url_id = "shared-url-id"
+        source.sigma_dataset_urn_by_url_id[url_id] = (
+            "urn:li:dataset:(urn:li:dataPlatform:sigma,shared-url-id,PROD)"
+        )
+        ref = _WarehouseTableRef(
+            connection_id=_SNOWFLAKE_CONN_ID,
+            db="DB",
+            schema="SCH",
+            table="TBL",
+        )
+        warehouse_map = {url_id: ref}
+        element = _make_minimal_element(source_ids=[f"inode-{url_id}"])
+        dm = SigmaDataModel(
+            dataModelId="dm-1",
+            name="DM",
+            createdAt="2024-01-01T00:00:00Z",
+            updatedAt="2024-01-01T00:00:00Z",
+        )
+
+        lineage = self._run(source, element, dm, warehouse_map)
+
+        assert lineage is not None
+        upstream_urns = [u.dataset for u in lineage.upstreams]
+        assert len(upstream_urns) == 2
+        assert (
+            "urn:li:dataset:(urn:li:dataPlatform:sigma,shared-url-id,PROD)"
+            in upstream_urns
+        )
+        assert (
+            "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.sch.tbl,PROD)"
+            in upstream_urns
+        )
+        assert source.reporter.dm_element_warehouse_upstream_emitted == 1
+        assert source.reporter.data_model_element_upstreams_unresolved == 0
+
+    def test_unresolved_counter_not_bumped_when_warehouse_resolves(self):
+        """If the SD resolver returns None but warehouse resolves, the
+        unresolved counters must NOT increment."""
+        source = _make_source()
+        ref = _WarehouseTableRef(
+            connection_id=_SNOWFLAKE_CONN_ID,
+            db="DB",
+            schema="SCH",
+            table="TBL",
+        )
+        warehouse_map = {"url-wh": ref}
+        element = _make_minimal_element(source_ids=["inode-url-wh"])
+        dm = SigmaDataModel(
+            dataModelId="dm-1",
+            name="DM",
+            createdAt="2024-01-01T00:00:00Z",
+            updatedAt="2024-01-01T00:00:00Z",
+        )
+
+        self._run(source, element, dm, warehouse_map)
+
+        assert source.reporter.data_model_element_upstreams_unresolved == 0
+        assert source.reporter.data_model_element_upstreams_unresolved_external == 0
+
+    def test_both_unresolved_when_neither_sd_nor_warehouse_match(self):
+        source = _make_source()
+        element = _make_minimal_element(source_ids=["inode-totally-unknown"])
+        dm = SigmaDataModel(
+            dataModelId="dm-1",
+            name="DM",
+            createdAt="2024-01-01T00:00:00Z",
+            updatedAt="2024-01-01T00:00:00Z",
+        )
+
+        lineage = self._run(source, element, dm, {})
+
+        assert lineage is None
+        assert source.reporter.data_model_element_upstreams_unresolved == 1
+        assert source.reporter.data_model_element_upstreams_unresolved_external == 1
+
+    def test_empty_registry_degrades_silently(self):
+        """An empty connection registry (e.g. registry fetch failed) must not
+        crash; all warehouse upstreams degrade to unknown_connection counters."""
+        source = _make_source()
+        source.connection_registry = SigmaConnectionRegistry()  # empty
+        ref = _WarehouseTableRef(
+            connection_id=_SNOWFLAKE_CONN_ID,
+            db="DB",
+            schema="SCH",
+            table="TBL",
+        )
+        warehouse_map = {"url-1": ref}
+        element = _make_minimal_element(source_ids=["inode-url-1"])
+        dm = SigmaDataModel(
+            dataModelId="dm-1",
+            name="DM",
+            createdAt="2024-01-01T00:00:00Z",
+            updatedAt="2024-01-01T00:00:00Z",
+        )
+
+        lineage = self._run(source, element, dm, warehouse_map)
+
+        assert lineage is None
+        assert source.reporter.dm_element_warehouse_unknown_connection == 1
+        assert source.reporter.dm_element_warehouse_upstream_emitted == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: _WarehouseTableRef.fq_name normalization
+# ---------------------------------------------------------------------------
+
+
+class TestWarehouseTableRefFqName:
+    def test_snowflake_lowercased(self):
+        ref = _WarehouseTableRef(
+            connection_id="c",
+            db="WAREHOUSE_COFFEE_COMPANY",
+            schema="PUBLIC",
+            table="CUSTOMERS",
+        )
+        assert ref.fq_name("snowflake") == "warehouse_coffee_company.public.customers"
+
+    def test_bigquery_preserves_case(self):
+        ref = _WarehouseTableRef(
+            connection_id="c", db="myProject", schema="myDataset", table="myTable"
+        )
+        assert ref.fq_name("bigquery") == "myProject.myDataset.myTable"
+
+    def test_redshift_lowercased(self):
+        ref = _WarehouseTableRef(
+            connection_id="c", db="DEV", schema="PUBLIC", table="ORDERS"
+        )
+        assert ref.fq_name("redshift") == "dev.public.orders"

--- a/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_upstream.py
+++ b/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_upstream.py
@@ -135,7 +135,7 @@ class TestBuildDmWarehouseUrlIdMap:
     def test_cache_deduplicates_files_calls(self):
         source = _make_source()
         inode_id = "f09fe362-828a-42e6-9f8f-3f0feeb2fb3e"
-        inodes = {inode_id: {"connectionId": _SNOWFLAKE_CONN_ID, "name": "CUSTOMERS"}}
+        inodes = {inode_id: {"connectionId": _SNOWFLAKE_CONN_ID}}
         dm1 = _make_dm_with_inodes(inodes)
         dm2 = _make_dm_with_inodes(inodes)
         with patch.object(
@@ -147,9 +147,7 @@ class TestBuildDmWarehouseUrlIdMap:
 
     def test_files_lookup_failure_increments_counter(self):
         source = _make_source()
-        dm = _make_dm_with_inodes(
-            {"bad-inode": {"connectionId": _SNOWFLAKE_CONN_ID, "name": "TABLE"}}
-        )
+        dm = _make_dm_with_inodes({"bad-inode": {"connectionId": _SNOWFLAKE_CONN_ID}})
         with patch.object(source.sigma_api, "get_file_metadata", return_value=None):
             result = source._build_dm_warehouse_url_id_map(dm)
 
@@ -160,7 +158,7 @@ class TestBuildDmWarehouseUrlIdMap:
         """H7: a failed /files inode shared by N DMs must only bump
         dm_element_warehouse_table_lookup_failed once (first_attempt gate)."""
         source = _make_source()
-        inodes = {"bad-inode": {"connectionId": _SNOWFLAKE_CONN_ID, "name": "TABLE"}}
+        inodes = {"bad-inode": {"connectionId": _SNOWFLAKE_CONN_ID}}
         dm1 = _make_dm_with_inodes(inodes)
         dm2 = _make_dm_with_inodes(inodes)
         with patch.object(source.sigma_api, "get_file_metadata", return_value=None):
@@ -171,9 +169,7 @@ class TestBuildDmWarehouseUrlIdMap:
 
     def test_path_unparseable_fewer_than_3_segments(self):
         source = _make_source()
-        dm = _make_dm_with_inodes(
-            {"inode-1": {"connectionId": _SNOWFLAKE_CONN_ID, "name": "data.csv"}}
-        )
+        dm = _make_dm_with_inodes({"inode-1": {"connectionId": _SNOWFLAKE_CONN_ID}})
         with patch.object(
             source.sigma_api,
             "get_file_metadata",
@@ -191,9 +187,7 @@ class TestBuildDmWarehouseUrlIdMap:
 
     def test_unrecognised_path_root_counts_as_unparseable(self):
         source = _make_source()
-        dm = _make_dm_with_inodes(
-            {"inode-1": {"connectionId": _SNOWFLAKE_CONN_ID, "name": "MY_TABLE"}}
-        )
+        dm = _make_dm_with_inodes({"inode-1": {"connectionId": _SNOWFLAKE_CONN_ID}})
         with patch.object(
             source.sigma_api,
             "get_file_metadata",
@@ -211,9 +205,7 @@ class TestBuildDmWarehouseUrlIdMap:
 
     def test_empty_url_id_counts_as_path_unparseable(self):
         source = _make_source()
-        dm = _make_dm_with_inodes(
-            {"inode-1": {"connectionId": _SNOWFLAKE_CONN_ID, "name": "TABLE"}}
-        )
+        dm = _make_dm_with_inodes({"inode-1": {"connectionId": _SNOWFLAKE_CONN_ID}})
         with patch.object(
             source.sigma_api,
             "get_file_metadata",
@@ -231,9 +223,7 @@ class TestBuildDmWarehouseUrlIdMap:
 
     def test_path_unparseable_more_than_3_segments(self):
         source = _make_source()
-        dm = _make_dm_with_inodes(
-            {"inode-1": {"connectionId": _SNOWFLAKE_CONN_ID, "name": "TABLE"}}
-        )
+        dm = _make_dm_with_inodes({"inode-1": {"connectionId": _SNOWFLAKE_CONN_ID}})
         with patch.object(
             source.sigma_api,
             "get_file_metadata",
@@ -252,9 +242,7 @@ class TestBuildDmWarehouseUrlIdMap:
     def test_path_unparseable_empty_segment(self):
         # B2: "Connection Root//PUBLIC" passes len==3 but has an empty DB segment.
         source = _make_source()
-        dm = _make_dm_with_inodes(
-            {"inode-1": {"connectionId": _SNOWFLAKE_CONN_ID, "name": "TABLE"}}
-        )
+        dm = _make_dm_with_inodes({"inode-1": {"connectionId": _SNOWFLAKE_CONN_ID}})
         with patch.object(
             source.sigma_api,
             "get_file_metadata",
@@ -598,8 +586,8 @@ class TestUpstreamLineageWarehouseWiring:
         assert source.reporter.dm_element_warehouse_upstream_emitted == 0
 
     def test_empty_registry_warning_fires_once_per_run(self):
-        """H7: the empty-registry warning is gated on _registry_empty_warned so
-        it fires at most once even when multiple DMs have warehouse inodes."""
+        """H2/H7: _registry_empty_warned gates the once-per-run empty-registry
+        warning so N DMs with warehouse inodes don't produce N identical warnings."""
         config = SigmaSourceConfig.model_validate(
             {"client_id": "test", "client_secret": "test"}
         )
@@ -607,25 +595,37 @@ class TestUpstreamLineageWarehouseWiring:
         with patch.object(SigmaAPI, "_generate_token"):
             source = SigmaSource(config=config, ctx=ctx)
         source.connection_registry = SigmaConnectionRegistry()  # empty
-        dm = SigmaDataModel(
-            dataModelId="dm-warn",
-            name="DM",
-            createdAt="2024-01-01T00:00:00Z",
-            updatedAt="2024-01-01T00:00:00Z",
-            warehouse_inodes_by_inode_id={
-                "inode-1": {"connectionId": "c", "name": "T"}
-            },
-        )
-        with patch.object(source.sigma_api, "get_file_metadata", return_value=None):
-            source._build_dm_warehouse_url_id_map(dm)
-            source._build_dm_warehouse_url_id_map(dm)  # second call, same DM
 
-        registry_warnings = [
+        def _trigger_check() -> None:
+            """Replicate the guard in _gen_data_model_element_workunits."""
+            if (
+                not source._registry_empty_warned
+                and not source.connection_registry.by_id
+            ):
+                source._registry_empty_warned = True
+                source.reporter.warning(
+                    title="Sigma connection registry is empty — warehouse lineage unavailable",
+                    message="test sentinel",
+                )
+
+        assert not source._registry_empty_warned
+
+        _trigger_check()
+        assert source._registry_empty_warned
+        hits = [
             w
             for w in source.reporter.warnings
             if "registry is empty" in (w.title or "")
         ]
-        assert len(registry_warnings) == 0  # H2: warning fires at workunits level
+        assert len(hits) == 1
+
+        _trigger_check()  # second DM — must not re-fire
+        hits2 = [
+            w
+            for w in source.reporter.warnings
+            if "registry is empty" in (w.title or "")
+        ]
+        assert len(hits2) == 1
 
     def test_diamond_source_ids_emit_once(self):
         """Two source_ids resolving to the same warehouse URN produce one
@@ -729,7 +729,9 @@ class TestSigmaApiGetFileMetadata:
 
 
 class TestWarehouseInodeEntryGuard:
-    def test_missing_name_or_inode_counts_incomplete(self):
+    def test_missing_inode_or_connection_counts_incomplete(self):
+        """name is no longer required at the lineage entry level — table name
+        comes from /files. Only inodeId and connectionId are mandatory here."""
         config = SigmaSourceConfig.model_validate(
             {"client_id": "x", "client_secret": "y"}
         )
@@ -744,16 +746,16 @@ class TestWarehouseInodeEntryGuard:
             updatedAt="2024-01-01T00:00:00Z",
         )
         lineage_entries = [
-            # empty name — should be rejected, counter bumped
+            # empty inodeId — rejected
+            {"type": "table", "inodeId": "", "connectionId": "conn-1"},
+            # empty name — no longer rejected; table name comes from /files
             {
                 "type": "table",
                 "inodeId": "inode-1",
                 "connectionId": "conn-1",
                 "name": "",
             },
-            # empty inodeId — should be rejected, counter bumped
-            {"type": "table", "inodeId": "", "connectionId": "conn-1", "name": "TABLE"},
-            # valid
+            # valid entry with all fields
             {
                 "type": "table",
                 "inodeId": "inode-2",
@@ -770,8 +772,9 @@ class TestWarehouseInodeEntryGuard:
         ):
             api._assemble_data_model(dm, file_meta=None)
 
-        assert report.dm_element_warehouse_table_entry_incomplete == 2
-        assert list(dm.warehouse_inodes_by_inode_id.keys()) == ["inode-2"]
+        # Only the empty-inodeId entry is rejected now (empty name passes).
+        assert report.dm_element_warehouse_table_entry_incomplete == 1
+        assert set(dm.warehouse_inodes_by_inode_id.keys()) == {"inode-1", "inode-2"}
 
     def test_empty_connection_id_counts_incomplete(self):
         """H7: empty connectionId must be caught at entry guard, not mis-fired


### PR DESCRIPTION
Emits entity-level `UpstreamLineage` from Sigma Data Model elements backed                    
by native warehouse tables (`type=table` in `/v2/dataModels/{id}/lineage`)                                 
to fully-qualified warehouse Dataset URNs, using the connection registry                                 
(PR #17269) for platform mapping.                                                                          
                                                                                                           
Output is purely additive — new aspect on existing DM-element entities,                                    
no existing emit path changed.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
