### PR TITLE
feat(ingestion/json-schema): add http_headers config for authenticated $ref resolution

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/schema/json_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/schema/json_schema.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from enum import auto
 from os.path import basename, dirname
 from pathlib import Path
-from typing import Any, Iterable, Optional, Union
+from typing import Any, Dict, Iterable, Optional, Union
 from urllib.parse import urlparse
 
 import jsonref
@@ -114,6 +114,12 @@ class JsonSchemaSourceConfig(StatefulIngestionConfigBase, DatasetSourceConfigMix
         default=None,
         description="Apply a string match-replace on the computed display name. "
         "Runs after dataset_name_strategy is applied.",
+    )
+    http_headers: Optional[Dict[str, str]] = Field(
+        default=None,
+        description="HTTP headers to include when fetching remote schemas "
+        "(e.g. for authentication). Applied to $ref resolution and "
+        "remote URL downloads.",
     )
 
     @field_validator("path", mode="after")
@@ -264,7 +270,13 @@ class JsonSchemaSource(StatefulIngestionSourceBase):
             return (resolved_dict, json.dumps(schema_dict))
 
     @staticmethod
-    def stringreplaceloader(match_string, replace_string, uri, **kwargs):
+    def stringreplaceloader(
+        match_string: str,
+        replace_string: str,
+        uri: str,
+        headers: Optional[Dict[str, str]] = None,
+        **kwargs: Any,
+    ) -> Any:
         """
         Provides a callable which takes a URI, and returns the loaded JSON referred
         to by that URI. Uses :mod:`requests` if available for HTTP URIs, and falls
@@ -272,7 +284,27 @@ class JsonSchemaSource(StatefulIngestionSourceBase):
         """
         uri = uri.replace(match_string, replace_string)
         logger.debug(f"Resolving ref to file {uri}")
-        return jsonref.jsonloader(uri, **kwargs)
+        return JsonSchemaSource._jsonloader_with_headers(uri, headers=headers, **kwargs)
+
+    @staticmethod
+    def _jsonloader_with_headers(
+        uri: str, headers: Optional[Dict[str, str]] = None, **kwargs: Any
+    ) -> Any:
+        """Like jsonref.jsonloader but supports custom HTTP headers."""
+        from urllib.parse import urlsplit
+        from urllib.request import urlopen
+
+        scheme = urlsplit(uri).scheme
+        if scheme in ("http", "https"):
+            resp = requests.get(uri, headers=headers or {})
+            resp.raise_for_status()
+            try:
+                return resp.json(**kwargs)
+            except TypeError:
+                return resp.json()
+        else:
+            with urlopen(uri) as content:
+                return json.loads(content.read().decode("utf-8"), **kwargs)
 
     def __init__(self, ctx: PipelineContext, config: JsonSchemaSourceConfig):
         super().__init__(ctx=ctx, config=config)
@@ -413,9 +445,13 @@ class JsonSchemaSource(StatefulIngestionSourceBase):
                 self.stringreplaceloader,
                 self.config.uri_replace_pattern.match,
                 self.config.uri_replace_pattern.replace,
+                headers=self.config.http_headers,
             )
         else:
-            ref_loader = jsonref.jsonloader
+            ref_loader = functools.partial(
+                self._jsonloader_with_headers,
+                headers=self.config.http_headers,
+            )
         browse_prefix = f"/{self.config.env.lower()}/{self.config.platform}"
         if self.config.platform_instance:
             browse_prefix = f"/{self.config.env.lower()}/{self.config.platform}/{self.config.platform_instance}"

