### PR TITLE
fix(SQL Parsing): Added new parsing functions for object construction

### DIFF
--- a/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
@@ -1317,10 +1317,7 @@ def _collect_source_cte_chain(
     )
     if not cte_select:
         return
-    from_clause = cte_select.find(sqlglot.exp.From)
-    if not from_clause:
-        return
-    for src_table in from_clause.find_all(sqlglot.exp.Table):
+    for src_table in cte_select.find_all(sqlglot.exp.Table):
         _collect_source_cte_chain(src_table.name.upper(), cte_map, visited)
 
 
@@ -1348,8 +1345,7 @@ def _collect_object_construct_source_aliases(
     }
 
     # Find CTEs that contain OBJECT_CONSTRUCT(*) and collect their full upstream CTE
-    # chain.  find_all on the FROM clause captures all joined sources, not just the
-    # first table.
+    # chain. find_all on the Select captures all tables including JOINed sources.
     source_cte_names: Set[str] = set()
     for cte in statement.find_all(sqlglot.exp.CTE):
         if not cte.find(sqlglot.exp.StarMap):
@@ -1361,10 +1357,7 @@ def _collect_object_construct_source_aliases(
         )
         if not cte_select:
             continue
-        from_clause = cte_select.find(sqlglot.exp.From)
-        if not from_clause:
-            continue
-        for source_table in from_clause.find_all(sqlglot.exp.Table):
+        for source_table in cte_select.find_all(sqlglot.exp.Table):
             _collect_source_cte_chain(
                 source_table.name.upper(), cte_map, source_cte_names
             )
