### PR TITLE
perf(metadata-io): coalesce same-(urn, aspect) MCLs in V2 update strategy

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/service/UpdateIndicesUtil.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/service/UpdateIndicesUtil.java
@@ -65,4 +65,22 @@ public class UpdateIndicesUtil {
   public static boolean isDeletingKey(Pair<EntitySpec, AspectSpec> specPair) {
     return specPair.getSecond().getName().equals(specPair.getFirst().getKeyAspectName());
   }
+
+  /**
+   * Groups update events by aspect name while preserving first-seen ordering within each group.
+   * Within a group, the last element is the surviving event for last-write-wins coalescing.
+   *
+   * @param updateEvents events for a single URN that have already been filtered to update change
+   *     types
+   * @return aspect-name → ordered list of events (first-seen order preserved across keys)
+   */
+  @Nonnull
+  public static LinkedHashMap<String, List<MCLItem>> groupUpdatesByAspect(
+      @Nonnull List<MCLItem> updateEvents) {
+    LinkedHashMap<String, List<MCLItem>> byAspect = new LinkedHashMap<>();
+    for (MCLItem event : updateEvents) {
+      byAspect.computeIfAbsent(event.getAspectName(), k -> new ArrayList<>()).add(event);
+    }
+    return byAspect;
+  }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/service/UpdateIndicesV2Strategy.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/service/UpdateIndicesV2Strategy.java
@@ -244,14 +244,22 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
     }
 
     MCLItem survivor = aspectEvents.get(aspectEvents.size() - 1);
-    if (structuredPropertiesHookEnabled) {
-      updateIndexMappings(opContext, survivor);
-    }
     // Use the oldest predecessor's previousRecordTemplate as the diff baseline, since that is
     // what ES actually had before the batch began. Otherwise the diff would compare against the
     // intermediate in-batch state and incorrectly skip the upsert when a no-op tail follows real
-    // changes earlier in the group.
+    // changes earlier in the group. This baseline is also the right one for the structured-
+    // property mapping diff: any entityType added by an earlier MCL in the group must still be
+    // applied to ES even though the survivor's own previousRecordTemplate already contains it.
     RecordTemplate baseline = aspectEvents.get(0).getPreviousRecordTemplate();
+    if (structuredPropertiesHookEnabled) {
+      updateIndexMappings(
+          opContext,
+          survivor.getUrn(),
+          survivor.getEntitySpec(),
+          survivor.getAspectSpec(),
+          survivor.getRecordTemplate(),
+          baseline);
+    }
     updateSearchIndicesForEvent(opContext, survivor, baseline);
     updateTimeseriesFieldsForEvent(opContext, survivor);
     appendCoalescedRunIds(opContext, survivor, aspectEvents);

--- a/metadata-io/src/main/java/com/linkedin/metadata/service/UpdateIndicesV2Strategy.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/service/UpdateIndicesV2Strategy.java
@@ -35,6 +35,8 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -72,6 +74,7 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
   private final TimeseriesAspectService timeseriesAspectService;
   private final String idHashAlgo;
   private final V2MappingsBuilder mappingsBuilder;
+  private final boolean coalesceBatchUpdates;
 
   // Semantic search configuration (optional - null if semantic search not configured)
   @Nullable private final SemanticSearchConfiguration semanticSearchConfig;