--- a/metadata-ingestion/tests/unit/schema/test_json_schema_http_headers.py
+++ b/metadata-ingestion/tests/unit/schema/test_json_schema_http_headers.py
@@ -1,0 +1,161 @@
+"""Tests for JsonSchemaSource http_headers support.
+
+Verifies that custom HTTP headers are passed through to $ref resolution
+when fetching remote schemas (e.g. behind CloudFront with auth).
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from datahub.ingestion.source.schema.json_schema import JsonSchemaSource
+
+
+class TestJsonloaderWithHeaders:
+    """Tests for the _jsonloader_with_headers static method."""
+
+    @patch("datahub.ingestion.source.schema.json_schema.requests.get")
+    def test_passes_headers_to_requests(self, mock_get: MagicMock) -> None:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"type": "object"}
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        result = JsonSchemaSource._jsonloader_with_headers(
+            "https://schema.example.com/my-schema.json",
+            headers={"Authorization": "Bearer secret123"},
+        )
+
+        mock_get.assert_called_once_with(
+            "https://schema.example.com/my-schema.json",
+            headers={"Authorization": "Bearer secret123"},
+        )
+        assert result == {"type": "object"}
+
+    @patch("datahub.ingestion.source.schema.json_schema.requests.get")
+    def test_passes_empty_headers_when_none(self, mock_get: MagicMock) -> None:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"type": "string"}
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        JsonSchemaSource._jsonloader_with_headers(
+            "https://schema.example.com/other.json",
+            headers=None,
+        )
+
+        mock_get.assert_called_once_with(
+            "https://schema.example.com/other.json",
+            headers={},
+        )
+
+    @patch("datahub.ingestion.source.schema.json_schema.requests.get")
+    def test_raises_on_http_error(self, mock_get: MagicMock) -> None:
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = Exception("403 Forbidden")
+        mock_get.return_value = mock_response
+
+        with pytest.raises(Exception, match="403 Forbidden"):
+            JsonSchemaSource._jsonloader_with_headers(
+                "https://schema.example.com/secret.json",
+                headers={"Authorization": "Bearer bad_token"},
+            )
+
+    def test_file_uri_does_not_use_requests(self, tmp_path: Path) -> None:
+        schema = {"type": "object", "properties": {"name": {"type": "string"}}}
+        schema_file = tmp_path / "local.json"
+        schema_file.write_text(json.dumps(schema))
+
+        result = JsonSchemaSource._jsonloader_with_headers(
+            f"file://{schema_file}",
+            headers={"Authorization": "Bearer should_not_matter"},
+        )
+
+        assert result == schema
+
+
+class TestStringReplaceLoaderWithHeaders:
+    """Tests for stringreplaceloader with headers support."""
+
+    @patch(
+        "datahub.ingestion.source.schema.json_schema.JsonSchemaSource._jsonloader_with_headers"
+    )
+    def test_passes_headers_through(self, mock_loader: MagicMock) -> None:
+        mock_loader.return_value = {"type": "object"}
+
+        result = JsonSchemaSource.stringreplaceloader(
+            "https://old.example.com",
+            "https://new.example.com",
+            "https://old.example.com/schemas/event.json",
+            headers={"X-Api-Key": "my-key"},
+        )
+
+        mock_loader.assert_called_once_with(
+            "https://new.example.com/schemas/event.json",
+            headers={"X-Api-Key": "my-key"},
+        )
+        assert result == {"type": "object"}
+
+    @patch(
+        "datahub.ingestion.source.schema.json_schema.JsonSchemaSource._jsonloader_with_headers"
+    )
+    def test_replaces_uri_before_loading(self, mock_loader: MagicMock) -> None:
+        mock_loader.return_value = {}
+
+        JsonSchemaSource.stringreplaceloader(
+            "https://remote.host",
+            "file:///local/path",
+            "https://remote.host/schemas/v1/event.json",
+            headers=None,
+        )
+
+        mock_loader.assert_called_once_with(
+            "file:///local/path/schemas/v1/event.json",
+            headers=None,
+        )
+
+
+class TestHttpHeadersConfig:
+    """Tests that http_headers config is wired into the source correctly."""
+
+    def test_config_accepts_http_headers(self, tmp_path: Path) -> None:
+        """Verify the config field is accepted without errors."""
+        schema = {"type": "object", "$id": "test-schema"}
+        schema_file = tmp_path / "test.json"
+        schema_file.write_text(json.dumps(schema))
+
+        from datahub.ingestion.api.common import PipelineContext
+
+        config = {
+            "path": str(tmp_path),
+            "platform": "test_platform",
+            "http_headers": {
+                "Authorization": "Bearer test-token",
+                "X-Custom-Header": "custom-value",
+            },
+        }
+        ctx = PipelineContext(run_id="test")
+        source = JsonSchemaSource.create(config, ctx)
+
+        assert source.config.http_headers == {
+            "Authorization": "Bearer test-token",
+            "X-Custom-Header": "custom-value",
+        }
+
+    def test_config_defaults_to_none(self, tmp_path: Path) -> None:
+        schema = {"type": "object", "$id": "test-schema"}
+        schema_file = tmp_path / "test.json"
+        schema_file.write_text(json.dumps(schema))
+
+        from datahub.ingestion.api.common import PipelineContext
+
+        config = {
+            "path": str(tmp_path),
+            "platform": "test_platform",
+        }
+        ctx = PipelineContext(run_id="test")
+        source = JsonSchemaSource.create(config, ctx)
+
+        assert source.config.http_headers is None


### PR DESCRIPTION
## Summary

Add an `http_headers` config field to the `json-schema` ingestion source, allowing custom HTTP headers to be passed when resolving remote `$ref` URIs. This enables ingestion from schema registries behind authentication (e.g. CloudFront with Lambda@Edge auth).

## Motivation

Organizations using CloudFront or similar CDNs with authentication in front of their schema registries cannot resolve `$ref` references during ingestion — the default `jsonref` loader makes unauthenticated HTTP requests that get rejected (403).

## Changes

- New config field: `http_headers: Optional[Dict[str, str]]`
- New `_jsonloader_with_headers()` static method — replaces `jsonref.jsonloader` with auth-aware HTTP fetching
- Updated `stringreplaceloader()` to accept and forward headers
- Both the default loader path and the URI-replace loader path now support headers
- No breaking changes — new optional field defaults to `None` (existing behavior unchanged)

## Example

```yaml
source:
  type: json-schema
  config:
    path: /schemas
    platform: schemaregistry
    http_headers:
      Authorization: "Bearer ${SCHEMA_AUTH_TOKEN}"
```

## Tests
8 new unit tests covering:

- Headers passed to requests.get() for HTTP URIs
- Empty headers when config is None
- HTTP error propagation (e.g. 403)
- File URIs bypass HTTP (no headers needed)
- stringreplaceloader passes headers through after URI rewrite
- Config field acceptance and default behavior

## Checklist
- PR conforms to the Contributing Guideline
- Tests added
- No breaking changes — new optional config field with None default