### PR TITLE
test(playwright): migrate glossary tests

### DIFF
--- a/e2e-test/ui/playwright/pages/common/confirmation-modal-component.ts
+++ b/e2e-test/ui/playwright/pages/common/confirmation-modal-component.ts
@@ -1,0 +1,30 @@
+import { Page, Locator } from '@playwright/test';
+import { ModalComponent } from './modal-component';
+
+/**
+ * datahub-web-react/src/app/sharedV2/modals/ConfirmationModal.tsx
+ */
+export class ConfirmationModalComponent extends ModalComponent {
+  readonly closeButton: Locator;
+  readonly confirmButton: Locator;
+  readonly cancelButton: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.closeButton = this.modal.locator('[data-testid="modal-close-icon"]');
+    this.confirmButton = this.modal.locator('[data-testid="modal-confirm-button"]');
+    this.cancelButton = this.modal.locator('[data-testid="modal-cancel-button"]');
+  }
+
+  async close(): Promise<void> {
+    await this.closeButton.click();
+  }
+
+  async confirm(): Promise<void> {
+    await this.confirmButton.click();
+  }
+
+  async cancel(): Promise<void> {
+    await this.cancelButton.click();
+  }
+}

--- a/e2e-test/ui/playwright/pages/common/modal-component.ts
+++ b/e2e-test/ui/playwright/pages/common/modal-component.ts
@@ -1,0 +1,22 @@
+import { Page, Locator, expect } from '@playwright/test';
+
+/**
+ * datahub-web-react/src/alchemy-components/components/Modal/Modal.tsx
+ */
+export class ModalComponent {
+  readonly modal: Locator;
+  readonly title: Locator;
+
+  constructor(page: Page) {
+    this.modal = page.locator('.ant-modal:visible'); // visible modal only
+    this.title = this.modal.locator('.ant-modal-title');
+  }
+
+  async waitForOpening(): Promise<void> {
+    await expect(this.modal).toBeVisible();
+  }
+
+  async expectTitleContainText(text: string): Promise<void> {
+    await expect(this.title).toContainText(text);
+  }
+}

