### PR TITLE
feat(ingest/sigma): parse customSQL DM element definitions

### DIFF
--- a/metadata-ingestion/docs/sources/sigma/sigma_post.md
+++ b/metadata-ingestion/docs/sources/sigma/sigma_post.md
@@ -20,6 +20,42 @@ The following report counters are available for operational visibility:
 | `dm_customsql_column_lineage_emitted`       | Elements with at least one column lineage entry emitted                                        |
 | `dm_customsql_fgl_downstream_unmapped`      | Individual FGL downstream fields dropped (SQL column name not found in Sigma formula metadata) |
 
+#### Data Model element -> warehouse table lineage
+
+When `ingest_data_models: true` and `extract_lineage: true` (both default), the connector also emits entity-level `UpstreamLineage` from each Sigma Data Model element to the warehouse table it is sourced from.
+Resolution uses Sigma's `/v2/dataModels/{id}/lineage` (`type=table` entries) and `/v2/files/{inodeId}` to recover the fully-qualified table path (`<DB>/<SCHEMA>/<TABLE>`), then maps the Sigma connection to a DataHub platform via the connection registry.
+
+**Supported platforms**: All Sigma connection types in `SIGMA_TYPE_TO_DATAHUB_PLATFORM_MAP` (Snowflake, BigQuery, Redshift, Databricks, Postgres, MySQL, Athena, Spark, Trino, Presto, Synapse/MSSQL).
+Identifier casing is preserved as Sigma reports it, which matches the warehouse catalog for most platforms.
+Snowflake is the only platform that requires a case bridge (Snowflake's catalog uses uppercase identifiers, but the DataHub Snowflake connector lowercases them by default).
+
+**Matching URNs to your warehouse connector**: The emitted URNs use the Sigma recipe's `env` and `platform_instance=None` by default.
+This is correct for single-environment, single-instance setups.
+For multi-environment or multi-instance setups, use `connection_to_platform_map` to specify the exact env and platform_instance per Sigma connectionId:
+
+```yml
+connection_to_platform_map:
+  # Key is the Sigma connectionId (UUID from /v2/connections).
+  "4b39cdcd-5a58-4ff6-af0d-8409ff880a23":
+    env: PROD
+    platform_instance: prod-snowflake
+    # Set to false only if the Snowflake connector was run with
+    # convert_urns_to_lowercase: false (non-default).
+    convert_urns_to_lowercase: true
+```
+
+If a Snowflake source recipe sets `convert_urns_to_lowercase: false`, the warehouse connector emits upper-cased URNs and the edges produced here will dangle unless you set `convert_urns_to_lowercase: false` in the matching `connection_to_platform_map` entry.
+
+**Counters to monitor** (visible in the ingestion report):
+
+| Counter                                       | Meaning                                             |
+| --------------------------------------------- | --------------------------------------------------- |
+| `dm_element_warehouse_upstream_emitted`       | Warehouse lineage edges successfully emitted        |
+| `dm_element_warehouse_unknown_connection`     | ConnectionId not in registry or platform unmappable |
+| `dm_element_warehouse_table_lookup_failed`    | `/files/{inodeId}` call failed                      |
+| `dm_element_warehouse_path_unparseable`       | `/files` path did not match expected format         |
+| `dm_element_warehouse_table_entry_incomplete` | Lineage entry missing inodeId or connectionId       |
+
 ##### Chart source platform mapping
 
 If you want to provide platform details(platform name, platform instance and env) for chart's all external upstream data sources, then you can use `chart_sources_platform_mapping` as below:

--- a/metadata-ingestion/docs/sources/sigma/sigma_post.md
+++ b/metadata-ingestion/docs/sources/sigma/sigma_post.md
@@ -2,6 +2,24 @@
 
 Use the **Important Capabilities** table above as the source of truth for supported features and whether additional configuration is required.
 
+#### Data Model customSQL element lineage
+
+Data Model elements backed by a customSQL source emit warehouse `UpstreamLineage` and column-level `FineGrainedLineage` automatically — no additional configuration is required beyond a valid connection in the Sigma connection registry.
+
+For elements with explicit column lists in their SQL (`SELECT col_a, col_b FROM ...`), column lineage is derived directly from the SQL by the parser (confidence score 0.2). For elements using `SELECT *`, column lineage is inferred from Sigma's formula metadata (`[Custom SQL/COL]` refs on each element column); these entries carry a confidence score of 0.1 — lower than SQL-parsed lineage — because they rely on formula-derived inference rather than direct SQL analysis.
+
+The following report counters are available for operational visibility:
+
+| Counter                                     | Meaning                                                                                        |
+| ------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `dm_customsql_aggregator_invocations`       | SQL definitions successfully registered for parsing                                            |
+| `dm_customsql_aggregator_invocation_errors` | Registration failures (non-zero indicates an internal error)                                   |
+| `dm_customsql_skipped`                      | Elements skipped before parsing (missing definition, unknown connection, unsupported platform) |
+| `dm_customsql_parse_failed`                 | Definitions the SQL parser could not interpret (syntax errors, unsupported features, etc.)     |
+| `dm_customsql_upstream_emitted`             | Entity-level `UpstreamLineage` aspects emitted                                                 |
+| `dm_customsql_column_lineage_emitted`       | Elements with at least one column lineage entry emitted                                        |
+| `dm_customsql_fgl_downstream_unmapped`      | Individual FGL downstream fields dropped (SQL column name not found in Sigma formula metadata) |
+
 ##### Chart source platform mapping
 
 If you want to provide platform details(platform name, platform instance and env) for chart's all external upstream data sources, then you can use `chart_sources_platform_mapping` as below:
@@ -55,42 +73,6 @@ chart_sources_platform_mapping:
     platform_instance: new_instance
     env: PROD
 ```
-
-##### Data Model element -> warehouse table lineage
-
-When `ingest_data_models: true` and `extract_lineage: true` (both default), the connector also emits entity-level `UpstreamLineage` from each Sigma Data Model element to the warehouse table it is sourced from.
-Resolution uses Sigma's `/v2/dataModels/{id}/lineage` (`type=table` entries) and `/v2/files/{inodeId}` to recover the fully-qualified table path (`<DB>/<SCHEMA>/<TABLE>`), then maps the Sigma connection to a DataHub platform via the connection registry.
-
-**Supported platforms**: All Sigma connection types in `SIGMA_TYPE_TO_DATAHUB_PLATFORM_MAP` (Snowflake, BigQuery, Redshift, Databricks, Postgres, MySQL, Athena, Spark, Trino, Presto, Synapse/MSSQL).
-Identifier casing is preserved as Sigma reports it, which matches the warehouse catalog for most platforms.
-Snowflake is the only platform that requires a case bridge (Snowflake's catalog uses uppercase identifiers, but the DataHub Snowflake connector lowercases them by default).
-
-**Matching URNs to your warehouse connector**: The emitted URNs use the Sigma recipe's `env` and `platform_instance=None` by default.
-This is correct for single-environment, single-instance setups.
-For multi-environment or multi-instance setups, use `connection_to_platform_map` to specify the exact env and platform_instance per Sigma connectionId:
-
-```yml
-connection_to_platform_map:
-  # Key is the Sigma connectionId (UUID from /v2/connections).
-  "4b39cdcd-5a58-4ff6-af0d-8409ff880a23":
-    env: PROD
-    platform_instance: prod-snowflake
-    # Set to false only if the Snowflake connector was run with
-    # convert_urns_to_lowercase: false (non-default).
-    convert_urns_to_lowercase: true
-```
-
-If a Snowflake source recipe sets `convert_urns_to_lowercase: false`, the warehouse connector emits upper-cased URNs and the edges produced here will dangle unless you set `convert_urns_to_lowercase: false` in the matching `connection_to_platform_map` entry.
-
-**Counters to monitor** (visible in the ingestion report):
-
-| Counter                                       | Meaning                                             |
-| --------------------------------------------- | --------------------------------------------------- |
-| `dm_element_warehouse_upstream_emitted`       | Warehouse lineage edges successfully emitted        |
-| `dm_element_warehouse_unknown_connection`     | ConnectionId not in registry or platform unmappable |
-| `dm_element_warehouse_table_lookup_failed`    | `/files/{inodeId}` call failed                      |
-| `dm_element_warehouse_path_unparseable`       | `/files` path did not match expected format         |
-| `dm_element_warehouse_table_entry_incomplete` | Lineage entry missing inodeId or connectionId       |
 
 ### Limitations
 

--- a/metadata-ingestion/pyproject.toml
+++ b/metadata-ingestion/pyproject.toml
@@ -566,9 +566,12 @@ fabric-data-factory = [
 
 fabric-onelake = [
     "azure-identity>=1.21.0,<2.0",
+    "patchy==2.8.0",
     "pyodbc>=4.0,<6.0.0",
     "requests>=2.28.0,<3.0",
     "sqlalchemy>=1.4,<3.0",
+    "sqlglot==30.0.3",
+    "sqlparse<0.6.0",
 ]
 
 feast = [

--- a/metadata-ingestion/pyproject.toml
+++ b/metadata-ingestion/pyproject.toml
@@ -566,12 +566,9 @@ fabric-data-factory = [
 
 fabric-onelake = [
     "azure-identity>=1.21.0,<2.0",
-    "patchy==2.8.0",
     "pyodbc>=4.0,<6.0.0",
     "requests>=2.28.0,<3.0",
     "sqlalchemy>=1.4,<3.0",
-    "sqlglot==30.0.3",
-    "sqlparse<0.6.0",
 ]
 
 feast = [
@@ -1169,6 +1166,7 @@ sigma = [
     "patchy==2.8.0",
     "requests<3.0.0",
     "sqlglot==30.0.3",
+    "sqlparse<0.6.0",
 ]
 
 slack = [

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -580,7 +580,9 @@ plugins: Dict[str, Set[str]] = {
         "azure-identity>=1.21.0,<2.0",
         # upper bound added to pass check-python-deps.yml github workflow
         "requests>=2.28.0,<3.0",
-    },
+    }
+    | sqlglot_lib
+    | usage_common,
     "bigquery": sql_common
     | bigquery_common
     | sqlglot_lib

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -580,9 +580,7 @@ plugins: Dict[str, Set[str]] = {
         "azure-identity>=1.21.0,<2.0",
         # upper bound added to pass check-python-deps.yml github workflow
         "requests>=2.28.0,<3.0",
-    }
-    | sqlglot_lib
-    | usage_common,
+    },
     "bigquery": sql_common
     | bigquery_common
     | sqlglot_lib
@@ -803,7 +801,9 @@ plugins: Dict[str, Set[str]] = {
     "dlt": {"dlt>=1.0.0,<2.0.0"},
     "snaplogic": set(),
     "qlik-sense": sqlglot_lib | {"requests<3.0.0", "websocket-client<2.0.0"},
-    "sigma": sqlglot_lib | {"requests<3.0.0"},
+    # sqlparse: transitive runtime dep of SqlParsingAggregator (imported by sigma.py).
+    # Not directly imported by the sigma source; revisit if SqlParsingAggregator use is removed.
+    "sigma": sqlglot_lib | {"sqlparse<0.6.0", "requests<3.0.0"},
     "sac": sac,
     "neo4j": {"pandas<3.0.0", "neo4j<7.0.0"},
     "vertexai": {"google-cloud-aiplatform>=1.80.0,<2.0.0"},

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
@@ -312,6 +312,19 @@ class SigmaSourceReport(StaleEntityRemovalSourceReport):
 
     element_dm_edge: ElementDmEdgeReport = field(default_factory=ElementDmEdgeReport)
 
+    # DM customSQL element SQL parsing counters.
+    # Elements skipped before aggregator registration (no definition, missing /
+    # unknown connection, unsupported platform, duplicate source_id).
+    dm_customsql_skipped: int = 0
+    dm_customsql_aggregator_invocations: int = 0
+    dm_customsql_aggregator_invocation_errors: int = 0
+    dm_customsql_parse_failed: int = 0
+    dm_customsql_upstream_emitted: int = 0
+    dm_customsql_column_lineage_emitted: int = 0
+    # FGL downstream fields dropped because the SQL column name had no matching
+    # Sigma display column (formula ref absent or element name mismatch).
+    dm_customsql_fgl_downstream_unmapped: int = 0
+
     # Connection registry counters.
     # Records whose Sigma type mapped to a known DataHub platform.
     connections_resolved: int = 0

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/data_classes.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/data_classes.py
@@ -272,6 +272,15 @@ class SigmaDataModelElement(BaseModel):
         return values
 
 
+class CustomSqlEntry(BaseModel):
+    """Shape of a ``customSQL`` entry from ``/v2/dataModels/{id}/lineage``."""
+
+    name: str
+    type: str = ""
+    connectionId: str = ""
+    definition: str = ""
+
+
 class SigmaDataModel(BaseModel):
     dataModelId: str  # UUID; stable across renames
     name: str
@@ -289,7 +298,7 @@ class SigmaDataModel(BaseModel):
     badge: Optional[str] = None
     elements: List[SigmaDataModelElement] = []
     # Populated from /lineage ``data-model`` type entries during assembly.
-    # Maps source DM dataModelId (UUID) → [element names from that source DM].
+    # Maps source DM dataModelId (UUID) -> [element names from that source DM].
     # Used by cross-DM entity-level resolution to look up the correct source
     # element name without requiring the consuming element to share that name.
     source_dm_element_names: Dict[str, List[str]] = Field(default_factory=dict)
@@ -300,6 +309,10 @@ class SigmaDataModel(BaseModel):
     warehouse_inodes_by_inode_id: Dict[str, WarehouseInodeRaw] = Field(
         default_factory=dict
     )
+    # Populated from /lineage ``customSQL`` type entries during assembly.
+    # Maps customSQL entry name (the identifier elements reference in sourceIds)
+    # -> raw lineage entry dict (carries connectionId and definition).
+    custom_sql_by_name: Dict[str, CustomSqlEntry] = Field(default_factory=dict)
 
     def get_url_id(self) -> str:
         """Return the DM's URL identifier: explicit ``urlId`` if set,

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -127,6 +127,12 @@ logger = logging.getLogger(__name__)
 # column field (or we add SQL-based inference), swap this out here.
 SIGMA_DM_UNKNOWN_COLUMN_NATIVE_TYPE = "unknown"
 
+# FGL confidence scores for customSQL element lineage.
+_FGL_CONFIDENCE_SQL_PARSED: float = (
+    0.2  # aggregator-derived; matches SqlParsingAggregator
+)
+_FGL_CONFIDENCE_FORMULA_DERIVED: float = 0.1  # SELECT * synthesis from formula refs
+
 
 def _dm_column_ranks_above(
     candidate: SigmaDataModelColumn, incumbent: SigmaDataModelColumn
@@ -1177,7 +1183,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                             downstreams=[
                                 builder.make_schema_field_urn(entity_urn, sigma_col)
                             ],
-                            confidenceScore=0.1,
+                            confidenceScore=_FGL_CONFIDENCE_FORMULA_DERIVED,
                         )
                         for sql_col, sigma_col in col_mapping.items()
                     ]
@@ -1239,11 +1245,16 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
     def _drain_sql_aggregators(self) -> Iterable[MetadataWorkUnit]:
         """Drain all per-platform aggregators and emit lineage workunits.
 
-        Called once at the end of ``get_workunits_internal`` after all DM
-        elements have been registered via ``add_view_definition``.  FGL
-        downstream schemaField URNs are rewritten to match Sigma display names
-        before yielding.  Each aggregator is closed in a finally block so
-        SQLite-backed tempfiles are released even if gen_metadata raises.
+        Intentionally deferred to the end of ``get_workunits_internal``: all DM
+        elements must be registered via ``add_view_definition`` before parsing
+        runs, so the aggregator sees the full view set in one pass.  The
+        consolidated ``UpstreamLineage`` MCP emitted here is the source of truth
+        for customSQL-backed element lineage; any earlier per-element
+        ``UpstreamLineage`` MCP (for non-customSQL upstreams) is superseded by
+        the merged aspect yielded below.  FGL downstream schemaField URNs are
+        rewritten to Sigma display names before yielding.  Each aggregator is
+        closed in a finally block so SQLite-backed tempfiles are released even
+        if gen_metadata raises.
         """
         for cache_key, aggregator in sorted(
             self._sql_aggregators.items(),

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -44,6 +44,7 @@ from datahub.ingestion.source.sigma.connection_registry import (
     SigmaConnectionRegistry,
 )
 from datahub.ingestion.source.sigma.data_classes import (
+    CustomSqlEntry,
     DataModelElementUpstream,
     DataModelKey,
     DatasetUpstream,
@@ -108,6 +109,8 @@ from datahub.metadata.schema_classes import (
     SubTypesClass,
     TagAssociationClass,
 )
+from datahub.metadata.urns import SchemaFieldUrn
+from datahub.sql_parsing.sql_parsing_aggregator import SqlParsingAggregator
 from datahub.sql_parsing.sqlglot_lineage import create_lineage_sql_parsed_result
 from datahub.utilities.urns.dataset_urn import DatasetUrn
 from datahub.utilities.urns.error import InvalidUrnError
@@ -282,6 +285,27 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         # dataModelIds whose bridge key collided with an earlier DM. The
         # emit loop skips these to avoid unlinked orphan Containers.
         self.dm_collided_data_model_ids: Set[str] = set()
+        # Per-platform SqlParsingAggregator instances for customSQL DM elements,
+        # keyed by (platform, env, platform_instance).
+        self._sql_aggregators: Dict[
+            Tuple[str, str, Optional[str]], SqlParsingAggregator
+        ] = {}
+        # element_dataset_urn -> {sql_col_lower -> sigma_col_name}.
+        # Built from ALL formula refs for FGL rewriting of named-column SELECTs.
+        self._customsql_col_mappings: Dict[str, Dict[str, str]] = {}
+        # Same key, but only single-ref (passthrough) formulas.
+        # Used for SELECT * synthesis to avoid fabricating upstream edges for
+        # computed expressions that reference multiple SQL columns.
+        self._customsql_passthrough_mappings: Dict[str, Dict[str, str]] = {}
+        # Element URNs registered with an aggregator via add_view_definition.
+        # Used to guard against multiple customSQL source_ids on one element
+        # and to scope dm_customsql_upstream_emitted to known registrations.
+        self._customsql_registered_urns: Set[str] = set()
+        # element_urn -> non-customSQL Upstream / FGL objects stashed from the
+        # per-element emit path.  Merged into the aggregator's UpstreamLineage
+        # MCP at drain so the final aspect is consolidated.
+        self._customsql_extra_upstreams: Dict[str, List[Upstream]] = {}
+        self._customsql_extra_fgls: Dict[str, List[FineGrainedLineageClass]] = {}
         # DM urlId → DM dataModelId (UUID). Reverse of get_url_id(); used to
         # correlate ``data-model`` lineage entries (keyed by dataModelId) with
         # source_id prefixes (keyed by urlId) in cross-DM upstream resolution.
@@ -948,6 +972,298 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         # ``malformed`` has no dedicated counter; falls into the caller's
         # generic ``data_model_element_upstreams_unresolved`` bump.
 
+    # ------------------------------------------------------------------
+    # customSQL DM element SQL parsing
+    # ------------------------------------------------------------------
+
+    def _get_sql_aggregator(
+        self,
+        platform: str,
+        env: str,
+        platform_instance: Optional[str],
+    ) -> SqlParsingAggregator:
+        """Return (or lazily create) the per-platform aggregator instance.
+
+        This path is independent of the ``generate_column_lineage=False``
+        kill-switch in ``_get_element_input_details`` (the workbook element
+        SQL path).  That flag guards ``sqlglot.lineage()`` /
+        ``create_lineage_sql_parsed_result`` which caused OOM on large workbook
+        SQL; the aggregator's ``add_view_definition`` uses a different, bounded
+        parsing path and does not share that kill-switch.
+        """
+        cache_key = (platform, env, platform_instance)
+        if cache_key not in self._sql_aggregators:
+            self._sql_aggregators[cache_key] = SqlParsingAggregator(
+                platform=platform,
+                platform_instance=platform_instance,
+                env=env,
+                schema_resolver=None,
+                graph=None,
+                generate_lineage=True,
+                generate_queries=False,
+                generate_query_subject_fields=False,
+                generate_usage_statistics=False,
+                generate_query_usage_statistics=False,
+                generate_operations=False,
+            )
+        return self._sql_aggregators[cache_key]
+
+    def _build_customsql_col_mapping(
+        self,
+        element: SigmaDataModelElement,
+        element_dataset_urn: str,
+    ) -> None:
+        """Populate ``_customsql_col_mappings`` for one customSQL-backed element.
+
+        Scans each column's formula for refs of the form ``[{element.name}/COL]``
+        and maps each SQL column name (lowercased) to the Sigma display column
+        name.  Only refs whose namespace matches the element's own name are
+        registered — cross-element refs (``[OtherElement/COL]``) are skipped so
+        they cannot pollute the rewrite map.  ``finditer`` is used so that
+        formulas referencing multiple SQL columns register all of them.
+        """
+        mapping: Dict[str, str] = {}
+        passthrough: Dict[str, str] = {}
+        for col in element.columns:
+            refs = extract_bracket_refs(col.formula)
+            for ref in refs:
+                if (
+                    ref.column is not None
+                    and ref.source.lower() == element.name.lower()
+                ):
+                    sql_col_lower = ref.column.lower()
+                    if sql_col_lower in mapping and mapping[sql_col_lower] != col.name:
+                        logger.warning(
+                            "DM element %r: SQL column %r referenced by multiple Sigma "
+                            "display columns (%r and %r); using the latter for FGL.",
+                            element_dataset_urn,
+                            ref.column,
+                            mapping[sql_col_lower],
+                            col.name,
+                        )
+                    mapping[sql_col_lower] = col.name
+                    # Single-ref formula = direct passthrough of an upstream column.
+                    # Multi-ref = computed expression; exclude from SELECT * synthesis
+                    # to avoid fabricating upstream edges for non-existent columns.
+                    if len(refs) == 1:
+                        passthrough[sql_col_lower] = col.name
+        if mapping:
+            self._customsql_col_mappings[element_dataset_urn] = mapping
+        if passthrough:
+            self._customsql_passthrough_mappings[element_dataset_urn] = passthrough
+
+    def _process_dm_customsql_element(
+        self,
+        element_dataset_urn: str,
+        customsql_entry: CustomSqlEntry,
+    ) -> None:
+        """Register one customSQL DM element with the per-platform aggregator."""
+        if element_dataset_urn in self._customsql_registered_urns:
+            self.reporter.dm_customsql_skipped += 1
+            self.reporter.warning(
+                title="Sigma DM element has multiple customSQL source_ids",
+                message="Only the first customSQL source_id is used for warehouse lineage; subsequent ones are skipped. The first-seen ordering is determined by Sigma's /lineage API response.",
+                context=(
+                    f"element_urn={element_dataset_urn!r}, "
+                    f"skipped_name={customsql_entry.name!r}, "
+                    f"skipped_definition_prefix={(customsql_entry.definition)[:80]!r}"
+                ),
+            )
+            return
+
+        definition = (customsql_entry.definition or "").strip()
+        if not definition:
+            self.reporter.dm_customsql_skipped += 1
+            return
+
+        connection_id = customsql_entry.connectionId
+        if not connection_id:
+            self.reporter.dm_customsql_skipped += 1
+            return
+        record = self.connection_registry.get(connection_id)
+        if record is None:
+            self.reporter.dm_customsql_skipped += 1
+            logger.warning(
+                "DM customSQL element %r: connectionId=%r not found in connection registry; "
+                "warehouse lineage will be absent.  Check /v2/connections scope/permissions.",
+                element_dataset_urn,
+                connection_id,
+            )
+            return
+        if not record.is_mappable:
+            self.reporter.dm_customsql_skipped += 1
+            logger.warning(
+                "DM customSQL element %r: Sigma connection type %r is not mapped to a "
+                "DataHub platform; warehouse lineage will be absent.  "
+                "Add it to SIGMA_TYPE_TO_DATAHUB_PLATFORM_MAP if supported.",
+                element_dataset_urn,
+                record.sigma_type,
+            )
+            return
+
+        aggregator = self._get_sql_aggregator(
+            platform=record.datahub_platform,
+            env=self.config.env,
+            platform_instance=self.config.platform_instance,
+        )
+        try:
+            aggregator.add_view_definition(
+                view_urn=element_dataset_urn,
+                view_definition=definition,
+                default_db=record.default_database,
+                default_schema=record.default_schema,
+            )
+            self.reporter.dm_customsql_aggregator_invocations += 1
+            self._customsql_registered_urns.add(element_dataset_urn)
+        except Exception as e:
+            self.reporter.dm_customsql_aggregator_invocation_errors += 1
+            self.reporter.warning(
+                title="Sigma DM customSQL element registration failed",
+                message="SqlParsingAggregator.add_view_definition raised; this element will be emitted without warehouse lineage.",
+                context=f"element_urn={element_dataset_urn}, customsql_name={customsql_entry.name!r}, connection_id={connection_id!r}, platform={record.datahub_platform}",
+                exc=e,
+            )
+
+    def _rewrite_fgl_downstreams(
+        self, mcp: MetadataChangeProposalWrapper
+    ) -> MetadataChangeProposalWrapper:
+        """Rewrite FGL downstream schemaField URNs to use Sigma column names.
+
+        The aggregator derives downstream field names from the SQL SELECT list
+        (e.g. ``customer_id``), but DataHub's SchemaMetadata for Sigma elements
+        uses the display names from ``/columns`` (e.g. ``Customer Id``).
+        ``_customsql_col_mappings`` bridges the two via the formula ref
+        ``[Custom SQL/CUSTOMER_ID]`` that Sigma stores on each column.
+
+        FGL entries whose downstreams cannot be rewritten are dropped; the
+        entity-level ``upstreams`` list on the aspect is always preserved.
+        """
+        aspect = mcp.aspect
+        if not isinstance(aspect, UpstreamLineage):
+            return mcp
+        entity_urn = str(mcp.entityUrn)
+        # Only count MCPs for element URNs we registered — the aggregator
+        # should only emit for those, but guard in case of future changes.
+        if entity_urn in self._customsql_registered_urns:
+            self.reporter.dm_customsql_upstream_emitted += 1
+
+        # Merge non-customSQL upstreams stashed from the per-element emit so the
+        # final aspect is consolidated rather than the second emission overwriting.
+        extra_upstreams = self._customsql_extra_upstreams.get(entity_urn)
+        if extra_upstreams:
+            aspect.upstreams = list(aspect.upstreams or []) + extra_upstreams
+
+        # Extra FGLs come from the non-customSQL path and already use Sigma
+        # display names — keep them separate from the aggregator FGL so the
+        # rewrite loop below doesn't try to remap them.
+        extra_fgls = self._customsql_extra_fgls.get(entity_urn)
+
+        if not aspect.fineGrainedLineages:
+            # For SELECT * on a single upstream, synthesize FGL from passthrough
+            # formula refs: only single-ref formulas are included so computed
+            # expressions (If([X]>0,[Y],0)) don't fabricate non-existent upstream
+            # column edges.  Confidence 0.1 (formula-derived, lower than SQL-parsed 0.2).
+            if len(aspect.upstreams) == 1:
+                col_mapping = self._customsql_passthrough_mappings.get(entity_urn)
+                if col_mapping:
+                    upstream_urn = aspect.upstreams[0].dataset
+                    aspect.fineGrainedLineages = [
+                        FineGrainedLineageClass(
+                            upstreamType=FineGrainedLineageUpstreamTypeClass.FIELD_SET,
+                            upstreams=[
+                                builder.make_schema_field_urn(upstream_urn, sql_col)
+                            ],
+                            downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
+                            downstreams=[
+                                builder.make_schema_field_urn(entity_urn, sigma_col)
+                            ],
+                            confidenceScore=0.1,
+                        )
+                        for sql_col, sigma_col in col_mapping.items()
+                    ]
+                    self.reporter.dm_customsql_column_lineage_emitted += 1
+                    if extra_fgls:
+                        aspect.fineGrainedLineages = (
+                            list(aspect.fineGrainedLineages) + extra_fgls
+                        )
+                    return mcp
+            # No synthesis possible; still merge stashed non-customSQL FGL.
+            if extra_fgls:
+                aspect.fineGrainedLineages = extra_fgls
+            return mcp
+
+        rewritten_fgls = []
+        for fgl in aspect.fineGrainedLineages:
+            rewritten_downstreams = []
+            for ds_urn in fgl.downstreams or []:
+                try:
+                    sfu = SchemaFieldUrn.from_string(ds_urn)
+                except InvalidUrnError:
+                    self.reporter.dm_customsql_fgl_downstream_unmapped += 1
+                    logger.warning(
+                        "Aggregator emitted malformed schemaField URN %r; dropping FGL entry.",
+                        ds_urn,
+                    )
+                    continue
+                ds_parent_urn, field_path = sfu.parent, sfu.field_path
+                col_mapping = self._customsql_col_mappings.get(ds_parent_urn)
+                if col_mapping is None:
+                    rewritten_downstreams.append(ds_urn)
+                    continue
+                sigma_col = col_mapping.get(field_path.lower())
+                if sigma_col:
+                    rewritten_downstreams.append(
+                        builder.make_schema_field_urn(ds_parent_urn, sigma_col)
+                    )
+                else:
+                    self.reporter.dm_customsql_fgl_downstream_unmapped += 1
+            if rewritten_downstreams:
+                rewritten_fgls.append(
+                    FineGrainedLineageClass(
+                        upstreamType=fgl.upstreamType,
+                        upstreams=fgl.upstreams,
+                        downstreamType=fgl.downstreamType,
+                        downstreams=rewritten_downstreams,
+                        confidenceScore=fgl.confidenceScore,
+                    )
+                )
+
+        # Append non-customSQL FGL after rewriting; they use Sigma display names
+        # already and must not be passed through the rewrite loop above.
+        all_fgls = rewritten_fgls + (extra_fgls or [])
+        aspect.fineGrainedLineages = all_fgls or None
+        if rewritten_fgls:
+            self.reporter.dm_customsql_column_lineage_emitted += 1
+        return mcp
+
+    def _drain_sql_aggregators(self) -> Iterable[MetadataWorkUnit]:
+        """Drain all per-platform aggregators and emit lineage workunits.
+
+        Called once at the end of ``get_workunits_internal`` after all DM
+        elements have been registered via ``add_view_definition``.  FGL
+        downstream schemaField URNs are rewritten to match Sigma display names
+        before yielding.  Each aggregator is closed in a finally block so
+        SQLite-backed tempfiles are released even if gen_metadata raises.
+        """
+        for cache_key, aggregator in sorted(
+            self._sql_aggregators.items(),
+            key=lambda kv: tuple(x or "" for x in kv[0]),
+        ):
+            try:
+                for mcp in aggregator.gen_metadata():
+                    yield self._rewrite_fgl_downstreams(mcp).as_workunit()
+                agg_report = aggregator.report
+                self.reporter.dm_customsql_parse_failed += agg_report.num_views_failed
+            except Exception as e:
+                self.reporter.warning(
+                    title="Sigma DM customSQL aggregator drain failed",
+                    message="SqlParsingAggregator.gen_metadata raised; warehouse lineage for this platform's customSQL elements may be partial.",
+                    context=f"aggregator_key={cache_key!r}",
+                    exc=e,
+                )
+            finally:
+                aggregator.close()
+
     def _gen_data_model_element_upstream_lineage(
         self,
         element: SigmaDataModelElement,
@@ -1048,6 +1364,16 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                         source_id,
                         cross_dm_outcome,
                     )
+            elif source_id in data_model.custom_sql_by_name:
+                # customSQL source: register with the aggregator for deferred
+                # SQL parsing.  The aggregator emits UpstreamLineage + FGL at
+                # drain time; no upstream_urn is added to the entity-level list
+                # here because the aggregator owns that emission.
+                self._process_dm_customsql_element(
+                    element_dataset_urn,
+                    data_model.custom_sql_by_name[source_id],
+                )
+                shape = "customSQL"
             else:
                 # Any other shape we don't parse (future Sigma vendor
                 # shape, or an existing shape we missed). Counted
@@ -1528,6 +1854,14 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                 aspect=BrowsePathsV2Class(browse_entries),
             ).as_workunit()
 
+            has_customsql = any(
+                sid in data_model.custom_sql_by_name for sid in element.source_ids
+            )
+            # Build formula-based col mapping before processing lineage so
+            # _drain_sql_aggregators can rewrite FGL downstream field names.
+            if has_customsql:
+                self._build_customsql_col_mapping(element, element_dataset_urn)
+
             upstream_lineage = self._gen_data_model_element_upstream_lineage(
                 element,
                 data_model,
@@ -1537,9 +1871,28 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                 warehouse_url_id_map=warehouse_url_id_map,
             )
             if upstream_lineage is not None:
-                yield MetadataChangeProposalWrapper(
-                    entityUrn=element_dataset_urn, aspect=upstream_lineage
-                ).as_workunit()
+                if (
+                    has_customsql
+                    and element_dataset_urn in self._customsql_registered_urns
+                ):
+                    # customSQL pre-flight succeeded: stash non-customSQL
+                    # upstreams/FGL and skip the immediate emit.  Drain will
+                    # merge them into the single consolidated UpstreamLineage
+                    # MCP, avoiding a redundant overwrite.
+                    if upstream_lineage.upstreams:
+                        self._customsql_extra_upstreams[element_dataset_urn] = list(
+                            upstream_lineage.upstreams
+                        )
+                    if upstream_lineage.fineGrainedLineages:
+                        self._customsql_extra_fgls[element_dataset_urn] = list(
+                            upstream_lineage.fineGrainedLineages
+                        )
+                else:
+                    # No customSQL registration (pre-flight failed or no
+                    # customSQL on this element): emit immediately.
+                    yield MetadataChangeProposalWrapper(
+                        entityUrn=element_dataset_urn, aspect=upstream_lineage
+                    ).as_workunit()
 
             self.reporter.data_model_elements_emitted += 1
             if data_model.workspaceId:
@@ -2207,7 +2560,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             all_sibling = False
 
             if formula is not None:
-                refs = list(extract_bracket_refs(formula))
+                refs = extract_bracket_refs(formula)
                 if refs:
                     param_count = 0
                     sibling_count = 0
@@ -2561,6 +2914,17 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
     def get_workunits_internal(self) -> Iterable[MetadataWorkUnit]:  # noqa: C901
         """DataHub Ingestion framework entry point."""
         logger.info("Sigma plugin execution is started")
+        # Reset per-run customSQL state so re-invoking this method on the same
+        # instance (e.g. in test harnesses) does not leak state from a prior run.
+        # Close existing aggregators before clearing so SQLite tempfiles are released.
+        for _agg in self._sql_aggregators.values():
+            _agg.close()
+        self._sql_aggregators.clear()
+        self._customsql_col_mappings.clear()
+        self._customsql_passthrough_mappings.clear()
+        self._customsql_registered_urns.clear()
+        self._customsql_extra_upstreams.clear()
+        self._customsql_extra_fgls.clear()
         self.sigma_api.fill_workspaces()
 
         # Materialize the Sigma Dataset list once and populate the
@@ -2794,6 +3158,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                     f"{workspace.name} ({workspace.workspaceId})"
                 )
         yield from self._gen_sigma_dataset_upstream_lineage_workunit()
+        yield from self._drain_sql_aggregators()
 
     def get_report(self) -> SourceReport:
         return self.reporter

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
@@ -28,6 +28,7 @@ from datahub.ingestion.source.sigma.config import (
     SigmaSourceReport,
 )
 from datahub.ingestion.source.sigma.data_classes import (
+    CustomSqlEntry,
     DataModelElementUpstream,
     DatasetUpstream,
     Element,
@@ -1061,6 +1062,7 @@ class SigmaAPI:
         # (e.g. during alias discovery) cannot accumulate stale entries.
         data_model.source_dm_element_names = {}
         data_model.warehouse_inodes_by_inode_id = {}
+        data_model.custom_sql_by_name = {}
         source_ids_by_element: Dict[str, List[str]] = {}
         for entry in lineage_entries:
             entry_type = entry.get(Constant.TYPE)
@@ -1094,10 +1096,6 @@ class SigmaAPI:
                 # needed to construct fully-qualified warehouse Dataset URNs.
                 inode_id = str(entry.get("inodeId") or "")
                 conn_id = str(entry.get("connectionId") or "")
-                # name is intentionally NOT required here: the table name is
-                # taken from /files/{inodeId} (the canonical source) rather
-                # than from the lineage entry, which may carry a display label,
-                # a stale name, or be absent entirely for some Sigma releases.
                 if not (inode_id and conn_id):
                     self.report.dm_element_warehouse_table_entry_incomplete += 1
                     missing = [
@@ -1121,8 +1119,25 @@ class SigmaAPI:
                     continue
                 raw: WarehouseInodeRaw = {"connectionId": conn_id}
                 data_model.warehouse_inodes_by_inode_id[inode_id] = raw
-            # ``type: dataset`` entries (CSV uploads) are terminal;
-            # warehouse lineage is handled above via type=table.
+            elif entry_type in ("customSQL", "customSql"):
+                name = entry.get("name")
+                if isinstance(name, str) and name:
+                    if name in data_model.custom_sql_by_name:
+                        self.report.warning(
+                            title="Sigma DM customSQL duplicate entry name",
+                            message="Two customSQL lineage entries share the same name; later entry overwrites earlier — elements sourcing the earlier entry will get the wrong SQL.",
+                            context=f"dataModelId={data_model.dataModelId!r}, name={name!r}",
+                        )
+                    data_model.custom_sql_by_name[name] = CustomSqlEntry.model_validate(
+                        entry
+                    )
+                else:
+                    self.report.warning(
+                        title="Sigma DM customSQL entry missing name",
+                        message="A customSQL lineage entry has a missing or non-string name field; it will be skipped and any elements referencing it will have no warehouse lineage.",
+                        context=f"dataModelId={data_model.dataModelId!r}, entry_keys={sorted(entry.keys())!r}",
+                    )
+            # ``type: dataset`` entries (CSV uploads) are terminal.
 
         for element in elements:
             element.columns = columns_by_element.get(element.elementId, [])

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
@@ -1122,6 +1122,10 @@ class SigmaAPI:
             elif entry_type in ("customSQL", "customSql"):
                 name = entry.get("name")
                 if isinstance(name, str) and name:
+                    # Sigma's API normally guarantees unique entry names within
+                    # a DM.  A collision here means a payload anomaly; last
+                    # entry wins so downstream elements still resolve (with a
+                    # warning so operators can investigate).
                     if name in data_model.custom_sql_by_name:
                         self.report.warning(
                             title="Sigma DM customSQL duplicate entry name",

--- a/metadata-ingestion/tests/integration/sigma/golden_test_sigma_ingest_data_models_customsql.json
+++ b/metadata-ingestion/tests/integration/sigma/golden_test_sigma_ingest_data_models_customsql.json
@@ -1,0 +1,421 @@
+[
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:5e4833d094f9dbaf1d8d535faaf800b3",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:b8430f8330e8295917b8e507b441363e"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778042208876,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:5e4833d094f9dbaf1d8d535faaf800b3",
+    "changeType": "UPSERT",
+    "aspectName": "containerProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "platform": "sigma",
+                "dataModelId": "aa000000-0000-0000-0000-000000000001",
+                "dataModelUrlId": "customsql-dm-urlid",
+                "path": "Test Workspace"
+            },
+            "name": "CustomSQL DM",
+            "created": {
+                "time": 1704067200000
+            },
+            "lastModified": {
+                "time": 1704153600000
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778042208876,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:5e4833d094f9dbaf1d8d535faaf800b3",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778042208877,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:5e4833d094f9dbaf1d8d535faaf800b3",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:sigma"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778042208877,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:5e4833d094f9dbaf1d8d535faaf800b3",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Sigma Data Model"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778042208877,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:5e4833d094f9dbaf1d8d535faaf800b3",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:b8430f8330e8295917b8e507b441363e",
+                    "urn": "urn:li:container:b8430f8330e8295917b8e507b441363e"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778042208878,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,aa000000-0000-0000-0000-000000000001.csql-el-01,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778042208886,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,aa000000-0000-0000-0000-000000000001.csql-el-01,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dataModelId": "aa000000-0000-0000-0000-000000000001",
+                "dataModelUrlId": "customsql-dm-urlid",
+                "elementId": "csql-el-01",
+                "type": "table"
+            },
+            "name": "Custom SQL",
+            "qualifiedName": "CustomSQL DM/Custom SQL",
+            "tags": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778042208887,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,aa000000-0000-0000-0000-000000000001.csql-el-01,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Sigma Data Model Element"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778042208887,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,aa000000-0000-0000-0000-000000000001.csql-el-01,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "Custom SQL",
+            "platform": "urn:li:dataPlatform:sigma",
+            "version": 0,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.OtherSchema": {
+                    "rawSchema": ""
+                }
+            },
+            "fields": [
+                {
+                    "fieldPath": "Amount",
+                    "nullable": false,
+                    "description": "Amount",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NullType": {}
+                        }
+                    },
+                    "nativeDataType": "unknown",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "Order Id",
+                    "nullable": false,
+                    "description": "Order Id",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NullType": {}
+                        }
+                    },
+                    "nativeDataType": "unknown",
+                    "recursive": false,
+                    "isPartOfKey": false
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778042447981,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,aa000000-0000-0000-0000-000000000001.csql-el-01,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:5e4833d094f9dbaf1d8d535faaf800b3"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778042208888,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,aa000000-0000-0000-0000-000000000001.csql-el-01,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:b8430f8330e8295917b8e507b441363e",
+                    "urn": "urn:li:container:b8430f8330e8295917b8e507b441363e"
+                },
+                {
+                    "id": "urn:li:container:5e4833d094f9dbaf1d8d535faaf800b3",
+                    "urn": "urn:li:container:5e4833d094f9dbaf1d8d535faaf800b3"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778042208889,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:b8430f8330e8295917b8e507b441363e",
+    "changeType": "UPSERT",
+    "aspectName": "containerProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "platform": "sigma",
+                "workspaceId": "bb000000-0000-0000-0000-000000000001"
+            },
+            "name": "Test Workspace",
+            "created": {
+                "time": 1704067200000
+            },
+            "lastModified": {
+                "time": 1704067200000
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778042208919,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:b8430f8330e8295917b8e507b441363e",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778042208920,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:b8430f8330e8295917b8e507b441363e",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:sigma"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778042208920,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:b8430f8330e8295917b8e507b441363e",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Sigma Workspace"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778042208920,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:b8430f8330e8295917b8e507b441363e",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778042208920,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,aa000000-0000-0000-0000-000000000001.csql-el-01,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "upstreamLineage",
+    "aspect": {
+        "json": {
+            "upstreams": [
+                {
+                    "auditStamp": {
+                        "time": 1778042447985,
+                        "actor": "urn:li:corpuser:_ingestion"
+                    },
+                    "created": {
+                        "time": 0,
+                        "actor": "urn:li:corpuser:_ingestion"
+                    },
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.orders,PROD)",
+                    "type": "VIEW"
+                }
+            ],
+            "fineGrainedLineages": [
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.orders,PROD),order_id)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:sigma,aa000000-0000-0000-0000-000000000001.csql-el-01,PROD),Order Id)"
+                    ],
+                    "confidenceScore": 0.2
+                },
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.orders,PROD),amount)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:sigma,aa000000-0000-0000-0000-000000000001.csql-el-01,PROD),Amount)"
+                    ],
+                    "confidenceScore": 0.2
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778042447988,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+}
+]

--- a/metadata-ingestion/tests/integration/sigma/test_sigma.py
+++ b/metadata-ingestion/tests/integration/sigma/test_sigma.py
@@ -6572,3 +6572,196 @@ def test_sigma_ingest_data_models_warehouse_upstream(
         output_path=output_path,
         golden_path=f"{test_resources_dir}/golden_test_sigma_dm_warehouse_upstream.json",
     )
+
+
+def _get_mock_customsql_dm_api() -> Dict[str, Dict]:
+    """Mock a single DM with one customSQL element (explicit column SELECT)."""
+    dm_id = "aa000000-0000-0000-0000-000000000001"
+    ws_id = "bb000000-0000-0000-0000-000000000001"
+    element_id = "csql-el-01"
+    conn_id = "conn-sf-csql"
+    return {
+        "https://aws-api.sigmacomputing.com/v2/connections": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "entries": [
+                    {
+                        "connectionId": conn_id,
+                        "name": "Test Connection",
+                        "type": "snowflake",
+                        "account": "test-account",
+                        "warehouse": "TEST_WH",
+                    }
+                ],
+                "total": 1,
+                "nextPage": None,
+            },
+        },
+        "https://aws-api.sigmacomputing.com/v2/workspaces?limit=50": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "entries": [
+                    {
+                        "workspaceId": ws_id,
+                        "name": "Test Workspace",
+                        "createdBy": "test-user",
+                        "updatedBy": "test-user",
+                        "createdAt": "2024-01-01T00:00:00.000Z",
+                        "updatedAt": "2024-01-01T00:00:00.000Z",
+                    }
+                ],
+                "total": 1,
+                "nextPage": None,
+            },
+        },
+        "https://aws-api.sigmacomputing.com/v2/files?typeFilters=data-model": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "entries": [
+                    {
+                        "id": dm_id,
+                        "urlId": "customsql-dm-urlid",
+                        "name": "CustomSQL DM",
+                        "type": "data-model",
+                        "parentId": ws_id,
+                        "parentUrlId": "test-ws-urlid",
+                        "permission": "edit",
+                        "path": "Test Workspace",
+                        "badge": None,
+                        "createdBy": "test-user",
+                        "updatedBy": "test-user",
+                        "createdAt": "2024-01-01T00:00:00.000Z",
+                        "updatedAt": "2024-01-02T00:00:00.000Z",
+                        "isArchived": False,
+                    }
+                ],
+                "total": 1,
+                "nextPage": None,
+            },
+        },
+        "https://aws-api.sigmacomputing.com/v2/dataModels": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "entries": [
+                    {
+                        "dataModelId": dm_id,
+                        "urlId": "customsql-dm-urlid",
+                        "name": "CustomSQL DM",
+                        "createdBy": "test-user",
+                        "createdAt": "2024-01-01T00:00:00.000Z",
+                        "updatedAt": "2024-01-02T00:00:00.000Z",
+                        "workspaceId": ws_id,
+                        "path": "Test Workspace",
+                    }
+                ],
+                "total": 1,
+                "nextPage": None,
+            },
+        },
+        f"https://aws-api.sigmacomputing.com/v2/dataModels/{dm_id}/elements": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "entries": [
+                    {
+                        "elementId": element_id,
+                        "name": "Custom SQL",
+                        "type": "table",
+                        "vizualizationType": None,
+                        "columns": [],
+                    }
+                ],
+                "total": 1,
+                "nextPage": None,
+            },
+        },
+        f"https://aws-api.sigmacomputing.com/v2/dataModels/{dm_id}/columns": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "entries": [
+                    {
+                        "columnId": "col-order-id",
+                        "elementId": element_id,
+                        "name": "Order Id",
+                        "label": "Order Id",
+                        "formula": "[Custom SQL/ORDER_ID]",
+                    },
+                    {
+                        "columnId": "col-amount",
+                        "elementId": element_id,
+                        "name": "Amount",
+                        "label": "Amount",
+                        "formula": "[Custom SQL/AMOUNT]",
+                    },
+                ],
+                "total": 2,
+                "nextPage": None,
+            },
+        },
+        f"https://aws-api.sigmacomputing.com/v2/dataModels/{dm_id}/lineage": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "entries": [
+                    {
+                        "name": "csql-src-1",
+                        "type": "customSQL",
+                        "connectionId": conn_id,
+                        "definition": (
+                            "SELECT ORDER_ID, AMOUNT FROM TEST_DB.TEST_SCHEMA.ORDERS"
+                        ),
+                    },
+                    {
+                        "elementId": element_id,
+                        "type": "element",
+                        "sourceIds": ["csql-src-1"],
+                        "dataSourceIds": ["csql-src-1"],
+                    },
+                ],
+                "total": 2,
+                "nextPage": None,
+            },
+        },
+    }
+
+
+@pytest.mark.integration
+def test_sigma_ingest_data_models_customsql(pytestconfig, tmp_path, requests_mock):
+    """DM customSQL element: UpstreamLineage + FGL emitted via SqlParsingAggregator.
+
+    Verifies:
+    - Entity-level UpstreamLineage emitted on the customSQL DM element Dataset.
+    - FGL downstream schemaField URNs use Sigma column display names (``Visit Id``,
+      ``Customer Id``), not SQL column names (``visit_id``, ``customer_id``).
+    - Counter shape: aggregator invocations == 1, upstream emitted == 1.
+    - Golden file captures the new UpstreamLineage + FineGrainedLineage aspects.
+    """
+    test_resources_dir = pytestconfig.rootpath / "tests/integration/sigma"
+
+    register_mock_api(
+        request_mock=requests_mock,
+        override_data=_get_mock_customsql_dm_api(),
+    )
+
+    output_path = f"{tmp_path}/sigma_customsql_mces.json"
+    pipeline = Pipeline.create(
+        _minimal_sigma_pipeline_config(output_path, ingest_data_models=True)
+    )
+    pipeline.run()
+    pipeline.raise_from_status()
+
+    report = _sigma_report(pipeline)
+    assert report.dm_customsql_aggregator_invocations == 1
+    assert report.dm_customsql_upstream_emitted == 1
+    assert report.dm_customsql_column_lineage_emitted == 1
+
+    mce_helpers.check_golden_file(
+        pytestconfig,
+        output_path=output_path,
+        golden_path=f"{test_resources_dir}/golden_test_sigma_ingest_data_models_customsql.json",
+    )

--- a/metadata-ingestion/tests/unit/sigma/test_dm_customsql_parsing.py
+++ b/metadata-ingestion/tests/unit/sigma/test_dm_customsql_parsing.py
@@ -487,7 +487,7 @@ class TestFglRewrite:
             ),
         )
         result = source._rewrite_fgl_downstreams(mcp)
-        aspect = result.aspect
+        aspect = cast(UpstreamLineage, result.aspect)
         fgls = aspect.fineGrainedLineages or []
         assert len(fgls) == 1
         # Original URN passed through unchanged.
@@ -562,10 +562,15 @@ class TestFglRewrite:
         cache_key = ("snowflake", "PROD", None)
         bad_aggregator = source._sql_aggregators[cache_key]
         close_mock = MagicMock(wraps=bad_aggregator.close)
-        bad_aggregator.close = close_mock
-        bad_aggregator.gen_metadata = MagicMock(side_effect=RuntimeError("boom"))
-
-        list(source._drain_sql_aggregators())
+        with (
+            patch.object(bad_aggregator, "close", close_mock),
+            patch.object(
+                bad_aggregator,
+                "gen_metadata",
+                MagicMock(side_effect=RuntimeError("boom")),
+            ),
+        ):
+            list(source._drain_sql_aggregators())
 
         # drain warning must be reported, close must still be called.
         assert any(

--- a/metadata-ingestion/tests/unit/sigma/test_dm_customsql_parsing.py
+++ b/metadata-ingestion/tests/unit/sigma/test_dm_customsql_parsing.py
@@ -1,0 +1,587 @@
+"""Unit tests for DM customSQL element SQL parsing (SqlParsingAggregator path)."""
+
+from typing import Dict, cast
+from unittest.mock import patch
+
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.api.workunit import MetadataWorkUnit
+from datahub.ingestion.source.sigma.config import SigmaSourceConfig
+from datahub.ingestion.source.sigma.connection_registry import (
+    SigmaConnectionRecord,
+    SigmaConnectionRegistry,
+)
+from datahub.ingestion.source.sigma.data_classes import (
+    CustomSqlEntry,
+    SigmaDataModelColumn,
+    SigmaDataModelElement,
+)
+from datahub.ingestion.source.sigma.sigma import SigmaSource
+from datahub.ingestion.source.sigma.sigma_api import SigmaAPI
+from datahub.metadata.com.linkedin.pegasus2avro.dataset import (
+    DatasetLineageType,
+    FineGrainedLineageClass,
+    FineGrainedLineageDownstreamTypeClass,
+    FineGrainedLineageUpstreamTypeClass,
+    Upstream,
+    UpstreamLineage,
+)
+from datahub.metadata.urns import SchemaFieldUrn
+from datahub.sql_parsing.sql_parsing_aggregator import SqlParsingAggregator
+
+
+def _entry(
+    name: str = "",
+    connectionId: str = "",
+    definition: str = "",
+    type: str = "customSQL",
+) -> CustomSqlEntry:
+    return CustomSqlEntry(
+        name=name, connectionId=connectionId, definition=definition, type=type
+    )
+
+
+def _get_aspect(wu: MetadataWorkUnit) -> UpstreamLineage:
+    """Extract UpstreamLineage aspect from a workunit, asserting the correct types."""
+    assert isinstance(wu.metadata, MetadataChangeProposalWrapper)
+    return cast(UpstreamLineage, wu.metadata.aspect)
+
+
+_SNOWFLAKE_CONN = SigmaConnectionRecord(
+    connection_id="conn-sf-1",
+    name="Snowflake",
+    sigma_type="snowflake",
+    datahub_platform="snowflake",
+    is_mappable=True,
+)
+
+_UNMAPPABLE_CONN = SigmaConnectionRecord(
+    connection_id="conn-csv-1",
+    name="CSV Upload",
+    sigma_type="csv",
+    datahub_platform="",
+    is_mappable=False,
+)
+
+_ELEMENT_URN = "urn:li:dataset:(urn:li:dataPlatform:sigma,dm.el1,PROD)"
+_SNOWFLAKE_TABLE = (
+    "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.orders,PROD)"
+)
+_SNOWFLAKE_TABLE_2 = (
+    "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.products,PROD)"
+)
+
+
+def _make_source() -> SigmaSource:
+    config = SigmaSourceConfig(
+        client_id="test_id",
+        client_secret="test_secret",
+    )
+    ctx = PipelineContext(run_id="test")
+    with (
+        patch.object(SigmaAPI, "_generate_token"),
+        patch.object(SigmaSource, "_build_connection_registry") as mock_reg,
+    ):
+        mock_reg.return_value = SigmaConnectionRegistry(
+            by_id={
+                _SNOWFLAKE_CONN.connection_id: _SNOWFLAKE_CONN,
+                _UNMAPPABLE_CONN.connection_id: _UNMAPPABLE_CONN,
+            }
+        )
+        source = SigmaSource(config=config, ctx=ctx)
+    return source
+
+
+def _run_customsql_pipeline(
+    sql: str,
+    col_mapping: Dict[str, str],
+) -> tuple[MetadataWorkUnit, SigmaSource]:
+    """Register sql, drain aggregator; return the UpstreamLineage MCP and source."""
+    source = _make_source()
+    if col_mapping:
+        source._customsql_col_mappings[_ELEMENT_URN] = col_mapping
+        # All test mappings use simple single-ref formulas; treat as passthroughs.
+        source._customsql_passthrough_mappings[_ELEMENT_URN] = col_mapping
+    source._process_dm_customsql_element(
+        _ELEMENT_URN,
+        _entry(name="q1", connectionId=_SNOWFLAKE_CONN.connection_id, definition=sql),
+    )
+    mcps = list(source._drain_sql_aggregators())
+    assert len(mcps) == 1, f"expected 1 workunit, got {len(mcps)}"
+    return mcps[0], source
+
+
+# ---------------------------------------------------------------------------
+# _build_customsql_col_mapping
+# ---------------------------------------------------------------------------
+
+
+class TestCustomSqlColMapping:
+    def test_formula_refs_produce_mapping(self) -> None:
+        source = _make_source()
+        element_urn = "urn:li:dataset:(urn:li:dataPlatform:sigma,dm.el,PROD)"
+        element = SigmaDataModelElement(elementId="el-1", name="Custom SQL")
+        # Assign columns directly to bypass the /elements bare-string validator.
+        element.columns = [
+            SigmaDataModelColumn(
+                columnId="c1",
+                elementId="el-1",
+                name="Customer Id",
+                formula="[Custom SQL/CUSTOMER_ID]",
+            ),
+            SigmaDataModelColumn(
+                columnId="c2",
+                elementId="el-1",
+                name="Total Spent",
+                formula="[Custom SQL/TOTAL_SPENT]",
+            ),
+            SigmaDataModelColumn(
+                columnId="c3",
+                elementId="el-1",
+                name="No Formula Col",
+                formula=None,
+            ),
+            # Cross-element ref: must be excluded from the mapping.
+            SigmaDataModelColumn(
+                columnId="c4",
+                elementId="el-1",
+                name="Cross Ref Col",
+                formula="[OtherElement/CUSTOMER_ID]",
+            ),
+        ]
+        source._build_customsql_col_mapping(element, element_urn)
+        mapping = source._customsql_col_mappings[element_urn]
+        assert mapping["customer_id"] == "Customer Id"
+        assert mapping["total_spent"] == "Total Spent"
+        # Cross-element ref must not pollute the map.
+        assert len(mapping) == 2
+
+    def test_multi_ref_formula_lands_in_col_mapping_not_passthrough(self) -> None:
+        # A formula like If([Custom SQL/A]>0,[Custom SQL/B],0) has two refs.
+        # Both A and B should land in _customsql_col_mappings for FGL rewriting
+        # but neither in _customsql_passthrough_mappings (no SELECT * synthesis).
+        source = _make_source()
+        element_urn = "urn:li:dataset:(urn:li:dataPlatform:sigma,dm.el,PROD)"
+        element = SigmaDataModelElement(elementId="el-1", name="Custom SQL")
+        element.columns = [
+            SigmaDataModelColumn(
+                columnId="c1",
+                elementId="el-1",
+                name="Computed Col",
+                formula="If([Custom SQL/A]>0,[Custom SQL/B],0)",
+            ),
+        ]
+        source._build_customsql_col_mapping(element, element_urn)
+        mapping = source._customsql_col_mappings.get(element_urn, {})
+        passthrough = source._customsql_passthrough_mappings.get(element_urn, {})
+        assert "a" in mapping and "b" in mapping
+        assert "a" not in passthrough and "b" not in passthrough
+
+    def test_case_insensitive_element_name_matching(self) -> None:
+        # ref.source case may differ from element.name; matching must be case-insensitive.
+        source = _make_source()
+        element_urn = "urn:li:dataset:(urn:li:dataPlatform:sigma,dm.el,PROD)"
+        element = SigmaDataModelElement(elementId="el-1", name="custom sql")
+        element.columns = [
+            SigmaDataModelColumn(
+                columnId="c1",
+                elementId="el-1",
+                name="Order Id",
+                formula="[CUSTOM SQL/ORDER_ID]",  # uppercase source name
+            ),
+        ]
+        source._build_customsql_col_mapping(element, element_urn)
+        mapping = source._customsql_col_mappings.get(element_urn, {})
+        assert mapping.get("order_id") == "Order Id"
+
+
+# ---------------------------------------------------------------------------
+# _process_dm_customsql_element pre-flight checks
+# ---------------------------------------------------------------------------
+
+
+class TestPreflightChecks:
+    def test_missing_definition_skips_aggregator(self) -> None:
+        source = _make_source()
+        source._process_dm_customsql_element(
+            "urn:li:dataset:(urn:li:dataPlatform:sigma,dm.el,PROD)",
+            _entry(
+                name="q1", connectionId=_SNOWFLAKE_CONN.connection_id, definition=""
+            ),
+        )
+        assert source.reporter.dm_customsql_skipped == 1
+        assert source.reporter.dm_customsql_aggregator_invocations == 0
+
+    def test_unknown_connection_skips_aggregator(self) -> None:
+        source = _make_source()
+        source._process_dm_customsql_element(
+            "urn:li:dataset:(urn:li:dataPlatform:sigma,dm.el,PROD)",
+            _entry(name="q1", connectionId="conn-unknown", definition="SELECT 1"),
+        )
+        assert source.reporter.dm_customsql_skipped == 1
+        assert source.reporter.dm_customsql_aggregator_invocations == 0
+
+    def test_unmappable_platform_skips_aggregator(self) -> None:
+        source = _make_source()
+        source._process_dm_customsql_element(
+            "urn:li:dataset:(urn:li:dataPlatform:sigma,dm.el,PROD)",
+            _entry(
+                name="q1",
+                connectionId=_UNMAPPABLE_CONN.connection_id,
+                definition="SELECT 1",
+            ),
+        )
+        assert source.reporter.dm_customsql_skipped == 1
+        assert source.reporter.dm_customsql_aggregator_invocations == 0
+
+    def test_multiple_customsql_source_ids_skips_second(self) -> None:
+        # Only the first customSQL source_id per element is registered;
+        # subsequent ones bump dm_customsql_skipped.
+        source = _make_source()
+        urn = "urn:li:dataset:(urn:li:dataPlatform:sigma,dm.el,PROD)"
+        e1 = _entry(
+            name="q1",
+            connectionId=_SNOWFLAKE_CONN.connection_id,
+            definition="SELECT ORDER_ID FROM TEST_DB.TEST_SCHEMA.ORDERS",
+        )
+        source._process_dm_customsql_element(urn, e1)
+        source._process_dm_customsql_element(
+            urn,
+            _entry(name="q2", connectionId=e1.connectionId, definition=e1.definition),
+        )
+        assert source.reporter.dm_customsql_aggregator_invocations == 1
+        assert source.reporter.dm_customsql_skipped == 1
+
+    def test_aggregator_invocation_error_counter(self) -> None:
+        source = _make_source()
+        with patch.object(
+            SqlParsingAggregator,
+            "add_view_definition",
+            side_effect=RuntimeError("boom"),
+        ):
+            source._process_dm_customsql_element(
+                _ELEMENT_URN,
+                _entry(
+                    name="q1",
+                    connectionId=_SNOWFLAKE_CONN.connection_id,
+                    definition="SELECT ORDER_ID FROM TEST_DB.TEST_SCHEMA.ORDERS",
+                ),
+            )
+        assert source.reporter.dm_customsql_aggregator_invocation_errors == 1
+        assert source.reporter.dm_customsql_aggregator_invocations == 0
+
+
+# ---------------------------------------------------------------------------
+# FGL rewrite and end-to-end aggregator (real SqlParsingAggregator)
+# ---------------------------------------------------------------------------
+
+
+class TestFglRewrite:
+    def test_named_columns_fgl_rewritten_to_sigma_names(self) -> None:
+        wu, _ = _run_customsql_pipeline(
+            sql="SELECT ORDER_ID, AMOUNT FROM TEST_DB.TEST_SCHEMA.ORDERS",
+            col_mapping={"order_id": "Order Id", "amount": "Amount"},
+        )
+        aspect = _get_aspect(wu)
+        assert isinstance(aspect, UpstreamLineage)
+        assert len(aspect.upstreams) == 1
+        assert aspect.upstreams[0].dataset == _SNOWFLAKE_TABLE
+
+        fgls = aspect.fineGrainedLineages or []
+        assert len(fgls) > 0
+        all_downstreams = [d for fgl in fgls for d in (fgl.downstreams or [])]
+        for ds in all_downstreams:
+            sfu = SchemaFieldUrn.from_string(ds)
+            assert sfu.field_path in ("Order Id", "Amount"), (
+                f"unexpected field: {sfu.field_path}"
+            )
+
+    def test_select_star_synthesizes_fgl_from_col_mapping(self) -> None:
+        # SELECT * with a col_mapping: FGL is synthesized column-by-column
+        # from the formula refs, connecting upstream table columns to Sigma
+        # display names without needing the aggregator to expand *.
+        wu, source = _run_customsql_pipeline(
+            sql="SELECT * FROM TEST_DB.TEST_SCHEMA.ORDERS",
+            col_mapping={"order_id": "Order Id", "amount": "Amount"},
+        )
+        aspect = _get_aspect(wu)
+        assert isinstance(aspect, UpstreamLineage)
+        assert len(aspect.upstreams) == 1
+        fgls = aspect.fineGrainedLineages or []
+        assert len(fgls) == 2
+        downstream_fields = {
+            SchemaFieldUrn.from_string(ds).field_path
+            for fgl in fgls
+            for ds in (fgl.downstreams or [])
+        }
+        assert downstream_fields == {"Order Id", "Amount"}
+        assert source.reporter.dm_customsql_column_lineage_emitted == 1
+
+    def test_select_star_no_col_mapping_emits_entity_lineage_only(self) -> None:
+        wu, source = _run_customsql_pipeline(
+            sql="SELECT * FROM TEST_DB.TEST_SCHEMA.ORDERS",
+            col_mapping={},
+        )
+        aspect = _get_aspect(wu)
+        assert isinstance(aspect, UpstreamLineage)
+        assert len(aspect.upstreams) == 1
+        assert not aspect.fineGrainedLineages
+        assert source.reporter.dm_customsql_column_lineage_emitted == 0
+
+    def test_cte_alias_not_in_upstreams(self) -> None:
+        wu, _ = _run_customsql_pipeline(
+            sql=(
+                "WITH recent AS ("
+                "  SELECT ORDER_ID FROM TEST_DB.TEST_SCHEMA.ORDERS"
+                ") SELECT ORDER_ID FROM recent"
+            ),
+            col_mapping={"order_id": "Order Id"},
+        )
+        aspect = _get_aspect(wu)
+        assert isinstance(aspect, UpstreamLineage)
+        upstream_datasets = {u.dataset for u in aspect.upstreams}
+        assert _SNOWFLAKE_TABLE in upstream_datasets
+        assert len(upstream_datasets) == 1
+
+    def test_join_produces_two_upstream_datasets(self) -> None:
+        wu, _ = _run_customsql_pipeline(
+            sql=(
+                "SELECT o.ORDER_ID, p.NAME "
+                "FROM TEST_DB.TEST_SCHEMA.ORDERS o "
+                "JOIN TEST_DB.TEST_SCHEMA.PRODUCTS p ON o.PRODUCT_ID = p.ID"
+            ),
+            col_mapping={"order_id": "Order Id", "name": "Name"},
+        )
+        aspect = _get_aspect(wu)
+        assert isinstance(aspect, UpstreamLineage)
+        upstream_datasets = {u.dataset for u in aspect.upstreams}
+        assert len(upstream_datasets) == 2
+        assert _SNOWFLAKE_TABLE in upstream_datasets
+
+    def test_unmapped_fgl_downstream_counter(self) -> None:
+        # col_mapping covers order_id but not amount — amount FGL entry is dropped.
+        source = _make_source()
+        source._customsql_col_mappings[_ELEMENT_URN] = {"order_id": "Order Id"}
+        source._process_dm_customsql_element(
+            _ELEMENT_URN,
+            _entry(
+                name="q1",
+                connectionId=_SNOWFLAKE_CONN.connection_id,
+                definition="SELECT ORDER_ID, AMOUNT FROM TEST_DB.TEST_SCHEMA.ORDERS",
+            ),
+        )
+        list(source._drain_sql_aggregators())
+        assert source.reporter.dm_customsql_fgl_downstream_unmapped == 1
+
+    def test_no_col_mapping_fgl_passthrough(self) -> None:
+        # No entry in _customsql_col_mappings -> FGL downstreams passed through unchanged.
+        source = _make_source()
+        source._process_dm_customsql_element(
+            _ELEMENT_URN,
+            _entry(
+                name="q1",
+                connectionId=_SNOWFLAKE_CONN.connection_id,
+                definition="SELECT ORDER_ID FROM TEST_DB.TEST_SCHEMA.ORDERS",
+            ),
+        )
+        mcps = list(source._drain_sql_aggregators())
+        assert len(mcps) == 1
+        assert isinstance(mcps[0].metadata, MetadataChangeProposalWrapper)
+        aspect = cast(UpstreamLineage, mcps[0].metadata.aspect)
+        assert isinstance(aspect, UpstreamLineage)
+        fgls = aspect.fineGrainedLineages or []
+        assert len(fgls) > 0
+        all_downstreams = [d for fgl in fgls for d in (fgl.downstreams or [])]
+        for ds in all_downstreams:
+            sfu = SchemaFieldUrn.from_string(ds)
+            assert sfu.field_path == "order_id"  # SQL name; not rewritten
+
+    def test_mixed_sources_extra_upstreams_and_fgls_merged(self) -> None:
+        # When an element has both customSQL and non-customSQL source_ids,
+        # both the non-customSQL Upstream edges and their FGL must appear in the
+        # final UpstreamLineage — not silently overwritten by the drain MCP.
+        source = _make_source()
+        source._customsql_col_mappings[_ELEMENT_URN] = {"order_id": "Order Id"}
+        source._customsql_passthrough_mappings[_ELEMENT_URN] = {"order_id": "Order Id"}
+        extra_urn = "urn:li:dataset:(urn:li:dataPlatform:sigma,some.intra.element,PROD)"
+        extra_field_urn = f"urn:li:schemaField:({extra_urn},intra_col)"
+        # Simulate stashed non-customSQL upstreams + FGL from the per-element path.
+        source._customsql_extra_upstreams[_ELEMENT_URN] = [
+            Upstream(dataset=extra_urn, type=DatasetLineageType.TRANSFORMED)
+        ]
+        source._customsql_extra_fgls[_ELEMENT_URN] = [
+            FineGrainedLineageClass(
+                upstreamType=FineGrainedLineageUpstreamTypeClass.FIELD_SET,
+                upstreams=[extra_field_urn],
+                downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
+                downstreams=[f"urn:li:schemaField:({_ELEMENT_URN},Order Id)"],
+                confidenceScore=1.0,
+            )
+        ]
+        source._process_dm_customsql_element(
+            _ELEMENT_URN,
+            _entry(
+                name="q1",
+                connectionId=_SNOWFLAKE_CONN.connection_id,
+                definition="SELECT ORDER_ID FROM TEST_DB.TEST_SCHEMA.ORDERS",
+            ),
+        )
+        mcps = list(source._drain_sql_aggregators())
+        assert len(mcps) == 1
+        assert isinstance(mcps[0].metadata, MetadataChangeProposalWrapper)
+        aspect = cast(UpstreamLineage, mcps[0].metadata.aspect)
+        assert isinstance(aspect, UpstreamLineage)
+        # Both customSQL and non-customSQL upstreams present.
+        upstream_datasets = {u.dataset for u in aspect.upstreams}
+        assert _SNOWFLAKE_TABLE in upstream_datasets
+        assert extra_urn in upstream_datasets
+        # Non-customSQL FGL must survive the drain merge.
+        all_upstream_fields = {
+            f
+            for fgl in (aspect.fineGrainedLineages or [])
+            for f in (fgl.upstreams or [])
+        }
+        assert extra_field_urn in all_upstream_fields
+
+    def test_preflight_failure_does_not_stash_extras(self) -> None:
+        # When customSQL pre-flight fails, _customsql_extra_upstreams is NOT
+        # stashed and the per-element MCP (non-customSQL upstreams) is emitted
+        # immediately — not silently dropped.
+
+        source = _make_source()
+        # Simulate: customSQL pre-flight will fail (unknown connection),
+        # so the element is NOT added to _customsql_registered_urns.
+        source._process_dm_customsql_element(
+            _ELEMENT_URN,
+            _entry(name="q1", connectionId="conn-unknown", definition="SELECT 1"),
+        )
+        assert _ELEMENT_URN not in source._customsql_registered_urns
+        # Extras must NOT be stashed (no customSQL lineage to consolidate with).
+        assert _ELEMENT_URN not in source._customsql_extra_upstreams
+
+    def test_fgl_rewrite_passes_through_when_ds_parent_not_in_mappings(self) -> None:
+        # When the downstream schemaField's parent URN is not in
+        # _customsql_col_mappings (e.g. FGL referencing a non-customSQL
+        # element), the original URN is passed through unchanged.
+        source = _make_source()
+        other_element_urn = "urn:li:dataset:(urn:li:dataPlatform:sigma,other.el,PROD)"
+        other_field_urn = f"urn:li:schemaField:({other_element_urn},some_col)"
+        upstream_field_urn = f"urn:li:schemaField:({_SNOWFLAKE_TABLE},order_id)"
+        source._customsql_registered_urns.add(_ELEMENT_URN)
+
+        mcp = MetadataChangeProposalWrapper(
+            entityUrn=_ELEMENT_URN,
+            aspect=UpstreamLineage(
+                upstreams=[
+                    Upstream(dataset=_SNOWFLAKE_TABLE, type=DatasetLineageType.VIEW)
+                ],
+                fineGrainedLineages=[
+                    FineGrainedLineageClass(
+                        upstreamType=FineGrainedLineageUpstreamTypeClass.FIELD_SET,
+                        upstreams=[upstream_field_urn],
+                        downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
+                        downstreams=[other_field_urn],  # parent not in col_mappings
+                        confidenceScore=0.2,
+                    )
+                ],
+            ),
+        )
+        result = source._rewrite_fgl_downstreams(mcp)
+        aspect = result.aspect
+        fgls = aspect.fineGrainedLineages or []
+        assert len(fgls) == 1
+        # Original URN passed through unchanged.
+        assert other_field_urn in (fgls[0].downstreams or [])
+
+    def test_select_star_join_emits_entity_lineage_only(self) -> None:
+        # SELECT * with multiple upstreams (JOIN): synthesis is skipped
+        # (can't assign columns to tables without schema) and only entity
+        # lineage is emitted.
+        wu, source = _run_customsql_pipeline(
+            sql=(
+                "SELECT * FROM TEST_DB.TEST_SCHEMA.ORDERS o "
+                "JOIN TEST_DB.TEST_SCHEMA.PRODUCTS p ON o.PRODUCT_ID = p.ID"
+            ),
+            col_mapping={"order_id": "Order Id"},
+        )
+        aspect = _get_aspect(wu)
+        assert isinstance(aspect, UpstreamLineage)
+        assert len(aspect.upstreams) == 2
+        assert not aspect.fineGrainedLineages
+        assert source.reporter.dm_customsql_column_lineage_emitted == 0
+
+    def test_select_star_with_computed_col_only_synthesizes_passthrough(self) -> None:
+        # When the element has a passthrough column AND a computed-expression column,
+        # only the passthrough (single-ref formula) appears in synthesised SELECT * FGL.
+        source = _make_source()
+        source._customsql_col_mappings[_ELEMENT_URN] = {
+            "order_id": "Order Id",
+            "a": "Computed",
+            "b": "Computed",
+        }
+        # Passthrough-only: order_id is single-ref; a and b come from a multi-ref formula.
+        source._customsql_passthrough_mappings[_ELEMENT_URN] = {"order_id": "Order Id"}
+        source._process_dm_customsql_element(
+            _ELEMENT_URN,
+            _entry(
+                name="q1",
+                connectionId=_SNOWFLAKE_CONN.connection_id,
+                definition="SELECT * FROM TEST_DB.TEST_SCHEMA.ORDERS",
+            ),
+        )
+        mcps = list(source._drain_sql_aggregators())
+        assert len(mcps) == 1
+        assert isinstance(mcps[0].metadata, MetadataChangeProposalWrapper)
+        aspect = cast(UpstreamLineage, mcps[0].metadata.aspect)
+        assert isinstance(aspect, UpstreamLineage)
+        fgls = aspect.fineGrainedLineages or []
+        downstream_fields = {
+            SchemaFieldUrn.from_string(ds).field_path
+            for fgl in fgls
+            for ds in (fgl.downstreams or [])
+        }
+        # Only the passthrough column should appear; computed columns excluded.
+        assert downstream_fields == {"Order Id"}
+
+    def test_drain_continues_after_aggregator_gen_metadata_fails(self) -> None:
+        # If gen_metadata raises for one aggregator, other platforms still drain
+        # and aggregator.close() is always called.
+        from unittest.mock import MagicMock
+
+        source = _make_source()
+        # Register two different platform aggregators.
+        source._process_dm_customsql_element(
+            _ELEMENT_URN,
+            _entry(
+                name="q1",
+                connectionId=_SNOWFLAKE_CONN.connection_id,
+                definition="SELECT ORDER_ID FROM TEST_DB.TEST_SCHEMA.ORDERS",
+            ),
+        )
+        # Patch gen_metadata on the Snowflake aggregator to raise.
+        cache_key = ("snowflake", "PROD", None)
+        bad_aggregator = source._sql_aggregators[cache_key]
+        close_mock = MagicMock(wraps=bad_aggregator.close)
+        bad_aggregator.close = close_mock
+        bad_aggregator.gen_metadata = MagicMock(side_effect=RuntimeError("boom"))
+
+        list(source._drain_sql_aggregators())
+
+        # drain warning must be reported, close must still be called.
+        assert any(
+            "drain failed" in (w.title or "").lower() for w in source.reporter.warnings
+        )
+        close_mock.assert_called_once()
+
+    def test_parse_failed_counter(self) -> None:
+        source = _make_source()
+        source._process_dm_customsql_element(
+            _ELEMENT_URN,
+            _entry(
+                name="q1",
+                connectionId=_SNOWFLAKE_CONN.connection_id,
+                definition="SELECT FROM",
+            ),
+        )
+        list(source._drain_sql_aggregators())
+        assert source.reporter.dm_customsql_parse_failed == 1

--- a/metadata-ingestion/tests/unit/sigma/test_sigma_api.py
+++ b/metadata-ingestion/tests/unit/sigma/test_sigma_api.py
@@ -2288,3 +2288,46 @@ class TestPaginatorWarningTitleIncludesStatusCode:
             f"so operators can triage rate-limited pages specifically; "
             f"got contexts {[w.context for w in api.report.warnings]!r}"
         )
+
+
+class TestCustomSqlDuplicateNameOverwrite:
+    def test_second_definition_wins_and_warning_emitted(self) -> None:
+        """Two same-name customSQL entries: second wins; report.warnings fires."""
+        api = _create_sigma_api()
+        dm = SigmaDataModel(
+            dataModelId="dm-uuid",
+            name="Test DM",
+            createdAt=_dt.datetime(2024, 1, 1, tzinfo=_dt.timezone.utc),
+            updatedAt=_dt.datetime(2024, 1, 1, tzinfo=_dt.timezone.utc),
+        )
+
+        lineage_entries = [
+            {
+                "name": "csql-1",
+                "type": "customSQL",
+                "connectionId": "conn-1",
+                "definition": "SELECT A FROM DB.S.T1",
+            },
+            {
+                "name": "csql-1",
+                "type": "customSQL",
+                "connectionId": "conn-1",
+                "definition": "SELECT B FROM DB.S.T2",
+            },
+        ]
+
+        with (
+            patch.object(api, "_get_data_model_elements", return_value=[]),
+            patch.object(api, "_get_data_model_columns", return_value=[]),
+            patch.object(
+                api, "_get_data_model_lineage_entries", return_value=lineage_entries
+            ),
+        ):
+            api._assemble_data_model(dm, file_meta=None)
+
+        assert dm.custom_sql_by_name["csql-1"].definition == "SELECT B FROM DB.S.T2"
+        assert any(
+            "duplicate" in (w.title or "").lower()
+            or "duplicate" in (w.message or "").lower()
+            for w in api.report.warnings
+        )

--- a/metadata-ingestion/uv.lock
+++ b/metadata-ingestion/uv.lock
@@ -1040,9 +1040,12 @@ fabric-data-factory = [
 ]
 fabric-onelake = [
     { name = "azure-identity" },
+    { name = "patchy" },
     { name = "pyodbc" },
     { name = "requests" },
     { name = "sqlalchemy" },
+    { name = "sqlglot" },
+    { name = "sqlparse" },
 ]
 feast = [
     { name = "dask", extra = ["dataframe"] },
@@ -2780,6 +2783,7 @@ requires-dist = [
     { name = "patchy", marker = "extra == 'doris'", specifier = "==2.8.0" },
     { name = "patchy", marker = "extra == 'dremio'", specifier = "==2.8.0" },
     { name = "patchy", marker = "extra == 'druid'", specifier = "==2.8.0" },
+    { name = "patchy", marker = "extra == 'fabric-onelake'", specifier = "==2.8.0" },
     { name = "patchy", marker = "extra == 'fivetran'", specifier = "==2.8.0" },
     { name = "patchy", marker = "extra == 'glue'", specifier = "==2.8.0" },
     { name = "patchy", marker = "extra == 'grafana'", specifier = "==2.8.0" },
@@ -3309,6 +3313,7 @@ requires-dist = [
     { name = "sqlglot", marker = "extra == 'doris'", specifier = "==30.0.3" },
     { name = "sqlglot", marker = "extra == 'dremio'", specifier = "==30.0.3" },
     { name = "sqlglot", marker = "extra == 'druid'", specifier = "==30.0.3" },
+    { name = "sqlglot", marker = "extra == 'fabric-onelake'", specifier = "==30.0.3" },
     { name = "sqlglot", marker = "extra == 'fivetran'", specifier = "==30.0.3" },
     { name = "sqlglot", marker = "extra == 'glue'", specifier = "==30.0.3" },
     { name = "sqlglot", marker = "extra == 'grafana'", specifier = "==30.0.3" },
@@ -3365,6 +3370,7 @@ requires-dist = [
     { name = "sqlparse", marker = "extra == 'doris'", specifier = "<0.6.0" },
     { name = "sqlparse", marker = "extra == 'dremio'", specifier = "<0.6.0" },
     { name = "sqlparse", marker = "extra == 'druid'", specifier = "<0.6.0" },
+    { name = "sqlparse", marker = "extra == 'fabric-onelake'", specifier = "<0.6.0" },
     { name = "sqlparse", marker = "extra == 'hana'", specifier = "<0.6.0" },
     { name = "sqlparse", marker = "extra == 'hive'", specifier = "<0.6.0" },
     { name = "sqlparse", marker = "extra == 'hive-metastore'", specifier = "<0.6.0" },

--- a/metadata-ingestion/uv.lock
+++ b/metadata-ingestion/uv.lock
@@ -1040,12 +1040,9 @@ fabric-data-factory = [
 ]
 fabric-onelake = [
     { name = "azure-identity" },
-    { name = "patchy" },
     { name = "pyodbc" },
     { name = "requests" },
     { name = "sqlalchemy" },
-    { name = "sqlglot" },
-    { name = "sqlparse" },
 ]
 feast = [
     { name = "dask", extra = ["dataframe"] },
@@ -1686,6 +1683,7 @@ sigma = [
     { name = "patchy" },
     { name = "requests" },
     { name = "sqlglot" },
+    { name = "sqlparse" },
 ]
 slack = [
     { name = "slack-sdk" },
@@ -2782,7 +2780,6 @@ requires-dist = [
     { name = "patchy", marker = "extra == 'doris'", specifier = "==2.8.0" },
     { name = "patchy", marker = "extra == 'dremio'", specifier = "==2.8.0" },
     { name = "patchy", marker = "extra == 'druid'", specifier = "==2.8.0" },
-    { name = "patchy", marker = "extra == 'fabric-onelake'", specifier = "==2.8.0" },
     { name = "patchy", marker = "extra == 'fivetran'", specifier = "==2.8.0" },
     { name = "patchy", marker = "extra == 'glue'", specifier = "==2.8.0" },
     { name = "patchy", marker = "extra == 'grafana'", specifier = "==2.8.0" },
@@ -3312,7 +3309,6 @@ requires-dist = [
     { name = "sqlglot", marker = "extra == 'doris'", specifier = "==30.0.3" },
     { name = "sqlglot", marker = "extra == 'dremio'", specifier = "==30.0.3" },
     { name = "sqlglot", marker = "extra == 'druid'", specifier = "==30.0.3" },
-    { name = "sqlglot", marker = "extra == 'fabric-onelake'", specifier = "==30.0.3" },
     { name = "sqlglot", marker = "extra == 'fivetran'", specifier = "==30.0.3" },
     { name = "sqlglot", marker = "extra == 'glue'", specifier = "==30.0.3" },
     { name = "sqlglot", marker = "extra == 'grafana'", specifier = "==30.0.3" },
@@ -3369,7 +3365,6 @@ requires-dist = [
     { name = "sqlparse", marker = "extra == 'doris'", specifier = "<0.6.0" },
     { name = "sqlparse", marker = "extra == 'dremio'", specifier = "<0.6.0" },
     { name = "sqlparse", marker = "extra == 'druid'", specifier = "<0.6.0" },
-    { name = "sqlparse", marker = "extra == 'fabric-onelake'", specifier = "<0.6.0" },
     { name = "sqlparse", marker = "extra == 'hana'", specifier = "<0.6.0" },
     { name = "sqlparse", marker = "extra == 'hive'", specifier = "<0.6.0" },
     { name = "sqlparse", marker = "extra == 'hive-metastore'", specifier = "<0.6.0" },
@@ -3386,6 +3381,7 @@ requires-dist = [
     { name = "sqlparse", marker = "extra == 'presto-on-hive'", specifier = "<0.6.0" },
     { name = "sqlparse", marker = "extra == 'redshift'", specifier = "<0.6.0" },
     { name = "sqlparse", marker = "extra == 'redshift-slim'", specifier = "<0.6.0" },
+    { name = "sqlparse", marker = "extra == 'sigma'", specifier = "<0.6.0" },
     { name = "sqlparse", marker = "extra == 'snowflake'", specifier = "<0.6.0" },
     { name = "sqlparse", marker = "extra == 'snowflake-queries'", specifier = "<0.6.0" },
     { name = "sqlparse", marker = "extra == 'snowflake-summary'", specifier = "<0.6.0" },


### PR DESCRIPTION
  - Parses the `definition` SQL on DM `customSQL` lineage entries via                    
    `SqlParsingAggregator.add_view_definition` and emits `UpstreamLineage`               
    + `FineGrainedLineage` on the backing DM element Dataset.             
  - FGL downstream field names are rewritten from SQL column names to Sigma              
    display names using each column's `[Custom SQL/SQL_COL]` formula ref,                
    so they match the `SchemaMetadata` already emitted for the element.                  
  - `generate_column_lineage=False` kill-switch is untouched.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
