### PR TITLE
docs(teams): document required Microsoft Graph permissions for Teams app

### DIFF
--- a/docs/managed-datahub/teams/saas-teams-setup.md
+++ b/docs/managed-datahub/teams/saas-teams-setup.md
@@ -8,6 +8,31 @@ import FeatureAvailability from '@site/src/components/FeatureAvailability';
 
 <FeatureAvailability saasOnly />
 
+## Required Permissions
+
+The DataHub Teams app requires the following permissions. Your Teams or Azure administrator may
+need to provide this list during your organization's security review.
+
+### Microsoft Graph (application permissions, admin-consent)
+
+These permissions are granted on the Azure AD app registration and are used to resolve users,
+teams, and channels referenced from DataHub.
+
+| Permission              | Why it's needed                                                        |
+| ----------------------- | ---------------------------------------------------------------------- |
+| `User.Read.All`         | Resolve Teams user IDs to names and email addresses for DM recipients. |
+| `TeamMember.Read.All`   | Read team membership for channel-scoped notifications.                 |
+| `Channel.ReadBasic.All` | List channels in the Teams picker and resolve a channel to its team.   |
+
+### Bot Framework (separate authentication, not a Graph scope)
+
+The app authenticates against `api.botframework.com` to actually send messages. This is a separate
+identity from Microsoft Graph — it uses the **same Azure AD app registration and client secret**,
+but a different scope (`https://api.botframework.com/.default`).
+
+All message sends, edits, and threaded replies go through Bot Framework, not through Microsoft
+Graph.
+
 ## Installing the DataHub Microsoft Teams App
 
 To enable the DataHub Teams app, you will need to install the DataHub Teams bot into your Teams workspace.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents the Microsoft Graph application permissions and Bot Framework authentication that the DataHub Microsoft Teams App requires. Customer security teams (e.g. during their app-approval / security-review process) need to know exactly which Graph scopes the app requests and why, and this information was not previously captured in the docs.

## Changes

Adds a new **Required Permissions** section to `docs/managed-datahub/teams/saas-teams-setup.md` covering:

- **Microsoft Graph application permissions (admin-consent):**
  - `User.Read.All` — resolve Teams user IDs to names/emails for DM recipients
  - `TeamMember.Read.All` — read team membership for channel-scoped notifications
  - `Channel.ReadBasic.All` — list channels in the Teams picker, resolve channel → team
- **Bot Framework auth** — clarifies that message sends/edits/threading go through `api.botframework.com` using the same Azure AD app registration + client secret but a different scope (`https://api.botframework.com/.default`), and that this is a separate identity from Microsoft Graph.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly PR Title Format)
- [ ] Links to related issues (if applicable) — N/A
- [ ] Tests for the changes have been added/updated (if applicable) — N/A (docs-only)
- [x] Docs related to the changes have been added/updated
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in Updating DataHub — N/A

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://datahub.slack.com/archives/C08CUDAE9E3/p1777296895884109?thread_ts=1777296895.884109&cid=C08CUDAE9E3)

<div><a href="https://cursor.com/agents/bc-bafe75ee-109a-5cea-babf-d0b4c39f86ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bafe75ee-109a-5cea-babf-d0b4c39f86ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