@@ -1509,8 +1502,14 @@ def _get_direct_raw_col_upstreams(
 
     # Build a child→parent map so we can look up what key is accessed on each column
     # when the column comes from OBJECT_CONSTRUCT(*) / StarMap.
+    # StarMap only appears in Snowflake-dialect ASTs (OBJECT_CONSTRUCT(*)), so skip
+    # this traversal for all other dialects.
     parents: Dict[int, sqlglot.lineage.Node] = {}
-    if table_name_schema_mapping:
+    if (
+        table_name_schema_mapping
+        and dialect is not None
+        and is_dialect_instance(dialect, "snowflake")
+    ):
 
         def _build_parents(root: sqlglot.lineage.Node) -> None:
             stack: List[Tuple[sqlglot.lineage.Node, Optional[sqlglot.lineage.Node]]] = [

--- a/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
@@ -1027,6 +1027,7 @@ def _select_statement_cll(
     table_name_schema_mapping: Dict[_TableName, SchemaInfo],
     default_db: Optional[str] = None,
     default_schema: Optional[str] = None,
+    object_construct_col_aliases: Optional[Dict[str, str]] = None,
 ) -> List[_ColumnLineageInfo]:
     column_lineage: List[_ColumnLineageInfo] = []
 
@@ -1076,6 +1077,8 @@ def _select_statement_cll(
                     dialect,
                     default_db,
                     default_schema,
+                    table_name_schema_mapping=table_name_schema_mapping,
+                    object_construct_col_aliases=object_construct_col_aliases,
                 )
             except Exception as e:
                 logger.warning(
@@ -1160,6 +1163,11 @@ def _column_level_lineage(
 
     try:
         assert select_statement is not None
+        # Collect CTE column alias mappings before optimization eliminates aliased
+        # columns that are only referenced via OBJECT_CONSTRUCT(*).
+        object_construct_col_aliases = _collect_object_construct_source_aliases(
+            select_statement
+        )
         (select_statement, column_resolver) = _prepare_query_columns(
             select_statement,
             dialect=dialect,
@@ -1215,6 +1223,7 @@ def _column_level_lineage(
         table_name_schema_mapping=table_name_schema_mapping,
         default_db=default_db,
         default_schema=default_schema,
+        object_construct_col_aliases=object_construct_col_aliases,
     )
 
     joins: Optional[List[_JoinInfo]] = None
@@ -1234,20 +1243,206 @@ def _column_level_lineage(
     )
 
 
+def _extract_json_path_keys(
+    expression: sqlglot.exp.Expr,
+    ref_table: str,
+    ref_column: str,
+) -> Set[str]:
+    """Find all JSON path keys accessed on ref_table.ref_column in an expression.
+
+    Matches patterns produced when Snowflake's col:KEY::TYPE semi-structured access
+    is parsed: JSONExtract(Bracket(Column(table=ref_table, this=ref_column), idx), JSONPath([..., JSONPathKey(KEY)])).
+    Returns the set of KEY strings (e.g. {'FIELD_A', 'FIELD_B'}).
+    """
+    keys: Set[str] = set()
+    for json_extract in expression.find_all(sqlglot.exp.JSONExtract):
+        obj = json_extract.this
+        # Unwrap bracket index access: col[0] → col
+        if isinstance(obj, sqlglot.exp.Bracket):
+            obj = obj.this
+        if isinstance(obj, sqlglot.exp.Column):
+            if (
+                obj.table.upper() == ref_table.upper()
+                and obj.name.upper() == ref_column.upper()
+            ):
+                path = json_extract.args.get("expression")
+                if isinstance(path, sqlglot.exp.JSONPath):
+                    for part in path.expressions:
+                        if isinstance(part, sqlglot.exp.JSONPathKey):
+                            keys.add(str(part.this))
+    return keys
+
+
+def _collect_object_construct_source_aliases(
+    statement: sqlglot.exp.Expression,
+) -> Dict[str, str]:
+    """Build alias→original column name map for CTEs that feed OBJECT_CONSTRUCT(*).
+
+    When OBJECT_CONSTRUCT(*) captures all columns in scope, the resulting JSON object
+    keys match the CTE column names — which may be aliases of the underlying base table
+    columns. pushdown_projections eliminates aliased columns that are not referenced
+    elsewhere, so the lineage tree loses the alias→original mapping. This function
+    extracts that mapping from the pre-optimization AST.
+
+    Returns {alias_name.upper(): original_col_name.upper()} for all aliased columns
+    in CTEs that directly feed a CTE containing OBJECT_CONSTRUCT(*).
+    """
+    # Find CTEs that contain OBJECT_CONSTRUCT(*) and note what they select FROM.
+    source_cte_names: Set[str] = set()
+    for cte in statement.find_all(sqlglot.exp.CTE):
+        if not cte.find(sqlglot.exp.StarMap):
+            continue
+        cte_select = (
+            cte.this
+            if isinstance(cte.this, sqlglot.exp.Select)
+            else cte.find(sqlglot.exp.Select)
+        )
+        if not cte_select:
+            continue
+        from_clause = cte_select.find(sqlglot.exp.From)
+        if not from_clause:
+            continue
+        source_table = from_clause.find(sqlglot.exp.Table)
+        if source_table:
+            source_cte_names.add(source_table.name.upper())
+
+    if not source_cte_names:
+        return {}
+
+    # For each source CTE, collect columns that are renamed (alias ≠ original name).
+    result: Dict[str, str] = {}
+    for cte in statement.find_all(sqlglot.exp.CTE):
+        if cte.alias.upper() not in source_cte_names:
+            continue
+        cte_select = (
+            cte.this
+            if isinstance(cte.this, sqlglot.exp.Select)
+            else cte.find(sqlglot.exp.Select)
+        )
+        if not cte_select:
+            continue
+        for sel_expr in cte_select.expressions:
+            if not isinstance(sel_expr, sqlglot.exp.Alias):
+                continue
+            alias_name = sel_expr.alias.upper()
+            inner = sel_expr.this
+            if isinstance(inner, sqlglot.exp.Column):
+                original_name = inner.name.upper()
+                if alias_name != original_name:
+                    result[alias_name] = original_name
+
+    return result
+
+
+def _get_star_map_col_upstreams(
+    star_map_node: sqlglot.lineage.Node,
+    parent_node: sqlglot.lineage.Node,
+    dialect: Optional[sqlglot.Dialect],
+    table_name_schema_mapping: Dict[_TableName, SchemaInfo],
+    object_construct_col_aliases: Optional[Dict[str, str]] = None,
+) -> Set[_ColumnRef]:
+    """Resolve column upstreams for a lineage node that contains OBJECT_CONSTRUCT(*).
+
+    When OBJECT_CONSTRUCT(*) feeds a JSON path access (e.g. col:KEY::TYPE, translated
+    to JSONExtract(col, '$.KEY')), the specific key maps deterministically to a column
+    of the same name in the source tables. This function:
+      1. Extracts which key(s) the parent accesses on this column.
+      2. Collects the real (non-CTE) Table leaf nodes already in the lineage subtree —
+         these already represent fully-traced source tables.
+      3. For each (key, table) pair, checks whether table_name_schema_mapping has a
+         matching column. If the key is a CTE alias (e.g. cost_structure aliasing
+         cost_structure_type), object_construct_col_aliases provides the original name.
+    """
+    if parent_node.expression is None:
+        return set()
+
+    parts = star_map_node.name.split(".")
+    if len(parts) < 2:
+        return set()
+    ref_table = parts[-2].strip('"')
+    ref_column = parts[-1].strip('"')
+
+    keys = _extract_json_path_keys(parent_node.expression, ref_table, ref_column)
+    if not keys:
+        return set()
+
+    # Gather Table leaf nodes already resolved in this subtree — they represent
+    # real base tables that CTEs in the StarMap source trace back to.
+    leaf_table_refs: Set[_TableName] = set()
+    for desc in star_map_node.walk():
+        if not desc.downstream and isinstance(desc.expression, sqlglot.exp.Table):
+            leaf_table_refs.add(
+                _table_name_from_sqlglot_table(desc.expression, dialect)
+            )
+
+    upstreams: Set[_ColumnRef] = set()
+    for key in keys:
+        # Try the key directly, then fall back to its pre-alias original name if available.
+        candidates = [key]
+        if object_construct_col_aliases:
+            original = object_construct_col_aliases.get(key.upper())
+            if original:
+                candidates.append(original)
+        for candidate in candidates:
+            for unqualified_ref in leaf_table_refs:
+                for qualified_name, schema in table_name_schema_mapping.items():
+                    if qualified_name.table.lower() == unqualified_ref.table.lower():
+                        for col_name in schema:
+                            if col_name.lower() == candidate.lower():
+                                upstreams.add(
+                                    _ColumnRef(table=unqualified_ref, column=col_name)
+                                )
+    return upstreams
+
+
 def _get_direct_raw_col_upstreams(
     lineage_node: sqlglot.lineage.Node,
     dialect: Optional[sqlglot.Dialect] = None,
     default_db: Optional[str] = None,
     default_schema: Optional[str] = None,
+    table_name_schema_mapping: Optional[Dict[_TableName, SchemaInfo]] = None,
+    object_construct_col_aliases: Optional[Dict[str, str]] = None,
 ) -> OrderedSet[_ColumnRef]:
     # Using an OrderedSet here to deduplicate upstreams while preserving "discovery" order.
     direct_raw_col_upstreams: OrderedSet[_ColumnRef] = OrderedSet()
 
+    # Build a child→parent map so we can look up what key is accessed on each column
+    # when the column comes from OBJECT_CONSTRUCT(*) / StarMap.
+    parents: Dict[int, sqlglot.lineage.Node] = {}
+    if table_name_schema_mapping:
+
+        def _build_parents(
+            node: sqlglot.lineage.Node,
+            parent: Optional[sqlglot.lineage.Node] = None,
+        ) -> None:
+            if parent is not None:
+                parents[id(node)] = parent
+            for child in node.downstream:
+                _build_parents(child, node)
+
+        _build_parents(lineage_node)
+
     for node in lineage_node.walk():
         cooperate()
         if node.downstream:
-            # We only want the leaf nodes.
-            pass
+            # Non-leaf: check whether the expression contains OBJECT_CONSTRUCT(*).
+            # When OBJECT_CONSTRUCT(*) is combined with a parent JSON path access
+            # (e.g. col:KEY) we can resolve the key as a concrete column upstream.
+            if (
+                table_name_schema_mapping
+                and node.expression is not None
+                and node.expression.find(sqlglot.exp.StarMap)
+            ):
+                parent = parents.get(id(node))
+                if parent is not None:
+                    star_map_upstreams = _get_star_map_col_upstreams(
+                        node,
+                        parent,
+                        dialect,
+                        table_name_schema_mapping,
+                        object_construct_col_aliases=object_construct_col_aliases,
+                    )
+                    direct_raw_col_upstreams.update(star_map_upstreams)
 
         elif isinstance(node.expression, sqlglot.exp.Table):
             table_ref = _table_name_from_sqlglot_table(node.expression, dialect)

--- a/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
@@ -1408,6 +1408,29 @@ def _collect_object_construct_source_aliases(
     return result
 
 
+def _table_name_matches(
+    qualified_name: _TableName, unqualified_ref: _TableName
+) -> bool:
+    """Match a possibly-unqualified leaf ref against a qualified schema-mapping key.
+
+    Leaf nodes from sqlglot lineage may not carry db/schema (both None). When a
+    component IS present in unqualified_ref it must agree with qualified_name
+    (case-insensitive). This avoids false-positive matches when two tables share
+    the same name across different databases or schemas.
+    """
+    if qualified_name.table.lower() != unqualified_ref.table.lower():
+        return False
+    if unqualified_ref.db_schema is not None:
+        if (
+            qualified_name.db_schema or ""
+        ).lower() != unqualified_ref.db_schema.lower():
+            return False
+    if unqualified_ref.database is not None:
+        if (qualified_name.database or "").lower() != unqualified_ref.database.lower():
+            return False
+    return True
+
+
 def _get_star_map_col_upstreams(
     star_map_node: sqlglot.lineage.Node,
     parent_node: sqlglot.lineage.Node,
@@ -1464,7 +1487,7 @@ def _get_star_map_col_upstreams(
         for candidate in candidates:
             for unqualified_ref in leaf_table_refs:
                 for qualified_name, schema in table_name_schema_mapping.items():
-                    if qualified_name.table.lower() == unqualified_ref.table.lower():
+                    if _table_name_matches(qualified_name, unqualified_ref):
                         for col_name in schema:
                             if col_name.lower() == candidate.lower():
                                 upstreams.add(

--- a/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
@@ -1028,6 +1028,7 @@ def _select_statement_cll(
     default_db: Optional[str] = None,
     default_schema: Optional[str] = None,
     object_construct_col_aliases: Optional[Dict[str, List[str]]] = None,
+    object_construct_base_tables: Optional[Set[str]] = None,
 ) -> List[_ColumnLineageInfo]:
     column_lineage: List[_ColumnLineageInfo] = []
 
@@ -1079,6 +1080,7 @@ def _select_statement_cll(
                     default_schema,
                     table_name_schema_mapping=table_name_schema_mapping,
                     object_construct_col_aliases=object_construct_col_aliases,
+                    object_construct_base_tables=object_construct_base_tables,
                 )
             except Exception as e:
                 logger.warning(
@@ -1163,14 +1165,17 @@ def _column_level_lineage(
 
     try:
         assert select_statement is not None
-        # Collect CTE column alias mappings before optimization eliminates aliased
-        # columns that are only referenced via OBJECT_CONSTRUCT(*).
+        # Collect CTE column alias mappings and base table names before optimization
+        # eliminates aliased columns that are only referenced via OBJECT_CONSTRUCT(*).
         # OBJECT_CONSTRUCT is Snowflake-specific syntax.
-        object_construct_col_aliases = (
-            _collect_object_construct_source_aliases(select_statement)
-            if is_dialect_instance(dialect, "snowflake")
-            else None
-        )
+        if is_dialect_instance(dialect, "snowflake"):
+            (
+                object_construct_col_aliases,
+                object_construct_base_tables,
+            ) = _collect_object_construct_source_aliases(select_statement)
+        else:
+            object_construct_col_aliases = None
+            object_construct_base_tables = None
         (select_statement, column_resolver) = _prepare_query_columns(
             select_statement,
             dialect=dialect,
@@ -1227,6 +1232,7 @@ def _column_level_lineage(
         default_db=default_db,
         default_schema=default_schema,
         object_construct_col_aliases=object_construct_col_aliases,
+        object_construct_base_tables=object_construct_base_tables,
     )
 
     joins: Optional[List[_JoinInfo]] = None
@@ -1258,6 +1264,12 @@ def _extract_json_path_keys(
     - GET(col[idx], 'KEY') → GetExtract(Bracket(Column(...), idx), Literal('KEY'))
 
     Returns the set of KEY strings (e.g. {'FIELD_A', 'FIELD_B'}).
+
+    The table qualifier is NOT checked: an intermediate CTE may rename the qualifier
+    (e.g. the StarMap node is SCO_FLAT.AVP but the ancestor expression references
+    INNER_Q.AVP after passing through a pass-through CTE). The column name alone is
+    a sufficient identifier because we are already operating within the specific
+    lineage subtree for a given output column.
     """
     keys: Set[str] = set()
 
@@ -1267,10 +1279,7 @@ def _extract_json_path_keys(
         if isinstance(obj, sqlglot.exp.Bracket):
             obj = obj.this
         if isinstance(obj, sqlglot.exp.Column):
-            if (
-                obj.table.upper() == ref_table.upper()
-                and obj.name.upper() == ref_column.upper()
-            ):
+            if obj.name.upper() == ref_column.upper():
                 path = json_extract.args.get("expression")
                 if isinstance(path, sqlglot.exp.JSONPath):
                     for part in path.expressions:
@@ -1283,10 +1292,7 @@ def _extract_json_path_keys(
         if isinstance(obj, sqlglot.exp.Bracket):
             obj = obj.this
         if isinstance(obj, sqlglot.exp.Column):
-            if (
-                obj.table.upper() == ref_table.upper()
-                and obj.name.upper() == ref_column.upper()
-            ):
+            if obj.name.upper() == ref_column.upper():
                 key_expr = get_extract.expression
                 if isinstance(key_expr, sqlglot.exp.Literal) and key_expr.is_string:
                     keys.add(str(key_expr.this))
@@ -1298,6 +1304,7 @@ def _collect_source_cte_chain(
     cte_name: str,
     cte_map: Dict[str, sqlglot.exp.CTE],
     visited: Set[str],
+    base_tables: Optional[Set[str]] = None,
 ) -> None:
     """Recursively add cte_name and all its CTE sources to visited.
 
@@ -1305,8 +1312,15 @@ def _collect_source_cte_chain(
     away from an OBJECT_CONSTRUCT(*) CTE are still captured (e.g. cte1 defines the
     alias, cte2 passes through with SELECT *, cte3 uses OBJECT_CONSTRUCT(*)).
     Stops at CTEs not in cte_map (i.e. real base tables).
+
+    When base_tables is provided, non-CTE source table names are added to it
+    (lowercased) so callers can identify the real base tables in the chain.
     """
-    if cte_name in visited or cte_name not in cte_map:
+    if cte_name in visited:
+        return
+    if cte_name not in cte_map:
+        if base_tables is not None:
+            base_tables.add(cte_name.lower())
         return
     visited.add(cte_name)
     cte = cte_map[cte_name]
@@ -1318,13 +1332,13 @@ def _collect_source_cte_chain(
     if not cte_select:
         return
     for src_table in cte_select.find_all(sqlglot.exp.Table):
-        _collect_source_cte_chain(src_table.name.upper(), cte_map, visited)
+        _collect_source_cte_chain(src_table.name.upper(), cte_map, visited, base_tables)
 
 
 def _collect_object_construct_source_aliases(
     statement: sqlglot.exp.Expression,
-) -> Dict[str, List[str]]:
-    """Build alias→source column names map for CTEs that feed OBJECT_CONSTRUCT(*).
+) -> Tuple[Dict[str, List[str]], Set[str]]:
+    """Build alias→source column names map and base table set for OBJECT_CONSTRUCT(*) CTEs.
 
     When OBJECT_CONSTRUCT(*) captures all columns in scope, the resulting JSON object
     keys match the CTE column names — which may be aliases of the underlying base table
@@ -1332,8 +1346,12 @@ def _collect_object_construct_source_aliases(
     elsewhere, so the lineage tree loses the alias→original mapping. This function
     extracts that mapping from the pre-optimization AST.
 
-    Returns {alias_name.upper(): [source_col.upper(), ...]} for all aliased columns
-    in the full CTE chain feeding any CTE containing OBJECT_CONSTRUCT(*).
+    Returns a tuple of:
+      - {alias_name.upper(): [source_col.upper(), ...]} for all aliased columns in the
+        full CTE chain feeding any CTE containing OBJECT_CONSTRUCT(*).
+      - Set of lowercased base table names (non-CTE sources) in that same chain. These
+        are used as a fallback when the lineage tree emits Placeholder leaves instead of
+        resolved Table nodes (e.g. columns from ARRAY_AGG CASE WHEN conditions).
 
     For simple column renames (col AS alias), the list contains one name.
     For function-expression aliases (to_date(col) AS alias, CONCAT(a, b) AS alias),
@@ -1347,6 +1365,7 @@ def _collect_object_construct_source_aliases(
     # Find CTEs that contain OBJECT_CONSTRUCT(*) and collect their full upstream CTE
     # chain. find_all on the Select captures all tables including JOINed sources.
     source_cte_names: Set[str] = set()
+    base_tables: Set[str] = set()
     for cte in statement.find_all(sqlglot.exp.CTE):
         if not cte.find(sqlglot.exp.StarMap):
             continue
@@ -1359,11 +1378,11 @@ def _collect_object_construct_source_aliases(
             continue
         for source_table in cte_select.find_all(sqlglot.exp.Table):
             _collect_source_cte_chain(
-                source_table.name.upper(), cte_map, source_cte_names
+                source_table.name.upper(), cte_map, source_cte_names, base_tables
             )
 
     if not source_cte_names:
-        return {}
+        return {}, base_tables
 
     # For each CTE in the chain, collect columns that are renamed (alias ≠ original
     # name).  Simple column renames map to one source; function expressions map to all
@@ -1398,7 +1417,7 @@ def _collect_object_construct_source_aliases(
                 if col_names:
                     result[alias_name] = col_names
 
-    return result
+    return result, base_tables
 
 
 def _table_name_matches(
@@ -1430,6 +1449,7 @@ def _get_star_map_col_upstreams(
     dialect: Optional[sqlglot.Dialect],
     table_name_schema_mapping: Dict[_TableName, SchemaInfo],
     object_construct_col_aliases: Optional[Dict[str, List[str]]] = None,
+    source_base_tables: Optional[Set[str]] = None,
 ) -> Set[_ColumnRef]:
     """Resolve column upstreams for a lineage node that contains OBJECT_CONSTRUCT(*).
 
@@ -1442,6 +1462,10 @@ def _get_star_map_col_upstreams(
       3. For each (key, table) pair, checks whether table_name_schema_mapping has a
          matching column. If the key is a CTE alias (e.g. alias_col aliasing
          real_col), object_construct_col_aliases provides the original name.
+
+    When the lineage tree emits Placeholder leaves instead of resolved Table nodes
+    (e.g. columns from ARRAY_AGG CASE WHEN conditions), source_base_tables provides
+    the base table names collected from the pre-optimization CTE chain as a fallback.
     """
     if parent_node.expression is None:
         return set()
@@ -1464,6 +1488,15 @@ def _get_star_map_col_upstreams(
             leaf_table_refs.add(
                 _table_name_from_sqlglot_table(desc.expression, dialect)
             )
+
+    # When ARRAY_AGG CASE WHEN conditions use columns from the source CTE, sqlglot
+    # emits Placeholder leaf nodes instead of resolved Table nodes, so leaf_table_refs
+    # ends up empty. Fall back to the pre-collected base table names from the CTE chain.
+    if not leaf_table_refs and source_base_tables:
+        for table_name in source_base_tables:
+            for qualified_name in table_name_schema_mapping:
+                if qualified_name.table.lower() == table_name:
+                    leaf_table_refs.add(_TableName(table=qualified_name.table))
 
     upstreams: Set[_ColumnRef] = set()
     # O(keys × leaf_tables × schema_entries × cols): acceptable for typical workloads
@@ -1517,6 +1550,7 @@ def _get_direct_raw_col_upstreams(
     default_schema: Optional[str] = None,
     table_name_schema_mapping: Optional[Dict[_TableName, SchemaInfo]] = None,
     object_construct_col_aliases: Optional[Dict[str, List[str]]] = None,
+    object_construct_base_tables: Optional[Set[str]] = None,
 ) -> OrderedSet[_ColumnRef]:
     # Using an OrderedSet here to deduplicate upstreams while preserving "discovery" order.
     direct_raw_col_upstreams: OrderedSet[_ColumnRef] = OrderedSet()
@@ -1546,16 +1580,25 @@ def _get_direct_raw_col_upstreams(
                 # StarMap is only produced by sqlglot for Snowflake-dialect ASTs
                 # (OBJECT_CONSTRUCT(*)), so no explicit dialect guard is needed here.
             ):
-                parent = parents.get(id(node))
-                if parent is not None:
+                # Walk up the ancestor chain until we find a node whose expression
+                # contains the JSON key access. The immediate parent may be a
+                # pass-through CTE alias that has no key access itself (e.g.
+                # "sco_flat.AVP AS AVP"), while the grandparent or higher holds the
+                # actual GET(AVP[0], 'RATE') expression.
+                ancestor = parents.get(id(node))
+                while ancestor is not None:
                     star_map_upstreams = _get_star_map_col_upstreams(
                         node,
-                        parent,
+                        ancestor,
                         dialect,
                         table_name_schema_mapping,
                         object_construct_col_aliases=object_construct_col_aliases,
+                        source_base_tables=object_construct_base_tables,
                     )
-                    direct_raw_col_upstreams.update(star_map_upstreams)
+                    if star_map_upstreams:
+                        direct_raw_col_upstreams.update(star_map_upstreams)
+                        break
+                    ancestor = parents.get(id(ancestor))
 
         elif isinstance(node.expression, sqlglot.exp.Table):
             table_ref = _table_name_from_sqlglot_table(node.expression, dialect)

--- a/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
@@ -1165,8 +1165,11 @@ def _column_level_lineage(
         assert select_statement is not None
         # Collect CTE column alias mappings before optimization eliminates aliased
         # columns that are only referenced via OBJECT_CONSTRUCT(*).
-        object_construct_col_aliases = _collect_object_construct_source_aliases(
-            select_statement
+        # OBJECT_CONSTRUCT is Snowflake-specific syntax.
+        object_construct_col_aliases = (
+            _collect_object_construct_source_aliases(select_statement)
+            if is_dialect_instance(dialect, "snowflake")
+            else None
         )
         (select_statement, column_resolver) = _prepare_query_columns(
             select_statement,
@@ -1250,11 +1253,14 @@ def _extract_json_path_keys(
 ) -> Set[str]:
     """Find all JSON path keys accessed on ref_table.ref_column in an expression.
 
-    Matches patterns produced when Snowflake's col:KEY::TYPE semi-structured access
-    is parsed: JSONExtract(Bracket(Column(table=ref_table, this=ref_column), idx), JSONPath([..., JSONPathKey(KEY)])).
+    Handles two Snowflake semi-structured access forms:
+    - col:KEY::TYPE  → JSONExtract(Bracket(Column(...), idx), JSONPath([JSONPathKey(KEY)]))
+    - GET(col[idx], 'KEY') → GetExtract(Bracket(Column(...), idx), Literal('KEY'))
+
     Returns the set of KEY strings (e.g. {'FIELD_A', 'FIELD_B'}).
     """
     keys: Set[str] = set()
+
     for json_extract in expression.find_all(sqlglot.exp.JSONExtract):
         obj = json_extract.this
         # Unwrap bracket index access: col[0] → col
@@ -1270,6 +1276,21 @@ def _extract_json_path_keys(
                     for part in path.expressions:
                         if isinstance(part, sqlglot.exp.JSONPathKey):
                             keys.add(str(part.this))
+
+    for get_extract in expression.find_all(sqlglot.exp.GetExtract):
+        obj = get_extract.this
+        # Unwrap bracket index access: col[0] → col
+        if isinstance(obj, sqlglot.exp.Bracket):
+            obj = obj.this
+        if isinstance(obj, sqlglot.exp.Column):
+            if (
+                obj.table.upper() == ref_table.upper()
+                and obj.name.upper() == ref_column.upper()
+            ):
+                key_expr = get_extract.expression
+                if isinstance(key_expr, sqlglot.exp.Literal) and key_expr.is_string:
+                    keys.add(str(key_expr.this))
+
     return keys
 
 
@@ -1489,6 +1510,8 @@ def _get_direct_raw_col_upstreams(
                 table_name_schema_mapping
                 and node.expression is not None
                 and node.expression.find(sqlglot.exp.StarMap)
+                # StarMap is only produced by sqlglot for Snowflake-dialect ASTs
+                # (OBJECT_CONSTRUCT(*)), so no explicit dialect guard is needed here.
             ):
                 parent = parents.get(id(node))
                 if parent is not None:

--- a/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
@@ -1489,14 +1489,20 @@ def _get_direct_raw_col_upstreams(
     parents: Dict[int, sqlglot.lineage.Node] = {}
     if table_name_schema_mapping:
 
-        def _build_parents(
-            node: sqlglot.lineage.Node,
-            parent: Optional[sqlglot.lineage.Node] = None,
-        ) -> None:
-            if parent is not None:
-                parents[id(node)] = parent
-            for child in node.downstream:
-                _build_parents(child, node)
+        def _build_parents(root: sqlglot.lineage.Node) -> None:
+            stack: List[Tuple[sqlglot.lineage.Node, Optional[sqlglot.lineage.Node]]] = [
+                (root, None)
+            ]
+            visited: Set[int] = set()
+            while stack:
+                node, parent = stack.pop()
+                if id(node) in visited:
+                    continue
+                visited.add(id(node))
+                if parent is not None:
+                    parents[id(node)] = parent
+                for child in node.downstream:
+                    stack.append((child, node))
 
         _build_parents(lineage_node)
 

--- a/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
@@ -1440,8 +1440,8 @@ def _get_star_map_col_upstreams(
       2. Collects the real (non-CTE) Table leaf nodes already in the lineage subtree —
          these already represent fully-traced source tables.
       3. For each (key, table) pair, checks whether table_name_schema_mapping has a
-         matching column. If the key is a CTE alias (e.g. cost_structure aliasing
-         cost_structure_type), object_construct_col_aliases provides the original name.
+         matching column. If the key is a CTE alias (e.g. alias_col aliasing
+         real_col), object_construct_col_aliases provides the original name.
     """
     if parent_node.expression is None:
         return set()
@@ -1489,6 +1489,27 @@ def _get_star_map_col_upstreams(
     return upstreams
 
 
+def _build_parents(
+    root: sqlglot.lineage.Node,
+    parents: Dict[int, sqlglot.lineage.Node],
+) -> None:
+    """Populate a child-id → parent map by iteratively traversing the lineage tree."""
+    stack: List[Tuple[sqlglot.lineage.Node, Optional[sqlglot.lineage.Node]]] = [
+        (root, None)
+    ]
+    visited: Set[int] = set()
+    while stack:
+        cooperate()
+        node, parent = stack.pop()
+        if id(node) in visited:
+            continue
+        visited.add(id(node))
+        if parent is not None:
+            parents[id(node)] = parent
+        for child in node.downstream:
+            stack.append((child, node))
+
+
 def _get_direct_raw_col_upstreams(
     lineage_node: sqlglot.lineage.Node,
     dialect: Optional[sqlglot.Dialect] = None,
@@ -1510,23 +1531,7 @@ def _get_direct_raw_col_upstreams(
         and dialect is not None
         and is_dialect_instance(dialect, "snowflake")
     ):
-
-        def _build_parents(root: sqlglot.lineage.Node) -> None:
-            stack: List[Tuple[sqlglot.lineage.Node, Optional[sqlglot.lineage.Node]]] = [
-                (root, None)
-            ]
-            visited: Set[int] = set()
-            while stack:
-                node, parent = stack.pop()
-                if id(node) in visited:
-                    continue
-                visited.add(id(node))
-                if parent is not None:
-                    parents[id(node)] = parent
-                for child in node.downstream:
-                    stack.append((child, node))
-
-        _build_parents(lineage_node)
+        _build_parents(lineage_node, parents)
 
     for node in lineage_node.walk():
         cooperate()

--- a/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
@@ -1027,7 +1027,7 @@ def _select_statement_cll(
     table_name_schema_mapping: Dict[_TableName, SchemaInfo],
     default_db: Optional[str] = None,
     default_schema: Optional[str] = None,
-    object_construct_col_aliases: Optional[Dict[str, str]] = None,
+    object_construct_col_aliases: Optional[Dict[str, List[str]]] = None,
 ) -> List[_ColumnLineageInfo]:
     column_lineage: List[_ColumnLineageInfo] = []
 
@@ -1273,10 +1273,40 @@ def _extract_json_path_keys(
     return keys
 
 
+def _collect_source_cte_chain(
+    cte_name: str,
+    cte_map: Dict[str, sqlglot.exp.CTE],
+    visited: Set[str],
+) -> None:
+    """Recursively add cte_name and all its CTE sources to visited.
+
+    Follows the full upstream chain so that aliases defined in CTEs several hops
+    away from an OBJECT_CONSTRUCT(*) CTE are still captured (e.g. cte1 defines the
+    alias, cte2 passes through with SELECT *, cte3 uses OBJECT_CONSTRUCT(*)).
+    Stops at CTEs not in cte_map (i.e. real base tables).
+    """
+    if cte_name in visited or cte_name not in cte_map:
+        return
+    visited.add(cte_name)
+    cte = cte_map[cte_name]
+    cte_select = (
+        cte.this
+        if isinstance(cte.this, sqlglot.exp.Select)
+        else cte.find(sqlglot.exp.Select)
+    )
+    if not cte_select:
+        return
+    from_clause = cte_select.find(sqlglot.exp.From)
+    if not from_clause:
+        return
+    for src_table in from_clause.find_all(sqlglot.exp.Table):
+        _collect_source_cte_chain(src_table.name.upper(), cte_map, visited)
+
+
 def _collect_object_construct_source_aliases(
     statement: sqlglot.exp.Expression,
-) -> Dict[str, str]:
-    """Build alias→original column name map for CTEs that feed OBJECT_CONSTRUCT(*).
+) -> Dict[str, List[str]]:
+    """Build alias→source column names map for CTEs that feed OBJECT_CONSTRUCT(*).
 
     When OBJECT_CONSTRUCT(*) captures all columns in scope, the resulting JSON object
     keys match the CTE column names — which may be aliases of the underlying base table
@@ -1284,10 +1314,21 @@ def _collect_object_construct_source_aliases(
     elsewhere, so the lineage tree loses the alias→original mapping. This function
     extracts that mapping from the pre-optimization AST.
 
-    Returns {alias_name.upper(): original_col_name.upper()} for all aliased columns
-    in CTEs that directly feed a CTE containing OBJECT_CONSTRUCT(*).
+    Returns {alias_name.upper(): [source_col.upper(), ...]} for all aliased columns
+    in the full CTE chain feeding any CTE containing OBJECT_CONSTRUCT(*).
+
+    For simple column renames (col AS alias), the list contains one name.
+    For function-expression aliases (to_date(col) AS alias, CONCAT(a, b) AS alias),
+    the list contains all Column leaf nodes referenced inside the function.
     """
-    # Find CTEs that contain OBJECT_CONSTRUCT(*) and note what they select FROM.
+    # Build a CTE name -> node map for O(1) lookup during chain traversal.
+    cte_map: Dict[str, sqlglot.exp.CTE] = {
+        cte.alias.upper(): cte for cte in statement.find_all(sqlglot.exp.CTE)
+    }
+
+    # Find CTEs that contain OBJECT_CONSTRUCT(*) and collect their full upstream CTE
+    # chain.  find_all on the FROM clause captures all joined sources, not just the
+    # first table.
     source_cte_names: Set[str] = set()
     for cte in statement.find_all(sqlglot.exp.CTE):
         if not cte.find(sqlglot.exp.StarMap):
@@ -1302,15 +1343,18 @@ def _collect_object_construct_source_aliases(
         from_clause = cte_select.find(sqlglot.exp.From)
         if not from_clause:
             continue
-        source_table = from_clause.find(sqlglot.exp.Table)
-        if source_table:
-            source_cte_names.add(source_table.name.upper())
+        for source_table in from_clause.find_all(sqlglot.exp.Table):
+            _collect_source_cte_chain(
+                source_table.name.upper(), cte_map, source_cte_names
+            )
 
     if not source_cte_names:
         return {}
 
-    # For each source CTE, collect columns that are renamed (alias ≠ original name).
-    result: Dict[str, str] = {}
+    # For each CTE in the chain, collect columns that are renamed (alias ≠ original
+    # name).  Simple column renames map to one source; function expressions map to all
+    # Column leaf nodes referenced inside them.
+    result: Dict[str, List[str]] = {}
     for cte in statement.find_all(sqlglot.exp.CTE):
         if cte.alias.upper() not in source_cte_names:
             continue
@@ -1329,7 +1373,16 @@ def _collect_object_construct_source_aliases(
             if isinstance(inner, sqlglot.exp.Column):
                 original_name = inner.name.upper()
                 if alias_name != original_name:
-                    result[alias_name] = original_name
+                    result[alias_name] = [original_name]
+            else:
+                # Function or complex expression: gather every Column leaf referenced.
+                col_names = [
+                    col.name.upper()
+                    for col in inner.find_all(sqlglot.exp.Column)
+                    if col.name
+                ]
+                if col_names:
+                    result[alias_name] = col_names
 
     return result
 
@@ -1339,7 +1392,7 @@ def _get_star_map_col_upstreams(
     parent_node: sqlglot.lineage.Node,
     dialect: Optional[sqlglot.Dialect],
     table_name_schema_mapping: Dict[_TableName, SchemaInfo],
-    object_construct_col_aliases: Optional[Dict[str, str]] = None,
+    object_construct_col_aliases: Optional[Dict[str, List[str]]] = None,
 ) -> Set[_ColumnRef]:
     """Resolve column upstreams for a lineage node that contains OBJECT_CONSTRUCT(*).
 
@@ -1376,13 +1429,17 @@ def _get_star_map_col_upstreams(
             )
 
     upstreams: Set[_ColumnRef] = set()
+    # O(keys × leaf_tables × schema_entries × cols): acceptable for typical workloads
+    # where keys is small (one JSON path access per column) and schemas are bounded.
+    # If this becomes a bottleneck, pre-build an inverted col→table index from
+    # table_name_schema_mapping.
     for key in keys:
         # Try the key directly, then fall back to its pre-alias original name if available.
         candidates = [key]
         if object_construct_col_aliases:
-            original = object_construct_col_aliases.get(key.upper())
-            if original:
-                candidates.append(original)
+            originals = object_construct_col_aliases.get(key.upper())
+            if originals:
+                candidates.extend(originals)
         for candidate in candidates:
             for unqualified_ref in leaf_table_refs:
                 for qualified_name, schema in table_name_schema_mapping.items():
@@ -1401,7 +1458,7 @@ def _get_direct_raw_col_upstreams(
     default_db: Optional[str] = None,
     default_schema: Optional[str] = None,
     table_name_schema_mapping: Optional[Dict[_TableName, SchemaInfo]] = None,
-    object_construct_col_aliases: Optional[Dict[str, str]] = None,
+    object_construct_col_aliases: Optional[Dict[str, List[str]]] = None,
 ) -> OrderedSet[_ColumnRef]:
     # Using an OrderedSet here to deduplicate upstreams while preserving "discovery" order.
     direct_raw_col_upstreams: OrderedSet[_ColumnRef] = OrderedSet()

--- a/metadata-ingestion/tests/unit/sql_parsing/goldens/test_bigquery_unaffected_by_object_construct_path.json
+++ b/metadata-ingestion/tests/unit/sql_parsing/goldens/test_bigquery_unaffected_by_object_construct_path.json
@@ -1,0 +1,60 @@
+{
+    "query_type": "SELECT",
+    "query_type_props": {},
+    "query_fingerprint": "07a1280a688fa3f0ff6e97149fec15fc041a39d6ac8f659272b33557b5c2abfb",
+    "in_tables": [
+        "urn:li:dataset:(urn:li:dataPlatform:bigquery,myproject.mydataset.src_table,PROD)"
+    ],
+    "out_tables": [],
+    "column_lineage": [
+        {
+            "downstream": {
+                "table": null,
+                "column": "col_a",
+                "column_type": {
+                    "type": {
+                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                    }
+                },
+                "native_column_type": "STRING"
+            },
+            "upstreams": [
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:bigquery,myproject.mydataset.src_table,PROD)",
+                    "column": "col_a"
+                }
+            ],
+            "logic": {
+                "is_direct_copy": true,
+                "column_logic": "`t`.`col_a` AS `col_a`"
+            }
+        },
+        {
+            "downstream": {
+                "table": null,
+                "column": "col_b",
+                "column_type": {
+                    "type": {
+                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                    }
+                },
+                "native_column_type": "STRING"
+            },
+            "upstreams": [
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:bigquery,myproject.mydataset.src_table,PROD)",
+                    "column": "col_b"
+                }
+            ],
+            "logic": {
+                "is_direct_copy": true,
+                "column_logic": "`t`.`col_b` AS `col_b`"
+            }
+        }
+    ],
+    "joins": [],
+    "debug_info": {
+        "confidence": 0.9,
+        "generalized_statement": "SELECT t.col_a, t.col_b FROM `myproject.mydataset.src_table` AS t"
+    }
+}

--- a/metadata-ingestion/tests/unit/sql_parsing/goldens/test_snowflake_object_construct_cross_schema_isolation.json
+++ b/metadata-ingestion/tests/unit/sql_parsing/goldens/test_snowflake_object_construct_cross_schema_isolation.json
@@ -1,0 +1,42 @@
+{
+    "query_type": "SELECT",
+    "query_type_props": {},
+    "query_fingerprint": "30de73ef9615991d49086d4a2087986741b728a27ce5c9d365ac3243a7ace50e",
+    "in_tables": [
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_table,PROD)"
+    ],
+    "out_tables": [],
+    "column_lineage": [
+        {
+            "downstream": {
+                "table": null,
+                "column": "output_col",
+                "column_type": {
+                    "type": {
+                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                    }
+                },
+                "native_column_type": "VARCHAR"
+            },
+            "upstreams": [
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_table,PROD)",
+                    "column": "shared_col"
+                },
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_table,PROD)",
+                    "column": "type_col"
+                }
+            ],
+            "logic": {
+                "is_direct_copy": false,
+                "column_logic": "CAST(GET_PATH(\"CTE_AGG\".\"OBJ\"[0], 'SHARED_COL') AS VARCHAR) AS \"OUTPUT_COL\""
+            }
+        }
+    ],
+    "joins": [],
+    "debug_info": {
+        "confidence": 0.9,
+        "generalized_statement": "WITH cte_src AS (SELECT shared_col, type_col FROM mydb.myschema.src_table), cte_agg AS (SELECT ARRAY_AGG(CASE WHEN type_col = ? THEN OBJECT_CONSTRUCT(*) END) AS obj FROM cte_src) SELECT CAST(GET_PATH(cte_agg.obj[?], 'SHARED_COL') AS VARCHAR) AS output_col FROM cte_agg"
+    }
+}

--- a/metadata-ingestion/tests/unit/sql_parsing/goldens/test_snowflake_object_construct_function_alias_lineage.json
+++ b/metadata-ingestion/tests/unit/sql_parsing/goldens/test_snowflake_object_construct_function_alias_lineage.json
@@ -1,0 +1,64 @@
+{
+    "query_type": "SELECT",
+    "query_type_props": {},
+    "query_fingerprint": "6f2cd466b65c5fc8beee55ca74e2bdfcef63f755755257905396551551e8f596",
+    "in_tables": [
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.base_table,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.other_table,PROD)"
+    ],
+    "out_tables": [],
+    "column_lineage": [
+        {
+            "downstream": {
+                "table": null,
+                "column": "output_col",
+                "column_type": {
+                    "type": {
+                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                    }
+                },
+                "native_column_type": "VARCHAR"
+            },
+            "upstreams": [
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.base_table,PROD)",
+                    "column": "filter_col"
+                },
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.base_table,PROD)",
+                    "column": "raw_col"
+                }
+            ],
+            "logic": {
+                "is_direct_copy": false,
+                "column_logic": "CAST(GET_PATH(\"AGG\".\"OBJ\"[0], 'DATE_COL') AS VARCHAR) AS \"OUTPUT_COL\""
+            }
+        }
+    ],
+    "joins": [
+        {
+            "join_type": "LEFT JOIN",
+            "left_tables": [
+                "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.other_table,PROD)"
+            ],
+            "right_tables": [
+                "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.base_table,PROD)"
+            ],
+            "on_clause": "\"AGG\".\"FILTER_COL\" = \"T\".\"ID\"",
+            "columns_involved": [
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.base_table,PROD)",
+                    "column": "FILTER_COL"
+                },
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.other_table,PROD)",
+                    "column": "ID"
+                }
+            ]
+        }
+    ],
+    "debug_info": {
+        "confidence": 0.9,
+        "generalized_statement": "WITH src AS (SELECT TO_DATE(raw_col) AS date_col, filter_col FROM mydb.myschema.base_table), agg AS (SELECT ARRAY_AGG(CASE WHEN filter_col = ? THEN OBJECT_CONSTRUCT(*) END) AS obj FROM src) SELECT CAST(GET_PATH(agg.obj[?], 'DATE_COL') AS VARCHAR) AS output_col FROM mydb.myschema.other_table AS t LEFT JOIN agg ON agg.filter_col = t.id"
+    }
+}

