### PR TITLE
feat(ingest/glue): add extract_column_parameters to surface column-level Parameters in Properties tab

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolver.java
@@ -288,6 +288,7 @@ public class AppConfigResolver implements DataFetcher<CompletableFuture<AppConfi
             .setMultipleDataProductsPerAsset(_featureFlags.isMultipleDataProductsPerAsset())
             .setGlossaryBasedPoliciesEnabled(_featureFlags.isGlossaryBasedPoliciesEnabled())
             .setShowColumnJsonProperties(_featureFlags.isShowColumnJsonProperties())
+            .setHideNullableColumnJsonProperties(_featureFlags.isHideNullableColumnJsonProperties())
             .build();
 
     appConfig.setFeatureFlags(featureFlagsConfig);

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolver.java
@@ -287,6 +287,7 @@ public class AppConfigResolver implements DataFetcher<CompletableFuture<AppConfi
             .setHideLineageInSearchCards(_featureFlags.isHideLineageInSearchCards())
             .setMultipleDataProductsPerAsset(_featureFlags.isMultipleDataProductsPerAsset())
             .setGlossaryBasedPoliciesEnabled(_featureFlags.isGlossaryBasedPoliciesEnabled())
+            .setShowColumnJsonProperties(_featureFlags.isShowColumnJsonProperties())
             .build();
 
     appConfig.setFeatureFlags(featureFlagsConfig);