--- a/e2e-test/ui/playwright/pages/dataset.page.ts
+++ b/e2e-test/ui/playwright/pages/dataset.page.ts
@@ -15,6 +15,7 @@ export class DatasetPage extends BasePage {
 
   // ── Glossary term sidebar ──────────────────────────────────────────────────
   readonly sidebarGlossarySection: Locator;
+  readonly addTermsButton: Locator;
   readonly tagTermModalInput: Locator;
   readonly tagTermOption: Locator;
   readonly addTagTermConfirmButton: Locator;
@@ -31,6 +32,7 @@ export class DatasetPage extends BasePage {
     this.propertiesTab = page.locator('[data-testid="properties-tab"]');
 
     this.sidebarGlossarySection = page.locator('#entity-profile-glossary-terms');
+    this.addTermsButton = this.sidebarGlossarySection.locator('[data-testid="add-terms-button"]');
     // AntD Select renders a div wrapper; target the inner search input for typing.
     this.tagTermModalInput = page.locator('[data-testid="tag-term-modal-input"] input');
     this.tagTermOption = page.locator('[data-testid="tag-term-option"]').first();
@@ -52,7 +54,7 @@ export class DatasetPage extends BasePage {
 
   async addGlossaryTerm(termName: string): Promise<void> {
     this.logger?.step('addGlossaryTerm', { termName });
-    await this.sidebarGlossarySection.locator('[data-testid="add-terms-button"]').click();
+    await this.addTermsButton.click();
     await expect(this.tagTermModalInput).toBeVisible();
     // AntD Select triggers search via keyboard events; pressSequentially (not fill) is required.
     await this.tagTermModalInput.pressSequentially(termName);

--- a/e2e-test/ui/playwright/pages/dataset.page.ts
+++ b/e2e-test/ui/playwright/pages/dataset.page.ts
@@ -1,24 +1,97 @@
 import { Page, Locator, expect } from '@playwright/test';
 import { BasePage } from './base.page';
 import type { DataHubLogger } from '../utils/logger';
+import { ConfirmationModalComponent } from './common/confirmation-modal-component';
+import { ModalComponent } from './common/modal-component';
 
 export class DatasetPage extends BasePage {
+  readonly modalComponent: ModalComponent;
+  readonly confirmationComponent: ConfirmationModalComponent;
+
   readonly datasetName: Locator;
   readonly schemaTab: Locator;
   readonly lineageTab: Locator;
   readonly propertiesTab: Locator;
 
+  // ── Glossary term sidebar ──────────────────────────────────────────────────
+  readonly sidebarGlossarySection: Locator;
+  readonly tagTermModalInput: Locator;
+  readonly tagTermOption: Locator;
+  readonly addTagTermConfirmButton: Locator;
+
   constructor(page: Page, logger?: DataHubLogger, logDir?: string) {
     super(page, logger, logDir);
+
+    this.modalComponent = new ModalComponent(page);
+    this.confirmationComponent = new ConfirmationModalComponent(page);
+
     this.datasetName = page.locator('[data-testid="dataset-name"]');
     this.schemaTab = page.locator('[data-testid="schema-tab"]');
     this.lineageTab = page.locator('[data-testid="lineage-tab"]');
     this.propertiesTab = page.locator('[data-testid="properties-tab"]');
+
+    this.sidebarGlossarySection = page.locator('#entity-profile-glossary-terms');
+    // AntD Select renders a div wrapper; target the inner search input for typing.
+    this.tagTermModalInput = page.locator('[data-testid="tag-term-modal-input"] input');
+    this.tagTermOption = page.locator('[data-testid="tag-term-option"]').first();
+    this.addTagTermConfirmButton = page.locator('[data-testid="add-tag-term-from-modal-btn"]');
   }
 
   async navigateToDataset(urn: string): Promise<void> {
     await this.navigate(`/dataset/${encodeURIComponent(urn)}`);
     await this.page.waitForLoadState('networkidle');
+  }
+
+  getGlossaryTermLocator(termName: string): Locator {
+    return this.page.locator(`[data-testid="term-${termName}"]`);
+  }
+
+  getGlossaryTermRemoveButtonLocator(glossaryTermLocator: Locator): Locator {
+    return glossaryTermLocator.locator('[data-testid="remove-icon"]');
+  }
+
+  async addGlossaryTerm(termName: string): Promise<void> {
+    this.logger?.step('addGlossaryTerm', { termName });
+    await this.sidebarGlossarySection.locator('[data-testid="add-terms-button"]').click();
+    await expect(this.tagTermModalInput).toBeVisible();
+    // AntD Select triggers search via keyboard events; pressSequentially (not fill) is required.
+    await this.tagTermModalInput.pressSequentially(termName);
+    await this.tagTermOption.click();
+    // Click the header to close the terms select dropdown if it stayed open.
+    await this.modalComponent.title.click();
+    await this.addTagTermConfirmButton.click();
+    await expect(this.addTagTermConfirmButton).toBeHidden();
+
+    await this.page.waitForLoadState('networkidle');
+  }
+
+  async removeGlossaryTerm(termName: string): Promise<void> {
+    this.logger?.step('removeGlossaryTerm', { termName });
+
+    // Click remove button on glossary terms pill
+    const glossaryTerm = this.getGlossaryTermLocator(termName);
+    await glossaryTerm.scrollIntoViewIfNeeded();
+    await glossaryTerm.hover();
+    const termRemoveButton = this.getGlossaryTermRemoveButtonLocator(glossaryTerm);
+    await expect(termRemoveButton).toBeVisible();
+    await termRemoveButton.click();
+
+    // Confirm deletion
+    await this.confirmationComponent.waitForOpening();
+    await this.confirmationComponent.expectTitleContainText(termName);
+    await this.confirmationComponent.confirm();
+
+    await this.page.waitForLoadState('networkidle');
+  }
+
+  async expectGlossaryTermVisible(termName: string): Promise<void> {
+    const glossaryTerm = this.getGlossaryTermLocator(termName);
+    await expect(glossaryTerm).toBeVisible();
+  }
+
+  async expectGlossaryTermNotVisible(termName: string): Promise<void> {
+    const glossaryTerm = this.getGlossaryTermLocator(termName);
+    await expect(glossaryTerm).toBeHidden();
   }
 
   async viewSchema(): Promise<void> {

--- a/e2e-test/ui/playwright/pages/glossary.page.ts
+++ b/e2e-test/ui/playwright/pages/glossary.page.ts
@@ -3,37 +3,23 @@
  *
  * Covers the full CRUD lifecycle for Glossary Term Groups and Glossary Terms,
  * including navigation, creation, moving, deleting, and adding terms to datasets.
- *
- * Key selectors are taken directly from the React source:
- *   - GlossaryContentProvider.tsx   → glossaryPageV2, add-term-group-button-v2
- *   - GlossarySidebar.tsx           → glossary-browser-sidebar, create-glossary-button
- *   - ChildrenTab.tsx               → add-term-button
- *   - EntityTabs.tsx                → ${name}-entity-tab-header
- *   - CreateGlossaryEntityModal.tsx → create-glossary-entity-modal-name, glossary-entity-modal-create-button
- *   - MoveGlossaryEntityModal.tsx   → move-glossary-entity-modal, glossary-entity-modal-move-button
- *   - EntityDropdown.tsx            → MoreVertOutlinedIcon (three-dot), entity-menu-delete-button, entity-menu-move-button
- *   - SidebarGlossaryTermsSection.tsx → entity-profile-glossary-terms, add-terms-button
- *   - AddTagsTermsModal.tsx         → tag-term-modal-input, tag-term-option, add-tag-term-from-modal-btn
- *   - EntityActions.tsx             → glossary-batch-add
- *   - EntitySearchResults.tsx       → checkbox-{urn} (entity select checkboxes in batch-add modal)
- *   - SearchSelectModal.tsx         → search-select-modal
- *   - EmbeddedListSearch            → search-results-advanced-search, adv-search-add-filter-tags
  */
 
 import { expect, type Locator, type Page } from '@playwright/test';
 import { BasePage } from './base.page';
 import type { DataHubLogger } from '../utils/logger';
+import { GraphQLHelper } from '../helpers/graphql-helper';
+import { ModalComponent } from './common/modal-component';
 
 export class GlossaryPage extends BasePage {
+  readonly modalComponent: ModalComponent;
+
   // ── Navigation ──────────────────────────────────────────────────────────────
-  readonly glossaryPageHeader: Locator;
   readonly sidebarContainer: Locator;
+  readonly activeTabPanel: Locator;
 
   // ── Root-level create buttons (GlossaryContentProvider header) ──────────────
   readonly addTermGroupButtonV2: Locator;
-
-  // ── Glossary sidebar (GlossarySidebar) ──────────────────────────────────────
-  readonly createGlossarySidebarButton: Locator;
 
   // ── Entity contents tab buttons (ChildrenTab) ────────────────────────────────
   readonly addTermButton: Locator;
@@ -44,6 +30,7 @@ export class GlossaryPage extends BasePage {
 
   // ── Move modal (MoveGlossaryEntityModal) ─────────────────────────────────────
   readonly moveModalContainer: Locator;
+  readonly moveModalSelectInput: Locator;
   readonly moveModalSubmitButton: Locator;
 
   // ── Three-dot entity menu (EntityDropdown) ────────────────────────────────────
@@ -51,68 +38,132 @@ export class GlossaryPage extends BasePage {
   readonly entityMenuDeleteButton: Locator;
   readonly entityMenuMoveButton: Locator;
 
-  // ── Dataset sidebar — add glossary term section ───────────────────────────────
-  readonly sidebarGlossarySection: Locator;
-  readonly addTermsButton: Locator;
-
-  // ── Add tag/term modal (AddTagsTermsModal) ─────────────────────────────────
-  readonly tagTermModalInput: Locator;
-  readonly tagTermOption: Locator;
-  readonly addTagTermConfirmButton: Locator;
-
-  // ── Batch-add glossary term button (EntityActions) ─────────────────────────
-  readonly batchAddGlossaryButton: Locator;
-
-  // ── Batch-add modal entity results (SearchSelectModal / EntitySearchResults) ─
-  readonly previewEntities: Locator;
-  readonly entityCheckboxes: Locator;
-
   // ── Search input (shared EmbeddedListSearch) ──────────────────────────────
   readonly searchInput: Locator;
 
-  // ── Continue button (entity selection modal) ──────────────────────────────
-  readonly continueButton: Locator;
+  // ── Filters toggle button (EmbeddedListSearchHeader) ─────────────────────
+  readonly filtersToggleButton: Locator;
+
+  // ── Advanced search / filter panel ───────────────────────────────────────
+  readonly advancedSearchButton: Locator;
+  readonly addFilterButton: Locator;
+  readonly addFilterTagsButton: Locator;
+  readonly filterTagSelectInput: Locator;
+  readonly addTagsConfirmButton: Locator;
+
+  // ── Batch Add to Assets (EntityActions → SearchSelectModal) ─────────────────
+  readonly batchAddButton: Locator;
+  readonly batchAddModalSearchInput: Locator;
+  readonly batchAddConfirmButton: Locator;
+  readonly batchAddedToast: Locator;
+
+  // ── Create modal headings ─────────────────────────────────────────────────
+  readonly createGlossaryHeading: Locator;
+  readonly createGlossaryTermHeading: Locator;
+
+  // ── Confirmation button / toast notifications ─────────────────────────────
+  readonly deleteConfirmButton: Locator;
+  readonly createdTermGroupToast: Locator;
+  readonly createdGlossaryTermToast: Locator;
+  readonly deletedEntityToast: Locator;
+  readonly movedEntityToast: Locator;
+
+  // ── Tabs ──────────────────────────────────────────────────────────────────
+  readonly propertiesTab: Locator;
+
+  private readonly graphqlHelper: GraphQLHelper;
 
   constructor(page: Page, logger?: DataHubLogger, logDir?: string) {
     super(page, logger, logDir);
+    this.graphqlHelper = new GraphQLHelper(page);
 
-    this.glossaryPageHeader = page.locator('[data-testid="glossaryPageV2"]');
-    this.sidebarContainer = page.locator('[data-testid="glossary-browser-sidebar"]');
+    this.modalComponent = new ModalComponent(page);
 
-    this.addTermGroupButtonV2 = page.locator('[data-testid="add-term-group-button-v2"]').first();
-    this.createGlossarySidebarButton = page.locator('[data-testid="create-glossary-button"]');
+    this.sidebarContainer = page.getByTestId('glossary-browser-sidebar');
+    this.activeTabPanel = page.locator('.ant-tabs-tabpane-active');
 
-    this.addTermButton = page.locator('[data-testid="add-term-button"]').first();
+    // `:visible` needed — multiple instances may exist in the DOM simultaneously.
+    this.addTermGroupButtonV2 = page.getByTestId('add-term-group-button-v2').and(page.locator(':visible'));
+    this.addTermButton = page.getByTestId('add-term-button').and(page.locator(':visible'));
 
-    this.createModalNameInput = page.locator('[data-testid="create-glossary-entity-modal-name"] input');
-    this.createModalSubmitButton = page.locator('[data-testid="glossary-entity-modal-create-button"]');
+    this.createModalNameInput = page.getByTestId('create-glossary-entity-modal-name').locator('input');
+    this.createModalSubmitButton = page.getByTestId('glossary-entity-modal-create-button');
 
-    // The AntD modal root is a wrapper; target the inner visible dialog content.
-    this.moveModalContainer = page.locator('[data-testid="move-glossary-entity-modal"] .ant-modal-content');
-    this.moveModalSubmitButton = page.locator('[data-testid="glossary-entity-modal-move-button"]');
+    // Target inner visible dialog content — the AntD modal root is just a wrapper.
+    this.moveModalContainer = page.getByTestId('move-glossary-entity-modal').locator('.ant-modal-content');
+    this.moveModalSelectInput = this.moveModalContainer.locator('.ant-select-selector input');
+    this.moveModalSubmitButton = page.getByTestId('glossary-entity-modal-move-button');
 
     // MoreVertOutlinedIcon is the data-testid set by EntityDropdown.tsx on the three-dot icon button.
-    this.entityMenuThreeDotButton = page.locator('[data-testid="MoreVertOutlinedIcon"]').first();
-    this.entityMenuDeleteButton = page.locator('[data-testid="entity-menu-delete-button"]');
-    this.entityMenuMoveButton = page.locator('[data-testid="entity-menu-move-button"]');
+    // `:visible` needed — multiple entity cards may render this icon simultaneously.
+    this.entityMenuThreeDotButton = page.getByTestId('MoreVertOutlinedIcon').and(page.locator(':visible'));
+    this.entityMenuDeleteButton = page.getByTestId('entity-menu-delete-button');
+    this.entityMenuMoveButton = page.getByTestId('entity-menu-move-button');
 
-    this.sidebarGlossarySection = page.locator('#entity-profile-glossary-terms');
-    this.addTermsButton = page.locator('[data-testid="add-terms-button"]');
+    // Scoped to the active tab panel to avoid matching the sidebar browser's search input.
+    this.searchInput = this.activeTabPanel.getByTestId('search-input');
 
-    // The AntD Select renders as a div wrapper; we target the inner search input for typing.
-    this.tagTermModalInput = page.locator('[data-testid="tag-term-modal-input"] input');
-    this.tagTermOption = page.locator('[data-testid="tag-term-option"]').first();
-    this.addTagTermConfirmButton = page.locator('[data-testid="add-tag-term-from-modal-btn"]');
+    this.filtersToggleButton = page.getByTestId('toggle-filters-button').and(page.locator(':visible'));
+    this.advancedSearchButton = page.getByTestId('search-results-advanced-search');
+    this.addFilterButton = page.getByTestId('adv-search-add-filter-select');
+    this.addFilterTagsButton = page.getByTestId('adv-search-add-filter-tags');
+    this.filterTagSelectInput = page.locator('div.ant-select-selection-overflow input');
+    this.addTagsConfirmButton = page.getByTestId('add-tag-term-from-modal-btn');
 
-    this.batchAddGlossaryButton = page.locator('[data-testid="glossary-batch-add"]').first();
+    this.batchAddButton = page.getByTestId('glossary-batch-add');
+    // Scoped to modal content to avoid matching the page-level search bar.
+    this.batchAddModalSearchInput = page.locator('.ant-modal-content').getByTestId('search-input');
+    this.batchAddConfirmButton = page.getByTestId('search-select-modal-continue-button');
+    this.batchAddedToast = page.getByText('Added Glossary Term to entities!');
 
-    // preview-urn: prefix is set by entity preview cards; checkbox- prefix by entity select checkboxes.
-    this.previewEntities = page.locator('[data-testid^="preview-urn:"]');
-    this.entityCheckboxes = page.locator('[data-testid^="checkbox-"]');
+    this.createGlossaryHeading = page.getByRole('heading', { name: 'Create Glossary' });
+    this.createGlossaryTermHeading = page.getByRole('heading', { name: 'Create Glossary Term' });
+    this.deleteConfirmButton = page.getByRole('button', { name: 'Yes' });
+    this.createdTermGroupToast = page.getByText('Created Term Group!');
+    this.createdGlossaryTermToast = page.getByText('Created Glossary Term!');
+    this.deletedEntityToast = page.getByText(/Deleted .+!/);
+    this.movedEntityToast = page.getByText(/Moved .+!/);
+    this.propertiesTab = page.locator('[role="tab"]:has([data-testid="Properties-entity-tab-header"])');
+  }
 
-    this.searchInput = page.locator('[data-testid="search-input"]').last();
+  // ── Dynamic locator getters ───────────────────────────────────────────────────
 
-    this.continueButton = page.locator('#continueButton');
+  getMoveDropdownOption(name: string): Locator {
+    return this.page.locator('.ant-select-dropdown').getByText(name, { exact: true });
+  }
+
+  getFacetTagCheckbox(tagUrn: string): Locator {
+    return this.page.getByTestId(`facet-tags-${tagUrn}`);
+  }
+
+  getBatchAddEntityCheckbox(entityUrn: string): Locator {
+    return this.page.getByTestId(`checkbox-${entityUrn}`);
+  }
+
+  getContentsTabItemLocator(urn: string): Locator {
+    return this.page.getByTestId(`glossary-entity-item-${urn}`);
+  }
+
+  getPreviewEntityLocator(urn: string): Locator {
+    // Prefix match covers both exact `preview-{urn}` and `preview-{urn}/subpath` testids
+    // that some entity types use.
+    return this.page.locator(`[data-testid^="preview-${urn}"]`);
+  }
+
+  getEntityTabLocator(tabName: string): Locator {
+    return this.page.getByTestId(`${tabName}-entity-tab-header`);
+  }
+
+  getTagFilterOption(tagName: string): Locator {
+    return this.page.getByTestId(`tag-term-option-${tagName}`);
+  }
+
+  getSidebarTermLocator(urn: string): Locator {
+    return this.sidebarContainer.getByTestId(`glossary-sidebar-term-${urn}`);
+  }
+
+  getSidebarNodeLocator(urn: string): Locator {
+    return this.sidebarContainer.getByTestId(`glossary-sidebar-node-${urn}`);
   }
 
   // ── Navigation ───────────────────────────────────────────────────────────────
@@ -120,80 +171,106 @@ export class GlossaryPage extends BasePage {
   async navigateToGlossary(): Promise<void> {
     this.logger?.step('navigate', { url: '/glossary' });
     await this.page.goto('/glossary');
-    await this.page.waitForLoadState('networkidle');
-    await expect(this.sidebarContainer).toBeVisible({ timeout: 30000 });
+    await this.waitForPageLoad();
+    await expect(this.sidebarContainer).toBeVisible();
   }
 
-  async navigateToGlossaryTerm(text: string): Promise<void> {
-    // Prefer clicking a visible link or text rather than a hidden sidebar span.
-    // Filter to only the visible match so we don't hit hidden sidebar browser entries.
-    const visibleElement = this.page.getByText(text).filter({ visible: true }).first();
-    await visibleElement.waitFor({ state: 'visible', timeout: 30000 });
-    await visibleElement.click();
-    await this.page.waitForLoadState('networkidle');
+  async navigateToGlossaryTermByUrn(urn: string): Promise<void> {
+    this.logger?.step('navigateToGlossaryTermByUrn', { urn });
+    await this.page.goto(`/glossaryTerm/${encodeURIComponent(urn)}`);
+    await this.waitForPageLoad();
   }
 
-  async navigateToEntityContentsTab(): Promise<void> {
-    await this.clickEntityTabByName('Contents');
+  async navigateToGlossaryNodeByUrn(urn: string): Promise<void> {
+    this.logger?.step('navigateToGlossaryNodeByUrn', { urn });
+    await this.page.goto(`/glossaryNode/${encodeURIComponent(urn)}`);
+    await this.waitForPageLoad();
   }
 
-  async navigateToEntityPropertiesTab(): Promise<void> {
-    await this.clickEntityTabByName('Properties');
+  async clickContentsTabItem(urn: string): Promise<void> {
+    this.logger?.step('clickContentsTabItem', { urn });
+    await this.getContentsTabItemLocator(urn).click();
+    await this.waitForPageLoad();
   }
 
-  async navigateToEntityRelatedAssetsTab(): Promise<void> {
-    await this.clickEntityTabByName('Related Assets');
+  async clickSidebarTerm(urn: string): Promise<void> {
+    this.logger?.step('clickSidebarTerm', { urn });
+    await this.getSidebarTermLocator(urn).click();
+    await this.waitForPageLoad();
   }
 
-  async clickEntityTabByName(tabName: string): Promise<void> {
-    const tabSelector = `[data-testid="${tabName}-entity-tab-header"]`;
-    await this.page.locator(tabSelector).click();
-    await this.page.waitForLoadState('networkidle');
+  async clickSidebarNode(urn: string): Promise<void> {
+    this.logger?.step('clickSidebarNode', { urn });
+    await this.getSidebarNodeLocator(urn).click();
+    await this.waitForPageLoad();
+  }
+
+  async openContentsTab(): Promise<void> {
+    await this.openTabByName('Contents');
+  }
+
+  async openPropertiesTab(): Promise<void> {
+    await this.openTabByName('Properties');
+  }
+
+  async openRelatedAssetsTab(): Promise<void> {
+    await this.openTabByName('Related Assets');
+  }
+
+  async openTabByName(tabName: string): Promise<void> {
+    await this.getEntityTabLocator(tabName).click();
+    await this.waitForPageLoad();
   }
 
   // ── Glossary Term Group CRUD ─────────────────────────────────────────────────
 
   /**
    * Creates a root-level Term Group from the glossary home page header button.
-   * Opens the modal, types the name, and confirms.
+   * Returns the URN of the created term group from the GraphQL response.
    */
-  async createTermGroup(name: string): Promise<void> {
+  async createTermGroup(name: string): Promise<string> {
     this.logger?.step('createTermGroup', { name });
     await this.addTermGroupButtonV2.click();
     // Wait for the modal heading (h1 role) specifically to avoid matching the button text.
-    await expect(this.page.getByRole('heading', { name: 'Create Glossary' })).toBeVisible({ timeout: 15000 });
+    await expect(this.createGlossaryHeading).toBeVisible();
     await this.createModalNameInput.fill(name);
+    const responsePromise = this.graphqlHelper.waitForGraphQLResponse('createGlossaryNode');
     await this.createModalSubmitButton.click();
-    await expect(this.page.getByText(`Created Term Group!`)).toBeVisible({ timeout: 15000 });
+    await expect(this.createdTermGroupToast).toBeVisible();
+    const response = await responsePromise;
+    return (response.data as Record<string, string>).createGlossaryNode;
   }
 
   /**
    * Creates a Glossary Term inside the currently-open entity (term group) page.
    * Requires the Contents tab to already be active.
+   * Returns the URN of the created term from the GraphQL response.
    */
-  async createTermInContentsTab(name: string): Promise<void> {
+  async createTermInContentsTab(name: string): Promise<string> {
     this.logger?.step('createTermInContentsTab', { name });
     await this.addTermButton.click();
-    await expect(this.page.getByRole('heading', { name: 'Create Glossary Term' })).toBeVisible({ timeout: 15000 });
+    await expect(this.createGlossaryTermHeading).toBeVisible();
     await this.createModalNameInput.fill(name);
+    const responsePromise = this.graphqlHelper.waitForGraphQLResponse('createGlossaryTerm');
     await this.createModalSubmitButton.click();
-    // The mutation fires async; wait for the success toast which appears after ~2s.
-    await expect(this.page.getByText('Created Glossary Term!')).toBeVisible({ timeout: 15000 });
+    await expect(this.createdGlossaryTermToast).toBeVisible();
+    await expect(this.createdGlossaryTermToast).toBeHidden();
+    const response = await responsePromise;
+    return (response.data as Record<string, string>).createGlossaryTerm;
   }
 
   // ── Three-dot entity menu actions ────────────────────────────────────────────
 
-  /** Opens the three-dot dropdown for the currently-viewed entity. */
   async openEntityMenu(): Promise<void> {
     await this.entityMenuThreeDotButton.click();
   }
 
-  /** Deletes the currently-viewed entity via the three-dot menu. */
   async deleteCurrentEntity(): Promise<void> {
     this.logger?.step('deleteCurrentEntity');
     await this.openEntityMenu();
-    await this.page.getByText('Delete').click();
-    await this.page.getByRole('button', { name: 'Yes' }).click();
+    await this.entityMenuDeleteButton.click();
+    await this.deleteConfirmButton.click();
+    await expect(this.deletedEntityToast).toBeVisible();
   }
 
   /**
@@ -205,76 +282,17 @@ export class GlossaryPage extends BasePage {
     await this.openEntityMenu();
     // Use the entity-menu-move-button testid to avoid matching hidden DnD accessibility elements.
     await this.entityMenuMoveButton.click();
-    await expect(this.moveModalContainer).toBeVisible({ timeout: 15000 });
+    await expect(this.moveModalContainer).toBeVisible();
     // Type into the AntD Select search input to filter results — more reliable than
     // scrolling through the GlossaryBrowser tree which accumulates entries across test runs.
-    const selectInput = this.moveModalContainer.locator('.ant-select-selector input');
-    await selectInput.click();
-    await selectInput.fill(targetName);
+    await this.moveModalSelectInput.click();
+    await this.moveModalSelectInput.fill(targetName);
     // The dropdown shows search results (not the tree browser) when a query is present.
-    const option = this.page.locator('.ant-select-dropdown').getByText(targetName, { exact: true }).first();
-    await expect(option).toBeVisible({ timeout: 15000 });
+    const option = this.getMoveDropdownOption(targetName);
+    await expect(option).toBeVisible();
     await option.click();
     await this.moveModalSubmitButton.click({ force: true });
-  }
-
-  // ── Dataset glossary term management ────────────────────────────────────────
-
-  /**
-   * Navigates to a dataset entity page and adds a glossary term via the sidebar.
-   * @param datasetPath - URL path segment after the base URL (e.g. "dataset/urn:li:...").
-   * @param datasetName - Display name to wait for after navigation.
-   * @param termName    - Glossary term to search for and add.
-   */
-  async addGlossaryTermToDataset(datasetPath: string, datasetName: string, termName: string): Promise<void> {
-    this.logger?.step('addGlossaryTermToDataset', { datasetName, termName });
-    await this.page.goto(`/${datasetPath}`);
-    await this.page.waitForLoadState('networkidle');
-    await expect(this.page.getByText(datasetName).first()).toBeVisible({ timeout: 30000 });
-    await this.sidebarGlossarySection.locator('[data-testid="add-terms-button"]').click();
-    await expect(this.tagTermModalInput).toBeVisible({ timeout: 15000 });
-    // AntD Select triggers search via keyboard events; pressSequentially (not fill) is required.
-    await this.tagTermModalInput.pressSequentially(termName);
-    await this.tagTermOption.click();
-    await this.addTagTermConfirmButton.click();
-    await expect(this.addTagTermConfirmButton).not.toBeVisible({ timeout: 15000 });
-    await expect(this.page.getByText(termName)).toBeVisible({ timeout: 15000 });
-  }
-
-  // ── Batch add term to entities ───────────────────────────────────────────────
-
-  /**
-   * Uses the "Add Assets" batch button on a glossary term entity page to assign
-   * the term to one or more datasets via the search modal.
-   */
-  async batchAddToFirstResult(): Promise<void> {
-    this.logger?.step('batchAddToFirstResult');
-    await this.batchAddGlossaryButton.click();
-    await expect(this.previewEntities.first()).toBeVisible({ timeout: 30000 });
-    await this.entityCheckboxes.first().click();
-    await this.continueButton.click();
-    await expect(this.page.getByText('Added Glossary Term to entities!')).toBeVisible({ timeout: 15000 });
-  }
-
-  /**
-   * Uses the "Add Assets" batch button to assign the term to a specific entity found by search query.
-   * Searches within the modal for the entity by name, waits for it to appear, then confirms.
-   */
-  async batchAddToEntityBySearch(query: string): Promise<void> {
-    this.logger?.step('batchAddToEntityBySearch', { query });
-    await this.batchAddGlossaryButton.click();
-    // Wait for the modal search input to be ready.
-    const modalSearchInput = this.page.locator('[data-testid="search-select-modal"] [data-testid="search-input"]');
-    await expect(modalSearchInput).toBeVisible({ timeout: 30000 });
-    // pressSequentially triggers the debounced search handler character by character.
-    await modalSearchInput.pressSequentially(query, { delay: 50 });
-    await this.page.waitForLoadState('networkidle');
-    // Wait for the search results to show the specific entity.
-    const entityTitle = this.previewEntities.locator('[data-testid="entity-title"]').filter({ hasText: query }).first();
-    await expect(entityTitle).toBeVisible({ timeout: 15000 });
-    await this.entityCheckboxes.first().click();
-    await this.continueButton.click();
-    await expect(this.page.getByText('Added Glossary Term to entities!')).toBeVisible({ timeout: 15000 });
+    await expect(this.movedEntityToast).toBeVisible();
   }
 
   // ── Search within an entity page ─────────────────────────────────────────────
@@ -284,25 +302,19 @@ export class GlossaryPage extends BasePage {
     await this.searchInput.click();
     await this.searchInput.fill(query);
     await this.searchInput.press('Enter');
-    await this.page.waitForLoadState('networkidle');
-  }
-
-  // ── Sidebar navigation ───────────────────────────────────────────────────────
-
-  /** Clicks an item by name in the glossary browser sidebar. */
-  async clickSidebarItem(name: string): Promise<void> {
-    await this.sidebarContainer.getByText(name).click();
-    await this.page.waitForLoadState('networkidle');
+    await this.waitForPageLoad();
   }
 
   // ── Related-assets filtering ─────────────────────────────────────────────────
 
   /**
-   * Opens the basic facet filter panel on the Related Assets / search-results panel.
-   * .anticon-filter is the AntD CSS class applied to the filter icon button; no data-testid exists.
+   * Opens the basic facet filter panel and clicks the checkbox for a specific tag.
+   * The facet checkbox data-testid is `facet-tags-{tagUrn}`.
    */
-  async clickFacetFilterIcon(): Promise<void> {
-    await this.page.locator('.anticon-filter').first().click();
+  async applyFacetTagFilter(tagUrn: string): Promise<void> {
+    this.logger?.step('applyFacetTagFilter', { tagUrn });
+    await this.filtersToggleButton.click();
+    await this.getFacetTagCheckbox(tagUrn).click();
   }
 
   /**
@@ -311,46 +323,67 @@ export class GlossaryPage extends BasePage {
    */
   async filterRelatedAssetsByTag(tagName: string): Promise<void> {
     this.logger?.step('filterRelatedAssetsByTag', { tagName });
-    await this.page.locator('[aria-label="filter"]').first().click();
-    await this.page.locator('#search-results-advanced-search').click();
-    await this.page.getByText('Add Filter').click();
-    await this.page.getByTestId('adv-search-add-filter-tags').click();
+    await this.filtersToggleButton.click();
+    await this.advancedSearchButton.click();
+    await this.addFilterButton.click();
+    await this.addFilterTagsButton.click();
     // AntD Select: type into the overflow input to trigger the options search.
-    await this.page.locator('div.ant-select-selection-overflow input').pressSequentially(tagName);
-    await this.page.locator(`[data-testid="tag-term-option-${tagName}"]`).click();
-    await this.page.getByText('Add Tags').click();
-    await this.addTagTermConfirmButton.click();
+    await this.filterTagSelectInput.pressSequentially(tagName);
+    await this.getTagFilterOption(tagName).click();
+    await this.modalComponent.title.click();
+    await this.addTagsConfirmButton.click();
+  }
+
+  // ── Batch add to assets ──────────────────────────────────────────────────────
+
+  async clickBatchAddButton(): Promise<void> {
+    this.logger?.step('clickBatchAddButton');
+    await this.batchAddButton.click();
+  }
+
+  async searchInBatchAddModal(query: string): Promise<void> {
+    this.logger?.step('searchInBatchAddModal', { query });
+    // pressSequentially triggers AntD AutoComplete's onSearch callback; fill() does not.
+    await this.batchAddModalSearchInput.click({ clickCount: 3 });
+    await this.batchAddModalSearchInput.pressSequentially(query);
+  }
+
+  async selectEntityInBatchAddModal(entityUrn: string): Promise<void> {
+    this.logger?.step('selectEntityInBatchAddModal', { entityUrn });
+    const checkbox = this.getBatchAddEntityCheckbox(entityUrn);
+    await expect(checkbox).toBeVisible({ timeout: 10000 });
+    await checkbox.click({ force: true });
+  }
+
+  async confirmBatchAdd(): Promise<void> {
+    this.logger?.step('confirmBatchAdd');
+    await this.batchAddConfirmButton.click();
+    await expect(this.batchAddedToast).toBeVisible({ timeout: 15000 });
   }
 
   // ── Assertions ───────────────────────────────────────────────────────────────
 
-  /**
-   * Asserts the Properties tab is the currently selected tab.
-   * Uses role="tab" ARIA selector instead of AntD-internal [data-node-key] + .ant-tabs-tab-btn.
-   */
-  async expectPropertiesTabActive(timeout = 10000): Promise<void> {
-    await expect(this.page.getByRole('tab', { name: 'Properties' }).first()).toHaveAttribute('aria-selected', 'true', {
-      timeout,
-    });
+  async expectPropertiesTabActive(): Promise<void> {
+    await expect(this.propertiesTab).toHaveAttribute('aria-selected', 'true');
   }
 
-  async expectTextVisible(text: string, timeout = 15000): Promise<void> {
-    await expect(this.page.getByText(text).filter({ visible: true }).first()).toBeVisible({ timeout });
+  async expectEntityInContentsTab(urn: string): Promise<void> {
+    await expect(this.getContentsTabItemLocator(urn)).toBeVisible();
   }
 
-  async expectTextNotPresent(text: string, timeout = 15000): Promise<void> {
-    await expect(this.page.getByText(text).first()).not.toBeVisible({ timeout });
+  async expectEntityNotInContentsTab(urn: string): Promise<void> {
+    await expect(this.getContentsTabItemLocator(urn)).toBeHidden();
   }
 
-  async expectSidebarContains(name: string, timeout = 15000): Promise<void> {
-    await expect(this.sidebarContainer.getByText(name)).toBeVisible({ timeout });
+  async expectSidebarContainsNode(urn: string): Promise<void> {
+    await expect(this.getSidebarNodeLocator(urn)).toBeVisible();
   }
 
-  async expectSidebarNotContains(name: string, timeout = 15000): Promise<void> {
-    await expect(this.sidebarContainer.getByText(name)).not.toBeVisible({ timeout });
+  async expectSidebarNotContainsNode(urn: string): Promise<void> {
+    await expect(this.getSidebarNodeLocator(urn)).toBeHidden();
   }
 
-  async expectPreviewEntitiesVisible(timeout = 30000): Promise<void> {
-    await expect(this.previewEntities.first()).toBeVisible({ timeout });
+  async expectPreviewEntityByUrn(urn: string): Promise<void> {
+    await expect(this.getPreviewEntityLocator(urn)).toBeVisible();
   }
 }

--- a/e2e-test/ui/playwright/pages/glossary.page.ts
+++ b/e2e-test/ui/playwright/pages/glossary.page.ts
@@ -291,7 +291,7 @@ export class GlossaryPage extends BasePage {
     const option = this.getMoveDropdownOption(targetName);
     await expect(option).toBeVisible();
     await option.click();
-    await this.moveModalSubmitButton.click({ force: true });
+    await this.moveModalSubmitButton.click();
     await expect(this.movedEntityToast).toBeVisible();
   }
 
@@ -344,21 +344,21 @@ export class GlossaryPage extends BasePage {
   async searchInBatchAddModal(query: string): Promise<void> {
     this.logger?.step('searchInBatchAddModal', { query });
     // pressSequentially triggers AntD AutoComplete's onSearch callback; fill() does not.
-    await this.batchAddModalSearchInput.click({ clickCount: 3 });
+    await this.batchAddModalSearchInput.click();
     await this.batchAddModalSearchInput.pressSequentially(query);
   }
 
   async selectEntityInBatchAddModal(entityUrn: string): Promise<void> {
     this.logger?.step('selectEntityInBatchAddModal', { entityUrn });
     const checkbox = this.getBatchAddEntityCheckbox(entityUrn);
-    await expect(checkbox).toBeVisible({ timeout: 10000 });
-    await checkbox.click({ force: true });
+    await expect(checkbox).toBeVisible();
+    await checkbox.click();
   }
 
   async confirmBatchAdd(): Promise<void> {
     this.logger?.step('confirmBatchAdd');
     await this.batchAddConfirmButton.click();
-    await expect(this.batchAddedToast).toBeVisible({ timeout: 15000 });
+    await expect(this.batchAddedToast).toBeVisible();
   }
 
   // ── Assertions ───────────────────────────────────────────────────────────────

--- a/e2e-test/ui/playwright/pages/glossary.page.ts
+++ b/e2e-test/ui/playwright/pages/glossary.page.ts
@@ -1,0 +1,356 @@
+/**
+ * GlossaryPage — page object for /glossary (Business Glossary).
+ *
+ * Covers the full CRUD lifecycle for Glossary Term Groups and Glossary Terms,
+ * including navigation, creation, moving, deleting, and adding terms to datasets.
+ *
+ * Key selectors are taken directly from the React source:
+ *   - GlossaryContentProvider.tsx   → glossaryPageV2, add-term-group-button-v2
+ *   - GlossarySidebar.tsx           → glossary-browser-sidebar, create-glossary-button
+ *   - ChildrenTab.tsx               → add-term-button
+ *   - EntityTabs.tsx                → ${name}-entity-tab-header
+ *   - CreateGlossaryEntityModal.tsx → create-glossary-entity-modal-name, glossary-entity-modal-create-button
+ *   - MoveGlossaryEntityModal.tsx   → move-glossary-entity-modal, glossary-entity-modal-move-button
+ *   - EntityDropdown.tsx            → MoreVertOutlinedIcon (three-dot), entity-menu-delete-button, entity-menu-move-button
+ *   - SidebarGlossaryTermsSection.tsx → entity-profile-glossary-terms, add-terms-button
+ *   - AddTagsTermsModal.tsx         → tag-term-modal-input, tag-term-option, add-tag-term-from-modal-btn
+ *   - EntityActions.tsx             → glossary-batch-add
+ *   - EntitySearchResults.tsx       → checkbox-{urn} (entity select checkboxes in batch-add modal)
+ *   - SearchSelectModal.tsx         → search-select-modal
+ *   - EmbeddedListSearch            → search-results-advanced-search, adv-search-add-filter-tags
+ */
+
+import { expect, type Locator, type Page } from '@playwright/test';
+import { BasePage } from './base.page';
+import type { DataHubLogger } from '../utils/logger';
+
+export class GlossaryPage extends BasePage {
+  // ── Navigation ──────────────────────────────────────────────────────────────
+  readonly glossaryPageHeader: Locator;
+  readonly sidebarContainer: Locator;
+
+  // ── Root-level create buttons (GlossaryContentProvider header) ──────────────
+  readonly addTermGroupButtonV2: Locator;
+
+  // ── Glossary sidebar (GlossarySidebar) ──────────────────────────────────────
+  readonly createGlossarySidebarButton: Locator;
+
+  // ── Entity contents tab buttons (ChildrenTab) ────────────────────────────────
+  readonly addTermButton: Locator;
+
+  // ── Create modal (CreateGlossaryEntityModal) ─────────────────────────────────
+  readonly createModalNameInput: Locator;
+  readonly createModalSubmitButton: Locator;
+
+  // ── Move modal (MoveGlossaryEntityModal) ─────────────────────────────────────
+  readonly moveModalContainer: Locator;
+  readonly moveModalSubmitButton: Locator;
+
+  // ── Three-dot entity menu (EntityDropdown) ────────────────────────────────────
+  readonly entityMenuThreeDotButton: Locator;
+  readonly entityMenuDeleteButton: Locator;
+  readonly entityMenuMoveButton: Locator;
+
+  // ── Dataset sidebar — add glossary term section ───────────────────────────────
+  readonly sidebarGlossarySection: Locator;
+  readonly addTermsButton: Locator;
+
+  // ── Add tag/term modal (AddTagsTermsModal) ─────────────────────────────────
+  readonly tagTermModalInput: Locator;
+  readonly tagTermOption: Locator;
+  readonly addTagTermConfirmButton: Locator;
+
+  // ── Batch-add glossary term button (EntityActions) ─────────────────────────
+  readonly batchAddGlossaryButton: Locator;
+
+  // ── Batch-add modal entity results (SearchSelectModal / EntitySearchResults) ─
+  readonly previewEntities: Locator;
+  readonly entityCheckboxes: Locator;
+
+  // ── Search input (shared EmbeddedListSearch) ──────────────────────────────
+  readonly searchInput: Locator;
+
+  // ── Continue button (entity selection modal) ──────────────────────────────
+  readonly continueButton: Locator;
+
+  constructor(page: Page, logger?: DataHubLogger, logDir?: string) {
+    super(page, logger, logDir);
+
+    this.glossaryPageHeader = page.locator('[data-testid="glossaryPageV2"]');
+    this.sidebarContainer = page.locator('[data-testid="glossary-browser-sidebar"]');
+
+    this.addTermGroupButtonV2 = page.locator('[data-testid="add-term-group-button-v2"]').first();
+    this.createGlossarySidebarButton = page.locator('[data-testid="create-glossary-button"]');
+
+    this.addTermButton = page.locator('[data-testid="add-term-button"]').first();
+
+    this.createModalNameInput = page.locator('[data-testid="create-glossary-entity-modal-name"] input');
+    this.createModalSubmitButton = page.locator('[data-testid="glossary-entity-modal-create-button"]');
+
+    // The AntD modal root is a wrapper; target the inner visible dialog content.
+    this.moveModalContainer = page.locator('[data-testid="move-glossary-entity-modal"] .ant-modal-content');
+    this.moveModalSubmitButton = page.locator('[data-testid="glossary-entity-modal-move-button"]');
+
+    // MoreVertOutlinedIcon is the data-testid set by EntityDropdown.tsx on the three-dot icon button.
+    this.entityMenuThreeDotButton = page.locator('[data-testid="MoreVertOutlinedIcon"]').first();
+    this.entityMenuDeleteButton = page.locator('[data-testid="entity-menu-delete-button"]');
+    this.entityMenuMoveButton = page.locator('[data-testid="entity-menu-move-button"]');
+
+    this.sidebarGlossarySection = page.locator('#entity-profile-glossary-terms');
+    this.addTermsButton = page.locator('[data-testid="add-terms-button"]');
+
+    // The AntD Select renders as a div wrapper; we target the inner search input for typing.
+    this.tagTermModalInput = page.locator('[data-testid="tag-term-modal-input"] input');
+    this.tagTermOption = page.locator('[data-testid="tag-term-option"]').first();
+    this.addTagTermConfirmButton = page.locator('[data-testid="add-tag-term-from-modal-btn"]');
+
+    this.batchAddGlossaryButton = page.locator('[data-testid="glossary-batch-add"]').first();
+
+    // preview-urn: prefix is set by entity preview cards; checkbox- prefix by entity select checkboxes.
+    this.previewEntities = page.locator('[data-testid^="preview-urn:"]');
+    this.entityCheckboxes = page.locator('[data-testid^="checkbox-"]');
+
+    this.searchInput = page.locator('[data-testid="search-input"]').last();
+
+    this.continueButton = page.locator('#continueButton');
+  }
+
+  // ── Navigation ───────────────────────────────────────────────────────────────
+
+  async navigateToGlossary(): Promise<void> {
+    this.logger?.step('navigate', { url: '/glossary' });
+    await this.page.goto('/glossary');
+    await this.page.waitForLoadState('networkidle');
+    await expect(this.sidebarContainer).toBeVisible({ timeout: 30000 });
+  }
+
+  async navigateToGlossaryTerm(text: string): Promise<void> {
+    // Prefer clicking a visible link or text rather than a hidden sidebar span.
+    // Filter to only the visible match so we don't hit hidden sidebar browser entries.
+    const visibleElement = this.page.getByText(text).filter({ visible: true }).first();
+    await visibleElement.waitFor({ state: 'visible', timeout: 30000 });
+    await visibleElement.click();
+    await this.page.waitForLoadState('networkidle');
+  }
+
+  async navigateToEntityContentsTab(): Promise<void> {
+    await this.clickEntityTabByName('Contents');
+  }
+
+  async navigateToEntityPropertiesTab(): Promise<void> {
+    await this.clickEntityTabByName('Properties');
+  }
+
+  async navigateToEntityRelatedAssetsTab(): Promise<void> {
+    await this.clickEntityTabByName('Related Assets');
+  }
+
+  async clickEntityTabByName(tabName: string): Promise<void> {
+    const tabSelector = `[data-testid="${tabName}-entity-tab-header"]`;
+    await this.page.locator(tabSelector).click();
+    await this.page.waitForLoadState('networkidle');
+  }
+
+  // ── Glossary Term Group CRUD ─────────────────────────────────────────────────
+
+  /**
+   * Creates a root-level Term Group from the glossary home page header button.
+   * Opens the modal, types the name, and confirms.
+   */
+  async createTermGroup(name: string): Promise<void> {
+    this.logger?.step('createTermGroup', { name });
+    await this.addTermGroupButtonV2.click();
+    // Wait for the modal heading (h1 role) specifically to avoid matching the button text.
+    await expect(this.page.getByRole('heading', { name: 'Create Glossary' })).toBeVisible({ timeout: 15000 });
+    await this.createModalNameInput.fill(name);
+    await this.createModalSubmitButton.click();
+    await expect(this.page.getByText(`Created Term Group!`)).toBeVisible({ timeout: 15000 });
+  }
+
+  /**
+   * Creates a Glossary Term inside the currently-open entity (term group) page.
+   * Requires the Contents tab to already be active.
+   */
+  async createTermInContentsTab(name: string): Promise<void> {
+    this.logger?.step('createTermInContentsTab', { name });
+    await this.addTermButton.click();
+    await expect(this.page.getByRole('heading', { name: 'Create Glossary Term' })).toBeVisible({ timeout: 15000 });
+    await this.createModalNameInput.fill(name);
+    await this.createModalSubmitButton.click();
+    // The mutation fires async; wait for the success toast which appears after ~2s.
+    await expect(this.page.getByText('Created Glossary Term!')).toBeVisible({ timeout: 15000 });
+  }
+
+  // ── Three-dot entity menu actions ────────────────────────────────────────────
+
+  /** Opens the three-dot dropdown for the currently-viewed entity. */
+  async openEntityMenu(): Promise<void> {
+    await this.entityMenuThreeDotButton.click();
+  }
+
+  /** Deletes the currently-viewed entity via the three-dot menu. */
+  async deleteCurrentEntity(): Promise<void> {
+    this.logger?.step('deleteCurrentEntity');
+    await this.openEntityMenu();
+    await this.page.getByText('Delete').click();
+    await this.page.getByRole('button', { name: 'Yes' }).click();
+  }
+
+  /**
+   * Moves the currently-viewed entity to a target parent using the three-dot menu.
+   * @param targetName - Display name of the target group shown in the move modal tree.
+   */
+  async moveCurrentEntityTo(targetName: string): Promise<void> {
+    this.logger?.step('moveCurrentEntityTo', { targetName });
+    await this.openEntityMenu();
+    // Use the entity-menu-move-button testid to avoid matching hidden DnD accessibility elements.
+    await this.entityMenuMoveButton.click();
+    await expect(this.moveModalContainer).toBeVisible({ timeout: 15000 });
+    // Type into the AntD Select search input to filter results — more reliable than
+    // scrolling through the GlossaryBrowser tree which accumulates entries across test runs.
+    const selectInput = this.moveModalContainer.locator('.ant-select-selector input');
+    await selectInput.click();
+    await selectInput.fill(targetName);
+    // The dropdown shows search results (not the tree browser) when a query is present.
+    const option = this.page.locator('.ant-select-dropdown').getByText(targetName, { exact: true }).first();
+    await expect(option).toBeVisible({ timeout: 15000 });
+    await option.click();
+    await this.moveModalSubmitButton.click({ force: true });
+  }
+
+  // ── Dataset glossary term management ────────────────────────────────────────
+
+  /**
+   * Navigates to a dataset entity page and adds a glossary term via the sidebar.
+   * @param datasetPath - URL path segment after the base URL (e.g. "dataset/urn:li:...").
+   * @param datasetName - Display name to wait for after navigation.
+   * @param termName    - Glossary term to search for and add.
+   */
+  async addGlossaryTermToDataset(datasetPath: string, datasetName: string, termName: string): Promise<void> {
+    this.logger?.step('addGlossaryTermToDataset', { datasetName, termName });
+    await this.page.goto(`/${datasetPath}`);
+    await this.page.waitForLoadState('networkidle');
+    await expect(this.page.getByText(datasetName).first()).toBeVisible({ timeout: 30000 });
+    await this.sidebarGlossarySection.locator('[data-testid="add-terms-button"]').click();
+    await expect(this.tagTermModalInput).toBeVisible({ timeout: 15000 });
+    // AntD Select triggers search via keyboard events; pressSequentially (not fill) is required.
+    await this.tagTermModalInput.pressSequentially(termName);
+    await this.tagTermOption.click();
+    await this.addTagTermConfirmButton.click();
+    await expect(this.addTagTermConfirmButton).not.toBeVisible({ timeout: 15000 });
+    await expect(this.page.getByText(termName)).toBeVisible({ timeout: 15000 });
+  }
+
+  // ── Batch add term to entities ───────────────────────────────────────────────
+
+  /**
+   * Uses the "Add Assets" batch button on a glossary term entity page to assign
+   * the term to one or more datasets via the search modal.
+   */
+  async batchAddToFirstResult(): Promise<void> {
+    this.logger?.step('batchAddToFirstResult');
+    await this.batchAddGlossaryButton.click();
+    await expect(this.previewEntities.first()).toBeVisible({ timeout: 30000 });
+    await this.entityCheckboxes.first().click();
+    await this.continueButton.click();
+    await expect(this.page.getByText('Added Glossary Term to entities!')).toBeVisible({ timeout: 15000 });
+  }
+
+  /**
+   * Uses the "Add Assets" batch button to assign the term to a specific entity found by search query.
+   * Searches within the modal for the entity by name, waits for it to appear, then confirms.
+   */
+  async batchAddToEntityBySearch(query: string): Promise<void> {
+    this.logger?.step('batchAddToEntityBySearch', { query });
+    await this.batchAddGlossaryButton.click();
+    // Wait for the modal search input to be ready.
+    const modalSearchInput = this.page.locator('[data-testid="search-select-modal"] [data-testid="search-input"]');
+    await expect(modalSearchInput).toBeVisible({ timeout: 30000 });
+    // pressSequentially triggers the debounced search handler character by character.
+    await modalSearchInput.pressSequentially(query, { delay: 50 });
+    await this.page.waitForLoadState('networkidle');
+    // Wait for the search results to show the specific entity.
+    const entityTitle = this.previewEntities.locator('[data-testid="entity-title"]').filter({ hasText: query }).first();
+    await expect(entityTitle).toBeVisible({ timeout: 15000 });
+    await this.entityCheckboxes.first().click();
+    await this.continueButton.click();
+    await expect(this.page.getByText('Added Glossary Term to entities!')).toBeVisible({ timeout: 15000 });
+  }
+
+  // ── Search within an entity page ─────────────────────────────────────────────
+
+  async searchWithinEntityPage(query: string): Promise<void> {
+    this.logger?.step('searchWithinEntityPage', { query });
+    await this.searchInput.click();
+    await this.searchInput.fill(query);
+    await this.searchInput.press('Enter');
+    await this.page.waitForLoadState('networkidle');
+  }
+
+  // ── Sidebar navigation ───────────────────────────────────────────────────────
+
+  /** Clicks an item by name in the glossary browser sidebar. */
+  async clickSidebarItem(name: string): Promise<void> {
+    await this.sidebarContainer.getByText(name).click();
+    await this.page.waitForLoadState('networkidle');
+  }
+
+  // ── Related-assets filtering ─────────────────────────────────────────────────
+
+  /**
+   * Opens the basic facet filter panel on the Related Assets / search-results panel.
+   * .anticon-filter is the AntD CSS class applied to the filter icon button; no data-testid exists.
+   */
+  async clickFacetFilterIcon(): Promise<void> {
+    await this.page.locator('.anticon-filter').first().click();
+  }
+
+  /**
+   * Applies an advanced-search tag filter on the Related Assets panel.
+   * Navigates: filter icon → Advanced → Add Filter → Tags → selects tag → confirms.
+   */
+  async filterRelatedAssetsByTag(tagName: string): Promise<void> {
+    this.logger?.step('filterRelatedAssetsByTag', { tagName });
+    await this.page.locator('[aria-label="filter"]').first().click();
+    await this.page.locator('#search-results-advanced-search').click();
+    await this.page.getByText('Add Filter').click();
+    await this.page.getByTestId('adv-search-add-filter-tags').click();
+    // AntD Select: type into the overflow input to trigger the options search.
+    await this.page.locator('div.ant-select-selection-overflow input').pressSequentially(tagName);
+    await this.page.locator(`[data-testid="tag-term-option-${tagName}"]`).click();
+    await this.page.getByText('Add Tags').click();
+    await this.addTagTermConfirmButton.click();
+  }
+
+  // ── Assertions ───────────────────────────────────────────────────────────────
+
+  /**
+   * Asserts the Properties tab is the currently selected tab.
+   * Uses role="tab" ARIA selector instead of AntD-internal [data-node-key] + .ant-tabs-tab-btn.
+   */
+  async expectPropertiesTabActive(timeout = 10000): Promise<void> {
+    await expect(this.page.getByRole('tab', { name: 'Properties' }).first()).toHaveAttribute('aria-selected', 'true', {
+      timeout,
+    });
+  }
+
+  async expectTextVisible(text: string, timeout = 15000): Promise<void> {
+    await expect(this.page.getByText(text).filter({ visible: true }).first()).toBeVisible({ timeout });
+  }
+
+  async expectTextNotPresent(text: string, timeout = 15000): Promise<void> {
+    await expect(this.page.getByText(text).first()).not.toBeVisible({ timeout });
+  }
+
+  async expectSidebarContains(name: string, timeout = 15000): Promise<void> {
+    await expect(this.sidebarContainer.getByText(name)).toBeVisible({ timeout });
+  }
+
+  async expectSidebarNotContains(name: string, timeout = 15000): Promise<void> {
+    await expect(this.sidebarContainer.getByText(name)).not.toBeVisible({ timeout });
+  }
+
+  async expectPreviewEntitiesVisible(timeout = 30000): Promise<void> {
+    await expect(this.previewEntities.first()).toBeVisible({ timeout });
+  }
+}

--- a/e2e-test/ui/playwright/tests/glossary/fixtures/data.json
+++ b/e2e-test/ui/playwright/tests/glossary/fixtures/data.json
@@ -1,0 +1,80 @@
+[
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:hdfs,SamplePlaywrightGlossaryDataset,PROD)",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+              "description": "Dataset used for glossary term tests",
+              "customProperties": {}
+            }
+          },
+          {
+            "com.linkedin.pegasus2avro.common.BrowsePaths": {
+              "paths": ["/prod/hdfs/SamplePlaywrightGlossaryDataset"]
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.GlossaryNodeSnapshot": {
+        "urn": "urn:li:glossaryNode:PlaywrightNode",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.glossary.GlossaryNodeInfo": {
+              "definition": "Playwright test parent node",
+              "name": "PlaywrightNode"
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.TagSnapshot": {
+        "urn": "urn:li:tag:PlaywrightGlossaryTag",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.tag.TagProperties": {
+              "name": "PlaywrightGlossaryTag",
+              "description": "Tag used in Playwright glossary advanced-search tests"
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:hdfs,PlaywrightGlossaryTaggedDataset,PROD)",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+              "description": "Dataset used in Playwright glossary advanced-search tests",
+              "customProperties": {}
+            }
+          },
+          {
+            "com.linkedin.pegasus2avro.common.GlobalTags": {
+              "tags": [
+                {
+                  "tag": "urn:li:tag:PlaywrightGlossaryTag"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+]

--- a/e2e-test/ui/playwright/tests/glossary/fixtures/data.json
+++ b/e2e-test/ui/playwright/tests/glossary/fixtures/data.json
@@ -23,6 +23,79 @@
   {
     "auditHeader": null,
     "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:hdfs,PlaywrightGlossaryBatchAddDataset,PROD)",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+              "description": "Dataset used in Playwright glossary batch-add test",
+              "customProperties": {}
+            }
+          },
+          {
+            "com.linkedin.pegasus2avro.common.BrowsePaths": {
+              "paths": ["/prod/hdfs/PlaywrightGlossaryBatchAddDataset"]
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.GlossaryNodeSnapshot": {
+        "urn": "urn:li:glossaryNode:PlaywrightNavPropsTest",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.glossary.GlossaryNodeInfo": {
+              "definition": "Node for Properties-tab-persistence navigation test",
+              "name": "PlaywrightNavPropsTest"
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.GlossaryTermSnapshot": {
+        "urn": "urn:li:glossaryTerm:PlaywrightNavPropsTest.PlaywrightNavTerm1",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.glossary.GlossaryTermInfo": {
+              "definition": "First term for Properties-tab-persistence navigation test",
+              "name": "PlaywrightNavTerm1",
+              "parentNode": "urn:li:glossaryNode:PlaywrightNavPropsTest",
+              "termSource": "INTERNAL"
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.GlossaryTermSnapshot": {
+        "urn": "urn:li:glossaryTerm:PlaywrightNavPropsTest.PlaywrightNavTerm2",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.glossary.GlossaryTermInfo": {
+              "definition": "Second term for Properties-tab-persistence navigation test",
+              "name": "PlaywrightNavTerm2",
+              "parentNode": "urn:li:glossaryNode:PlaywrightNavPropsTest",
+              "termSource": "INTERNAL"
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
       "com.linkedin.pegasus2avro.metadata.snapshot.GlossaryNodeSnapshot": {
         "urn": "urn:li:glossaryNode:PlaywrightNode",
         "aspects": [
@@ -30,6 +103,114 @@
             "com.linkedin.pegasus2avro.glossary.GlossaryNodeInfo": {
               "definition": "Playwright test parent node",
               "name": "PlaywrightNode"
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.TagSnapshot": {
+        "urn": "urn:li:tag:PlaywrightGlossarySearchTag",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.tag.TagProperties": {
+              "name": "PlaywrightGlossarySearchTag",
+              "description": "Tag used in Playwright glossary search-by-query test"
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:hdfs,PlaywrightGlossarySearchDataset,PROD)",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+              "description": "Dataset used in Playwright glossary search-by-query test",
+              "customProperties": {}
+            }
+          },
+          {
+            "com.linkedin.pegasus2avro.common.GlobalTags": {
+              "tags": [
+                {
+                  "tag": "urn:li:tag:PlaywrightGlossarySearchTag"
+                }
+              ]
+            }
+          },
+          {
+            "com.linkedin.pegasus2avro.common.GlossaryTerms": {
+              "terms": [
+                {
+                  "urn": "urn:li:glossaryTerm:PlaywrightGlossaryTermTests.PlaywrightSearchRelated"
+                }
+              ],
+              "auditStamp": {
+                "time": 1581407189000,
+                "actor": "urn:li:corpuser:datahub"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.TagSnapshot": {
+        "urn": "urn:li:tag:PlaywrightGlossaryFilterTag",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.tag.TagProperties": {
+              "name": "PlaywrightGlossaryFilterTag",
+              "description": "Tag used in Playwright glossary facet-filter test"
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:hdfs,PlaywrightGlossaryFilterDataset,PROD)",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+              "description": "Dataset used in Playwright glossary facet-filter test",
+              "customProperties": {}
+            }
+          },
+          {
+            "com.linkedin.pegasus2avro.common.GlobalTags": {
+              "tags": [
+                {
+                  "tag": "urn:li:tag:PlaywrightGlossaryFilterTag"
+                }
+              ]
+            }
+          },
+          {
+            "com.linkedin.pegasus2avro.common.GlossaryTerms": {
+              "terms": [
+                {
+                  "urn": "urn:li:glossaryTerm:PlaywrightGlossaryTermTests.PlaywrightFilterRelated"
+                }
+              ],
+              "auditStamp": {
+                "time": 1581407189000,
+                "actor": "urn:li:corpuser:datahub"
+              }
             }
           }
         ]
@@ -71,6 +252,89 @@
                   "tag": "urn:li:tag:PlaywrightGlossaryTag"
                 }
               ]
+            }
+          },
+          {
+            "com.linkedin.pegasus2avro.common.GlossaryTerms": {
+              "terms": [
+                {
+                  "urn": "urn:li:glossaryTerm:PlaywrightGlossaryTermTests.PlaywrightTaggedRelated"
+                }
+              ],
+              "auditStamp": {
+                "time": 1581407189000,
+                "actor": "urn:li:corpuser:datahub"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.GlossaryNodeSnapshot": {
+        "urn": "urn:li:glossaryNode:PlaywrightGlossaryTermTests",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.glossary.GlossaryNodeInfo": {
+              "definition": "Parent node for Playwright glossary term entity tests",
+              "name": "PlaywrightGlossaryTermTests"
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.GlossaryTermSnapshot": {
+        "urn": "urn:li:glossaryTerm:PlaywrightGlossaryTermTests.PlaywrightSearchRelated",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.glossary.GlossaryTermInfo": {
+              "definition": "Term for glossary search-by-query test",
+              "name": "PlaywrightSearchRelated",
+              "parentNode": "urn:li:glossaryNode:PlaywrightGlossaryTermTests",
+              "termSource": "INTERNAL"
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.GlossaryTermSnapshot": {
+        "urn": "urn:li:glossaryTerm:PlaywrightGlossaryTermTests.PlaywrightFilterRelated",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.glossary.GlossaryTermInfo": {
+              "definition": "Term for glossary facet-filter test",
+              "name": "PlaywrightFilterRelated",
+              "parentNode": "urn:li:glossaryNode:PlaywrightGlossaryTermTests",
+              "termSource": "INTERNAL"
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.GlossaryTermSnapshot": {
+        "urn": "urn:li:glossaryTerm:PlaywrightGlossaryTermTests.PlaywrightTaggedRelated",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.glossary.GlossaryTermInfo": {
+              "definition": "Term for glossary advanced tag-filter test",
+              "name": "PlaywrightTaggedRelated",
+              "parentNode": "urn:li:glossaryNode:PlaywrightGlossaryTermTests",
+              "termSource": "INTERNAL"
             }
           }
         ]

--- a/e2e-test/ui/playwright/tests/glossary/v2-glossary-navigation.spec.ts
+++ b/e2e-test/ui/playwright/tests/glossary/v2-glossary-navigation.spec.ts
@@ -44,13 +44,10 @@ test.describe('glossary sidebar navigation', () => {
   });
 
   test('Properties tab persists when switching between terms', async () => {
-    // Uses pre-seeded PlaywrightNavPropsTest node with two child terms — no setup needed.
     await glossaryPage.navigateToGlossaryTermByUrn(PROPS_TEST_TERM1_URN);
     await glossaryPage.openPropertiesTab();
     await glossaryPage.expectPropertiesTabActive();
 
-    // Navigating to a child term auto-expands its parent node in the sidebar,
-    // making the sibling term visible and clickable without any additional navigation.
     await glossaryPage.clickSidebarTerm(PROPS_TEST_TERM2_URN);
     await glossaryPage.expectPropertiesTabActive();
   });

--- a/e2e-test/ui/playwright/tests/glossary/v2-glossary-navigation.spec.ts
+++ b/e2e-test/ui/playwright/tests/glossary/v2-glossary-navigation.spec.ts
@@ -1,0 +1,131 @@
+/**
+ * Glossary Sidebar Navigation tests — migrated from Cypress e2e/glossaryV2/v2_glossary_navigation.js
+ *
+ * Tests the move and sidebar navigation behaviour for glossary entities:
+ *   1. Create a root-level Term Group and two Terms inside it.
+ *   2. Move each Term back into the same Term Group (confirming move messages).
+ *   3. Switch between Terms and verify the Properties tab persists as the active tab.
+ *   4. Move the Term Group under the parent node (PlaywrightNode).
+ *   5. Delete both Terms and the Term Group, verifying the sidebar clears.
+ *
+ * Each test run uses a unique timestamp-based suffix so tests are fully independent
+ * and can run in parallel without colliding on entity names.
+ *
+ * Prerequisites: `PlaywrightNode` glossary node must exist (seeded via fixtures/data.json).
+ */
+
+import { test, expect } from '../../fixtures/base-test';
+import { GlossaryPage } from '../../pages/glossary.page';
+
+test.use({ featureName: 'glossary' });
+
+// Serial: tests build on state created in earlier tests within this suite.
+test.describe.configure({ mode: 'serial' });
+
+const runId = Date.now();
+const TERM_GROUP_NAME = `PlaywrightNavGroup${runId}`;
+const TERM_NAME = `PlaywrightNavTerm${runId}`;
+const SECOND_TERM_NAME = `PlaywrightNavTerm2${runId}`;
+const PARENT_NODE = 'PlaywrightNode';
+
+test.describe('glossary sidebar navigation', () => {
+  test('create term group and terms, move to group, verify sidebar', async ({ page, logger, logDir }) => {
+    test.setTimeout(120000);
+
+    const glossaryPage = new GlossaryPage(page, logger, logDir);
+
+    // ── Step 1: Create root-level Term Group ────────────────────────────────
+    await glossaryPage.navigateToGlossary();
+    await glossaryPage.createTermGroup(TERM_GROUP_NAME);
+
+    await glossaryPage.navigateToGlossary();
+    await glossaryPage.expectSidebarContains(TERM_GROUP_NAME);
+
+    // ── Step 2: Create first Term inside the group ──────────────────────────
+    await glossaryPage.clickSidebarItem(TERM_GROUP_NAME);
+    await glossaryPage.navigateToEntityContentsTab();
+    await glossaryPage.createTermInContentsTab(TERM_NAME);
+
+    // ── Step 3: Move first Term back into the same Term Group ───────────────
+    await glossaryPage.navigateToGlossaryTerm(TERM_NAME);
+    await expect(page.getByText('Created Glossary Term!')).not.toBeVisible({ timeout: 5000 });
+    await glossaryPage.moveCurrentEntityTo(TERM_GROUP_NAME);
+    await expect(page.getByText('Moved Glossary Term!')).toBeVisible({ timeout: 15000 });
+
+    // Verify the term appears under the group in the sidebar.
+    await glossaryPage.clickSidebarItem(TERM_GROUP_NAME);
+    await glossaryPage.navigateToEntityContentsTab();
+    await glossaryPage.expectTextVisible(TERM_NAME);
+
+    // ── Step 4: Create second Term ──────────────────────────────────────────
+    await glossaryPage.navigateToGlossaryTerm(TERM_GROUP_NAME);
+    await expect(page.getByText('Moved Glossary Term!')).not.toBeVisible({ timeout: 5000 });
+    await glossaryPage.navigateToEntityContentsTab();
+    await glossaryPage.createTermInContentsTab(SECOND_TERM_NAME);
+
+    // ── Step 5: Move second Term back into the same Term Group ──────────────
+    await glossaryPage.navigateToGlossaryTerm(SECOND_TERM_NAME);
+    await glossaryPage.moveCurrentEntityTo(TERM_GROUP_NAME);
+    await expect(page.getByText('Moved Glossary Term!')).toBeVisible({ timeout: 15000 });
+
+    // Verify the second term appears under the group.
+    await glossaryPage.clickSidebarItem(TERM_GROUP_NAME);
+    await glossaryPage.navigateToEntityContentsTab();
+    await glossaryPage.expectTextVisible(SECOND_TERM_NAME);
+
+    // ── Step 6: Switch between terms; Properties tab should stay active ──────
+    await glossaryPage.navigateToGlossaryTerm(TERM_NAME);
+    await glossaryPage.clickEntityTabByName('Properties');
+    await glossaryPage.expectPropertiesTabActive();
+
+    await glossaryPage.navigateToGlossaryTerm(SECOND_TERM_NAME);
+    await glossaryPage.expectPropertiesTabActive();
+
+    // ── Step 7: Move the Term Group under PlaywrightNode ─────────────────────
+    await glossaryPage.navigateToGlossary();
+    await glossaryPage.navigateToGlossaryTerm(TERM_GROUP_NAME);
+    await glossaryPage.moveCurrentEntityTo(PARENT_NODE);
+    await expect(page.getByText('Moved Term Group!')).toBeVisible({ timeout: 15000 });
+
+    // Verify the Term Group now appears under PlaywrightNode.
+    await glossaryPage.clickSidebarItem(PARENT_NODE);
+    await glossaryPage.navigateToEntityContentsTab();
+    await glossaryPage.expectTextVisible(TERM_GROUP_NAME);
+
+    // ── Step 8: Delete first Term ─────────────────────────────────────────────
+    await glossaryPage.navigateToGlossary();
+    await glossaryPage.navigateToGlossaryTerm(PARENT_NODE);
+    await glossaryPage.navigateToGlossaryTerm(TERM_GROUP_NAME);
+    await glossaryPage.navigateToGlossaryTerm(TERM_NAME);
+    await glossaryPage.deleteCurrentEntity();
+    await expect(page.getByText('Deleted Glossary Term!')).toBeVisible({ timeout: 15000 });
+
+    await glossaryPage.navigateToGlossaryTerm(PARENT_NODE);
+    await glossaryPage.navigateToGlossaryTerm(TERM_GROUP_NAME);
+    await glossaryPage.expectTextNotPresent(TERM_NAME);
+
+    // ── Step 9: Delete second Term ─────────────────────────────────────────────
+    await glossaryPage.navigateToGlossary();
+    await glossaryPage.navigateToGlossaryTerm(PARENT_NODE);
+    await glossaryPage.navigateToGlossaryTerm(TERM_GROUP_NAME);
+    await glossaryPage.navigateToGlossaryTerm(SECOND_TERM_NAME);
+    await glossaryPage.deleteCurrentEntity();
+    await expect(page.getByText('Deleted Glossary Term!')).toBeVisible({ timeout: 15000 });
+
+    await glossaryPage.navigateToGlossaryTerm(PARENT_NODE);
+    await glossaryPage.navigateToGlossaryTerm(TERM_GROUP_NAME);
+    await glossaryPage.expectTextNotPresent(SECOND_TERM_NAME);
+
+    // ── Step 10: Delete the Term Group ─────────────────────────────────────────
+    await glossaryPage.navigateToGlossary();
+    await glossaryPage.navigateToGlossaryTerm(PARENT_NODE);
+    await glossaryPage.navigateToGlossaryTerm(TERM_GROUP_NAME);
+    await glossaryPage.deleteCurrentEntity();
+    await expect(page.getByText('Deleted Term Group!')).toBeVisible({ timeout: 15000 });
+
+    // Verify the sidebar no longer shows the group or either term.
+    await glossaryPage.navigateToGlossary();
+    await glossaryPage.expectSidebarNotContains(TERM_NAME);
+    await glossaryPage.expectSidebarNotContains(TERM_GROUP_NAME);
+  });
+});

--- a/e2e-test/ui/playwright/tests/glossary/v2-glossary-navigation.spec.ts
+++ b/e2e-test/ui/playwright/tests/glossary/v2-glossary-navigation.spec.ts
@@ -1,131 +1,77 @@
 /**
  * Glossary Sidebar Navigation tests — migrated from Cypress e2e/glossaryV2/v2_glossary_navigation.js
  *
- * Tests the move and sidebar navigation behaviour for glossary entities:
- *   1. Create a root-level Term Group and two Terms inside it.
- *   2. Move each Term back into the same Term Group (confirming move messages).
- *   3. Switch between Terms and verify the Properties tab persists as the active tab.
- *   4. Move the Term Group under the parent node (PlaywrightNode).
- *   5. Delete both Terms and the Term Group, verifying the sidebar clears.
- *
- * Each test run uses a unique timestamp-based suffix so tests are fully independent
- * and can run in parallel without colliding on entity names.
- *
- * Prerequisites: `PlaywrightNode` glossary node must exist (seeded via fixtures/data.json).
+ * Tests the move and sidebar navigation behaviour for glossary entities.
  */
 
-import { test, expect } from '../../fixtures/base-test';
+import { test } from '../../fixtures/base-test';
 import { GlossaryPage } from '../../pages/glossary.page';
+import { withRandomSuffix } from '../../utils/random';
+
+// Pre-seeded via fixtures/data.json — scoped to the Properties-tab-persistence test.
+const PROPS_TEST_TERM1_URN = 'urn:li:glossaryTerm:PlaywrightNavPropsTest.PlaywrightNavTerm1';
+const PROPS_TEST_TERM2_URN = 'urn:li:glossaryTerm:PlaywrightNavPropsTest.PlaywrightNavTerm2';
 
 test.use({ featureName: 'glossary' });
 
-// Serial: tests build on state created in earlier tests within this suite.
-test.describe.configure({ mode: 'serial' });
-
-const runId = Date.now();
-const TERM_GROUP_NAME = `PlaywrightNavGroup${runId}`;
-const TERM_NAME = `PlaywrightNavTerm${runId}`;
-const SECOND_TERM_NAME = `PlaywrightNavTerm2${runId}`;
-const PARENT_NODE = 'PlaywrightNode';
-
 test.describe('glossary sidebar navigation', () => {
-  test('create term group and terms, move to group, verify sidebar', async ({ page, logger, logDir }) => {
-    test.setTimeout(120000);
+  let glossaryPage: GlossaryPage;
 
-    const glossaryPage = new GlossaryPage(page, logger, logDir);
-
-    // ── Step 1: Create root-level Term Group ────────────────────────────────
+  test.beforeEach(async ({ page, logger, logDir }) => {
+    glossaryPage = new GlossaryPage(page, logger, logDir);
     await glossaryPage.navigateToGlossary();
-    await glossaryPage.createTermGroup(TERM_GROUP_NAME);
+  });
+
+  test('can move a term into its parent term group', async ({ cleanup }) => {
+    const termGroup = withRandomSuffix('NavGroup');
+    const term = withRandomSuffix('NavTerm');
+
+    const termGroupUrn = await glossaryPage.createTermGroup(termGroup);
+    cleanup.track(termGroupUrn);
 
     await glossaryPage.navigateToGlossary();
-    await glossaryPage.expectSidebarContains(TERM_GROUP_NAME);
+    await glossaryPage.clickSidebarNode(termGroupUrn);
+    await glossaryPage.openContentsTab();
+    const termUrn = await glossaryPage.createTermInContentsTab(term);
+    cleanup.track(termUrn);
 
-    // ── Step 2: Create first Term inside the group ──────────────────────────
-    await glossaryPage.clickSidebarItem(TERM_GROUP_NAME);
-    await glossaryPage.navigateToEntityContentsTab();
-    await glossaryPage.createTermInContentsTab(TERM_NAME);
+    await glossaryPage.clickContentsTabItem(termUrn);
+    await glossaryPage.moveCurrentEntityTo(termGroup);
 
-    // ── Step 3: Move first Term back into the same Term Group ───────────────
-    await glossaryPage.navigateToGlossaryTerm(TERM_NAME);
-    await expect(page.getByText('Created Glossary Term!')).not.toBeVisible({ timeout: 5000 });
-    await glossaryPage.moveCurrentEntityTo(TERM_GROUP_NAME);
-    await expect(page.getByText('Moved Glossary Term!')).toBeVisible({ timeout: 15000 });
+    await glossaryPage.clickSidebarNode(termGroupUrn);
+    await glossaryPage.openContentsTab();
+    await glossaryPage.expectEntityInContentsTab(termUrn);
+  });
 
-    // Verify the term appears under the group in the sidebar.
-    await glossaryPage.clickSidebarItem(TERM_GROUP_NAME);
-    await glossaryPage.navigateToEntityContentsTab();
-    await glossaryPage.expectTextVisible(TERM_NAME);
-
-    // ── Step 4: Create second Term ──────────────────────────────────────────
-    await glossaryPage.navigateToGlossaryTerm(TERM_GROUP_NAME);
-    await expect(page.getByText('Moved Glossary Term!')).not.toBeVisible({ timeout: 5000 });
-    await glossaryPage.navigateToEntityContentsTab();
-    await glossaryPage.createTermInContentsTab(SECOND_TERM_NAME);
-
-    // ── Step 5: Move second Term back into the same Term Group ──────────────
-    await glossaryPage.navigateToGlossaryTerm(SECOND_TERM_NAME);
-    await glossaryPage.moveCurrentEntityTo(TERM_GROUP_NAME);
-    await expect(page.getByText('Moved Glossary Term!')).toBeVisible({ timeout: 15000 });
-
-    // Verify the second term appears under the group.
-    await glossaryPage.clickSidebarItem(TERM_GROUP_NAME);
-    await glossaryPage.navigateToEntityContentsTab();
-    await glossaryPage.expectTextVisible(SECOND_TERM_NAME);
-
-    // ── Step 6: Switch between terms; Properties tab should stay active ──────
-    await glossaryPage.navigateToGlossaryTerm(TERM_NAME);
-    await glossaryPage.clickEntityTabByName('Properties');
+  test('Properties tab persists when switching between terms', async () => {
+    // Uses pre-seeded PlaywrightNavPropsTest node with two child terms — no setup needed.
+    await glossaryPage.navigateToGlossaryTermByUrn(PROPS_TEST_TERM1_URN);
+    await glossaryPage.openPropertiesTab();
     await glossaryPage.expectPropertiesTabActive();
 
-    await glossaryPage.navigateToGlossaryTerm(SECOND_TERM_NAME);
+    // Navigating to a child term auto-expands its parent node in the sidebar,
+    // making the sibling term visible and clickable without any additional navigation.
+    await glossaryPage.clickSidebarTerm(PROPS_TEST_TERM2_URN);
     await glossaryPage.expectPropertiesTabActive();
+  });
 
-    // ── Step 7: Move the Term Group under PlaywrightNode ─────────────────────
+  test('can move a term group under a parent node', async ({ cleanup }) => {
+    const parentNode = withRandomSuffix('NavParent');
+    const termGroup = withRandomSuffix('NavGroup');
+
+    const parentNodeUrn = await glossaryPage.createTermGroup(parentNode);
+    cleanup.track(parentNodeUrn);
+
     await glossaryPage.navigateToGlossary();
-    await glossaryPage.navigateToGlossaryTerm(TERM_GROUP_NAME);
-    await glossaryPage.moveCurrentEntityTo(PARENT_NODE);
-    await expect(page.getByText('Moved Term Group!')).toBeVisible({ timeout: 15000 });
+    const termGroupUrn = await glossaryPage.createTermGroup(termGroup);
+    cleanup.track(termGroupUrn);
 
-    // Verify the Term Group now appears under PlaywrightNode.
-    await glossaryPage.clickSidebarItem(PARENT_NODE);
-    await glossaryPage.navigateToEntityContentsTab();
-    await glossaryPage.expectTextVisible(TERM_GROUP_NAME);
-
-    // ── Step 8: Delete first Term ─────────────────────────────────────────────
     await glossaryPage.navigateToGlossary();
-    await glossaryPage.navigateToGlossaryTerm(PARENT_NODE);
-    await glossaryPage.navigateToGlossaryTerm(TERM_GROUP_NAME);
-    await glossaryPage.navigateToGlossaryTerm(TERM_NAME);
-    await glossaryPage.deleteCurrentEntity();
-    await expect(page.getByText('Deleted Glossary Term!')).toBeVisible({ timeout: 15000 });
+    await glossaryPage.navigateToGlossaryNodeByUrn(termGroupUrn);
+    await glossaryPage.moveCurrentEntityTo(parentNode);
 
-    await glossaryPage.navigateToGlossaryTerm(PARENT_NODE);
-    await glossaryPage.navigateToGlossaryTerm(TERM_GROUP_NAME);
-    await glossaryPage.expectTextNotPresent(TERM_NAME);
-
-    // ── Step 9: Delete second Term ─────────────────────────────────────────────
-    await glossaryPage.navigateToGlossary();
-    await glossaryPage.navigateToGlossaryTerm(PARENT_NODE);
-    await glossaryPage.navigateToGlossaryTerm(TERM_GROUP_NAME);
-    await glossaryPage.navigateToGlossaryTerm(SECOND_TERM_NAME);
-    await glossaryPage.deleteCurrentEntity();
-    await expect(page.getByText('Deleted Glossary Term!')).toBeVisible({ timeout: 15000 });
-
-    await glossaryPage.navigateToGlossaryTerm(PARENT_NODE);
-    await glossaryPage.navigateToGlossaryTerm(TERM_GROUP_NAME);
-    await glossaryPage.expectTextNotPresent(SECOND_TERM_NAME);
-
-    // ── Step 10: Delete the Term Group ─────────────────────────────────────────
-    await glossaryPage.navigateToGlossary();
-    await glossaryPage.navigateToGlossaryTerm(PARENT_NODE);
-    await glossaryPage.navigateToGlossaryTerm(TERM_GROUP_NAME);
-    await glossaryPage.deleteCurrentEntity();
-    await expect(page.getByText('Deleted Term Group!')).toBeVisible({ timeout: 15000 });
-
-    // Verify the sidebar no longer shows the group or either term.
-    await glossaryPage.navigateToGlossary();
-    await glossaryPage.expectSidebarNotContains(TERM_NAME);
-    await glossaryPage.expectSidebarNotContains(TERM_GROUP_NAME);
+    await glossaryPage.clickSidebarNode(parentNodeUrn);
+    await glossaryPage.openContentsTab();
+    await glossaryPage.expectEntityInContentsTab(termGroupUrn);
   });
 });

--- a/e2e-test/ui/playwright/tests/glossary/v2-glossary-term.spec.ts
+++ b/e2e-test/ui/playwright/tests/glossary/v2-glossary-term.spec.ts
@@ -2,136 +2,63 @@
  * Glossary Term V2 tests — migrated from PlaywrightGlossaryTag e2e/glossaryV2/v2_glossaryTerm.js
  *
  * Tests glossary term operations from the entity profile:
- *   1. Search related entities by query (batch add + search by name).
+ *   1. Search related entities by query.
  *   2. Apply tag filters on related entities.
- *   3. Use advanced search to filter by tag, then delete the term.
+ *   3. Use advanced search to filter by tag.
  *
- * Each test run uses a unique timestamp-based suffix so tests are independent
- * and can run in parallel without colliding on entity names.
- *
- * Prerequisites:
- *   - `PlaywrightNode` glossary node exists (seeded via fixtures/data.json).
- *   - A dataset with tag "PlaywrightGlossaryTag" exists in the test environment.
- *   - A dataset named "PlaywrightGlossaryTaggedDataset" tagged with "PlaywrightGlossaryTag" exists (seeded via fixtures/data.json).
- *
- * Note: Tests in this file share a term created in the first test (serial mode).
- * The term is deleted in the last test.
+ * Prerequisites (all seeded via tests/glossary/fixtures/data.json):
+ *   - PlaywrightGlossaryTermTests node containing three terms:
+ *     - PlaywrightSearchRelated → linked to PlaywrightGlossarySearchDataset (tagged PlaywrightGlossarySearchTag)
+ *     - PlaywrightFilterRelated → linked to PlaywrightGlossaryFilterDataset (tagged PlaywrightGlossaryFilterTag)
+ *     - PlaywrightTaggedRelated → linked to PlaywrightGlossaryTaggedDataset (tagged PlaywrightGlossaryTag)
  */
 
-import { test, expect } from '../../fixtures/base-test';
+import { test } from '../../fixtures/base-test';
 import { GlossaryPage } from '../../pages/glossary.page';
 
 test.use({ featureName: 'glossary' });
 
-// Serial mode: tests share the same term created in test 1 and deleted in test 3.
-test.describe.configure({ mode: 'serial' });
+const SEARCH_TERM_URN = 'urn:li:glossaryTerm:PlaywrightGlossaryTermTests.PlaywrightSearchRelated';
+const FILTER_TERM_URN = 'urn:li:glossaryTerm:PlaywrightGlossaryTermTests.PlaywrightFilterRelated';
+const TAGGED_TERM_URN = 'urn:li:glossaryTerm:PlaywrightGlossaryTermTests.PlaywrightTaggedRelated';
 
-const runId = Date.now();
-const TERM_NAME = `GlossaryNewTerm${runId}`;
-const PARENT_NODE = 'PlaywrightNode';
+const SEARCH_DATASET = 'PlaywrightGlossarySearchDataset';
+const SEARCH_DATASET_URN = 'urn:li:dataset:(urn:li:dataPlatform:hdfs,PlaywrightGlossarySearchDataset,PROD)';
+
+const FILTER_TAG_URN = 'urn:li:tag:PlaywrightGlossaryFilterTag';
+const FILTER_DATASET_URN = 'urn:li:dataset:(urn:li:dataPlatform:hdfs,PlaywrightGlossaryFilterDataset,PROD)';
+
+const GLOSSARY_TAG = 'PlaywrightGlossaryTag';
+const TAGGED_DATASET = 'PlaywrightGlossaryTaggedDataset';
+const TAGGED_DATASET_URN = 'urn:li:dataset:(urn:li:dataPlatform:hdfs,PlaywrightGlossaryTaggedDataset,PROD)';
 
 test.describe('glossary term entity operations', () => {
+  let glossaryPage: GlossaryPage;
+
   test.beforeEach(async ({ page, logger, logDir }) => {
-    const glossaryPage = new GlossaryPage(page, logger, logDir);
-    await glossaryPage.navigateToGlossary();
-    // Wait for the sidebar to stabilise before each test.
-    await expect(glossaryPage.sidebarContainer).toBeVisible({ timeout: 15000 });
+    glossaryPage = new GlossaryPage(page, logger, logDir);
   });
 
-  test('can search related entities by query', async ({ page, logger, logDir }) => {
-    const glossaryPage = new GlossaryPage(page, logger, logDir);
-
-    // Navigate to the parent node and create the term.
-    await glossaryPage.navigateToGlossaryTerm(PARENT_NODE);
-    await glossaryPage.navigateToEntityContentsTab();
-    await glossaryPage.createTermInContentsTab(TERM_NAME);
-    // Wait for the term to appear in the refreshed Contents list before clicking.
-    await expect(page.getByText(TERM_NAME).first()).toBeVisible({ timeout: 15000 });
-    await glossaryPage.navigateToGlossaryTerm(TERM_NAME);
-
-    // Batch-add the term to the seeded dataset that carries PlaywrightGlossaryTag,
-    // so test 3 can filter related assets by that tag and reliably find it.
-    await glossaryPage.batchAddToEntityBySearch('PlaywrightGlossaryTaggedDataset');
-
-    // Switch to Related Assets tab.
-    await glossaryPage.navigateToEntityRelatedAssetsTab();
-    await glossaryPage.expectPreviewEntitiesVisible();
-
-    // Read the title of the first related asset, then search for it.
-    const firstTitle = await page
-      .locator('[data-testid^="preview-urn:"] [data-testid="entity-title"]')
-      .first()
-      .innerText();
-
-    await glossaryPage.searchWithinEntityPage(firstTitle);
-    await page.waitForLoadState('networkidle');
-
-    await expect(page.locator('[data-testid^="preview-urn:"] [data-testid="entity-title"]').first()).toHaveText(
-      firstTitle,
-      { timeout: 15000 },
-    );
+  test('can search related entities by query', async () => {
+    await glossaryPage.navigateToGlossaryTermByUrn(SEARCH_TERM_URN);
+    await glossaryPage.openRelatedAssetsTab();
+    await glossaryPage.searchWithinEntityPage(SEARCH_DATASET);
+    await glossaryPage.expectPreviewEntityByUrn(SEARCH_DATASET_URN);
   });
 
-  test('can apply filters on related entities', async ({ page, logger, logDir }) => {
-    const glossaryPage = new GlossaryPage(page, logger, logDir);
-
-    await glossaryPage.navigateToGlossaryTerm(PARENT_NODE);
-    await glossaryPage.navigateToEntityContentsTab();
-    await glossaryPage.navigateToGlossaryTerm(TERM_NAME);
-    await glossaryPage.navigateToEntityRelatedAssetsTab();
-    await glossaryPage.expectPreviewEntitiesVisible();
-
-    // Open the basic facet filter panel.
-    await glossaryPage.clickFacetFilterIcon();
-    // Wait for the tag facet checkboxes to appear.
-    const tagCheckbox = page.locator('input.ant-checkbox-input[data-testid^="facet-tags-urn:li:tag:"]').first();
-    await expect(tagCheckbox).toBeVisible({ timeout: 10000 });
-
-    // Click the first tag checkbox to filter.
-    await tagCheckbox.click();
-
-    // After filtering, results should still be present.
-    await glossaryPage.expectPreviewEntitiesVisible();
-
-    // Get the title of the first result and navigate to it.
-    const firstEntityTitle = page.locator('[data-testid^="preview-urn:"] [data-testid="entity-title"]').first();
-    await expect(firstEntityTitle).toBeVisible({ timeout: 15000 });
-    const entityName = await firstEntityTitle.innerText();
-    await firstEntityTitle.click();
-    await page.waitForLoadState('networkidle');
-
-    // The entity name should appear on the entity page.
-    await expect(page.getByText(entityName).first()).toBeVisible({ timeout: 15000 });
+  test('can apply filters on related entities', async () => {
+    await glossaryPage.navigateToGlossaryTermByUrn(FILTER_TERM_URN);
+    await glossaryPage.openRelatedAssetsTab();
+    await glossaryPage.applyFacetTagFilter(FILTER_TAG_URN);
+    await glossaryPage.expectPreviewEntityByUrn(FILTER_DATASET_URN);
   });
 
-  test('can search related entities by a specific tag using advanced search, then delete term', async ({
-    page,
-    logger,
-    logDir,
-  }) => {
-    const glossaryPage = new GlossaryPage(page, logger, logDir);
-
-    await glossaryPage.navigateToGlossaryTerm(PARENT_NODE);
-    await glossaryPage.navigateToEntityContentsTab();
-    await glossaryPage.navigateToGlossaryTerm(TERM_NAME);
-    await glossaryPage.navigateToEntityRelatedAssetsTab();
-    await glossaryPage.expectPreviewEntitiesVisible();
-
-    await glossaryPage.filterRelatedAssetsByTag('PlaywrightGlossaryTag');
-    await glossaryPage.expectPreviewEntitiesVisible();
-
-    // Search for a known entity and verify it appears.
-    await glossaryPage.searchWithinEntityPage('PlaywrightGlossaryTaggedDataset');
-    await glossaryPage.expectPreviewEntitiesVisible();
-    await expect(page.getByText('PlaywrightGlossaryTaggedDataset').filter({ visible: true }).first()).toBeVisible({
-      timeout: 15000,
-    });
-
-    // Delete the term to clean up.
-    await glossaryPage.navigateToGlossaryTerm(PARENT_NODE);
-    await glossaryPage.navigateToEntityContentsTab();
-    await glossaryPage.navigateToGlossaryTerm(TERM_NAME);
-    await glossaryPage.deleteCurrentEntity();
-    await expect(page.getByText('Deleted Glossary Term!')).toBeVisible({ timeout: 15000 });
+  test('can search related entities by a specific tag using advanced search', async () => {
+    await glossaryPage.navigateToGlossaryTermByUrn(TAGGED_TERM_URN);
+    await glossaryPage.openRelatedAssetsTab();
+    await glossaryPage.filterRelatedAssetsByTag(GLOSSARY_TAG);
+    await glossaryPage.expectPreviewEntityByUrn(TAGGED_DATASET_URN);
+    await glossaryPage.searchWithinEntityPage(TAGGED_DATASET);
+    await glossaryPage.expectPreviewEntityByUrn(TAGGED_DATASET_URN);
   });
 });

--- a/e2e-test/ui/playwright/tests/glossary/v2-glossary-term.spec.ts
+++ b/e2e-test/ui/playwright/tests/glossary/v2-glossary-term.spec.ts
@@ -1,0 +1,137 @@
+/**
+ * Glossary Term V2 tests — migrated from PlaywrightGlossaryTag e2e/glossaryV2/v2_glossaryTerm.js
+ *
+ * Tests glossary term operations from the entity profile:
+ *   1. Search related entities by query (batch add + search by name).
+ *   2. Apply tag filters on related entities.
+ *   3. Use advanced search to filter by tag, then delete the term.
+ *
+ * Each test run uses a unique timestamp-based suffix so tests are independent
+ * and can run in parallel without colliding on entity names.
+ *
+ * Prerequisites:
+ *   - `PlaywrightNode` glossary node exists (seeded via fixtures/data.json).
+ *   - A dataset with tag "PlaywrightGlossaryTag" exists in the test environment.
+ *   - A dataset named "PlaywrightGlossaryTaggedDataset" tagged with "PlaywrightGlossaryTag" exists (seeded via fixtures/data.json).
+ *
+ * Note: Tests in this file share a term created in the first test (serial mode).
+ * The term is deleted in the last test.
+ */
+
+import { test, expect } from '../../fixtures/base-test';
+import { GlossaryPage } from '../../pages/glossary.page';
+
+test.use({ featureName: 'glossary' });
+
+// Serial mode: tests share the same term created in test 1 and deleted in test 3.
+test.describe.configure({ mode: 'serial' });
+
+const runId = Date.now();
+const TERM_NAME = `GlossaryNewTerm${runId}`;
+const PARENT_NODE = 'PlaywrightNode';
+
+test.describe('glossary term entity operations', () => {
+  test.beforeEach(async ({ page, logger, logDir }) => {
+    const glossaryPage = new GlossaryPage(page, logger, logDir);
+    await glossaryPage.navigateToGlossary();
+    // Wait for the sidebar to stabilise before each test.
+    await expect(glossaryPage.sidebarContainer).toBeVisible({ timeout: 15000 });
+  });
+
+  test('can search related entities by query', async ({ page, logger, logDir }) => {
+    const glossaryPage = new GlossaryPage(page, logger, logDir);
+
+    // Navigate to the parent node and create the term.
+    await glossaryPage.navigateToGlossaryTerm(PARENT_NODE);
+    await glossaryPage.navigateToEntityContentsTab();
+    await glossaryPage.createTermInContentsTab(TERM_NAME);
+    // Wait for the term to appear in the refreshed Contents list before clicking.
+    await expect(page.getByText(TERM_NAME).first()).toBeVisible({ timeout: 15000 });
+    await glossaryPage.navigateToGlossaryTerm(TERM_NAME);
+
+    // Batch-add the term to the seeded dataset that carries PlaywrightGlossaryTag,
+    // so test 3 can filter related assets by that tag and reliably find it.
+    await glossaryPage.batchAddToEntityBySearch('PlaywrightGlossaryTaggedDataset');
+
+    // Switch to Related Assets tab.
+    await glossaryPage.navigateToEntityRelatedAssetsTab();
+    await glossaryPage.expectPreviewEntitiesVisible();
+
+    // Read the title of the first related asset, then search for it.
+    const firstTitle = await page
+      .locator('[data-testid^="preview-urn:"] [data-testid="entity-title"]')
+      .first()
+      .innerText();
+
+    await glossaryPage.searchWithinEntityPage(firstTitle);
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('[data-testid^="preview-urn:"] [data-testid="entity-title"]').first()).toHaveText(
+      firstTitle,
+      { timeout: 15000 },
+    );
+  });
+
+  test('can apply filters on related entities', async ({ page, logger, logDir }) => {
+    const glossaryPage = new GlossaryPage(page, logger, logDir);
+
+    await glossaryPage.navigateToGlossaryTerm(PARENT_NODE);
+    await glossaryPage.navigateToEntityContentsTab();
+    await glossaryPage.navigateToGlossaryTerm(TERM_NAME);
+    await glossaryPage.navigateToEntityRelatedAssetsTab();
+    await glossaryPage.expectPreviewEntitiesVisible();
+
+    // Open the basic facet filter panel.
+    await glossaryPage.clickFacetFilterIcon();
+    // Wait for the tag facet checkboxes to appear.
+    const tagCheckbox = page.locator('input.ant-checkbox-input[data-testid^="facet-tags-urn:li:tag:"]').first();
+    await expect(tagCheckbox).toBeVisible({ timeout: 10000 });
+
+    // Click the first tag checkbox to filter.
+    await tagCheckbox.click();
+
+    // After filtering, results should still be present.
+    await glossaryPage.expectPreviewEntitiesVisible();
+
+    // Get the title of the first result and navigate to it.
+    const firstEntityTitle = page.locator('[data-testid^="preview-urn:"] [data-testid="entity-title"]').first();
+    await expect(firstEntityTitle).toBeVisible({ timeout: 15000 });
+    const entityName = await firstEntityTitle.innerText();
+    await firstEntityTitle.click();
+    await page.waitForLoadState('networkidle');
+
+    // The entity name should appear on the entity page.
+    await expect(page.getByText(entityName).first()).toBeVisible({ timeout: 15000 });
+  });
+
+  test('can search related entities by a specific tag using advanced search, then delete term', async ({
+    page,
+    logger,
+    logDir,
+  }) => {
+    const glossaryPage = new GlossaryPage(page, logger, logDir);
+
+    await glossaryPage.navigateToGlossaryTerm(PARENT_NODE);
+    await glossaryPage.navigateToEntityContentsTab();
+    await glossaryPage.navigateToGlossaryTerm(TERM_NAME);
+    await glossaryPage.navigateToEntityRelatedAssetsTab();
+    await glossaryPage.expectPreviewEntitiesVisible();
+
+    await glossaryPage.filterRelatedAssetsByTag('PlaywrightGlossaryTag');
+    await glossaryPage.expectPreviewEntitiesVisible();
+
+    // Search for a known entity and verify it appears.
+    await glossaryPage.searchWithinEntityPage('PlaywrightGlossaryTaggedDataset');
+    await glossaryPage.expectPreviewEntitiesVisible();
+    await expect(page.getByText('PlaywrightGlossaryTaggedDataset').filter({ visible: true }).first()).toBeVisible({
+      timeout: 15000,
+    });
+
+    // Delete the term to clean up.
+    await glossaryPage.navigateToGlossaryTerm(PARENT_NODE);
+    await glossaryPage.navigateToEntityContentsTab();
+    await glossaryPage.navigateToGlossaryTerm(TERM_NAME);
+    await glossaryPage.deleteCurrentEntity();
+    await expect(page.getByText('Deleted Glossary Term!')).toBeVisible({ timeout: 15000 });
+  });
+});

--- a/e2e-test/ui/playwright/tests/glossary/v2-glossary.spec.ts
+++ b/e2e-test/ui/playwright/tests/glossary/v2-glossary.spec.ts
@@ -1,0 +1,83 @@
+/**
+ * Glossary V2 tests — migrated from Cypress e2e/glossaryV2/v2_glossary.js
+ *
+ * Tests the full lifecycle of a Glossary Term Group and Glossary Term:
+ *   1. Create a root-level Term Group.
+ *   2. Create a Glossary Term inside the group.
+ *   3. Assign the term to a dataset via the entity sidebar.
+ *   4. Delete the term; verify it is no longer visible.
+ *   5. Delete the term group; verify it is no longer visible.
+ *
+ * Each test run uses a unique timestamp-based suffix so tests are independent
+ * and can run in parallel with other suites without colliding on entity names.
+ *
+ * Prerequisites: `PlaywrightNode` glossary node and
+ *   `SamplePlaywrightGlossaryDataset` dataset must exist (seeded via fixtures/data.json).
+ */
+
+import { test, expect } from '../../fixtures/base-test';
+import { GlossaryPage } from '../../pages/glossary.page';
+
+test.use({ featureName: 'glossary' });
+
+// Use serial mode because these tests mutate shared state (the same term group and term).
+test.describe.configure({ mode: 'serial' });
+
+const runId = Date.now();
+const TERM_GROUP_NAME = `PlaywrightGlossaryGroup${runId}`;
+const TERM_NAME = `PlaywrightGlossaryTerm${runId}`;
+
+const DATASET_PATH = 'dataset/urn:li:dataset:(urn:li:dataPlatform:hdfs,SamplePlaywrightGlossaryDataset,PROD)/';
+const DATASET_NAME = 'SamplePlaywrightGlossaryDataset';
+
+test.describe('glossary term group and term lifecycle', () => {
+  test('create term group at root level', async ({ page, logger, logDir }) => {
+    const glossaryPage = new GlossaryPage(page, logger, logDir);
+    await glossaryPage.navigateToGlossary();
+
+    await glossaryPage.createTermGroup(TERM_GROUP_NAME);
+
+    await glossaryPage.navigateToGlossary();
+    await glossaryPage.expectTextVisible(TERM_GROUP_NAME);
+  });
+
+  test('create glossary term inside term group', async ({ page, logger, logDir }) => {
+    const glossaryPage = new GlossaryPage(page, logger, logDir);
+    await glossaryPage.navigateToGlossary();
+
+    await glossaryPage.navigateToGlossaryTerm(TERM_GROUP_NAME);
+    await glossaryPage.navigateToEntityContentsTab();
+    await glossaryPage.createTermInContentsTab(TERM_NAME);
+  });
+
+  test('add glossary term to dataset via sidebar', async ({ page, logger, logDir }) => {
+    const glossaryPage = new GlossaryPage(page, logger, logDir);
+    await glossaryPage.addGlossaryTermToDataset(DATASET_PATH, DATASET_NAME, TERM_NAME);
+  });
+
+  test('delete glossary term', async ({ page, logger, logDir }) => {
+    const glossaryPage = new GlossaryPage(page, logger, logDir);
+    await glossaryPage.navigateToGlossary();
+
+    await glossaryPage.navigateToGlossaryTerm(TERM_GROUP_NAME);
+    await glossaryPage.navigateToGlossaryTerm(TERM_NAME);
+    await glossaryPage.deleteCurrentEntity();
+    await expect(page.getByText('Deleted Glossary Term!')).toBeVisible({ timeout: 15000 });
+
+    await glossaryPage.navigateToGlossary();
+    await glossaryPage.navigateToGlossaryTerm(TERM_GROUP_NAME);
+    await glossaryPage.expectTextNotPresent(TERM_NAME);
+  });
+
+  test('delete term group', async ({ page, logger, logDir }) => {
+    const glossaryPage = new GlossaryPage(page, logger, logDir);
+    await glossaryPage.navigateToGlossary();
+
+    await glossaryPage.navigateToGlossaryTerm(TERM_GROUP_NAME);
+    await glossaryPage.deleteCurrentEntity();
+    await expect(page.getByText('Deleted Term Group!')).toBeVisible({ timeout: 15000 });
+
+    await glossaryPage.navigateToGlossary();
+    await glossaryPage.expectTextNotPresent(TERM_GROUP_NAME);
+  });
+});

--- a/e2e-test/ui/playwright/tests/glossary/v2-glossary.spec.ts
+++ b/e2e-test/ui/playwright/tests/glossary/v2-glossary.spec.ts
@@ -8,76 +8,122 @@
  *   4. Delete the term; verify it is no longer visible.
  *   5. Delete the term group; verify it is no longer visible.
  *
- * Each test run uses a unique timestamp-based suffix so tests are independent
- * and can run in parallel with other suites without colliding on entity names.
- *
- * Prerequisites: `PlaywrightNode` glossary node and
+ * Prerequisites:
  *   `SamplePlaywrightGlossaryDataset` dataset must exist (seeded via fixtures/data.json).
  */
 
-import { test, expect } from '../../fixtures/base-test';
+import { test } from '../../fixtures/base-test';
 import { GlossaryPage } from '../../pages/glossary.page';
+import { DatasetPage } from '../../pages/dataset.page';
+import { withRandomSuffix } from '../../utils/random';
 
 test.use({ featureName: 'glossary' });
 
-// Use serial mode because these tests mutate shared state (the same term group and term).
-test.describe.configure({ mode: 'serial' });
-
-const runId = Date.now();
-const TERM_GROUP_NAME = `PlaywrightGlossaryGroup${runId}`;
-const TERM_NAME = `PlaywrightGlossaryTerm${runId}`;
-
-const DATASET_PATH = 'dataset/urn:li:dataset:(urn:li:dataPlatform:hdfs,SamplePlaywrightGlossaryDataset,PROD)/';
-const DATASET_NAME = 'SamplePlaywrightGlossaryDataset';
+const DATASET_URN = 'urn:li:dataset:(urn:li:dataPlatform:hdfs,SamplePlaywrightGlossaryDataset,PROD)';
+const BATCH_ADD_DATASET_URN = 'urn:li:dataset:(urn:li:dataPlatform:hdfs,PlaywrightGlossaryBatchAddDataset,PROD)';
 
 test.describe('glossary term group and term lifecycle', () => {
-  test('create term group at root level', async ({ page, logger, logDir }) => {
-    const glossaryPage = new GlossaryPage(page, logger, logDir);
-    await glossaryPage.navigateToGlossary();
+  let glossaryPage: GlossaryPage;
 
-    await glossaryPage.createTermGroup(TERM_GROUP_NAME);
-
+  test.beforeEach(async ({ page, logger, logDir }) => {
+    glossaryPage = new GlossaryPage(page, logger, logDir);
     await glossaryPage.navigateToGlossary();
-    await glossaryPage.expectTextVisible(TERM_GROUP_NAME);
   });
 
-  test('create glossary term inside term group', async ({ page, logger, logDir }) => {
-    const glossaryPage = new GlossaryPage(page, logger, logDir);
-    await glossaryPage.navigateToGlossary();
+  test('create term group at root level', async ({ cleanup }) => {
+    const termGroupName = withRandomSuffix('GlossaryGroup');
 
-    await glossaryPage.navigateToGlossaryTerm(TERM_GROUP_NAME);
-    await glossaryPage.navigateToEntityContentsTab();
-    await glossaryPage.createTermInContentsTab(TERM_NAME);
+    const termGroupUrn = await glossaryPage.createTermGroup(termGroupName);
+    cleanup.track(termGroupUrn);
+
+    await glossaryPage.navigateToGlossary();
+    await glossaryPage.expectSidebarContainsNode(termGroupUrn);
   });
 
-  test('add glossary term to dataset via sidebar', async ({ page, logger, logDir }) => {
-    const glossaryPage = new GlossaryPage(page, logger, logDir);
-    await glossaryPage.addGlossaryTermToDataset(DATASET_PATH, DATASET_NAME, TERM_NAME);
+  test('create glossary term inside term group', async ({ cleanup }) => {
+    const termGroupName = withRandomSuffix('GlossaryGroup');
+    const termName = withRandomSuffix('GlossaryTerm');
+
+    const termGroupUrn = await glossaryPage.createTermGroup(termGroupName);
+    cleanup.track(termGroupUrn);
+    await glossaryPage.navigateToGlossaryNodeByUrn(termGroupUrn);
+    await glossaryPage.openContentsTab();
+    const termUrn = await glossaryPage.createTermInContentsTab(termName);
+    cleanup.track(termUrn);
+
+    await glossaryPage.expectEntityInContentsTab(termUrn);
   });
 
-  test('delete glossary term', async ({ page, logger, logDir }) => {
-    const glossaryPage = new GlossaryPage(page, logger, logDir);
-    await glossaryPage.navigateToGlossary();
+  test('add glossary term to dataset via sidebar', async ({ page, logger, logDir, cleanup }) => {
+    const termGroupName = withRandomSuffix('GlossaryGroup');
+    const termName = withRandomSuffix('GlossaryTerm');
 
-    await glossaryPage.navigateToGlossaryTerm(TERM_GROUP_NAME);
-    await glossaryPage.navigateToGlossaryTerm(TERM_NAME);
+    const termGroupUrn = await glossaryPage.createTermGroup(termGroupName);
+    cleanup.track(termGroupUrn);
+    await glossaryPage.navigateToGlossaryNodeByUrn(termGroupUrn);
+    await glossaryPage.openContentsTab();
+    const termUrn = await glossaryPage.createTermInContentsTab(termName);
+    cleanup.track(termUrn);
+
+    const datasetPage = new DatasetPage(page, logger, logDir);
+    await datasetPage.navigateToDataset(DATASET_URN);
+    await datasetPage.addGlossaryTerm(termName);
+    await datasetPage.expectGlossaryTermVisible(termName);
+    await datasetPage.removeGlossaryTerm(termName);
+    await datasetPage.expectGlossaryTermNotVisible(termName);
+  });
+
+  test('batch add term to dataset via Add to Assets', async ({ page, logger, logDir, cleanup }) => {
+    const termGroupName = withRandomSuffix('GlossaryGroup');
+    const termName = withRandomSuffix('GlossaryTerm');
+
+    const termGroupUrn = await glossaryPage.createTermGroup(termGroupName);
+    cleanup.track(termGroupUrn);
+    await glossaryPage.navigateToGlossaryNodeByUrn(termGroupUrn);
+    await glossaryPage.openContentsTab();
+    const termUrn = await glossaryPage.createTermInContentsTab(termName);
+    cleanup.track(termUrn);
+
+    await glossaryPage.navigateToGlossaryTermByUrn(termUrn);
+    await glossaryPage.clickBatchAddButton();
+    await glossaryPage.searchInBatchAddModal('PlaywrightGlossaryBatchAddDataset');
+    await glossaryPage.selectEntityInBatchAddModal(BATCH_ADD_DATASET_URN);
+    await glossaryPage.confirmBatchAdd();
+
+    const datasetPage = new DatasetPage(page, logger, logDir);
+    await datasetPage.navigateToDataset(BATCH_ADD_DATASET_URN);
+    await datasetPage.expectGlossaryTermVisible(termName);
+    await datasetPage.removeGlossaryTerm(termName);
+    await datasetPage.expectGlossaryTermNotVisible(termName);
+  });
+
+  test('delete glossary term', async ({ cleanup }) => {
+    const termGroupName = withRandomSuffix('GlossaryGroup');
+    const termName = withRandomSuffix('GlossaryTerm');
+
+    const termGroupUrn = await glossaryPage.createTermGroup(termGroupName);
+    cleanup.track(termGroupUrn);
+    await glossaryPage.navigateToGlossaryNodeByUrn(termGroupUrn);
+    await glossaryPage.openContentsTab();
+    const termUrn = await glossaryPage.createTermInContentsTab(termName);
+
+    await glossaryPage.clickContentsTabItem(termUrn);
     await glossaryPage.deleteCurrentEntity();
-    await expect(page.getByText('Deleted Glossary Term!')).toBeVisible({ timeout: 15000 });
 
-    await glossaryPage.navigateToGlossary();
-    await glossaryPage.navigateToGlossaryTerm(TERM_GROUP_NAME);
-    await glossaryPage.expectTextNotPresent(TERM_NAME);
+    await glossaryPage.navigateToGlossaryNodeByUrn(termGroupUrn);
+    await glossaryPage.openContentsTab();
+    await glossaryPage.expectEntityNotInContentsTab(termUrn);
   });
 
-  test('delete term group', async ({ page, logger, logDir }) => {
-    const glossaryPage = new GlossaryPage(page, logger, logDir);
-    await glossaryPage.navigateToGlossary();
+  test('delete term group', async () => {
+    const termGroupName = withRandomSuffix('GlossaryGroup');
 
-    await glossaryPage.navigateToGlossaryTerm(TERM_GROUP_NAME);
+    const termGroupUrn = await glossaryPage.createTermGroup(termGroupName);
+
+    await glossaryPage.navigateToGlossaryNodeByUrn(termGroupUrn);
     await glossaryPage.deleteCurrentEntity();
-    await expect(page.getByText('Deleted Term Group!')).toBeVisible({ timeout: 15000 });
 
     await glossaryPage.navigateToGlossary();
-    await glossaryPage.expectTextNotPresent(TERM_GROUP_NAME);
+    await glossaryPage.expectSidebarNotContainsNode(termGroupUrn);
   });
 });


### PR DESCRIPTION
This PR migrates glossary related cypress tests to playwright

Depends on https://github.com/datahub-project/datahub/pull/17377

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