--- a/metadata-ingestion/tests/unit/sql_parsing/goldens/test_snowflake_object_construct_function_alias_lineage.json
+++ b/metadata-ingestion/tests/unit/sql_parsing/goldens/test_snowflake_object_construct_function_alias_lineage.json
@@ -1,7 +1,7 @@
 {
     "query_type": "SELECT",
     "query_type_props": {},
-    "query_fingerprint": "6f2cd466b65c5fc8beee55ca74e2bdfcef63f755755257905396551551e8f596",
+    "query_fingerprint": "3fd57022eeee86c56788f58e76b06c4faa7a419ab077be4b6c311e140b8f1c78",
     "in_tables": [
         "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.base_table,PROD)",
         "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.other_table,PROD)"
@@ -37,28 +37,19 @@
     ],
     "joins": [
         {
-            "join_type": "LEFT JOIN",
+            "join_type": "CROSS JOIN",
             "left_tables": [
                 "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.other_table,PROD)"
             ],
             "right_tables": [
                 "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.base_table,PROD)"
             ],
-            "on_clause": "\"AGG\".\"FILTER_COL\" = \"T\".\"ID\"",
-            "columns_involved": [
-                {
-                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.base_table,PROD)",
-                    "column": "FILTER_COL"
-                },
-                {
-                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.other_table,PROD)",
-                    "column": "ID"
-                }
-            ]
+            "on_clause": null,
+            "columns_involved": []
         }
     ],
     "debug_info": {
         "confidence": 0.9,
-        "generalized_statement": "WITH src AS (SELECT TO_DATE(raw_col) AS date_col, filter_col FROM mydb.myschema.base_table), agg AS (SELECT ARRAY_AGG(CASE WHEN filter_col = ? THEN OBJECT_CONSTRUCT(*) END) AS obj FROM src) SELECT CAST(GET_PATH(agg.obj[?], 'DATE_COL') AS VARCHAR) AS output_col FROM mydb.myschema.other_table AS t LEFT JOIN agg ON agg.filter_col = t.id"
+        "generalized_statement": "WITH src AS (SELECT TO_DATE(raw_col) AS date_col, filter_col FROM mydb.myschema.base_table), agg AS (SELECT ARRAY_AGG(CASE WHEN filter_col = ? THEN OBJECT_CONSTRUCT(*) END) AS obj FROM src) SELECT CAST(GET_PATH(agg.obj[?], 'DATE_COL') AS VARCHAR) AS output_col FROM mydb.myschema.other_table AS t CROSS JOIN agg"
     }
 }