@@ -99,6 +102,32 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
       @Nonnull String idHashAlgo,
       @Nullable SemanticSearchConfiguration semanticSearchConfig,
       @Nonnull IndexConvention indexConvention) {
+    this(
+        v2Config,
+        elasticSearchService,
+        searchDocumentTransformer,
+        timeseriesAspectService,
+        idHashAlgo,
+        semanticSearchConfig,
+        indexConvention,
+        true);
+  }
+
+  /**
+   * Same as the 7-arg constructor, but allows toggling per-(urn, aspect) coalescing of batched
+   * updates. When {@code coalesceBatchUpdates} is true (default), N MCLs targeting the same (urn,
+   * aspect) within a batch produce a single ES upsert (last-write-wins, with predecessor runIds
+   * still appended). When false, the legacy per-event behavior is preserved as a rollback.
+   */
+  public UpdateIndicesV2Strategy(
+      @Nonnull EntityIndexVersionConfiguration v2Config,
+      @Nonnull ElasticSearchService elasticSearchService,
+      @Nonnull SearchDocumentTransformer searchDocumentTransformer,
+      @Nonnull TimeseriesAspectService timeseriesAspectService,
+      @Nonnull String idHashAlgo,
+      @Nullable SemanticSearchConfiguration semanticSearchConfig,
+      @Nonnull IndexConvention indexConvention,
+      boolean coalesceBatchUpdates) {
     this.v2Config = v2Config;
     this.elasticSearchService = elasticSearchService;
     this.searchDocumentTransformer = searchDocumentTransformer;
@@ -106,6 +135,7 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
     this.idHashAlgo = idHashAlgo;
     this.semanticSearchConfig = semanticSearchConfig;
     this.indexConvention = indexConvention;
+    this.coalesceBatchUpdates = coalesceBatchUpdates;
     this.mappingsBuilder =
         new V2MappingsBuilder(
             com.linkedin.metadata.config.search.EntityIndexConfiguration.builder()
@@ -147,14 +177,22 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
               .collect(Collectors.toList());
 
       if (!updateEvents.isEmpty()) {
-        updateEvents.forEach(
-            event -> {
-              if (structuredPropertiesHookEnabled) {
-                updateIndexMappings(opContext, event);
-              }
-              updateSearchIndicesForEvent(opContext, event);
-              updateTimeseriesFieldsForEvent(opContext, event);
-            });
+        if (coalesceBatchUpdates) {
+          LinkedHashMap<String, List<MCLItem>> byAspect =
+              UpdateIndicesUtil.groupUpdatesByAspect(updateEvents);
+          for (List<MCLItem> aspectEvents : byAspect.values()) {
+            processAspectGroup(opContext, aspectEvents, structuredPropertiesHookEnabled);
+          }
+        } else {
+          // Legacy per-event behavior preserved for rollback via flag.
+          for (MCLItem event : updateEvents) {
+            if (structuredPropertiesHookEnabled) {
+              updateIndexMappings(opContext, event);
+            }
+            updateSearchIndicesForEvent(opContext, event);
+            updateTimeseriesFieldsForEvent(opContext, event);
+          }
+        }
       }
 
       // Process delete events
@@ -181,7 +219,81 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
     }
   }
 