--- a/datahub-graphql-core/src/main/resources/app.graphql
+++ b/datahub-graphql-core/src/main/resources/app.graphql
@@ -873,6 +873,11 @@ type FeatureFlagsConfig {
   If enabled, hides lineage information in search result cards
   """
   hideLineageInSearchCards: Boolean!
+
+  """
+  If enabled, shows jsonProps values for schema fields in the Properties tab.
+  """
+  showColumnJsonProperties: Boolean!
 }
 
 """

--- a/datahub-graphql-core/src/main/resources/app.graphql
+++ b/datahub-graphql-core/src/main/resources/app.graphql
@@ -878,6 +878,11 @@ type FeatureFlagsConfig {
   If enabled, shows jsonProps values for schema fields in the Properties tab.
   """
   showColumnJsonProperties: Boolean!
+
+  """
+  If enabled, hides the nullAllowed jsonProp from the Properties tab (Glue marks all columns nullable by default, making this property noisy).
+  """
+  hideNullableColumnJsonProperties: Boolean!
 }
 
 """

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/SchemaFieldDrawer.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/SchemaFieldDrawer.tsx
@@ -230,6 +230,7 @@ export default function SchemaFieldDrawer({
                 fieldPath: expandedField?.fieldPath,
                 fieldUrn: expandedField?.schemaFieldEntity?.urn,
                 fieldProperties: expandedField?.schemaFieldEntity?.structuredProperties,
+                jsonProps: expandedField?.jsonProps,
                 refetch,
             },
         },

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Properties/PropertiesTab.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Properties/PropertiesTab.tsx
@@ -17,7 +17,7 @@ import { useHydratedEntityMap } from '@app/entityV2/shared/tabs/Properties/useHy
 import useStructuredProperties from '@app/entityV2/shared/tabs/Properties/useStructuredProperties';
 import { parseJsonPropsToRows } from '@app/entityV2/shared/tabs/Properties/utils';
 import { TabRenderType } from '@app/entityV2/shared/types';
-import { useShowColumnJsonProperties } from '@app/useAppConfig';
+import { useHideNullableColumnJsonProperties, useShowColumnJsonProperties } from '@app/useAppConfig';
 import { useEntityRegistryV2 } from '@app/useEntityRegistry';
 import { EditColumn } from '@src/app/entity/shared/tabs/Properties/Edit/EditColumn';
 import { Maybe, StructuredProperties } from '@src/types.generated';
@@ -60,6 +60,7 @@ export const PropertiesTab = ({ renderType = TabRenderType.DEFAULT, properties }
     const { entityData } = useEntityData();
     const entityRegistry = useEntityRegistryV2();
     const showColumnJsonProperties = useShowColumnJsonProperties();
+    const hideNullableColumnJsonProperties = useHideNullableColumnJsonProperties();
 
     const { structuredPropertyRows, expandedRowsFromFilter, structuredPropertyRowsRaw } = useStructuredProperties(
         entityRegistry,
@@ -72,10 +73,11 @@ export const PropertiesTab = ({ renderType = TabRenderType.DEFAULT, properties }
     const customProperties = !fieldPath ? getFilteredCustomProperties(filterText, entityData) || [] : [];
     const customPropertyRows = mapCustomPropertiesToPropertyRows(customProperties);
 
-    const jsonPropsRows = useMemo(
-        () => (showColumnJsonProperties ? parseJsonPropsToRows(properties?.jsonProps, filterText) : []),
-        [showColumnJsonProperties, properties?.jsonProps, filterText],
-    );
+    const jsonPropsRows = useMemo(() => {
+        if (!showColumnJsonProperties) return [];
+        const rows = parseJsonPropsToRows(properties?.jsonProps, filterText);
+        return hideNullableColumnJsonProperties ? rows.filter((row) => row.displayName !== 'nullAllowed') : rows;
+    }, [showColumnJsonProperties, hideNullableColumnJsonProperties, properties?.jsonProps, filterText]);
 
     const dataSource: PropertyRow[] = structuredPropertyRows
         .concat(customPropertyRows)

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Properties/PropertiesTab.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Properties/PropertiesTab.tsx
@@ -1,5 +1,5 @@
 import { Empty, Table } from 'antd';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import styled from 'styled-components';
 
 import { useEntityData } from '@app/entity/shared/EntityContext';
@@ -15,7 +15,9 @@ import NameColumn from '@app/entityV2/shared/tabs/Properties/NameColumn';
 import ValuesColumn from '@app/entityV2/shared/tabs/Properties/ValuesColumn';
 import { useHydratedEntityMap } from '@app/entityV2/shared/tabs/Properties/useHydratedEntityMap';
 import useStructuredProperties from '@app/entityV2/shared/tabs/Properties/useStructuredProperties';
+import { parseJsonPropsToRows } from '@app/entityV2/shared/tabs/Properties/utils';
 import { TabRenderType } from '@app/entityV2/shared/types';
+import { useShowColumnJsonProperties } from '@app/useAppConfig';
 import { useEntityRegistryV2 } from '@app/useEntityRegistry';
 import { EditColumn } from '@src/app/entity/shared/tabs/Properties/Edit/EditColumn';
 import { Maybe, StructuredProperties } from '@src/types.generated';
@@ -41,6 +43,7 @@ interface Props {
         fieldPath?: string;
         fieldUrn?: string;
         fieldProperties?: Maybe<StructuredProperties>;
+        jsonProps?: string | null;
         refetch?: () => void;
         disableEdit?: boolean;
         disableSearch?: boolean;
@@ -56,18 +59,27 @@ export const PropertiesTab = ({ renderType = TabRenderType.DEFAULT, properties }
     const [filterText, setFilterText] = useState('');
     const { entityData } = useEntityData();
     const entityRegistry = useEntityRegistryV2();
+    const showColumnJsonProperties = useShowColumnJsonProperties();
 
     const { structuredPropertyRows, expandedRowsFromFilter, structuredPropertyRowsRaw } = useStructuredProperties(
         entityRegistry,
         fieldPath || null,
         filterText,
+        fieldProperties,
     );
 
     // only show entity custom properties on entity level, not on field level
     const customProperties = !fieldPath ? getFilteredCustomProperties(filterText, entityData) || [] : [];
     const customPropertyRows = mapCustomPropertiesToPropertyRows(customProperties);
+
+    const jsonPropsRows = useMemo(
+        () => (showColumnJsonProperties ? parseJsonPropsToRows(properties?.jsonProps, filterText) : []),
+        [showColumnJsonProperties, properties?.jsonProps, filterText],
+    );
+
     const dataSource: PropertyRow[] = structuredPropertyRows
         .concat(customPropertyRows)
+        .concat(jsonPropsRows)
         .filter((row) => !row.structuredProperty?.settings?.isHidden);
 
     const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Properties/__tests__/parseJsonPropsToRows.test.ts
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Properties/__tests__/parseJsonPropsToRows.test.ts
@@ -1,0 +1,73 @@
+import { parseJsonPropsToRows } from '@app/entityV2/shared/tabs/Properties/utils';
+
+describe('parseJsonPropsToRows', () => {
+    it('returns empty array for null or undefined', () => {
+        expect(parseJsonPropsToRows(null)).toEqual([]);
+        expect(parseJsonPropsToRows(undefined)).toEqual([]);
+        expect(parseJsonPropsToRows('')).toEqual([]);
+    });
+
+    it('parses valid jsonProps into PropertyRows', () => {
+        const jsonProps = JSON.stringify({
+            'iceberg.field.id': '1',
+            'iceberg.field.optional': 'false',
+        });
+        const rows = parseJsonPropsToRows(jsonProps);
+        expect(rows).toHaveLength(2);
+        expect(rows[0]).toMatchObject({
+            displayName: 'iceberg.field.id',
+            qualifiedName: '__jsonProp__iceberg.field.id',
+            values: [{ value: '1', entity: null }],
+        });
+        expect(rows[1]).toMatchObject({
+            displayName: 'iceberg.field.optional',
+            qualifiedName: '__jsonProp__iceberg.field.optional',
+            values: [{ value: 'false', entity: null }],
+        });
+    });
+
+    it('filters by key when filterText is provided', () => {
+        const jsonProps = JSON.stringify({ nullAllowed: 'false', otherProp: 'value' });
+        const rows = parseJsonPropsToRows(jsonProps, 'null');
+        expect(rows).toHaveLength(1);
+        expect(rows[0].displayName).toBe('nullAllowed');
+    });
+
+    it('filters by value when filterText matches value', () => {
+        const jsonProps = JSON.stringify({ prop1: 'hello', prop2: 'world' });
+        const rows = parseJsonPropsToRows(jsonProps, 'world');
+        expect(rows).toHaveLength(1);
+        expect(rows[0].displayName).toBe('prop2');
+    });
+
+    it('filter is case-insensitive', () => {
+        const jsonProps = JSON.stringify({ NullAllowed: 'False' });
+        expect(parseJsonPropsToRows(jsonProps, 'nullallowed')).toHaveLength(1);
+        expect(parseJsonPropsToRows(jsonProps, 'FALSE')).toHaveLength(1);
+    });
+
+    it('returns empty array and warns on malformed JSON', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const rows = parseJsonPropsToRows('{not valid json}');
+        expect(rows).toEqual([]);
+        expect(warnSpy).toHaveBeenCalledWith('Failed to parse jsonProps for schema field:', expect.any(Error));
+        warnSpy.mockRestore();
+    });
+
+    it('prefixes qualifiedName to avoid rowKey collisions with structured properties', () => {
+        const jsonProps = JSON.stringify({ 'some.key': 'value' });
+        const rows = parseJsonPropsToRows(jsonProps);
+        expect(rows[0].qualifiedName).toBe('__jsonProp__some.key');
+        expect(rows[0].qualifiedName).not.toBe('some.key');
+    });
+
+    it('returns empty array for valid JSON that is not an object (array)', () => {
+        expect(parseJsonPropsToRows('["a", "b"]')).toEqual([]);
+    });
+
+    it('returns empty array for valid JSON that is not an object (primitive)', () => {
+        expect(parseJsonPropsToRows('42')).toEqual([]);
+        expect(parseJsonPropsToRows('"just a string"')).toEqual([]);
+        expect(parseJsonPropsToRows('null')).toEqual([]);
+    });
+});

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Properties/useStructuredProperties.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Properties/useStructuredProperties.tsx
@@ -6,7 +6,7 @@ import { useGetEntityWithSchema } from '@app/entityV2/shared/tabs/Dataset/Schema
 import { PropertyRow } from '@app/entityV2/shared/tabs/Properties/types';
 import { filterStructuredProperties } from '@app/entityV2/shared/tabs/Properties/utils';
 
-import { PropertyValue, StructuredPropertiesEntry } from '@types';
+import { Maybe, PropertyValue, StructuredProperties, StructuredPropertiesEntry } from '@types';
 
 const typeNameToType = {
     StringValue: { type: 'string', nativeDataType: 'text' },
@@ -216,12 +216,20 @@ export default function useStructuredProperties(
     entityRegistry: EntityRegistry,
     fieldPath: string | null,
     filterText?: string,
+    fieldProperties?: Maybe<StructuredProperties>,
 ) {
     const { entityData } = useEntityData();
     const { entityWithSchema } = useGetEntityWithSchema(!fieldPath);
 
     let structuredPropertyRowsRaw: PropertyRow[] = [];
-    if (fieldPath) {
+    if (fieldPath && fieldProperties?.properties) {
+        // Use the pre-fetched fieldProperties directly — this data comes from the same
+        // getDatasetSchema query that populates the Schema tab rows, so it's always current
+        // and avoids a secondary schema search that can miss if the Apollo cache is stale.
+        structuredPropertyRowsRaw = fieldProperties.properties
+            .filter((entry) => entry.structuredProperty.exists)
+            .map((entry) => mapStructuredPropertyToPropertyRow(entry));
+    } else if (fieldPath) {
         structuredPropertyRowsRaw = getFieldStructuredPropertyRows(
             fieldPath,
             entityWithSchema as GenericEntityProperties,

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Properties/utils.ts
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Properties/utils.ts
@@ -1,6 +1,33 @@
 import EntityRegistry from '@app/entityV2/EntityRegistry';
 import { PropertyRow, ValueColumnData } from '@app/entityV2/shared/tabs/Properties/types';
 
+export function parseJsonPropsToRows(jsonProps: string | null | undefined, filterText = ''): PropertyRow[] {
+    if (!jsonProps) return [];
+    try {
+        const rawParsed = JSON.parse(jsonProps);
+        if (typeof rawParsed !== 'object' || rawParsed === null || Array.isArray(rawParsed)) {
+            return [];
+        }
+        const parsed = rawParsed as Record<string, unknown>;
+        return Object.entries(parsed)
+            .filter(
+                ([key, value]) =>
+                    !filterText ||
+                    key.toLocaleLowerCase().includes(filterText.toLocaleLowerCase()) ||
+                    String(value).toLocaleLowerCase().includes(filterText.toLocaleLowerCase()),
+            )
+            .map(([key, value]) => ({
+                displayName: key,
+                qualifiedName: `__jsonProp__${key}`,
+                values: [{ value: String(value), entity: null }],
+                type: { type: 'string', nativeDataType: 'string' },
+            }));
+    } catch (e) {
+        console.warn('Failed to parse jsonProps for schema field:', e);
+        return [];
+    }
+}
+
 function matchesName(name: string, filterText: string) {
     return name.toLocaleLowerCase().includes(filterText.toLocaleLowerCase());
 }

--- a/datahub-web-react/src/app/useAppConfig.ts
+++ b/datahub-web-react/src/app/useAppConfig.ts
@@ -56,6 +56,11 @@ export function useShowColumnJsonProperties(): boolean {
     return appConfig.config.featureFlags.showColumnJsonProperties;
 }
 
+export function useHideNullableColumnJsonProperties(): boolean {
+    const appConfig = useAppConfig();
+    return appConfig.config.featureFlags.hideNullableColumnJsonProperties;
+}
+
 function useFlagWithLocalStorageSync(key: string, f: (appConfig: AppConfig) => boolean) {
     const { config, loaded } = useAppConfig();
     const flagValue = f(config);

--- a/datahub-web-react/src/app/useAppConfig.ts
+++ b/datahub-web-react/src/app/useAppConfig.ts
@@ -51,6 +51,11 @@ export function useIsContextDocumentsEnabled(): boolean {
     return appConfig.config.featureFlags.contextDocumentsEnabled;
 }
 
+export function useShowColumnJsonProperties(): boolean {
+    const appConfig = useAppConfig();
+    return appConfig.config.featureFlags.showColumnJsonProperties;
+}
+
 function useFlagWithLocalStorageSync(key: string, f: (appConfig: AppConfig) => boolean) {
     const { config, loaded } = useAppConfig();
     const flagValue = f(config);

--- a/datahub-web-react/src/appConfigContext.tsx
+++ b/datahub-web-react/src/appConfigContext.tsx
@@ -102,6 +102,7 @@ export const DEFAULT_APP_CONFIG = {
         glossaryBasedPoliciesEnabled: false,
         multipleDataProductsPerAsset: false,
         showColumnJsonProperties: false,
+        hideNullableColumnJsonProperties: false,
     },
     chromeExtensionConfig: {
         enabled: false,

--- a/datahub-web-react/src/appConfigContext.tsx
+++ b/datahub-web-react/src/appConfigContext.tsx
@@ -101,6 +101,7 @@ export const DEFAULT_APP_CONFIG = {
         hideLineageInSearchCards: false,
         glossaryBasedPoliciesEnabled: false,
         multipleDataProductsPerAsset: false,
+        showColumnJsonProperties: false,
     },
     chromeExtensionConfig: {
         enabled: false,

--- a/datahub-web-react/src/graphql/app.graphql
+++ b/datahub-web-react/src/graphql/app.graphql
@@ -125,6 +125,7 @@ query appConfig {
             glossaryBasedPoliciesEnabled
             multipleDataProductsPerAsset
             showColumnJsonProperties
+            hideNullableColumnJsonProperties
         }
         chromeExtensionConfig {
             enabled

--- a/datahub-web-react/src/graphql/app.graphql
+++ b/datahub-web-react/src/graphql/app.graphql
@@ -124,6 +124,7 @@ query appConfig {
             hideLineageInSearchCards
             glossaryBasedPoliciesEnabled
             multipleDataProductsPerAsset
+            showColumnJsonProperties
         }
         chromeExtensionConfig {
             enabled

--- a/datahub-web-react/src/graphql/fragments.graphql
+++ b/datahub-web-react/src/graphql/fragments.graphql
@@ -992,6 +992,7 @@ fragment entitySchemaFieldFields on SchemaField {
     recursive
     isPartOfKey
     isPartitioningKey
+    jsonProps
     globalTags {
         ...globalTagsFields
     }

--- a/metadata-ingestion/docs/sources/glue/glue_post.md
+++ b/metadata-ingestion/docs/sources/glue/glue_post.md
@@ -110,6 +110,32 @@ source:
 
 When this is configured, dataset URNs produced by the Glue connector will include the same `platform_instance` and `env` as the target platform's connector, ensuring entities merge correctly in DataHub. If the target platform connector does not use a `platform_instance`, no configuration is needed — URNs will match by default.
 
+#### Column Parameters
+
+AWS Glue stores additional column-level metadata in a `Parameters` dictionary on each column in
+`StorageDescriptor.Columns`. For example, Iceberg tables store `iceberg.field.id`,
+`iceberg.field.current`, and `iceberg.field.optional` there, and non-Iceberg tables may store
+custom properties such as `nullAllowed`.
+
+By default this data is not ingested. To surface it in DataHub's column **Properties** tab, enable:
+
+```yaml
+source:
+  type: glue
+  config:
+    extract_column_parameters: true
+```
+
+When enabled, each column's `Parameters` dict is serialized to JSON and stored in the `jsonProps`
+field of the corresponding schema field. The values appear as key-value pairs in the column
+Properties panel in the DataHub UI.
+
+> **Note:** This setting applies only to tables whose schema is read from
+> `StorageDescriptor.Columns`, which is the default for most table formats (Parquet, ORC, Avro,
+> Iceberg, etc.). Delta tables that use `extract_delta_schema_from_parameters: true` reconstruct
+> their schema from an embedded Spark JSON schema at the table level, where individual column
+> `Parameters` dicts are not present, so this setting has no effect for them.
+
 ### Limitations
 
 Module behavior is constrained by source APIs, permissions, and metadata exposed by the platform. Refer to capability notes for unsupported or conditional features.

--- a/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
@@ -267,6 +267,16 @@ class GlueSourceConfig(
         description="If enabled, delta schemas can be alternatively fetched from table parameters.",
     )
 
+    extract_column_parameters: bool = Field(
+        default=False,
+        description=(
+            "If enabled, column-level Parameters from Glue StorageDescriptor columns are extracted "
+            "and stored in the jsonProps field of each schema field. Useful for surfacing column "
+            "metadata such as nullability flags (e.g. nullAllowed) or Iceberg field metadata "
+            "(e.g. iceberg.field.id) that Glue stores in the column Parameters dict."
+        ),
+    )
+
     include_column_lineage: bool = Field(
         default=True,
         description="When enabled, column-level lineage will be extracted between Glue table columns and storage location fields.",
@@ -1870,6 +1880,14 @@ class GlueSource(StatefulIngestionSourceBase):
             and columns[0].get("Type", "") == "array<string>"
         )
 
+    def _get_column_json_props(self, column: Dict) -> Optional[str]:
+        """Return JSON-serialized column Parameters for jsonProps, or None if disabled/empty."""
+        if not self.source_config.extract_column_parameters:
+            return None
+        params = column.get("Parameters")
+        # sort_keys ensures deterministic output regardless of AWS API key ordering
+        return json.dumps(params, sort_keys=True) if params else None
+
     def _get_glue_schema_metadata(
         self, table: Dict, table_name: str
     ) -> Optional[SchemaMetadata]:
@@ -1886,6 +1904,7 @@ class GlueSource(StatefulIngestionSourceBase):
                 default_nullable=True,
             )
             if schema_fields:
+                schema_fields[0].jsonProps = self._get_column_json_props(field)
                 fields.extend(schema_fields)
 
         # Process partition keys
@@ -1898,6 +1917,7 @@ class GlueSource(StatefulIngestionSourceBase):
                 default_nullable=False,
             )
             if schema_fields:
+                schema_fields[0].jsonProps = self._get_column_json_props(partition_key)
                 fields.extend(schema_fields)
 
         return SchemaMetadata(
@@ -1912,7 +1932,13 @@ class GlueSource(StatefulIngestionSourceBase):
     def _get_delta_schema_metadata(
         self, table: Dict, table_name: str, dataset_urn: str
     ) -> Optional[SchemaMetadata]:
-        """Extract schema metadata from Delta table parameters."""
+        """Extract schema metadata from Delta table parameters.
+
+        Note: extract_column_parameters does not apply here. Delta schemas are
+        reconstructed from the Spark JSON schema embedded in table-level Parameters,
+        not from StorageDescriptor.Columns, so individual column Parameters dicts
+        are not present in this code path.
+        """
         try:
             # Reconstruct schema from parameters
             num_parts = int(table["Parameters"]["spark.sql.sources.schema.numParts"])

--- a/metadata-ingestion/tests/unit/glue/glue_column_params_mces_golden.json
+++ b/metadata-ingestion/tests/unit/glue/glue_column_params_mces_golden.json
@@ -1,0 +1,456 @@
+[
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:7b1cebd8c7c0732529ba13ccd19f5597",
+    "changeType": "UPSERT",
+    "aspectName": "containerProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "platform": "glue",
+                "env": "PROD",
+                "database": "iceberg-database",
+                "CreateTime": "June 09, 2021 at 14:14:19"
+            },
+            "name": "iceberg-database",
+            "qualifiedName": "arn:aws:glue:us-west-2:123412341234:database/iceberg-database",
+            "env": "PROD"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586862000000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:7b1cebd8c7c0732529ba13ccd19f5597",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586862000000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:7b1cebd8c7c0732529ba13ccd19f5597",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:glue"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586862000000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:7b1cebd8c7c0732529ba13ccd19f5597",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Database"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586862000000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:7b1cebd8c7c0732529ba13ccd19f5597",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586862000000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:glue,iceberg-database.test_table_nullable,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "table_name": "test_table_nullable",
+                            "Location": "s3://test-bucket/test_table_nullable",
+                            "InputFormat": "org.apache.hadoop.mapred.TextInputFormat",
+                            "OutputFormat": "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat",
+                            "Compressed": "False",
+                            "NumberOfBuckets": "0",
+                            "SerdeInfo": "{'SerializationLibrary': 'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe', 'Parameters': {}}",
+                            "SortColumns": "[]",
+                            "StoredAsSubDirectories": "False"
+                        },
+                        "name": "test_table_nullable",
+                        "qualifiedName": "arn:aws:glue:us-west-2:123412341234:table/iceberg-database/test_table_nullable",
+                        "lastModified": {
+                            "time": 1623248255000
+                        },
+                        "tags": []
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                        "schemaName": "iceberg-database.test_table_nullable",
+                        "platform": "urn:li:dataPlatform:glue",
+                        "version": 0,
+                        "created": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "lastModified": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "hash": "",
+                        "platformSchema": {
+                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                "tableSchema": ""
+                            }
+                        },
+                        "fields": [
+                            {
+                                "fieldPath": "[version=2.0].[type=string].col1",
+                                "nullable": true,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "string",
+                                "recursive": false,
+                                "isPartOfKey": false,
+                                "jsonProps": "{\"nullAllowed\": \"false\"}"
+                            },
+                            {
+                                "fieldPath": "[version=2.0].[type=string].col2",
+                                "nullable": true,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "string",
+                                "recursive": false,
+                                "isPartOfKey": false,
+                                "jsonProps": "{\"nullAllowed\": \"true\"}"
+                            },
+                            {
+                                "fieldPath": "[version=2.0].[type=string].col3",
+                                "nullable": true,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "string",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "[version=2.0].[type=string].partition_date",
+                                "nullable": true,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "varchar(8)",
+                                "recursive": false,
+                                "isPartOfKey": false,
+                                "jsonProps": "{\"partition_key_info\": \"daily\"}"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.DataPlatformInstance": {
+                        "platform": "urn:li:dataPlatform:glue"
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.Ownership": {
+                        "owners": [
+                            {
+                                "owner": "urn:li:corpuser:owner",
+                                "type": "DATAOWNER"
+                            }
+                        ],
+                        "ownerTypes": {},
+                        "lastModified": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586862000000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,iceberg-database.test_table_nullable,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Table"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586862000000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,iceberg-database.test_table_nullable,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:7b1cebd8c7c0732529ba13ccd19f5597"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586862000000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,iceberg-database.test_table_nullable,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:7b1cebd8c7c0732529ba13ccd19f5597",
+                    "urn": "urn:li:container:7b1cebd8c7c0732529ba13ccd19f5597"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586862000000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:glue,iceberg-database.test_iceberg_column_params,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "table_type": "ICEBERG",
+                            "metadata_location": "s3://test-bucket/test_iceberg_column_params/metadata/00001.metadata.json",
+                            "Location": "s3://test-bucket/test_iceberg_column_params",
+                            "Compressed": "False",
+                            "NumberOfBuckets": "0",
+                            "SortColumns": "[]",
+                            "StoredAsSubDirectories": "False"
+                        },
+                        "name": "test_iceberg_column_params",
+                        "qualifiedName": "arn:aws:glue:us-west-2:123412341234:table/iceberg-database/test_iceberg_column_params",
+                        "lastModified": {
+                            "time": 1623248255000
+                        },
+                        "tags": []
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                        "schemaName": "iceberg-database.test_iceberg_column_params",
+                        "platform": "urn:li:dataPlatform:glue",
+                        "version": 0,
+                        "created": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "lastModified": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "hash": "",
+                        "platformSchema": {
+                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                "tableSchema": ""
+                            }
+                        },
+                        "fields": [
+                            {
+                                "fieldPath": "[version=2.0].[type=string].emp_std_id",
+                                "nullable": true,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "string",
+                                "recursive": false,
+                                "isPartOfKey": false,
+                                "jsonProps": "{\"iceberg.field.current\": \"true\", \"iceberg.field.id\": \"1\", \"iceberg.field.optional\": \"false\"}"
+                            },
+                            {
+                                "fieldPath": "[version=2.0].[type=string].dept_cd",
+                                "nullable": true,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "string",
+                                "recursive": false,
+                                "isPartOfKey": false,
+                                "jsonProps": "{\"iceberg.field.current\": \"true\", \"iceberg.field.id\": \"2\", \"iceberg.field.optional\": \"false\"}"
+                            },
+                            {
+                                "fieldPath": "[version=2.0].[type=bytes].yr_nb",
+                                "nullable": true,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "decimal(10,0)",
+                                "recursive": false,
+                                "isPartOfKey": false,
+                                "jsonProps": "{\"iceberg.field.current\": \"true\", \"iceberg.field.id\": \"3\", \"iceberg.field.optional\": \"false\"}"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.DataPlatformInstance": {
+                        "platform": "urn:li:dataPlatform:glue"
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.Ownership": {
+                        "owners": [
+                            {
+                                "owner": "urn:li:corpuser:owner",
+                                "type": "DATAOWNER"
+                            }
+                        ],
+                        "ownerTypes": {},
+                        "lastModified": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586862000000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,iceberg-database.test_iceberg_column_params,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Table"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586862000000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,iceberg-database.test_iceberg_column_params,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:7b1cebd8c7c0732529ba13ccd19f5597"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586862000000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,iceberg-database.test_iceberg_column_params,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:7b1cebd8c7c0732529ba13ccd19f5597",
+                    "urn": "urn:li:container:7b1cebd8c7c0732529ba13ccd19f5597"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586862000000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+}
+]

--- a/metadata-ingestion/tests/unit/glue/glue_column_params_mces_golden.json
+++ b/metadata-ingestion/tests/unit/glue/glue_column_params_mces_golden.json
@@ -90,6 +90,28 @@
     }
 },
 {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,iceberg-database.test_table_nullable,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "operation",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1623248255000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "operationType": "CREATE",
+            "lastUpdatedTimestamp": 1623248255000
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586862000000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:glue,iceberg-database.test_table_nullable,PROD)",
@@ -114,6 +136,9 @@
                         },
                         "name": "test_table_nullable",
                         "qualifiedName": "arn:aws:glue:us-west-2:123412341234:table/iceberg-database/test_table_nullable",
+                        "created": {
+                            "time": 1623248255000
+                        },
                         "lastModified": {
                             "time": 1623248255000
                         },
@@ -279,6 +304,28 @@
     }
 },
 {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,iceberg-database.test_iceberg_column_params,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "operation",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1623248255000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "operationType": "CREATE",
+            "lastUpdatedTimestamp": 1623248255000
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586862000000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:glue,iceberg-database.test_iceberg_column_params,PROD)",
@@ -301,6 +348,9 @@
                         },
                         "name": "test_iceberg_column_params",
                         "qualifiedName": "arn:aws:glue:us-west-2:123412341234:table/iceberg-database/test_iceberg_column_params",
+                        "created": {
+                            "time": 1623248255000
+                        },
                         "lastModified": {
                             "time": 1623248255000
                         },

--- a/metadata-ingestion/tests/unit/glue/test_glue_source.py
+++ b/metadata-ingestion/tests/unit/glue/test_glue_source.py
@@ -42,6 +42,7 @@ from tests.unit.glue.test_glue_source_stubs import (
     empty_database,
     flights_database,
     get_bucket_tagging,
+    get_databases_column_params_response,
     get_databases_delta_response,
     get_databases_response,
     get_databases_response_for_lineage,
@@ -65,6 +66,7 @@ from tests.unit.glue.test_glue_source_stubs import (
     get_tables_lineage_response_1,
     get_tables_response_1,
     get_tables_response_2,
+    get_tables_response_column_params,
     get_tables_response_for_mixed_database,
     get_tables_response_for_target_database,
     get_tables_response_profiling_1,
@@ -92,6 +94,7 @@ def glue_source(
     use_s3_bucket_tags: bool = True,
     use_s3_object_tags: bool = True,
     extract_delta_schema_from_parameters: bool = False,
+    extract_column_parameters: bool = False,
     emit_storage_lineage: bool = False,
     include_column_lineage: bool = False,
     extract_transforms: bool = True,
@@ -110,6 +113,7 @@ def glue_source(
             use_s3_bucket_tags=use_s3_bucket_tags,
             use_s3_object_tags=use_s3_object_tags,
             extract_delta_schema_from_parameters=extract_delta_schema_from_parameters,
+            extract_column_parameters=extract_column_parameters,
             emit_storage_lineage=emit_storage_lineage,
             include_column_lineage=include_column_lineage,
             extract_lakeformation_tags=extract_lakeformation_tags,
@@ -1556,4 +1560,124 @@ def test_glue_redact_job_script_secret_fields(secret_name):
 
     assert _redact_secret_fields_in_dataflow_script(script) == script.replace(
         secret_value, "*****"
+    )
+
+
+def test_extract_column_parameters_disabled_by_default() -> None:
+    """Verify jsonProps is not set when extract_column_parameters=False (the default)."""
+    source = GlueSource(
+        ctx=PipelineContext(run_id="test"),
+        config=GlueSourceConfig(aws_region="us-west-2"),
+    )
+    table = {
+        "StorageDescriptor": {
+            "Columns": [
+                {
+                    "Name": "col1",
+                    "Type": "string",
+                    "Parameters": {"nullAllowed": "false"},
+                },
+            ]
+        },
+        "PartitionKeys": [],
+    }
+    schema = source._get_glue_schema_metadata(table, "test_table")
+    assert schema is not None
+    assert all(f.jsonProps is None for f in schema.fields)
+
+
+def test_extract_column_parameters_empty_params_produces_no_json_props() -> None:
+    """Verify a column with an empty Parameters dict produces jsonProps=None, not '{}'."""
+    source = GlueSource(
+        ctx=PipelineContext(run_id="test"),
+        config=GlueSourceConfig(aws_region="us-west-2", extract_column_parameters=True),
+    )
+    table = {
+        "StorageDescriptor": {
+            "Columns": [
+                {"Name": "col1", "Type": "string", "Parameters": {}},
+                {"Name": "col2", "Type": "string"},
+            ]
+        },
+        "PartitionKeys": [],
+    }
+    schema = source._get_glue_schema_metadata(table, "test_table")
+    assert schema is not None
+    assert all(f.jsonProps is None for f in schema.fields)
+
+
+def test_extract_column_parameters_struct_only_sets_top_level_field() -> None:
+    """Verify jsonProps is set only on the top-level field, not on nested struct sub-fields."""
+    source = GlueSource(
+        ctx=PipelineContext(run_id="test"),
+        config=GlueSourceConfig(aws_region="us-west-2", extract_column_parameters=True),
+    )
+    table = {
+        "StorageDescriptor": {
+            "Columns": [
+                {
+                    "Name": "address",
+                    "Type": "struct<city:string,zip:string>",
+                    "Parameters": {"nullAllowed": "true"},
+                },
+            ]
+        },
+        "PartitionKeys": [],
+    }
+    schema = source._get_glue_schema_metadata(table, "test_table")
+    assert schema is not None
+    # First field is the top-level 'address' column — it should carry the jsonProps
+    assert schema.fields[0].fieldPath.endswith(".address")
+    assert schema.fields[0].jsonProps == '{"nullAllowed": "true"}'
+    # Nested sub-fields (city, zip) should not inherit the column-level Parameters
+    for sub_field in schema.fields[1:]:
+        assert sub_field.jsonProps is None
+
+
+def test_extract_column_parameters_sort_keys_deterministic() -> None:
+    """Verify output is sorted regardless of dict insertion order."""
+    source = GlueSource(
+        ctx=PipelineContext(run_id="test"),
+        config=GlueSourceConfig(aws_region="us-west-2", extract_column_parameters=True),
+    )
+    # Define params in reverse-alphabetical order to confirm sort_keys applies
+    col_z_first = {"Name": "col", "Type": "string", "Parameters": {"z": "1", "a": "2"}}
+    col_a_first = {"Name": "col", "Type": "string", "Parameters": {"a": "2", "z": "1"}}
+    result_z = source._get_column_json_props(col_z_first)
+    result_a = source._get_column_json_props(col_a_first)
+    assert result_z == result_a == '{"a": "2", "z": "1"}'
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+def test_glue_with_extract_column_parameters(
+    tmp_path: Path,
+    pytestconfig: pytest.Config,
+) -> None:
+    glue_source_instance = glue_source(
+        use_s3_bucket_tags=False,
+        use_s3_object_tags=False,
+        extract_column_parameters=True,
+    )
+
+    with Stubber(glue_source_instance.glue_client) as glue_stubber:
+        glue_stubber.add_response(
+            "get_databases", get_databases_column_params_response, {}
+        )
+        glue_stubber.add_response(
+            "get_tables",
+            get_tables_response_column_params,
+            {"DatabaseName": "iceberg-database"},
+        )
+        glue_stubber.add_response("get_jobs", get_jobs_response_empty, {})
+
+        mce_objects = [wu.metadata for wu in glue_source_instance.get_workunits()]
+
+        glue_stubber.assert_no_pending_responses()
+
+        write_metadata_file(tmp_path / "glue_column_params_mces.json", mce_objects)
+
+    mce_helpers.check_golden_file(
+        pytestconfig,
+        output_path=tmp_path / "glue_column_params_mces.json",
+        golden_path=test_resources_dir / "glue_column_params_mces_golden.json",
     )

--- a/metadata-ingestion/tests/unit/glue/test_glue_source_stubs.py
+++ b/metadata-ingestion/tests/unit/glue/test_glue_source_stubs.py
@@ -1,6 +1,6 @@
 import datetime
 import io
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from botocore.response import StreamingBody
 
@@ -1320,3 +1320,137 @@ def get_bucket_tagging() -> Dict[str, Any]:
 
 def get_object_tagging() -> Dict[str, Any]:
     return {"TagSet": [{"Key": "baz", "Value": "bob"}]}
+
+
+# Stubs for extract_column_parameters tests
+get_databases_column_params_response: Dict[str, Any] = {
+    "DatabaseList": [
+        {
+            "Name": "iceberg-database",
+            "CreateTime": datetime.datetime(2021, 6, 9, 14, 14, 19),
+            "CreateTableDefaultPermissions": [
+                {
+                    "Principal": {
+                        "DataLakePrincipalIdentifier": "IAM_ALLOWED_PRINCIPALS"
+                    },
+                    "Permissions": ["ALL"],
+                }
+            ],
+            "CatalogId": "123412341234",
+        },
+    ]
+}
+
+column_params_tables: List[Dict[str, Any]] = [
+    {
+        "Name": "test_table_nullable",
+        "DatabaseName": "iceberg-database",
+        "Owner": "owner",
+        "CreateTime": datetime.datetime(2021, 6, 9, 14, 17, 35),
+        "UpdateTime": datetime.datetime(
+            2021, 6, 9, 14, 17, 35, tzinfo=datetime.timezone.utc
+        ),
+        "LastAccessTime": datetime.datetime(2021, 6, 9, 14, 17, 35),
+        "Retention": 0,
+        "StorageDescriptor": {
+            "Columns": [
+                {
+                    "Name": "col1",
+                    "Type": "string",
+                    "Parameters": {"nullAllowed": "false"},
+                },
+                {
+                    "Name": "col2",
+                    "Type": "string",
+                    "Parameters": {"nullAllowed": "true"},
+                },
+                {
+                    "Name": "col3",
+                    "Type": "string",
+                },
+            ],
+            "Location": "s3://test-bucket/test_table_nullable",
+            "InputFormat": "org.apache.hadoop.mapred.TextInputFormat",
+            "OutputFormat": "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat",
+            "Compressed": False,
+            "NumberOfBuckets": 0,
+            "SerdeInfo": {
+                "SerializationLibrary": "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe",
+                "Parameters": {},
+            },
+            "SortColumns": [],
+            "StoredAsSubDirectories": False,
+        },
+        "PartitionKeys": [
+            {
+                "Name": "partition_date",
+                "Type": "varchar(8)",
+                "Parameters": {"partition_key_info": "daily"},
+            }
+        ],
+        "TableType": "EXTERNAL_TABLE",
+        "Parameters": {"table_name": "test_table_nullable"},
+        "CreatedBy": "arn:aws:sts::123412341234:assumed-role/AWSGlueServiceRole/session",
+        "IsRegisteredWithLakeFormation": False,
+        "CatalogId": "123412341234",
+        "VersionId": "0",
+    },
+    {
+        "Name": "test_iceberg_column_params",
+        "DatabaseName": "iceberg-database",
+        "Owner": "owner",
+        "CreateTime": datetime.datetime(2021, 6, 9, 14, 17, 35),
+        "UpdateTime": datetime.datetime(
+            2021, 6, 9, 14, 17, 35, tzinfo=datetime.timezone.utc
+        ),
+        "LastAccessTime": datetime.datetime(2021, 6, 9, 14, 17, 35),
+        "Retention": 0,
+        "StorageDescriptor": {
+            "Columns": [
+                {
+                    "Name": "emp_std_id",
+                    "Type": "string",
+                    "Parameters": {
+                        "iceberg.field.current": "true",
+                        "iceberg.field.id": "1",
+                        "iceberg.field.optional": "false",
+                    },
+                },
+                {
+                    "Name": "dept_cd",
+                    "Type": "string",
+                    "Parameters": {
+                        "iceberg.field.current": "true",
+                        "iceberg.field.id": "2",
+                        "iceberg.field.optional": "false",
+                    },
+                },
+                {
+                    "Name": "yr_nb",
+                    "Type": "decimal(10,0)",
+                    "Parameters": {
+                        "iceberg.field.current": "true",
+                        "iceberg.field.id": "3",
+                        "iceberg.field.optional": "false",
+                    },
+                },
+            ],
+            "Location": "s3://test-bucket/test_iceberg_column_params",
+            "Compressed": False,
+            "NumberOfBuckets": 0,
+            "SortColumns": [],
+            "StoredAsSubDirectories": False,
+        },
+        "TableType": "EXTERNAL_TABLE",
+        "Parameters": {
+            "table_type": "ICEBERG",
+            "metadata_location": "s3://test-bucket/test_iceberg_column_params/metadata/00001.metadata.json",
+        },
+        "CreatedBy": "arn:aws:sts::123412341234:assumed-role/AWSGlueServiceRole/session",
+        "IsRegisteredWithLakeFormation": False,
+        "CatalogId": "123412341234",
+        "VersionId": "1",
+    },
+]
+
+get_tables_response_column_params: Dict[str, Any] = {"TableList": column_params_tables}

--- a/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
@@ -524,6 +524,7 @@ public class PropertiesCollectorConfigurationTest extends AbstractTestNGSpringCo
           "featureFlags.showStatsTabRedesign",
           "featureFlags.showSearchBarAutocompleteRedesign",
           "featureFlags.showSearchFiltersV2",
+          "featureFlags.hideNullableColumnJsonProperties",
           "featureFlags.showColumnJsonProperties",
           "featureFlags.showSeparateSiblings",
           "featureFlags.showSimplifiedHomepageByDefault",

--- a/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
@@ -524,6 +524,7 @@ public class PropertiesCollectorConfigurationTest extends AbstractTestNGSpringCo
           "featureFlags.showStatsTabRedesign",
           "featureFlags.showSearchBarAutocompleteRedesign",
           "featureFlags.showSearchFiltersV2",
+          "featureFlags.showColumnJsonProperties",
           "featureFlags.showSeparateSiblings",
           "featureFlags.showSimplifiedHomepageByDefault",
           "featureFlags.themeV2Default",

--- a/metadata-service/configuration/src/main/java/com/linkedin/datahub/graphql/featureflags/FeatureFlags.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/datahub/graphql/featureflags/FeatureFlags.java
@@ -59,6 +59,7 @@ public class FeatureFlags {
   private boolean hideLineageInSearchCards = false;
   private boolean contextDocumentsEnabled = false;
   private boolean glossaryBasedPoliciesEnabled = false;
+  private boolean showColumnJsonProperties = false;
   private boolean createSchemaVersionIndex = false;
   private boolean aspectMigrationMutatorEnabled = false;
 }

--- a/metadata-service/configuration/src/main/java/com/linkedin/datahub/graphql/featureflags/FeatureFlags.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/datahub/graphql/featureflags/FeatureFlags.java
@@ -60,6 +60,7 @@ public class FeatureFlags {
   private boolean contextDocumentsEnabled = false;
   private boolean glossaryBasedPoliciesEnabled = false;
   private boolean showColumnJsonProperties = false;
+  private boolean hideNullableColumnJsonProperties = false;
   private boolean createSchemaVersionIndex = false;
   private boolean aspectMigrationMutatorEnabled = false;
 }


### PR DESCRIPTION
## Summary

- **Glue ingestion**: adds `extract_column_parameters` config option (default `false`) that ingests AWS Glue column-level `Parameters` as `jsonProps` on each `SchemaField`
- **Frontend**: renders `jsonProps` in the column Properties tab alongside structured properties, with filter-bar search support
- **Feature flag**: `showColumnJsonProperties` (default `false`) lets operators opt in to displaying jsonProps without affecting other sources (Salesforce, Snowflake, Avro, JSON Schema) that also populate the field
- **Bug fix**: wires pre-fetched `fieldProperties` directly into `useStructuredProperties` to eliminate Apollo cache staleness — structured properties applied after page load now appear immediately without requiring a full page reload

## Motivation

AWS Glue stores rich column-level metadata in the `Parameters` map (e.g. Iceberg field IDs, nullability flags). This data was ingested but not surfaced in the UI. The `extract_column_parameters` flag makes it visible as read-only rows in the column Properties tab, intermingled with structured properties.

The `showColumnJsonProperties` feature flag is added because `jsonProps` is populated by multiple sources for different purposes — gating display behind a flag means operators can enable it intentionally rather than having internal schema metadata appear by default.

## Test plan

- [ ] Set `extract_column_parameters: true` in a Glue recipe and re-ingest; verify column `Parameters` appear as rows in the Properties tab when `showColumnJsonProperties=true`
- [ ] Verify filter search works across structured properties and jsonProps rows simultaneously
- [ ] Verify `showColumnJsonProperties=false` (default) hides jsonProps rows entirely
- [ ] Verify structured properties on schema fields display correctly without requiring a page reload after being applied (Apollo cache fix)
- [ ] Unit tests: `test_glue_source.py` covers golden-file output; `parseJsonPropsToRows.test.ts` covers frontend parsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)