--- a/metadata-ingestion/tests/unit/sql_parsing/goldens/test_snowflake_object_construct_get_lineage.json
+++ b/metadata-ingestion/tests/unit/sql_parsing/goldens/test_snowflake_object_construct_get_lineage.json
@@ -1,0 +1,64 @@
+{
+    "query_type": "SELECT",
+    "query_type_props": {},
+    "query_fingerprint": "3318785a0226dddbdacfb382ed0e77401943d38a6e2c07717eb5733af4348192",
+    "in_tables": [
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.other_table,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_table,PROD)"
+    ],
+    "out_tables": [],
+    "column_lineage": [
+        {
+            "downstream": {
+                "table": null,
+                "column": "output_col",
+                "column_type": {
+                    "type": {
+                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                    }
+                },
+                "native_column_type": "VARCHAR"
+            },
+            "upstreams": [
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_table,PROD)",
+                    "column": "type_col"
+                },
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_table,PROD)",
+                    "column": "val_col"
+                }
+            ],
+            "logic": {
+                "is_direct_copy": false,
+                "column_logic": "CAST(GET(\"CTE_AGG\".\"OBJ_ARRAY\"[0], 'VAL_COL') AS VARCHAR) AS \"OUTPUT_COL\""
+            }
+        }
+    ],
+    "joins": [
+        {
+            "join_type": "LEFT JOIN",
+            "left_tables": [
+                "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.other_table,PROD)"
+            ],
+            "right_tables": [
+                "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_table,PROD)"
+            ],
+            "on_clause": "\"CTE_AGG\".\"RECORD_ID\" = \"LI\".\"ID\"",
+            "columns_involved": [
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.other_table,PROD)",
+                    "column": "ID"
+                },
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_table,PROD)",
+                    "column": "RECORD_ID"
+                }
+            ]
+        }
+    ],
+    "debug_info": {
+        "confidence": 0.9,
+        "generalized_statement": "WITH cte_src AS (SELECT val_col, type_col, record_id FROM mydb.myschema.src_table), cte_agg AS (SELECT record_id, ARRAY_AGG(CASE WHEN type_col = ? THEN OBJECT_CONSTRUCT(*) END) AS obj_array FROM cte_src GROUP BY record_id) SELECT CAST(GET(cte_agg.obj_array[?], ?) AS VARCHAR) AS output_col FROM mydb.myschema.other_table AS li LEFT JOIN cte_agg ON cte_agg.record_id = li.id"
+    }
+}