+  /**
+   * Process a single (urn, aspect) group of update events. Timeseries aspects are processed per
+   * event; non-timeseries aspects are coalesced to last-write-wins so a batch with N updates to the
+   * same (urn, aspect) emits one upsert. RunIds from coalesced predecessors are still appended so
+   * rollback-by-run remains accurate.
+   */
+  private void processAspectGroup(
+      @Nonnull OperationContext opContext,
+      @Nonnull List<MCLItem> aspectEvents,
+      boolean structuredPropertiesHookEnabled) {
+    if (aspectEvents.isEmpty()) {
+      return;
+    }
+    if (aspectEvents.get(0).getAspectSpec().isTimeseries()) {
+      for (MCLItem event : aspectEvents) {
+        if (structuredPropertiesHookEnabled) {
+          updateIndexMappings(opContext, event);
+        }
+        updateSearchIndicesForEvent(opContext, event);
+        updateTimeseriesFieldsForEvent(opContext, event);
+      }
+      return;
+    }
+
+    MCLItem survivor = aspectEvents.get(aspectEvents.size() - 1);
+    if (structuredPropertiesHookEnabled) {
+      updateIndexMappings(opContext, survivor);
+    }
+    // Use the oldest predecessor's previousRecordTemplate as the diff baseline, since that is
+    // what ES actually had before the batch began. Otherwise the diff would compare against the
+    // intermediate in-batch state and incorrectly skip the upsert when a no-op tail follows real
+    // changes earlier in the group.
+    RecordTemplate baseline = aspectEvents.get(0).getPreviousRecordTemplate();
+    updateSearchIndicesForEvent(opContext, survivor, baseline);
+    updateTimeseriesFieldsForEvent(opContext, survivor);
+    appendCoalescedRunIds(opContext, survivor, aspectEvents);
+  }
+
+  /**
+   * After the survivor's upsert (which already appended its own runId), append any additional
+   * distinct runIds carried by predecessors so rollback-by-run still finds the URN for those runs.
+   */
+  private void appendCoalescedRunIds(
+      @Nonnull OperationContext opContext,
+      @Nonnull MCLItem survivor,
+      @Nonnull List<MCLItem> aspectEvents) {
+    if (aspectEvents.size() <= 1) {
+      return;
+    }
+    SystemMetadata survivorSm = survivor.getSystemMetadata();
+    String survivorRunId =
+        (survivorSm != null && survivorSm.hasRunId()) ? survivorSm.getRunId() : null;
+    LinkedHashSet<String> additionalRunIds = new LinkedHashSet<>();
+    for (int i = 0; i < aspectEvents.size() - 1; i++) {
+      SystemMetadata sm = aspectEvents.get(i).getSystemMetadata();
+      if (sm != null && sm.hasRunId()) {
+        String runId = sm.getRunId();
+        if (!runId.equals(survivorRunId)) {
+          additionalRunIds.add(runId);
+        }
+      }
+    }
+    for (String runId : additionalRunIds) {
+      elasticSearchService.appendRunId(opContext, survivor.getUrn(), runId);
+    }
+  }
+
   void updateSearchIndicesForEvent(@Nonnull OperationContext opContext, @Nonnull MCLItem event) {
+    updateSearchIndicesForEvent(opContext, event, event.getPreviousRecordTemplate());
+  }
+
+  void updateSearchIndicesForEvent(
+      @Nonnull OperationContext opContext,
+      @Nonnull MCLItem event,
+      @Nullable RecordTemplate previousAspect) {
     // V2 search index update logic - full implementation
     log.debug("Updating V2 search indices for entity: {}", event.getUrn());
 
@@ -189,7 +301,6 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
     RecordTemplate aspect = event.getRecordTemplate();
     AspectSpec aspectSpec = event.getAspectSpec();
     SystemMetadata systemMetadata = event.getSystemMetadata();
-    RecordTemplate previousAspect = event.getPreviousRecordTemplate();
     String entityName = event.getEntitySpec().getName();
 
     Optional<ObjectNode> searchDocument;

--- a/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateIndicesV2StrategyTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateIndicesV2StrategyTest.java
@@ -14,12 +14,14 @@ import static org.testng.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.linkedin.common.AuditStamp;
+import com.linkedin.common.UrnArray;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.data.DataMap;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.data.template.StringMap;
 import com.linkedin.events.metadata.ChangeType;
+import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.aspect.batch.MCLItem;
 import com.linkedin.metadata.config.search.EntityIndexVersionConfiguration;
 import com.linkedin.metadata.config.search.SemanticSearchConfiguration;
@@ -976,5 +978,110 @@ public class UpdateIndicesV2StrategyTest {
             eq(ownershipSpec),
             eq(false),
             any(AuditStamp.class));
+  }
+
+  @Test
+  public void testProcessBatch_CoalesceStructuredPropertyMappingsUseOldestPredecessorBaseline()
+      throws Exception {
+    // Two MCLs in the same batch on the same structured-property URN:
+    //   MCL 1: prev entityTypes [] -> new [X]
+    //   MCL 2 (survivor): prev [X] -> new [X, Y]
+    // Pre-coalesce, X's mapping was applied by MCL 1 and Y's by MCL 2. Under coalesce we fire
+    // updateIndexMappings only for the survivor, so the diff baseline must be the oldest
+    // predecessor's previousRecordTemplate ([]) — not the survivor's previous ([X]) — otherwise
+    // X's mapping is silently dropped.
+    AspectSpec spdSpec = mock(AspectSpec.class);
+    when(spdSpec.getName()).thenReturn(Constants.STRUCTURED_PROPERTY_DEFINITION_ASPECT_NAME);
+    when(spdSpec.isTimeseries()).thenReturn(false);
+    EntitySpec spEntitySpec = mock(EntitySpec.class);
+    when(spEntitySpec.getName()).thenReturn(Constants.STRUCTURED_PROPERTY_ENTITY_NAME);
+
+    Urn typeX = UrnUtils.getUrn("urn:li:entityType:datahub.dataset");
+    Urn typeY = UrnUtils.getUrn("urn:li:entityType:datahub.dashboard");
+
+    StructuredPropertyDefinition baselineDef =
+        new StructuredPropertyDefinition()
+            .setVersion("00000000000001")
+            .setQualifiedName("foo")
+            .setEntityTypes(new UrnArray())
+            .setValueType(UrnUtils.getUrn("urn:li:logicalType:STRING"));
+    StructuredPropertyDefinition intermediateDef =
+        new StructuredPropertyDefinition()
+            .setVersion("00000000000001")
+            .setQualifiedName("foo")
+            .setEntityTypes(new UrnArray(typeX))
+            .setValueType(UrnUtils.getUrn("urn:li:logicalType:STRING"));
+    StructuredPropertyDefinition survivorDef =
+        new StructuredPropertyDefinition()
+            .setVersion("00000000000001")
+            .setQualifiedName("foo")
+            .setEntityTypes(new UrnArray(typeX, typeY))
+            .setValueType(UrnUtils.getUrn("urn:li:logicalType:STRING"));
+
+    MCLItem first =
+        makeStructuredPropertyEvent(
+            spEntitySpec, spdSpec, intermediateDef, baselineDef, "run-1", ChangeType.UPSERT);
+    MCLItem second =
+        makeStructuredPropertyEvent(
+            spEntitySpec, spdSpec, survivorDef, intermediateDef, "run-1", ChangeType.UPSERT);
+
+    ObjectNode doc = mock(ObjectNode.class);
+    when(doc.toString()).thenReturn("{\"v\":1}");
+    when(searchDocumentTransformer.transformAspect(
+            any(OperationContext.class),
+            any(Urn.class),
+            any(RecordTemplate.class),
+            any(AspectSpec.class),
+            eq(false),
+            any(AuditStamp.class)))
+        .thenReturn(Optional.of(doc));
+    when(elasticSearchService.buildReindexConfigsWithNewStructProp(
+            any(OperationContext.class), any(Urn.class), any(StructuredPropertyDefinition.class)))
+        .thenReturn(Collections.emptyList());
+
+    strategy.processBatch(operationContext, groupedFor(List.of(first, second)), true);
+
+    org.mockito.ArgumentCaptor<StructuredPropertyDefinition> defCaptor =
+        org.mockito.ArgumentCaptor.forClass(StructuredPropertyDefinition.class);
+    verify(elasticSearchService)
+        .buildReindexConfigsWithNewStructProp(
+            any(OperationContext.class), eq(testUrn), defCaptor.capture());
+
+    UrnArray applied = defCaptor.getValue().getEntityTypes();
+    assertTrue(
+        applied.contains(typeX),
+        "Coalesced mapping diff dropped entityType X added by an earlier MCL in the batch");
+    assertTrue(applied.contains(typeY), "Coalesced mapping diff missing newly-added entityType Y");
+  }
+
+  private MCLItem makeStructuredPropertyEvent(
+      EntitySpec entitySpec,
+      AspectSpec aspectSpec,
+      StructuredPropertyDefinition aspect,
+      StructuredPropertyDefinition previousAspect,
+      String runId,
+      ChangeType changeType) {
+    String aspectName = aspectSpec.getName();
+    MCLItem event = mock(MCLItem.class);
+    when(event.getUrn()).thenReturn(testUrn);
+    when(event.getAspectSpec()).thenReturn(aspectSpec);
+    when(event.getAspectName()).thenReturn(aspectName);
+    when(event.getEntitySpec()).thenReturn(entitySpec);
+    when(event.getRecordTemplate()).thenReturn(aspect);
+    when(event.getPreviousRecordTemplate()).thenReturn(previousAspect);
+    when(event.getAuditStamp()).thenReturn(mockAuditStamp);
+    when(event.getChangeType()).thenReturn(changeType);
+
+    SystemMetadata sm = mock(SystemMetadata.class);
+    if (runId != null) {
+      when(sm.hasRunId()).thenReturn(true);
+      when(sm.getRunId()).thenReturn(runId);
+    }
+    when(event.getSystemMetadata()).thenReturn(sm);
+
+    MetadataChangeLog mcl = mock(MetadataChangeLog.class);
+    when(mcl.getChangeType()).thenReturn(changeType);
+    when(event.getMetadataChangeLog()).thenReturn(mcl);
+    return event;
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateIndicesV2StrategyTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateIndicesV2StrategyTest.java
@@ -31,12 +31,16 @@ import com.linkedin.metadata.search.transformer.SearchDocumentTransformer;
 import com.linkedin.metadata.systemmetadata.SystemMetadataService;
 import com.linkedin.metadata.timeseries.TimeseriesAspectService;
 import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
+import com.linkedin.mxe.MetadataChangeLog;
 import com.linkedin.mxe.SystemMetadata;
 import com.linkedin.structured.StructuredPropertyDefinition;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.mockito.Mock;
@@ -650,5 +654,327 @@ public class UpdateIndicesV2StrategyTest {
     verify(elasticSearchService).deleteDocument(eq(operationContext), eq("dataset"), anyString());
     verify(elasticSearchService)
         .deleteDocumentByIndexName(eq("datasetindex_v2_semantic"), anyString());
+  }
+
+  // ==================== processBatch coalescing tests ====================
+
+  private MCLItem makeEvent(
+      String aspectName,
+      AspectSpec aspectSpec,
+      RecordTemplate aspect,
+      RecordTemplate previousAspect,
+      String runId,
+      ChangeType changeType) {
+    MCLItem event = mock(MCLItem.class);
+    when(event.getUrn()).thenReturn(testUrn);
+    when(event.getAspectSpec()).thenReturn(aspectSpec);
+    when(event.getAspectName()).thenReturn(aspectName);
+    when(event.getEntitySpec()).thenReturn(mockEntitySpec);
+    when(event.getRecordTemplate()).thenReturn(aspect);
+    when(event.getPreviousRecordTemplate()).thenReturn(previousAspect);
+    when(event.getAuditStamp()).thenReturn(mockAuditStamp);
+    when(event.getChangeType()).thenReturn(changeType);
+
+    SystemMetadata sm = mock(SystemMetadata.class);
+    if (runId != null) {
+      when(sm.hasRunId()).thenReturn(true);
+      when(sm.getRunId()).thenReturn(runId);
+    }
+    when(event.getSystemMetadata()).thenReturn(sm);
+
+    MetadataChangeLog mcl = mock(MetadataChangeLog.class);
+    when(mcl.getChangeType()).thenReturn(changeType);
+    when(event.getMetadataChangeLog()).thenReturn(mcl);
+    return event;
+  }
+
+  private Map<Urn, List<MCLItem>> groupedFor(List<MCLItem> events) {
+    Map<Urn, List<MCLItem>> grouped = new LinkedHashMap<>();
+    grouped.put(testUrn, events);
+    return grouped;
+  }
+
+  @Test
+  public void testProcessBatch_CoalesceSameUrnSameAspect_OnlyLatestUpserted() throws Exception {
+    AspectSpec ownershipSpec = mock(AspectSpec.class);
+    when(ownershipSpec.getName()).thenReturn("ownership");
+    when(ownershipSpec.isTimeseries()).thenReturn(false);
+
+    RecordTemplate aspectA = mock(RecordTemplate.class);
+    RecordTemplate aspectB = mock(RecordTemplate.class);
+
+    MCLItem first =
+        makeEvent("ownership", ownershipSpec, aspectA, null, "run-1", ChangeType.UPSERT);
+    MCLItem second =
+        makeEvent("ownership", ownershipSpec, aspectB, aspectA, "run-1", ChangeType.UPSERT);
+
+    ObjectNode survivorDoc = mock(ObjectNode.class);
+    when(survivorDoc.toString()).thenReturn("{\"v\":2}");
+    when(searchDocumentTransformer.transformAspect(
+            any(OperationContext.class),
+            any(Urn.class),
+            any(RecordTemplate.class),
+            any(AspectSpec.class),
+            eq(false),
+            any(AuditStamp.class)))
+        .thenReturn(Optional.of(survivorDoc));
+
+    strategy.processBatch(operationContext, groupedFor(List.of(first, second)), false);
+
+    verify(searchDocumentTransformer)
+        .transformAspect(
+            any(OperationContext.class),
+            eq(testUrn),
+            eq(aspectB),
+            eq(ownershipSpec),
+            eq(false),
+            any(AuditStamp.class));
+    verify(searchDocumentTransformer, never())
+        .transformAspect(
+            any(OperationContext.class),
+            eq(testUrn),
+            eq(aspectA),
+            eq(ownershipSpec),
+            eq(false),
+            any(AuditStamp.class));
+    verify(elasticSearchService, times(1))
+        .upsertDocument(eq(operationContext), eq("dataset"), anyString(), anyString());
+  }
+
+  @Test
+  public void testProcessBatch_CoalesceSameUrnDifferentAspects_BothProcessed() throws Exception {
+    AspectSpec ownershipSpec = mock(AspectSpec.class);
+    when(ownershipSpec.getName()).thenReturn("ownership");
+    when(ownershipSpec.isTimeseries()).thenReturn(false);
+    AspectSpec tagsSpec = mock(AspectSpec.class);
+    when(tagsSpec.getName()).thenReturn("globalTags");
+    when(tagsSpec.isTimeseries()).thenReturn(false);
+
+    RecordTemplate ownershipAspect = mock(RecordTemplate.class);
+    RecordTemplate tagsAspect = mock(RecordTemplate.class);
+
+    MCLItem ownershipEvent =
+        makeEvent("ownership", ownershipSpec, ownershipAspect, null, "run-1", ChangeType.UPSERT);
+    MCLItem tagsEvent =
+        makeEvent("globalTags", tagsSpec, tagsAspect, null, "run-1", ChangeType.UPSERT);
+
+    ObjectNode doc = mock(ObjectNode.class);
+    when(doc.toString()).thenReturn("{\"k\":1}");
+    when(searchDocumentTransformer.transformAspect(
+            any(OperationContext.class),
+            any(Urn.class),
+            any(RecordTemplate.class),
+            any(AspectSpec.class),
+            eq(false),
+            any(AuditStamp.class)))
+        .thenReturn(Optional.of(doc));
+
+    strategy.processBatch(operationContext, groupedFor(List.of(ownershipEvent, tagsEvent)), false);
+
+    verify(elasticSearchService, times(2))
+        .upsertDocument(eq(operationContext), eq("dataset"), anyString(), anyString());
+  }
+
+  @Test
+  public void testProcessBatch_TimeseriesNotCoalesced() throws Exception {
+    AspectSpec tsSpec = mock(AspectSpec.class);
+    when(tsSpec.getName()).thenReturn("datasetProfile");
+    when(tsSpec.isTimeseries()).thenReturn(true);
+    when(tsSpec.getTimeseriesFieldSpecs()).thenReturn(Collections.emptyList());
+    when(tsSpec.getTimeseriesFieldCollectionSpecs()).thenReturn(Collections.emptyList());
+
+    DataMap data1 = new DataMap();
+    data1.put("timestampMillis", 1L);
+    DataMap data2 = new DataMap();
+    data2.put("timestampMillis", 2L);
+    RecordTemplate ts1 = mock(RecordTemplate.class);
+    RecordTemplate ts2 = mock(RecordTemplate.class);
+    when(ts1.data()).thenReturn(data1);
+    when(ts2.data()).thenReturn(data2);
+
+    MCLItem first = makeEvent("datasetProfile", tsSpec, ts1, null, "run-1", ChangeType.UPSERT);
+    MCLItem second = makeEvent("datasetProfile", tsSpec, ts2, null, "run-1", ChangeType.UPSERT);
+
+    when(searchDocumentTransformer.transformAspect(
+            any(OperationContext.class),
+            any(Urn.class),
+            any(RecordTemplate.class),
+            any(AspectSpec.class),
+            eq(false),
+            any(AuditStamp.class)))
+        .thenReturn(Optional.empty());
+
+    strategy.processBatch(operationContext, groupedFor(List.of(first, second)), false);
+
+    verify(searchDocumentTransformer)
+        .transformAspect(
+            any(OperationContext.class),
+            eq(testUrn),
+            eq(ts1),
+            eq(tsSpec),
+            eq(false),
+            any(AuditStamp.class));
+    verify(searchDocumentTransformer)
+        .transformAspect(
+            any(OperationContext.class),
+            eq(testUrn),
+            eq(ts2),
+            eq(tsSpec),
+            eq(false),
+            any(AuditStamp.class));
+    verify(timeseriesAspectService, times(2))
+        .upsertDocument(any(OperationContext.class), anyString(), anyString(), anyString(), any());
+  }
+
+  @Test
+  public void testProcessBatch_CoalesceAppendsRunIdsFromPredecessors() throws Exception {
+    AspectSpec ownershipSpec = mock(AspectSpec.class);
+    when(ownershipSpec.getName()).thenReturn("ownership");
+    when(ownershipSpec.isTimeseries()).thenReturn(false);
+
+    RecordTemplate aspectA = mock(RecordTemplate.class);
+    RecordTemplate aspectB = mock(RecordTemplate.class);
+
+    MCLItem first =
+        makeEvent("ownership", ownershipSpec, aspectA, null, "run-A", ChangeType.UPSERT);
+    MCLItem second =
+        makeEvent("ownership", ownershipSpec, aspectB, aspectA, "run-B", ChangeType.UPSERT);
+
+    ObjectNode doc = mock(ObjectNode.class);
+    when(doc.toString()).thenReturn("{\"v\":1}");
+    when(searchDocumentTransformer.transformAspect(
+            any(OperationContext.class),
+            any(Urn.class),
+            any(RecordTemplate.class),
+            any(AspectSpec.class),
+            eq(false),
+            any(AuditStamp.class)))
+        .thenReturn(Optional.of(doc));
+
+    strategy.processBatch(operationContext, groupedFor(List.of(first, second)), false);
+
+    verify(elasticSearchService).appendRunId(eq(operationContext), eq(testUrn), eq("run-B"));
+    verify(elasticSearchService).appendRunId(eq(operationContext), eq(testUrn), eq("run-A"));
+  }
+
+  @Test
+  public void testProcessBatch_FlagDisabled_PreservesPerEventBehavior() throws Exception {
+    UpdateIndicesV2Strategy legacyStrategy =
+        new UpdateIndicesV2Strategy(
+            v2Config,
+            elasticSearchService,
+            searchDocumentTransformer,
+            timeseriesAspectService,
+            "MD5",
+            null,
+            mock(IndexConvention.class),
+            false);
+
+    AspectSpec ownershipSpec = mock(AspectSpec.class);
+    when(ownershipSpec.getName()).thenReturn("ownership");
+    when(ownershipSpec.isTimeseries()).thenReturn(false);
+
+    RecordTemplate aspectA = mock(RecordTemplate.class);
+    RecordTemplate aspectB = mock(RecordTemplate.class);
+
+    // previousRecordTemplate=null on both events skips the per-event diff short-circuit so we can
+    // observe pure per-event upsert behavior under coalesceBatchUpdates=false.
+    MCLItem first =
+        makeEvent("ownership", ownershipSpec, aspectA, null, "run-1", ChangeType.UPSERT);
+    MCLItem second =
+        makeEvent("ownership", ownershipSpec, aspectB, null, "run-1", ChangeType.UPSERT);
+
+    ObjectNode doc = mock(ObjectNode.class);
+    when(doc.toString()).thenReturn("{\"v\":1}");
+    when(searchDocumentTransformer.transformAspect(
+            any(OperationContext.class),
+            any(Urn.class),
+            any(RecordTemplate.class),
+            any(AspectSpec.class),
+            eq(false),
+            any(AuditStamp.class)))
+        .thenReturn(Optional.of(doc));
+
+    legacyStrategy.processBatch(operationContext, groupedFor(List.of(first, second)), false);
+
+    verify(searchDocumentTransformer)
+        .transformAspect(
+            any(OperationContext.class),
+            eq(testUrn),
+            eq(aspectA),
+            eq(ownershipSpec),
+            eq(false),
+            any(AuditStamp.class));
+    verify(searchDocumentTransformer)
+        .transformAspect(
+            any(OperationContext.class),
+            eq(testUrn),
+            eq(aspectB),
+            eq(ownershipSpec),
+            eq(false),
+            any(AuditStamp.class));
+    verify(elasticSearchService, times(2))
+        .upsertDocument(eq(operationContext), eq("dataset"), anyString(), anyString());
+  }
+
+  @Test
+  public void testProcessBatch_CoalesceUsesOldestPredecessorAsDiffBaseline() throws Exception {
+    AspectSpec ownershipSpec = mock(AspectSpec.class);
+    when(ownershipSpec.getName()).thenReturn("ownership");
+    when(ownershipSpec.isTimeseries()).thenReturn(false);
+
+    RecordTemplate baselineRec = mock(RecordTemplate.class);
+    RecordTemplate intermediate = mock(RecordTemplate.class);
+    RecordTemplate finalRec = mock(RecordTemplate.class);
+
+    MCLItem first =
+        makeEvent(
+            "ownership", ownershipSpec, intermediate, baselineRec, "run-1", ChangeType.UPSERT);
+    MCLItem second =
+        makeEvent("ownership", ownershipSpec, finalRec, intermediate, "run-1", ChangeType.UPSERT);
+    MCLItem third =
+        makeEvent("ownership", ownershipSpec, finalRec, finalRec, "run-1", ChangeType.UPSERT);
+
+    ObjectNode finalDoc = mock(ObjectNode.class);
+    when(finalDoc.toString()).thenReturn("{\"v\":\"final\"}");
+    ObjectNode baselineDoc = mock(ObjectNode.class);
+    when(baselineDoc.toString()).thenReturn("{\"v\":\"base\"}");
+    when(searchDocumentTransformer.transformAspect(
+            any(OperationContext.class),
+            any(Urn.class),
+            eq(finalRec),
+            any(AspectSpec.class),
+            eq(false),
+            any(AuditStamp.class)))
+        .thenReturn(Optional.of(finalDoc));
+    when(searchDocumentTransformer.transformAspect(
+            any(OperationContext.class),
+            any(Urn.class),
+            eq(baselineRec),
+            any(AspectSpec.class),
+            eq(false),
+            any(AuditStamp.class)))
+        .thenReturn(Optional.of(baselineDoc));
+
+    strategy.processBatch(operationContext, groupedFor(List.of(first, second, third)), false);
+
+    verify(elasticSearchService)
+        .upsertDocument(eq(operationContext), eq("dataset"), anyString(), anyString());
+    verify(searchDocumentTransformer)
+        .transformAspect(
+            any(OperationContext.class),
+            eq(testUrn),
+            eq(baselineRec),
+            eq(ownershipSpec),
+            eq(false),
+            any(AuditStamp.class));
+    verify(searchDocumentTransformer, never())
+        .transformAspect(
+            any(OperationContext.class),
+            eq(testUrn),
+            eq(intermediate),
+            eq(ownershipSpec),
+            eq(false),
+            any(AuditStamp.class));
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
@@ -969,6 +969,7 @@ public class PropertiesCollectorConfigurationTest extends AbstractTestNGSpringCo
           "mclProcessing.cdcSource.debeziumConfig.mysqlConfig.database.server.id",
           "mclProcessing.cdcSource.debeziumConfig.mysqlConfig.database.include.list",
           "elasticsearch.entityIndex.v2.cleanup",
+          "elasticsearch.entityIndex.v2.coalesceBatchUpdates",
           "elasticsearch.entityIndex.v3.analyzerConfig",
           "elasticsearch.entityIndex.v3.mappingConfig",
           "elasticsearch.entityIndex.v3.cleanup",

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -395,6 +395,7 @@ elasticsearch:
     v2:
       enabled: ${ELASTICSEARCH_ENTITY_INDEX_V2_ENABLED:true}
       cleanup: ${ELASTICSEARCH_ENTITY_INDEX_V2_CLEANUP:true}
+      coalesceBatchUpdates: ${ELASTICSEARCH_ENTITY_INDEX_V2_COALESCE_BATCH_UPDATES:true}
     v3:
       enabled: ${ELASTICSEARCH_ENTITY_INDEX_V3_ENABLED:false}
       cleanup: ${ELASTICSEARCH_ENTITY_INDEX_V3_CLEANUP:false}

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entity/update/indices/UpdateIndicesStrategyFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entity/update/indices/UpdateIndicesStrategyFactory.java
@@ -36,7 +36,9 @@ public class UpdateIndicesStrategyFactory {
       ConfigurationProvider configProvider,
       @Qualifier(IndexConventionFactory.INDEX_CONVENTION_BEAN) IndexConvention indexConvention,
       @Value("${elasticsearch.idHashAlgo}") String idHashAlgo,
-      @Value("${elasticsearch.entityIndex.v2.cleanup:false}") boolean v2Cleanup) {
+      @Value("${elasticsearch.entityIndex.v2.cleanup:false}") boolean v2Cleanup,
+      @Value("${elasticsearch.entityIndex.v2.coalesceBatchUpdates:true}")
+          boolean coalesceBatchUpdates) {
 
     EntityIndexVersionConfiguration v2Config =
         EntityIndexVersionConfiguration.builder().enabled(true).cleanup(v2Cleanup).build();
@@ -70,7 +72,8 @@ public class UpdateIndicesStrategyFactory {
         timeseriesAspectService,
         idHashAlgo,
         semanticSearchConfig,
-        indexConvention);
+        indexConvention,
+        coalesceBatchUpdates);
   }
 
   @Bean("updateIndicesV3Strategy")


### PR DESCRIPTION
## Summary

Within a batched MCL flush in the MAE consumer, the V2 update-indices strategy was emitting one Elasticsearch upsert per MCL even when many MCLs in the batch targeted the same (urn, aspect). V3 already coalesces (`UpdateIndicesV3Strategy.buildV3SearchDocument`); this brings V2 to parity.

For each (urn, aspect) update group within a batch:
- **Timeseries aspects** are still processed per event (every datapoint matters).
- **Non-timeseries aspects** are coalesced to last-write-wins — only the latest event's `transformAspect` runs and only one `upsertDocument` is issued.

Two correctness details that fall out of coalescing:
- **Diff baseline**: the existing `searchDiffMode` short-circuit compares the survivor's transformed search doc against `previousRecordTemplate`. Under coalescing, that previous template is the in-batch intermediate state, not what ES has. The new path passes the **oldest predecessor's** `previousRecordTemplate` as the explicit baseline so a no-op tail (e.g. `[A→B, B→B]`) cannot incorrectly suppress an upsert that the pre-coalesce path would have done.
- **runId fan-out**: the per-event `appendRunId` call previously fired once per MCL. After coalescing it only fires for the survivor, which would lose older runs from the doc's `runId` array and break rollback-by-run. The new `appendCoalescedRunIds` helper appends each distinct predecessor runId explicitly.

The behavior is gated by a flag for safe rollback:
- `elasticsearch.entityIndex.v2.coalesceBatchUpdates` — default `true`.
- Env var: `ELASTICSEARCH_ENTITY_INDEX_V2_COALESCE_BATCH_UPDATES=false` reverts to the legacy per-event path verbatim.

## Files changed

- `metadata-io/.../service/UpdateIndicesUtil.java` — new `groupUpdatesByAspect` helper.
- `metadata-io/.../service/UpdateIndicesV2Strategy.java` — flag field + 8-arg ctor (7-arg delegates with `true`); gated coalesce in `processBatch`; new `processAspectGroup` and `appendCoalescedRunIds`; split `updateSearchIndicesForEvent` to accept an explicit baseline.
- `metadata-io/.../service/UpdateIndicesV2StrategyTest.java` — 6 new tests (5 coalesce + 1 flag-disabled).
- `metadata-service/configuration/.../application.yaml` — new flag declaration.
- `metadata-service/factories/.../UpdateIndicesStrategyFactory.java` — wires `@Value`-injected flag into the V2 ctor.

## Checklist

- [x] PR conforms to the [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md), particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format)
- [x] Tests added for the changes (6 new tests in `UpdateIndicesV2StrategyTest`; all `UpdateIndices*` tests pass)
- [ ] Linked issues — n/a
- [ ] Docs — n/a (operator-facing flag is self-documenting via the YAML default)
- [ ] Breaking change entry in `updating-datahub.md` — n/a (default behavior is the safer/correct one with the runId fix; legacy behavior preserved behind the flag)