### PR TITLE
docs-website: fix Schema.org structured data validation errors

### DIFF
--- a/docs-website/src/pages/docs/_components/FilterPage/index.jsx
+++ b/docs-website/src/pages/docs/_components/FilterPage/index.jsx
@@ -92,14 +92,18 @@ export function FilterPage(
     mainEntity: {
       "@type": "ItemList",
       numberOfItems: metadata.length,
+      // Each item is a documentation page describing a DataHub integration.
+      // Using @type "WebPage" (not "SoftwareApplication") because Google's rich
+      // result requirements for SoftwareApplication mandate offers and
+      // aggregateRating, which don't apply to documentation entries.
       itemListElement: metadata.map((source, i) => ({
         "@type": "ListItem",
         position: i + 1,
         item: {
-          "@type": "SoftwareApplication",
+          "@type": "WebPage",
           name: source.Title,
           description: source.Description,
-          applicationCategory: source.tags?.["Platform Type"] || undefined,
+          about: source.tags?.["Platform Type"] || undefined,
           url: source.Path
             ? `https://docs.datahub.com/${source.Path}`
             : undefined,

--- a/docs-website/src/theme/DocBreadcrumbs/index.js
+++ b/docs-website/src/theme/DocBreadcrumbs/index.js
@@ -1,0 +1,110 @@
+// Swizzled from @docusaurus/theme-classic v2.4.1 to fix Schema.org BreadcrumbList
+// validation errors flagged by Google Search Console.
+//
+// The upstream component (see https://github.com/facebook/docusaurus/issues/7241)
+// emits `<meta itemProp="position">` on every breadcrumb item but only adds the
+// surrounding `itemScope itemProp="itemListElement" itemType=".../ListItem"`
+// microdata when the item has an href. For non-link breadcrumb items (parent
+// categories that aren't themselves linkable), this leaves an orphan `position`
+// property that Google rejects with: "The property position is not recognized
+// by Schema.org vocabulary."
+//
+// This swizzle wraps every breadcrumb item in proper ListItem microdata so the
+// `position` property is always within a valid scope. Non-link items also get
+// `itemProp="name"` so the ListItem has a name even without a URL.
+
+import React from "react";
+import clsx from "clsx";
+import { ThemeClassNames } from "@docusaurus/theme-common";
+import {
+  useSidebarBreadcrumbs,
+  useHomePageRoute,
+} from "@docusaurus/theme-common/internal";
+import Link from "@docusaurus/Link";
+import { translate } from "@docusaurus/Translate";
+import HomeBreadcrumbItem from "@theme/DocBreadcrumbs/Items/Home";
+
+import styles from "./styles.module.css";
+
+function BreadcrumbsItemLink({ children, href, isLast }) {
+  const className = "breadcrumbs__link";
+  if (isLast) {
+    // Last (active) breadcrumb: no link, but still carries the ListItem name.
+    return (
+      <span className={className} itemProp="name">
+        {children}
+      </span>
+    );
+  }
+  if (href) {
+    return (
+      <Link className={className} href={href} itemProp="item">
+        <span itemProp="name">{children}</span>
+      </Link>
+    );
+  }
+  // Intermediate non-link breadcrumb (parent category without its own page).
+  // Provide `itemProp="name"` so the surrounding ListItem still has a name.
+  return (
+    <span className={className} itemProp="name">
+      {children}
+    </span>
+  );
+}
+
+function BreadcrumbsItem({ children, active, index }) {
+  return (
+    <li
+      itemScope
+      itemProp="itemListElement"
+      itemType="https://schema.org/ListItem"
+      className={clsx("breadcrumbs__item", {
+        "breadcrumbs__item--active": active,
+      })}
+    >
+      {children}
+      <meta itemProp="position" content={String(index + 1)} />
+    </li>
+  );
+}
+
+export default function DocBreadcrumbs() {
+  const breadcrumbs = useSidebarBreadcrumbs();
+  const homePageRoute = useHomePageRoute();
+
+  if (!breadcrumbs) {
+    return null;
+  }
+
+  return (
+    <nav
+      className={clsx(
+        ThemeClassNames.docs.docBreadcrumbs,
+        styles.breadcrumbsContainer,
+      )}
+      aria-label={translate({
+        id: "theme.docs.breadcrumbs.navAriaLabel",
+        message: "Breadcrumbs",
+        description: "The ARIA label for the breadcrumbs",
+      })}
+    >
+      <ul
+        className="breadcrumbs"
+        itemScope
+        itemType="https://schema.org/BreadcrumbList"
+      >
+        {homePageRoute && <HomeBreadcrumbItem />}
+        {breadcrumbs.map((item, idx) => {
+          const isLast = idx === breadcrumbs.length - 1;
+          return (
+            <BreadcrumbsItem key={idx} active={isLast} index={idx}>
+              <BreadcrumbsItemLink href={item.href} isLast={isLast}>
+                {item.label}
+              </BreadcrumbsItemLink>
+            </BreadcrumbsItem>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/docs-website/src/theme/DocBreadcrumbs/styles.module.css
+++ b/docs-website/src/theme/DocBreadcrumbs/styles.module.css
@@ -1,0 +1,10 @@
+/**
+ * Copied from @docusaurus/theme-classic v2.4.1.
+ * Required by the swizzled DocBreadcrumbs/index.js so the breadcrumb container
+ * keeps the same visual styling as upstream.
+ */
+
+.breadcrumbsContainer {
+  --ifm-breadcrumb-size-multiplier: 0.8;
+  margin-bottom: 0.8rem;
+}


### PR DESCRIPTION
## Summary

Google Search Console flagged **756 structured data errors** across docs.datahub.com (354 breadcrumb errors + 200 each of two SoftwareApplication errors on the `/integrations` page). Both root causes are now fixed.

## Issue 1 — Breadcrumb `position` orphan property (~354 URLs)

**Symptom (Search Console):**
> The property `position` is not recognized by Schema.org vocabulary.

**Root cause:** The upstream `@docusaurus/theme-classic` v2.4.1 [`DocBreadcrumbs` component](https://github.com/facebook/docusaurus/blob/v2.4.1/packages/docusaurus-theme-classic/src/theme/DocBreadcrumbs/index.tsx) renders breadcrumb items like this:

```jsx
<li
  {...(addMicrodata && {
    itemScope: true,
    itemProp: "itemListElement",
    itemType: "https://schema.org/ListItem",
  })}
  ...>
  {children}
  <meta itemProp="position" content={String(index + 1)} />  {/* always emitted */}
</li>
```

`addMicrodata = !!item.href` — so non-link parent categories (e.g. "Actions" inside `/docs/actions/actions/executor`) render an orphan `<meta itemProp="position">` outside any ListItem context. There's even a `// TODO` in the upstream source acknowledging the issue (see [facebook/docusaurus#7241](https://github.com/facebook/docusaurus/issues/7241)).

**Fix:** Swizzle `DocBreadcrumbs/index.js` to always wrap every breadcrumb item in proper ListItem microdata, and give intermediate non-link items `itemProp="name"` so the ListItem still has a name without a URL.

## Issue 2 — SoftwareApplication missing `offers` / `aggregateRating` (`/integrations`, 200 + 200 errors)

**Symptom (Search Console):**
> A value for the `offers` field is required.
> A value for the `aggregateRating or review` field is required.

**Root cause:** `docs-website/src/pages/docs/_components/FilterPage/index.jsx` wraps each integration card as a `SoftwareApplication` inside the page's `CollectionPage > ItemList`. Google's [rich result requirements for SoftwareApplication](https://developers.google.com/search/docs/appearance/structured-data/software-app) mandate `offers` and `aggregateRating` — neither of which applies to documentation entries.

**Fix:** Change `@type` from `SoftwareApplication` to `WebPage` (no required fields, accurately describes the items as doc pages). `applicationCategory` becomes `about` to match the new type.

## Files changed

- `docs-website/src/pages/docs/_components/FilterPage/index.jsx` — change SoftwareApplication → WebPage
- `docs-website/src/theme/DocBreadcrumbs/index.js` (**new**, swizzled) — fix orphan position
- `docs-website/src/theme/DocBreadcrumbs/styles.module.css` (**new**, copied verbatim from upstream so the swizzled component keeps the same visual styling)

## Test plan

- [ ] CI passes (Docusaurus build, prettier check)
- [ ] After merge, validate a sample page in [Google's Rich Results Test](https://search.google.com/test/rich-results) to confirm:
  - Breadcrumbs parse cleanly with no orphan-property warnings
  - `/integrations` no longer flags SoftwareApplication errors
- [ ] Verify breadcrumb visual rendering on the deploy preview is unchanged

## Related SEO work (for context — not part of this PR)

- #17155 — duplicate title tag fixes (merged)
- #17188 — SCIM page H1 fixes (merged)
- #17224 / #17243 / #17258 / #17275 — meta description Phases 1–4 (all merged)