--- a/metadata-ingestion/tests/unit/sql_parsing/goldens/test_snowflake_object_construct_get_passthrough_cte_lineage.json
+++ b/metadata-ingestion/tests/unit/sql_parsing/goldens/test_snowflake_object_construct_get_passthrough_cte_lineage.json
@@ -1,0 +1,68 @@
+{
+    "query_type": "SELECT",
+    "query_type_props": {},
+    "query_fingerprint": "b86afa00e19139fcf98e7d7743cae0bcef637c0228e53bbe4ab48cae48d28a27",
+    "in_tables": [
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.other_table,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_table,PROD)"
+    ],
+    "out_tables": [],
+    "column_lineage": [
+        {
+            "downstream": {
+                "table": null,
+                "column": "output_col",
+                "column_type": {
+                    "type": {
+                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                    }
+                },
+                "native_column_type": "VARCHAR"
+            },
+            "upstreams": [
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_table,PROD)",
+                    "column": "filter_col_a"
+                },
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_table,PROD)",
+                    "column": "filter_col_b"
+                },
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_table,PROD)",
+                    "column": "val_col"
+                }
+            ],
+            "logic": {
+                "is_direct_copy": false,
+                "column_logic": "CAST(GET(\"MID_CTE\".\"OBJ_ARRAY\"[0], 'VAL_COL') AS VARCHAR) AS \"OUTPUT_COL\""
+            }
+        }
+    ],
+    "joins": [
+        {
+            "join_type": "LEFT JOIN",
+            "left_tables": [
+                "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.other_table,PROD)"
+            ],
+            "right_tables": [
+                "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_table,PROD)"
+            ],
+            "on_clause": "\"MID_CTE\".\"ID\" = \"T\".\"ID\"",
+            "columns_involved": [
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.other_table,PROD)",
+                    "column": "ID"
+                },
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_table,PROD)",
+                    "column": "ID"
+                }
+            ]
+        }
+    ],
+    "debug_info": {
+        "confidence": 0.9,
+        "generalized_statement": "WITH src AS (SELECT val_col, filter_col_a, filter_col_b, id FROM mydb.myschema.src_table), src_agg AS (SELECT id, ARRAY_AGG(CASE WHEN filter_col_a = ? AND filter_col_b = ? THEN OBJECT_CONSTRUCT(*) END) AS obj_array FROM src GROUP BY id), mid_cte AS (SELECT * FROM src_agg) SELECT CAST(GET(obj_array[?], ?) AS VARCHAR) AS output_col FROM mydb.myschema.other_table AS t LEFT JOIN mid_cte ON mid_cte.id = t.id"
+    }
+}

--- a/metadata-ingestion/tests/unit/sql_parsing/goldens/test_snowflake_object_construct_join_source_placeholder_fallback.json
+++ b/metadata-ingestion/tests/unit/sql_parsing/goldens/test_snowflake_object_construct_join_source_placeholder_fallback.json
@@ -1,0 +1,72 @@
+{
+    "query_type": "SELECT",
+    "query_type_props": {},
+    "query_fingerprint": "486b8afe86f75d73dbfc4b3412bcbd7c12a7b236649382e0efc1f2e21fe05234",
+    "in_tables": [
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_left,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_right,PROD)"
+    ],
+    "out_tables": [],
+    "column_lineage": [
+        {
+            "downstream": {
+                "table": null,
+                "column": "output_col",
+                "column_type": {
+                    "type": {
+                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                    }
+                },
+                "native_column_type": "VARCHAR"
+            },
+            "upstreams": [
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_left,PROD)",
+                    "column": "filter_col_a"
+                },
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_left,PROD)",
+                    "column": "filter_col_b"
+                },
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_left,PROD)",
+                    "column": "other_col"
+                },
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_left,PROD)",
+                    "column": "real_col"
+                }
+            ],
+            "logic": {
+                "is_direct_copy": false,
+                "column_logic": "CASE WHEN CAST(GET_PATH(\"AGG_CTE\".\"OBJ\"[0], 'ALIAS_COL') AS VARCHAR) = 'x' AND LOWER(CAST(GET_PATH(\"AGG_CTE\".\"OBJ\"[0], 'OTHER_COL') AS VARCHAR)) = 'y' THEN 'A' WHEN CAST(GET_PATH(\"AGG_CTE\".\"OBJ\"[0], 'ALIAS_COL') AS VARCHAR) = 'p' AND LOWER(CAST(GET_PATH(\"AGG_CTE\".\"OBJ\"[0], 'OTHER_COL') AS VARCHAR)) = 'q' THEN 'B' ELSE NULL END AS \"OUTPUT_COL\""
+            }
+        }
+    ],
+    "joins": [
+        {
+            "join_type": "JOIN",
+            "left_tables": [
+                "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_left,PROD)"
+            ],
+            "right_tables": [
+                "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_right,PROD)"
+            ],
+            "on_clause": "\"A\".\"FK\" = \"B\".\"ID\"",
+            "columns_involved": [
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_left,PROD)",
+                    "column": "FK"
+                },
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_right,PROD)",
+                    "column": "ID"
+                }
+            ]
+        }
+    ],
+    "debug_info": {
+        "confidence": 0.9,
+        "generalized_statement": "WITH base_cte AS (SELECT a.real_col AS alias_col, a.other_col, a.filter_col_a, a.filter_col_b, b.id FROM mydb.myschema.src_left AS a JOIN mydb.myschema.src_right AS b ON a.fk = b.id), agg_cte AS (SELECT id, ARRAY_AGG(CASE WHEN filter_col_a = ? AND filter_col_b = ? THEN OBJECT_CONSTRUCT(*) END) AS obj FROM base_cte GROUP BY id) SELECT CASE WHEN CAST(GET_PATH(agg_cte.obj[?], 'ALIAS_COL') AS VARCHAR) = ? AND LOWER(CAST(GET_PATH(agg_cte.obj[?], 'OTHER_COL') AS VARCHAR)) = ? THEN ? WHEN CAST(GET_PATH(agg_cte.obj[?], 'ALIAS_COL') AS VARCHAR) = ? AND LOWER(CAST(GET_PATH(agg_cte.obj[?], 'OTHER_COL') AS VARCHAR)) = ? THEN ? ELSE NULL END AS output_col FROM agg_cte"
+    }
+}

--- a/metadata-ingestion/tests/unit/sql_parsing/goldens/test_snowflake_object_construct_multihop_alias_lineage.json
+++ b/metadata-ingestion/tests/unit/sql_parsing/goldens/test_snowflake_object_construct_multihop_alias_lineage.json
@@ -1,0 +1,42 @@
+{
+    "query_type": "SELECT",
+    "query_type_props": {},
+    "query_fingerprint": "4adf89889b8f7268a5380bf907fc073d2bd9af176e18136d24d62e868573c2ae",
+    "in_tables": [
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_table,PROD)"
+    ],
+    "out_tables": [],
+    "column_lineage": [
+        {
+            "downstream": {
+                "table": null,
+                "column": "output_col",
+                "column_type": {
+                    "type": {
+                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                    }
+                },
+                "native_column_type": "VARCHAR"
+            },
+            "upstreams": [
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_table,PROD)",
+                    "column": "id"
+                },
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_table,PROD)",
+                    "column": "original_col"
+                }
+            ],
+            "logic": {
+                "is_direct_copy": false,
+                "column_logic": "CAST(GET_PATH(\"AGG_CTE\".\"OBJ\"[0], 'RENAMED_COL') AS VARCHAR) AS \"OUTPUT_COL\""
+            }
+        }
+    ],
+    "joins": [],
+    "debug_info": {
+        "confidence": 0.9,
+        "generalized_statement": "WITH base_cte AS (SELECT original_col AS renamed_col, id FROM mydb.myschema.src_table), pass_cte AS (SELECT * FROM base_cte), agg_cte AS (SELECT ARRAY_AGG(CASE WHEN id > ? THEN OBJECT_CONSTRUCT(*) END) AS obj FROM pass_cte) SELECT CAST(GET_PATH(agg_cte.obj[?], 'RENAMED_COL') AS VARCHAR) AS output_col FROM agg_cte"
+    }
+}

--- a/metadata-ingestion/tests/unit/sql_parsing/goldens/test_snowflake_object_construct_no_key_access.json
+++ b/metadata-ingestion/tests/unit/sql_parsing/goldens/test_snowflake_object_construct_no_key_access.json
@@ -1,0 +1,33 @@
+{
+    "query_type": "SELECT",
+    "query_type_props": {},
+    "query_fingerprint": "ceb55b77903b3c4cd8bb27ad9829c0c765bb9280bbdd74b1946229cbff077f9c",
+    "in_tables": [
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.base_table,PROD)"
+    ],
+    "out_tables": [],
+    "column_lineage": [
+        {
+            "downstream": {
+                "table": null,
+                "column": "raw_obj",
+                "column_type": {
+                    "type": {
+                        "com.linkedin.pegasus2avro.schema.ArrayType": {}
+                    }
+                },
+                "native_column_type": "ARRAY"
+            },
+            "upstreams": [],
+            "logic": {
+                "is_direct_copy": true,
+                "column_logic": "\"AGG\".\"OBJ\" AS \"RAW_OBJ\""
+            }
+        }
+    ],
+    "joins": [],
+    "debug_info": {
+        "confidence": 0.9,
+        "generalized_statement": "WITH src AS (SELECT col_a, col_b FROM mydb.myschema.base_table), agg AS (SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*)) AS obj FROM src) SELECT agg.obj AS raw_obj FROM agg"
+    }
+}

--- a/metadata-ingestion/tests/unit/sql_parsing/goldens/test_snowflake_object_construct_star_alias_lineage.json
+++ b/metadata-ingestion/tests/unit/sql_parsing/goldens/test_snowflake_object_construct_star_alias_lineage.json
@@ -1,7 +1,7 @@
 {
     "query_type": "SELECT",
     "query_type_props": {},
-    "query_fingerprint": "728af46c4030718613a78ab3c573869b7b32b8d4507ef31be595b9342c38508d",
+    "query_fingerprint": "3c39567a0bbbce27889fc47478a5053aa2f0b009f98ffcd7e6fa9e39ddbe24f1",
     "in_tables": [
         "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.base_table,PROD)",
         "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.other_table,PROD)"
@@ -37,28 +37,19 @@
     ],
     "joins": [
         {
-            "join_type": "LEFT JOIN",
+            "join_type": "CROSS JOIN",
             "left_tables": [
                 "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.other_table,PROD)"
             ],
             "right_tables": [
                 "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.base_table,PROD)"
             ],
-            "on_clause": "\"AGG\".\"FILTER_COL\" = \"T\".\"ID\"",
-            "columns_involved": [
-                {
-                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.base_table,PROD)",
-                    "column": "FILTER_COL"
-                },
-                {
-                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.other_table,PROD)",
-                    "column": "ID"
-                }
-            ]
+            "on_clause": null,
+            "columns_involved": []
         }
     ],
     "debug_info": {
         "confidence": 0.9,
-        "generalized_statement": "WITH src AS (SELECT real_col AS alias_col, filter_col FROM mydb.myschema.base_table), agg AS (SELECT ARRAY_AGG(CASE WHEN filter_col = ? THEN OBJECT_CONSTRUCT(*) END) AS obj FROM src) SELECT CAST(GET_PATH(agg.obj[?], 'ALIAS_COL') AS VARCHAR) AS output_col FROM mydb.myschema.other_table AS t LEFT JOIN agg ON agg.filter_col = t.id"
+        "generalized_statement": "WITH src AS (SELECT real_col AS alias_col, filter_col FROM mydb.myschema.base_table), agg AS (SELECT ARRAY_AGG(CASE WHEN filter_col = ? THEN OBJECT_CONSTRUCT(*) END) AS obj FROM src) SELECT CAST(GET_PATH(agg.obj[?], 'ALIAS_COL') AS VARCHAR) AS output_col FROM mydb.myschema.other_table AS t CROSS JOIN agg"
     }
 }

--- a/metadata-ingestion/tests/unit/sql_parsing/goldens/test_snowflake_object_construct_star_alias_lineage.json
+++ b/metadata-ingestion/tests/unit/sql_parsing/goldens/test_snowflake_object_construct_star_alias_lineage.json
@@ -1,0 +1,64 @@
+{
+    "query_type": "SELECT",
+    "query_type_props": {},
+    "query_fingerprint": "728af46c4030718613a78ab3c573869b7b32b8d4507ef31be595b9342c38508d",
+    "in_tables": [
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.base_table,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.other_table,PROD)"
+    ],
+    "out_tables": [],
+    "column_lineage": [
+        {
+            "downstream": {
+                "table": null,
+                "column": "output_col",
+                "column_type": {
+                    "type": {
+                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                    }
+                },
+                "native_column_type": "VARCHAR"
+            },
+            "upstreams": [
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.base_table,PROD)",
+                    "column": "filter_col"
+                },
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.base_table,PROD)",
+                    "column": "real_col"
+                }
+            ],
+            "logic": {
+                "is_direct_copy": false,
+                "column_logic": "CAST(GET_PATH(\"AGG\".\"OBJ\"[0], 'ALIAS_COL') AS VARCHAR) AS \"OUTPUT_COL\""
+            }
+        }
+    ],
+    "joins": [
+        {
+            "join_type": "LEFT JOIN",
+            "left_tables": [
+                "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.other_table,PROD)"
+            ],
+            "right_tables": [
+                "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.base_table,PROD)"
+            ],
+            "on_clause": "\"AGG\".\"FILTER_COL\" = \"T\".\"ID\"",
+            "columns_involved": [
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.base_table,PROD)",
+                    "column": "FILTER_COL"
+                },
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.other_table,PROD)",
+                    "column": "ID"
+                }
+            ]
+        }
+    ],
+    "debug_info": {
+        "confidence": 0.9,
+        "generalized_statement": "WITH src AS (SELECT real_col AS alias_col, filter_col FROM mydb.myschema.base_table), agg AS (SELECT ARRAY_AGG(CASE WHEN filter_col = ? THEN OBJECT_CONSTRUCT(*) END) AS obj FROM src) SELECT CAST(GET_PATH(agg.obj[?], 'ALIAS_COL') AS VARCHAR) AS output_col FROM mydb.myschema.other_table AS t LEFT JOIN agg ON agg.filter_col = t.id"
+    }
+}

--- a/metadata-ingestion/tests/unit/sql_parsing/goldens/test_snowflake_object_construct_star_lineage.json
+++ b/metadata-ingestion/tests/unit/sql_parsing/goldens/test_snowflake_object_construct_star_lineage.json
@@ -1,0 +1,72 @@
+{
+    "query_type": "SELECT",
+    "query_type_props": {},
+    "query_fingerprint": "fb4013cabd320a94e507338e3e6c8bf46c4be2b2d6003b5bbcb561f4d0e42934",
+    "in_tables": [
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_attributes,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_records,PROD)"
+    ],
+    "out_tables": [],
+    "column_lineage": [
+        {
+            "downstream": {
+                "table": null,
+                "column": "output_col",
+                "column_type": {
+                    "type": {
+                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                    }
+                },
+                "native_column_type": "VARCHAR"
+            },
+            "upstreams": [
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_attributes,PROD)",
+                    "column": "field_a"
+                },
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_attributes,PROD)",
+                    "column": "field_b"
+                },
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_attributes,PROD)",
+                    "column": "grp_col"
+                },
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_attributes,PROD)",
+                    "column": "type_col"
+                }
+            ],
+            "logic": {
+                "is_direct_copy": false,
+                "column_logic": "CASE WHEN CAST(GET_PATH(\"CTE_AGG\".\"OBJ_ARRAY\"[0], 'FIELD_A') AS VARCHAR) = 'val1' AND LOWER(CAST(GET_PATH(\"CTE_AGG\".\"OBJ_ARRAY\"[0], 'FIELD_B') AS VARCHAR)) = 'type_x' THEN 'X' WHEN CAST(GET_PATH(\"CTE_AGG\".\"OBJ_ARRAY\"[0], 'FIELD_A') AS VARCHAR) = 'val1' AND LOWER(CAST(GET_PATH(\"CTE_AGG\".\"OBJ_ARRAY\"[0], 'FIELD_B') AS VARCHAR)) = 'type_y' THEN 'Y' ELSE NULL END AS \"OUTPUT_COL\""
+            }
+        }
+    ],
+    "joins": [
+        {
+            "join_type": "LEFT JOIN",
+            "left_tables": [
+                "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_records,PROD)"
+            ],
+            "right_tables": [
+                "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_attributes,PROD)"
+            ],
+            "on_clause": "\"CTE_AGG\".\"RECORD_ID\" = \"LI\".\"ID\"",
+            "columns_involved": [
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_attributes,PROD)",
+                    "column": "RECORD_ID"
+                },
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_records,PROD)",
+                    "column": "ID"
+                }
+            ]
+        }
+    ],
+    "debug_info": {
+        "confidence": 0.9,
+        "generalized_statement": "WITH cte_src AS (SELECT field_a, field_b, type_col, grp_col, record_id FROM mydb.myschema.src_attributes), cte_agg AS (SELECT record_id, ARRAY_AGG(CASE WHEN type_col = ? AND grp_col = ? THEN OBJECT_CONSTRUCT(*) END) AS obj_array FROM cte_src GROUP BY record_id) SELECT CASE WHEN CAST(GET_PATH(cte_agg.obj_array[?], 'FIELD_A') AS VARCHAR) = ? AND LOWER(CAST(GET_PATH(cte_agg.obj_array[?], 'FIELD_B') AS VARCHAR)) = ? THEN ? WHEN CAST(GET_PATH(cte_agg.obj_array[?], 'FIELD_A') AS VARCHAR) = ? AND LOWER(CAST(GET_PATH(cte_agg.obj_array[?], 'FIELD_B') AS VARCHAR)) = ? THEN ? ELSE NULL END AS output_col FROM mydb.myschema.src_records AS li LEFT JOIN cte_agg ON cte_agg.record_id = li.id"
+    }
+}

--- a/metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_lineage.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_lineage.py
@@ -1954,6 +1954,111 @@ FROM db1.raw_events
     )
 
 
+def test_snowflake_object_construct_star_lineage() -> None:
+    """Test lineage through OBJECT_CONSTRUCT(*) with semi-structured key access.
+
+    OBJECT_CONSTRUCT(*) creates a JSON object from ALL columns in scope, using
+    column names as keys. When specific keys are then accessed via :KEY notation
+    (translated to JSONExtract), DataHub should resolve each key to the column
+    of the same name in the source table.
+
+    This pattern appears in Snowpark-generated SQL where rows are aggregated into
+    semi-structured arrays and then filtered/accessed by field name:
+        obj_array = ARRAY_AGG(CASE WHEN type_col=1 AND grp_col=0 THEN OBJECT_CONSTRUCT(*))
+        output_col = CASE WHEN obj_array[0]:FIELD_A = '...'
+                              AND obj_array[0]:FIELD_B = '...' THEN 'X' ...
+
+    Expected: output_col traces to:
+      - field_a and field_b   (from :FIELD_A and :FIELD_B key accesses)
+      - type_col and grp_col  (from CASE WHEN filter conditions)
+    """
+    assert_sql_result(
+        """
+with cte_src as (
+    select field_a, field_b, type_col, grp_col, record_id
+    from mydb.myschema.src_attributes
+),
+cte_agg as (
+    select record_id,
+           ARRAY_AGG(CASE WHEN type_col = 1 AND grp_col = 0 THEN OBJECT_CONSTRUCT(*) END) AS obj_array
+    from cte_src group by record_id
+)
+select
+    CASE
+        WHEN cte_agg.obj_array[0]:FIELD_A::VARCHAR = 'val1'
+             AND lower(cte_agg.obj_array[0]:FIELD_B::varchar) = 'type_x' THEN 'X'
+        WHEN cte_agg.obj_array[0]:FIELD_A::VARCHAR = 'val1'
+             AND lower(cte_agg.obj_array[0]:FIELD_B::varchar) = 'type_y' THEN 'Y'
+        ELSE NULL
+    END AS output_col
+from mydb.myschema.src_records li
+left join cte_agg on cte_agg.record_id = li.id
+""",
+        dialect="snowflake",
+        default_db="mydb",
+        default_schema="myschema",
+        schemas={
+            "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_attributes,PROD)": {
+                "field_a": "VARCHAR",
+                "field_b": "VARCHAR",
+                "type_col": "NUMBER",
+                "grp_col": "NUMBER",
+                "record_id": "VARCHAR",
+            },
+            "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_records,PROD)": {
+                "id": "VARCHAR",
+                "record_id": "VARCHAR",
+            },
+        },
+        expected_file=RESOURCE_DIR
+        / "test_snowflake_object_construct_star_lineage.json",
+    )
+
+
+def test_snowflake_object_construct_star_alias_lineage() -> None:
+    """Test lineage through OBJECT_CONSTRUCT(*) when the source CTE renames a column.
+
+    When an intermediate CTE aliases a column (e.g. real_col AS alias_col) before it
+    is consumed by OBJECT_CONSTRUCT(*), the JSON object key is the alias name. After
+    pushdown_projections optimization, the aliased column is eliminated from the CTE
+    (since the optimizer treats the star access as opaque), so the alias→original
+    mapping must be extracted from the pre-optimization AST.
+
+    Expected: output_col traces to both:
+      - real_col   (resolved via alias mapping: ALIAS_COL → real_col)
+      - filter_col (from the CASE WHEN condition, resolved via normal Table leaf path)
+    """
+    assert_sql_result(
+        """
+with src as (
+    select real_col as alias_col, filter_col
+    from mydb.myschema.base_table
+),
+agg as (
+    select ARRAY_AGG(CASE WHEN filter_col = 1 THEN OBJECT_CONSTRUCT(*) END) AS obj
+    from src
+)
+select agg.obj[0]:ALIAS_COL::VARCHAR as output_col
+from mydb.myschema.other_table t
+left join agg on agg.filter_col = t.id
+""",
+        dialect="snowflake",
+        default_db="mydb",
+        default_schema="myschema",
+        schemas={
+            "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.base_table,PROD)": {
+                "real_col": "VARCHAR",
+                "filter_col": "NUMBER",
+            },
+            "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.other_table,PROD)": {
+                "id": "NUMBER",
+            },
+        },
+        expected_file=RESOURCE_DIR
+        / "test_snowflake_object_construct_star_alias_lineage.json",
+    )
+
+
 def test_clickhouse_materialized_view_to_table() -> None:
     """Test ClickHouse CREATE MATERIALIZED VIEW ... TO target_table syntax.
 

--- a/metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_lineage.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_lineage.py
@@ -2338,6 +2338,127 @@ from agg
     assert col_upstreams.get("output_col", []) == []
 
 
+def test_snowflake_object_construct_get_passthrough_cte_lineage() -> None:
+    """GET() key access on OBJECT_CONSTRUCT(*) through an intermediate pass-through CTE.
+
+    An intermediate CTE (mid_cte) passes through the aggregated array from src_agg
+    without adding a table qualifier. In the sqlglot lineage tree, the table alias for
+    the array column becomes 'mid_cte' instead of 'src_agg'. Previously, the table
+    qualifier check in _extract_json_path_keys would fail to match because
+    obj.table='MID_CTE' != ref_table='SRC_AGG', returning no key upstreams.
+
+    The fix drops the table qualifier check: the column name alone is sufficient within
+    the specific lineage subtree for a given output column.
+
+    Expected: output_col traces to:
+      - val_col       (resolved via GET key 'VAL_COL' through the pass-through CTE)
+      - filter_col_a  (Table leaf from CASE WHEN filter condition in ARRAY_AGG)
+      - filter_col_b  (Table leaf from CASE WHEN filter condition in ARRAY_AGG)
+    """
+    assert_sql_result(
+        """
+with src as (
+    select val_col, filter_col_a, filter_col_b, id
+    from mydb.myschema.src_table
+),
+src_agg as (
+    select id,
+           ARRAY_AGG(CASE WHEN filter_col_a = 1 AND filter_col_b = 1 THEN OBJECT_CONSTRUCT(*) END) AS obj_array
+    from src group by id
+),
+mid_cte as (
+    select * from src_agg
+)
+select GET(obj_array[0], 'VAL_COL')::VARCHAR as output_col
+from mydb.myschema.other_table t
+left join mid_cte on mid_cte.id = t.id
+""",
+        dialect="snowflake",
+        default_db="mydb",
+        default_schema="myschema",
+        schemas={
+            "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_table,PROD)": {
+                "val_col": "FLOAT",
+                "filter_col_a": "NUMBER",
+                "filter_col_b": "NUMBER",
+                "id": "VARCHAR",
+            },
+            "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.other_table,PROD)": {
+                "id": "VARCHAR",
+            },
+        },
+        expected_file=RESOURCE_DIR
+        / "test_snowflake_object_construct_get_passthrough_cte_lineage.json",
+    )
+
+
+def test_snowflake_object_construct_join_source_placeholder_fallback() -> None:
+    """OBJECT_CONSTRUCT(*) :KEY access resolves correctly when source CTE is a JOIN.
+
+    When the source CTE feeding OBJECT_CONSTRUCT(*) is a JOIN between two tables,
+    sqlglot emits Placeholder leaf nodes for the columns used in the ARRAY_AGG CASE
+    WHEN filter rather than resolved Table leaf nodes. This leaves leaf_table_refs
+    empty, so the normal key-resolution path finds nothing.
+
+    The fix uses source_base_tables (pre-collected from the CTE chain) as a fallback:
+    it populates leaf_table_refs from the schema mapping using lowercased table names,
+    then proceeds with the normal key lookup against that set.
+
+    The source CTE also renames a column (real_col AS alias_col), so the alias map
+    (ALIAS_COL → REAL_COL) is required to match the :ALIAS_COL key to the real column.
+
+    Expected: output_col traces to:
+      - real_col      (resolved via alias ALIAS_COL → REAL_COL in src_left,
+                       using the base-tables fallback)
+      - other_col     (resolved via :OTHER_COL key directly in src_left)
+    """
+    assert_sql_result(
+        """
+with base_cte as (
+    select
+        a.real_col as alias_col,
+        a.other_col,
+        a.filter_col_a,
+        a.filter_col_b,
+        b.id
+    from mydb.myschema.src_left a
+    join mydb.myschema.src_right b on a.fk = b.id
+),
+agg_cte as (
+    select id,
+           ARRAY_AGG(CASE WHEN filter_col_a = 1 AND filter_col_b = 2 THEN OBJECT_CONSTRUCT(*) END) AS obj
+    from base_cte group by id
+)
+select
+    CASE
+        WHEN agg_cte.obj[0]:ALIAS_COL::VARCHAR = 'x'
+             AND lower(agg_cte.obj[0]:OTHER_COL::varchar) = 'y' THEN 'A'
+        WHEN agg_cte.obj[0]:ALIAS_COL::VARCHAR = 'p'
+             AND lower(agg_cte.obj[0]:OTHER_COL::varchar) = 'q' THEN 'B'
+        ELSE NULL
+    END AS output_col
+from agg_cte
+""",
+        dialect="snowflake",
+        default_db="mydb",
+        default_schema="myschema",
+        schemas={
+            "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_left,PROD)": {
+                "real_col": "VARCHAR",
+                "other_col": "VARCHAR",
+                "filter_col_a": "NUMBER",
+                "filter_col_b": "NUMBER",
+                "fk": "VARCHAR",
+            },
+            "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_right,PROD)": {
+                "id": "VARCHAR",
+            },
+        },
+        expected_file=RESOURCE_DIR
+        / "test_snowflake_object_construct_join_source_placeholder_fallback.json",
+    )
+
+
 def test_clickhouse_materialized_view_to_table() -> None:
     """Test ClickHouse CREATE MATERIALIZED VIEW ... TO target_table syntax.
 

--- a/metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_lineage.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_lineage.py
@@ -2,8 +2,9 @@ import pathlib
 
 import pytest
 
+from datahub.sql_parsing._models import _TableName
 from datahub.sql_parsing.schema_resolver import SchemaResolver
-from datahub.sql_parsing.sqlglot_lineage import sqlglot_lineage
+from datahub.sql_parsing.sqlglot_lineage import _table_name_matches, sqlglot_lineage
 from datahub.testing.check_sql_parser_result import assert_sql_result
 
 RESOURCE_DIR = pathlib.Path(__file__).parent / "goldens"
@@ -2141,6 +2142,33 @@ left join cte_agg on cte_agg.record_id = li.id
             },
         },
         expected_file=RESOURCE_DIR / "test_snowflake_object_construct_get_lineage.json",
+    )
+
+
+def test_table_name_matches_respects_db_and_schema() -> None:
+    """_table_name_matches must not conflate same-named tables across databases/schemas."""
+    prod_orders = _TableName(database="prod", db_schema="billing", table="orders")
+    staging_orders = _TableName(database="staging", db_schema="billing", table="orders")
+    unqualified = _TableName(table="orders")
+
+    # Fully-qualified refs must distinguish databases
+    assert _table_name_matches(prod_orders, prod_orders)
+    assert not _table_name_matches(prod_orders, staging_orders)
+
+    # Unqualified refs (None db/schema) act as wildcards — matches any same-named table
+    assert _table_name_matches(prod_orders, unqualified)
+    assert _table_name_matches(staging_orders, unqualified)
+
+    # Schema-scoped ref matches only the right schema
+    billing_ref = _TableName(db_schema="billing", table="orders")
+    payments_ref = _TableName(db_schema="payments", table="orders")
+    assert _table_name_matches(prod_orders, billing_ref)
+    assert not _table_name_matches(prod_orders, payments_ref)
+
+    # Different table names never match regardless of db/schema
+    assert not _table_name_matches(
+        _TableName(database="prod", db_schema="billing", table="orders"),
+        _TableName(database="prod", db_schema="billing", table="invoices"),
     )
 
 

--- a/metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_lineage.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_lineage.py
@@ -2041,7 +2041,7 @@ agg as (
 )
 select agg.obj[0]:ALIAS_COL::VARCHAR as output_col
 from mydb.myschema.other_table t
-left join agg on agg.filter_col = t.id
+cross join agg
 """,
         dialect="snowflake",
         default_db="mydb",
@@ -2083,7 +2083,7 @@ agg as (
 )
 select agg.obj[0]:DATE_COL::VARCHAR as output_col
 from mydb.myschema.other_table t
-left join agg on agg.filter_col = t.id
+cross join agg
 """,
         dialect="snowflake",
         default_db="mydb",
@@ -2170,6 +2170,172 @@ def test_table_name_matches_respects_db_and_schema() -> None:
         _TableName(database="prod", db_schema="billing", table="orders"),
         _TableName(database="prod", db_schema="billing", table="invoices"),
     )
+
+
+def test_snowflake_object_construct_no_key_access() -> None:
+    """OBJECT_CONSTRUCT(*) without a downstream :KEY access should not crash.
+
+    When the aggregated object is passed through without a semi-structured key
+    access, the star-map resolver returns an empty set rather than raising.
+    Normal table-level lineage is still produced.
+    """
+    assert_sql_result(
+        """
+with src as (
+    select col_a, col_b
+    from mydb.myschema.base_table
+),
+agg as (
+    select ARRAY_AGG(OBJECT_CONSTRUCT(*)) AS obj
+    from src
+)
+select agg.obj as raw_obj
+from agg
+""",
+        dialect="snowflake",
+        default_db="mydb",
+        default_schema="myschema",
+        schemas={
+            "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.base_table,PROD)": {
+                "col_a": "VARCHAR",
+                "col_b": "VARCHAR",
+            },
+        },
+        expected_file=RESOURCE_DIR
+        / "test_snowflake_object_construct_no_key_access.json",
+    )
+
+
+def test_snowflake_object_construct_multihop_alias_lineage() -> None:
+    """OBJECT_CONSTRUCT(*) resolves aliases through a multi-hop CTE chain.
+
+    An alias defined in base_cte is passed through pass_cte via SELECT * before
+    being consumed by OBJECT_CONSTRUCT(*) in agg_cte. _collect_source_cte_chain
+    must recurse two hops (agg_cte → pass_cte → base_cte) to capture the mapping.
+
+    Expected: output_col traces to original_col via the two-hop alias chain
+    RENAMED_COL → original_col.
+    """
+    assert_sql_result(
+        """
+with base_cte as (
+    select original_col as renamed_col, id
+    from mydb.myschema.src_table
+),
+pass_cte as (
+    select * from base_cte
+),
+agg_cte as (
+    select ARRAY_AGG(CASE WHEN id > 0 THEN OBJECT_CONSTRUCT(*) END) AS obj
+    from pass_cte
+)
+select agg_cte.obj[0]:RENAMED_COL::VARCHAR as output_col
+from agg_cte
+""",
+        dialect="snowflake",
+        default_db="mydb",
+        default_schema="myschema",
+        schemas={
+            "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_table,PROD)": {
+                "original_col": "VARCHAR",
+                "id": "NUMBER",
+            },
+        },
+        expected_file=RESOURCE_DIR
+        / "test_snowflake_object_construct_multihop_alias_lineage.json",
+    )
+
+
+def test_snowflake_object_construct_cross_schema_isolation() -> None:
+    """OBJECT_CONSTRUCT(*) must not produce false-positive upstreams from same-named tables in other databases.
+
+    When two tables in different databases share the same name and column, the
+    star-map resolver must only emit the table actually referenced in the SQL.
+    The golden file must contain shared_col from mydb only, not from staging.
+    """
+    assert_sql_result(
+        """
+with cte_src as (
+    select shared_col, type_col
+    from mydb.myschema.src_table
+),
+cte_agg as (
+    select ARRAY_AGG(CASE WHEN type_col = 1 THEN OBJECT_CONSTRUCT(*) END) AS obj
+    from cte_src
+)
+select cte_agg.obj[0]:SHARED_COL::VARCHAR as output_col
+from cte_agg
+""",
+        dialect="snowflake",
+        default_db="mydb",
+        default_schema="myschema",
+        schemas={
+            "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_table,PROD)": {
+                "shared_col": "VARCHAR",
+                "type_col": "NUMBER",
+            },
+            # Same table name in a different database — must NOT appear in upstreams
+            "urn:li:dataset:(urn:li:dataPlatform:snowflake,staging.myschema.src_table,PROD)": {
+                "shared_col": "VARCHAR",
+                "type_col": "NUMBER",
+            },
+        },
+        expected_file=RESOURCE_DIR
+        / "test_snowflake_object_construct_cross_schema_isolation.json",
+    )
+
+
+def test_bigquery_unaffected_by_object_construct_path() -> None:
+    """Non-Snowflake dialects must not be affected by the OBJECT_CONSTRUCT(*) code path.
+
+    _build_parents is gated on the Snowflake dialect; a BigQuery query with schemas
+    provided must produce correct column lineage without regression.
+    """
+    assert_sql_result(
+        """
+SELECT t.col_a, t.col_b
+FROM `myproject.mydataset.src_table` AS t
+""",
+        dialect="bigquery",
+        schemas={
+            "urn:li:dataset:(urn:li:dataPlatform:bigquery,myproject.mydataset.src_table,PROD)": {
+                "col_a": "VARCHAR",
+                "col_b": "VARCHAR",
+            },
+        },
+        expected_file=RESOURCE_DIR
+        / "test_bigquery_unaffected_by_object_construct_path.json",
+    )
+
+
+def test_snowflake_object_construct_missing_key_no_upstream() -> None:
+    """Accessing a key absent from the source schema returns no upstream, not an error."""
+    schema_resolver = SchemaResolver(platform="snowflake")
+    schema_resolver.add_raw_schema_info(
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.base_table,PROD)",
+        {"col_a": "VARCHAR"},
+    )
+    result = sqlglot_lineage(
+        """
+with src as (
+    select col_a from mydb.myschema.base_table
+),
+agg as (
+    select ARRAY_AGG(OBJECT_CONSTRUCT(*)) AS obj from src
+)
+select agg.obj[0]:MISSING_KEY::VARCHAR as output_col
+from agg
+""",
+        schema_resolver=schema_resolver,
+        default_db="mydb",
+        default_schema="myschema",
+    )
+    assert result.debug_info.table_error is None
+    assert result.debug_info.column_error is None
+    col_upstreams = {
+        c.downstream.column: c.upstreams for c in (result.column_lineage or [])
+    }
+    assert col_upstreams.get("output_col", []) == []
 
 
 def test_clickhouse_materialized_view_to_table() -> None:

--- a/metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_lineage.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_lineage.py
@@ -2059,6 +2059,49 @@ left join agg on agg.filter_col = t.id
     )
 
 
+def test_snowflake_object_construct_get_lineage() -> None:
+    """Test lineage through OBJECT_CONSTRUCT(*) accessed via GET() instead of :KEY.
+
+    GET(col[idx], 'KEY') is the function form of Snowflake semi-structured access.
+    It produces a GetExtract AST node rather than JSONExtract, so it requires a
+    separate walk in _extract_json_path_keys.
+
+    Expected: output_col traces to val_col (resolved via GET key) and type_col
+    (from the CASE WHEN filter condition).
+    """
+    assert_sql_result(
+        """
+with cte_src as (
+    select val_col, type_col, record_id
+    from mydb.myschema.src_table
+),
+cte_agg as (
+    select record_id,
+           ARRAY_AGG(CASE WHEN type_col = 1 THEN OBJECT_CONSTRUCT(*) END) AS obj_array
+    from cte_src group by record_id
+)
+select GET(cte_agg.obj_array[0], 'VAL_COL')::VARCHAR as output_col
+from mydb.myschema.other_table li
+left join cte_agg on cte_agg.record_id = li.id
+""",
+        dialect="snowflake",
+        default_db="mydb",
+        default_schema="myschema",
+        schemas={
+            "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.src_table,PROD)": {
+                "val_col": "VARCHAR",
+                "type_col": "NUMBER",
+                "record_id": "VARCHAR",
+            },
+            "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.other_table,PROD)": {
+                "id": "VARCHAR",
+                "record_id": "VARCHAR",
+            },
+        },
+        expected_file=RESOURCE_DIR / "test_snowflake_object_construct_get_lineage.json",
+    )
+
+
 def test_clickhouse_materialized_view_to_table() -> None:
     """Test ClickHouse CREATE MATERIALIZED VIEW ... TO target_table syntax.
 

--- a/metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_lineage.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_lineage.py
@@ -2059,6 +2059,48 @@ left join agg on agg.filter_col = t.id
     )
 
 
+def test_snowflake_object_construct_function_alias_lineage() -> None:
+    """Test lineage through OBJECT_CONSTRUCT(*) when the source CTE uses a function alias.
+
+    When a source CTE aliases a function expression (e.g. to_date(raw_col) AS date_col),
+    _collect_object_construct_source_aliases must walk the function's Column leaf nodes
+    to build the alias→source mapping. Without this, accessing obj[0]:DATE_COL would
+    fail to resolve because DATE_COL is not a real column name in the base table schema.
+
+    Expected: output_col traces to raw_col (via function alias: DATE_COL → raw_col)
+    and filter_col (from the CASE WHEN condition).
+    """
+    assert_sql_result(
+        """
+with src as (
+    select to_date(raw_col) as date_col, filter_col
+    from mydb.myschema.base_table
+),
+agg as (
+    select ARRAY_AGG(CASE WHEN filter_col = 1 THEN OBJECT_CONSTRUCT(*) END) AS obj
+    from src
+)
+select agg.obj[0]:DATE_COL::VARCHAR as output_col
+from mydb.myschema.other_table t
+left join agg on agg.filter_col = t.id
+""",
+        dialect="snowflake",
+        default_db="mydb",
+        default_schema="myschema",
+        schemas={
+            "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.base_table,PROD)": {
+                "raw_col": "VARCHAR",
+                "filter_col": "NUMBER",
+            },
+            "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.other_table,PROD)": {
+                "id": "NUMBER",
+            },
+        },
+        expected_file=RESOURCE_DIR
+        / "test_snowflake_object_construct_function_alias_lineage.json",
+    )
+
+
 def test_snowflake_object_construct_get_lineage() -> None:
     """Test lineage through OBJECT_CONSTRUCT(*) accessed via GET() instead of :KEY.
 


### PR DESCRIPTION
## Summary

**Problem:** Column lineage through Snowflake's `OBJECT_CONSTRUCT(*)` pattern failed when the source CTE renamed a column (e.g. `cost_structure_type AS cost_structure`). The JSON object keys use the CTE alias names, but sqlglot's `pushdown_projections` optimizer eliminates aliased columns that aren't referenced elsewhere — discarding the alias→original mapping before lineage resolution could use it.

**Fix (`sqlglot_lineage.py`):**

- Added `_collect_object_construct_source_aliases()` — walks the pre-optimization AST to find CTEs feeding `OBJECT_CONSTRUCT(*)` and builds an alias→original column name map
- Added `_extract_json_path_keys()` — extracts JSON path key strings from semi-structured access expressions like `col[0]:KEY::TYPE`
- Added `_get_star_map_col_upstreams()` — resolves upstream column refs for `StarMap` nodes by matching JSON path keys against schema column names, with alias fallback
- Extended `_get_direct_raw_col_upstreams()` and `_select_statement_cll()` to thread `object_construct_col_aliases` through to the star map resolution
- Fixed mypy type error: widened `_extract_json_path_keys()` parameter from `sqlglot.exp.Expression` to `sqlglot.exp.Expr` to match the actual type of `lineage.Node.expression`

**Tests:**
- Added `test_snowflake_object_construct_star_lineage` — baseline coverage for `OBJECT_CONSTRUCT(*)` lineage through a CTE
- Added `test_snowflake_object_construct_star_alias_lineage` — covers the aliased-CTE case where JSON keys don't match base table column names directly
