### PR TITLE
feat(ingest/glue): emit column Parameters as structured properties on schemaField

### DIFF
--- a/metadata-ingestion/docs/sources/glue/glue_post.md
+++ b/metadata-ingestion/docs/sources/glue/glue_post.md
@@ -110,6 +110,31 @@ source:
 
 When this is configured, dataset URNs produced by the Glue connector will include the same `platform_instance` and `env` as the target platform's connector, ensuring entities merge correctly in DataHub. If the target platform connector does not use a `platform_instance`, no configuration is needed — URNs will match by default.
 
+#### Column Parameters as Structured Properties
+
+When `extract_column_parameters` is enabled, column-level `Parameters` from the Glue catalog are
+ingested as [structured properties](https://docs.datahub.com/docs/features/feature-guides/properties)
+on each `schemaField` entity. This surfaces Glue metadata such as Iceberg field IDs directly in the
+DataHub Properties tab.
+
+```yaml
+source:
+  type: glue
+  config:
+    extract_column_parameters: true
+```
+
+**How it works:**
+
+- For each column that has a non-empty `Parameters` map, a `StructuredProperties` aspect is emitted
+  on the corresponding `schemaField` entity.
+- Each unique parameter key produces one `StructuredPropertyDefinition` per recipe run. Subsequent
+  columns reusing the same key share the existing definition (no duplicate upserts).
+- Property URNs follow the pattern
+  `urn:li:structuredProperty:io.datahubproject.glue.column.<sanitized-key>`, where non-alphanumeric
+  characters (except `.`) are replaced with `_`.
+- Partition key columns are also processed.
+
 ### Limitations
 
 Module behavior is constrained by source APIs, permissions, and metadata exposed by the platform. Refer to capability notes for unsupported or conditional features.

--- a/metadata-ingestion/docs/sources/glue/glue_post.md
+++ b/metadata-ingestion/docs/sources/glue/glue_post.md
@@ -113,8 +113,7 @@ When this is configured, dataset URNs produced by the Glue connector will includ
 #### Column Parameters as Structured Properties
 
 When `extract_column_parameters` is enabled, column-level `Parameters` from the Glue catalog are
-ingested as [structured properties](https://docs.datahub.com/docs/features/feature-guides/properties)
-on each `schemaField` entity. This surfaces Glue metadata such as Iceberg field IDs directly in the
+ingested as structured properties on each `schemaField` entity. This surfaces Glue metadata such as Iceberg field IDs directly in the
 DataHub Properties tab.
 
 ```yaml

--- a/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
@@ -2021,8 +2021,10 @@ class GlueSource(StatefulIngestionSourceBase):
                 )
                 assignments = []
                 for key, value in params.items():
-                    qualified_name = f"io.datahubproject.glue.column.{re.sub(r'[^a-zA-Z0-9._]', '_', key)}"
-                    property_urn = f"urn:li:structuredProperty:{qualified_name}"
+                    property_urn = self._column_param_property_urn(key)
+                    qualified_name = property_urn.removeprefix(
+                        "urn:li:structuredProperty:"
+                    )
                     if property_urn not in self._seen_column_param_urns:
                         yield MetadataChangeProposalWrapper(
                             entityUrn=property_urn,

--- a/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
@@ -2049,8 +2049,8 @@ class GlueSource(StatefulIngestionSourceBase):
                     ).as_workunit()
             except Exception as e:
                 self.report.report_warning(
-                    key=dataset_urn,
-                    reason=f"Failed to emit column parameters for column {column.get('Name', '?')!r}: {e}",
+                    message="Failed to emit column parameters for column",
+                    context=f"dataset={dataset_urn} column={column.get('Name', '?')!r}: {e}",
                 )
 
     def _get_s3_tags(self, table: Dict, dataset_urn: str) -> Optional[GlobalTagsClass]:

--- a/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
@@ -13,6 +13,7 @@ from typing import (
     Literal,
     Mapping,
     Optional,
+    Set,
     Tuple,
 )
 from urllib.parse import urlparse
@@ -123,6 +124,9 @@ from datahub.metadata.schema_classes import (
     QueryLanguageClass,
     QueryStatementClass,
     SchemaMetadataClass,
+    StructuredPropertiesClass,
+    StructuredPropertyDefinitionClass,
+    StructuredPropertyValueAssignmentClass,
     TagAssociationClass,
     TimeStampClass,
     UpstreamClass,
@@ -272,6 +276,15 @@ class GlueSourceConfig(
         description="When enabled, column-level lineage will be extracted between Glue table columns and storage location fields.",
     )
 
+    extract_column_parameters: bool = Field(
+        default=False,
+        description=(
+            "When enabled, column-level Parameters from Glue are ingested as structured properties "
+            "on each schemaField entity. A StructuredPropertyDefinition is upserted once per unique "
+            "parameter key per recipe run; subsequent columns reuse the cached definition."
+        ),
+    )
+
     target_platform_configs: Dict[str, TargetPlatformConfig] = Field(
         default_factory=dict,
         description=(
@@ -393,6 +406,9 @@ class GlueSource(StatefulIngestionSourceBase):
         self.extract_transforms = config.extract_transforms
         self.env = config.env
         self._glue_connection_cache: Dict[str, Optional[Tuple[str, str]]] = {}
+        # Tracks which structured property definitions have been emitted this run
+        # so each key's definition is only upserted once.
+        self._seen_column_param_urns: Set[str] = set()
 
         self.platform_resource_repository: Optional[
             "GluePlatformResourceRepository"
@@ -1777,6 +1793,9 @@ class GlueSource(StatefulIngestionSourceBase):
         metadata_record = MetadataChangeEvent(proposedSnapshot=dataset_snapshot)
         yield MetadataWorkUnit(table_name, mce=metadata_record)
 
+        if self.source_config.extract_column_parameters:
+            yield from self._get_column_param_workunits(table, dataset_urn)
+
         # Add lineage if enabled
         lineage_wu = self.get_lineage_if_enabled(metadata_record)
         if lineage_wu:
@@ -1979,6 +1998,48 @@ class GlueSource(StatefulIngestionSourceBase):
             )
         ]
         return OwnershipClass(owners=owners)
+
+    @staticmethod
+    def _column_param_property_urn(key: str) -> str:
+        sanitized = re.sub(r"[^a-zA-Z0-9._]", "_", key)
+        return f"urn:li:structuredProperty:io.datahubproject.glue.column.{sanitized}"
+
+    def _get_column_param_workunits(
+        self, table: Dict, dataset_urn: str
+    ) -> Iterable[MetadataWorkUnit]:
+        columns = table.get("StorageDescriptor", {}).get("Columns", [])
+        columns = columns + table.get("PartitionKeys", [])
+        for column in columns:
+            params = column.get("Parameters")
+            if not params:
+                continue
+            field_urn = mce_builder.make_schema_field_urn(dataset_urn, column["Name"])
+            assignments = []
+            for key, value in params.items():
+                property_urn = self._column_param_property_urn(key)
+                if property_urn not in self._seen_column_param_urns:
+                    self._seen_column_param_urns.add(property_urn)
+                    sanitized = re.sub(r"[^a-zA-Z0-9._]", "_", key)
+                    yield MetadataChangeProposalWrapper(
+                        entityUrn=property_urn,
+                        aspect=StructuredPropertyDefinitionClass(
+                            qualifiedName=f"io.datahubproject.glue.column.{sanitized}",
+                            displayName=key,
+                            valueType="urn:li:dataType:datahub.string",
+                            entityTypes=["urn:li:entityType:datahub.schemaField"],
+                        ),
+                    ).as_workunit()
+                assignments.append(
+                    StructuredPropertyValueAssignmentClass(
+                        propertyUrn=property_urn,
+                        values=[value],
+                    )
+                )
+            if assignments:
+                yield MetadataChangeProposalWrapper(
+                    entityUrn=field_urn,
+                    aspect=StructuredPropertiesClass(properties=assignments),
+                ).as_workunit()
 
     def _get_s3_tags(self, table: Dict, dataset_urn: str) -> Optional[GlobalTagsClass]:
         """Extract S3 tags if enabled."""

--- a/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
@@ -2001,8 +2001,10 @@ class GlueSource(StatefulIngestionSourceBase):
 
     @staticmethod
     def _column_param_property_urn(key: str) -> str:
-        sanitized = re.sub(r"[^a-zA-Z0-9._]", "_", key)
-        return f"urn:li:structuredProperty:io.datahubproject.glue.column.{sanitized}"
+        qualified_name = (
+            f"io.datahubproject.glue.column.{re.sub(r'[^a-zA-Z0-9._]', '_', key)}"
+        )
+        return f"urn:li:structuredProperty:{qualified_name}"
 
     def _get_column_param_workunits(
         self, table: Dict, dataset_urn: str
@@ -2010,36 +2012,46 @@ class GlueSource(StatefulIngestionSourceBase):
         columns = table.get("StorageDescriptor", {}).get("Columns", [])
         columns = columns + table.get("PartitionKeys", [])
         for column in columns:
-            params = column.get("Parameters")
-            if not params:
-                continue
-            field_urn = mce_builder.make_schema_field_urn(dataset_urn, column["Name"])
-            assignments = []
-            for key, value in params.items():
-                property_urn = self._column_param_property_urn(key)
-                if property_urn not in self._seen_column_param_urns:
-                    self._seen_column_param_urns.add(property_urn)
-                    sanitized = re.sub(r"[^a-zA-Z0-9._]", "_", key)
-                    yield MetadataChangeProposalWrapper(
-                        entityUrn=property_urn,
-                        aspect=StructuredPropertyDefinitionClass(
-                            qualifiedName=f"io.datahubproject.glue.column.{sanitized}",
-                            displayName=key,
-                            valueType="urn:li:dataType:datahub.string",
-                            entityTypes=["urn:li:entityType:datahub.schemaField"],
-                        ),
-                    ).as_workunit()
-                assignments.append(
-                    StructuredPropertyValueAssignmentClass(
-                        propertyUrn=property_urn,
-                        values=[value],
-                    )
+            try:
+                params = column.get("Parameters")
+                if not params:
+                    continue
+                field_urn = mce_builder.make_schema_field_urn(
+                    dataset_urn, column["Name"]
                 )
-            if assignments:
-                yield MetadataChangeProposalWrapper(
-                    entityUrn=field_urn,
-                    aspect=StructuredPropertiesClass(properties=assignments),
-                ).as_workunit()
+                assignments = []
+                for key, value in params.items():
+                    qualified_name = f"io.datahubproject.glue.column.{re.sub(r'[^a-zA-Z0-9._]', '_', key)}"
+                    property_urn = f"urn:li:structuredProperty:{qualified_name}"
+                    if property_urn not in self._seen_column_param_urns:
+                        yield MetadataChangeProposalWrapper(
+                            entityUrn=property_urn,
+                            aspect=StructuredPropertyDefinitionClass(
+                                qualifiedName=qualified_name,
+                                displayName=key,
+                                valueType="urn:li:dataType:datahub.string",
+                                entityTypes=["urn:li:entityType:datahub.schemaField"],
+                            ),
+                        ).as_workunit()
+                        # Only cache after successful yield so a dropped MCP
+                        # (network blip, GMS rejection) doesn't prevent retry.
+                        self._seen_column_param_urns.add(property_urn)
+                    assignments.append(
+                        StructuredPropertyValueAssignmentClass(
+                            propertyUrn=property_urn,
+                            values=[value],
+                        )
+                    )
+                if assignments:
+                    yield MetadataChangeProposalWrapper(
+                        entityUrn=field_urn,
+                        aspect=StructuredPropertiesClass(properties=assignments),
+                    ).as_workunit()
+            except Exception as e:
+                self.report.report_warning(
+                    key=dataset_urn,
+                    reason=f"Failed to emit column parameters for column {column.get('Name', '?')!r}: {e}",
+                )
 
     def _get_s3_tags(self, table: Dict, dataset_urn: str) -> Optional[GlobalTagsClass]:
         """Extract S3 tags if enabled."""

--- a/metadata-ingestion/tests/unit/glue/test_glue_source.py
+++ b/metadata-ingestion/tests/unit/glue/test_glue_source.py
@@ -1557,3 +1557,174 @@ def test_glue_redact_job_script_secret_fields(secret_name):
     assert _redact_secret_fields_in_dataflow_script(script) == script.replace(
         secret_value, "*****"
     )
+
+
+# ── extract_column_parameters (structured properties) ─────────────────────────
+
+
+def _make_glue_source_with_column_params() -> GlueSource:
+    pipeline_context = PipelineContext(run_id="glue-col-params-test")
+    return GlueSource(
+        ctx=pipeline_context,
+        config=GlueSourceConfig(
+            aws_region="us-west-2",
+            extract_transforms=False,
+            use_s3_bucket_tags=False,
+            use_s3_object_tags=False,
+            extract_column_parameters=True,
+        ),
+    )
+
+
+def _make_table_with_column_params() -> Dict[str, Any]:
+    return {
+        "Name": "test_table",
+        "DatabaseName": "test_db",
+        "StorageDescriptor": {
+            "Columns": [
+                {
+                    "Name": "col_a",
+                    "Type": "string",
+                    "Parameters": {
+                        "iceberg.field.id": "1",
+                        "iceberg.field.optional": "true",
+                    },
+                },
+                {
+                    "Name": "col_b",
+                    "Type": "int",
+                    "Parameters": {"iceberg.field.id": "2"},
+                },
+                {
+                    "Name": "col_no_params",
+                    "Type": "boolean",
+                },
+            ]
+        },
+        "PartitionKeys": [
+            {
+                "Name": "dt",
+                "Type": "string",
+                "Parameters": {"iceberg.field.id": "3"},
+            }
+        ],
+    }
+
+
+def test_column_param_property_urn_sanitizes_special_chars() -> None:
+    assert GlueSource._column_param_property_urn("iceberg.field.id") == (
+        "urn:li:structuredProperty:io.datahubproject.glue.column.iceberg.field.id"
+    )
+    assert GlueSource._column_param_property_urn("some-key with spaces!") == (
+        "urn:li:structuredProperty:io.datahubproject.glue.column.some_key_with_spaces_"
+    )
+
+
+def test_get_column_param_workunits_emits_definitions_once() -> None:
+    """Each unique key's StructuredPropertyDefinition should be emitted only once per run."""
+    source = _make_glue_source_with_column_params()
+    table = _make_table_with_column_params()
+    dataset_urn = "urn:li:dataset:(urn:li:dataPlatform:glue,test_db.test_table,PROD)"
+
+    workunits = list(source._get_column_param_workunits(table, dataset_urn))
+
+    definition_urns = [
+        wu.get_urn()
+        for wu in workunits
+        if wu.get_aspect_of_type(models.StructuredPropertyDefinitionClass) is not None
+    ]
+    # iceberg.field.id appears on col_a, col_b, and dt — definition should be emitted once
+    assert (
+        definition_urns.count(
+            "urn:li:structuredProperty:io.datahubproject.glue.column.iceberg.field.id"
+        )
+        == 1
+    )
+    # iceberg.field.optional only appears on col_a
+    assert (
+        definition_urns.count(
+            "urn:li:structuredProperty:io.datahubproject.glue.column.iceberg.field.optional"
+        )
+        == 1
+    )
+
+
+def test_get_column_param_workunits_skips_columns_without_params() -> None:
+    """Columns with no Parameters should produce no work units."""
+    source = _make_glue_source_with_column_params()
+    dataset_urn = "urn:li:dataset:(urn:li:dataPlatform:glue,test_db.test_table,PROD)"
+    table = {
+        "Name": "t",
+        "DatabaseName": "db",
+        "StorageDescriptor": {
+            "Columns": [{"Name": "col_no_params", "Type": "boolean"}]
+        },
+        "PartitionKeys": [],
+    }
+
+    workunits = list(source._get_column_param_workunits(table, dataset_urn))
+
+    assert workunits == []
+
+
+def test_get_column_param_workunits_values_assigned_correctly() -> None:
+    """StructuredProperties aspect on each field should carry the correct values."""
+    source = _make_glue_source_with_column_params()
+    table = _make_table_with_column_params()
+    dataset_urn = "urn:li:dataset:(urn:li:dataPlatform:glue,test_db.test_table,PROD)"
+
+    workunits = list(source._get_column_param_workunits(table, dataset_urn))
+
+    # Find the StructuredProperties workunit for col_a
+    col_a_urn = "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:glue,test_db.test_table,PROD),col_a)"
+    col_a_props_wu = next(
+        (
+            wu
+            for wu in workunits
+            if wu.get_urn() == col_a_urn
+            and wu.get_aspect_of_type(models.StructuredPropertiesClass) is not None
+        ),
+        None,
+    )
+    assert col_a_props_wu is not None
+    aspect = col_a_props_wu.get_aspect_of_type(models.StructuredPropertiesClass)
+    assert aspect is not None
+    assigned_urns = {a.propertyUrn for a in aspect.properties}
+    assert (
+        "urn:li:structuredProperty:io.datahubproject.glue.column.iceberg.field.id"
+        in assigned_urns
+    )
+    assert (
+        "urn:li:structuredProperty:io.datahubproject.glue.column.iceberg.field.optional"
+        in assigned_urns
+    )
+    id_assignment = next(
+        a
+        for a in aspect.properties
+        if a.propertyUrn
+        == "urn:li:structuredProperty:io.datahubproject.glue.column.iceberg.field.id"
+    )
+    assert id_assignment.values == ["1"]
+
+
+def test_seen_definitions_not_re_emitted_across_tables() -> None:
+    """Once a definition has been emitted for a key, it must not appear again for a second table."""
+    source = _make_glue_source_with_column_params()
+    dataset_urn = "urn:li:dataset:(urn:li:dataPlatform:glue,test_db.test_table,PROD)"
+    table = _make_table_with_column_params()
+
+    first_run = list(source._get_column_param_workunits(table, dataset_urn))
+    second_run = list(source._get_column_param_workunits(table, dataset_urn))
+
+    first_defs = [
+        wu
+        for wu in first_run
+        if wu.get_aspect_of_type(models.StructuredPropertyDefinitionClass) is not None
+    ]
+    second_defs = [
+        wu
+        for wu in second_run
+        if wu.get_aspect_of_type(models.StructuredPropertyDefinitionClass) is not None
+    ]
+    assert len(first_defs) > 0
+    assert second_defs == []


### PR DESCRIPTION
## Summary

- Adds `extract_column_parameters` config flag to the Glue source (default `false`)
- When enabled, column-level `Parameters` from the Glue catalog are emitted as `StructuredProperties` on each `schemaField` entity — no frontend or backend changes required
- Each unique parameter key's `StructuredPropertyDefinition` is upserted once per recipe run (cached in `_seen_column_param_urns`); repeated columns reuse the existing definition
- Partition key columns are also processed
- Property URNs follow the pattern `urn:li:structuredProperty:io.datahubproject.glue.column.<sanitized-key>`

## Motivation

Glue tables backed by Iceberg (and other formats) carry column-level metadata in `Parameters` (e.g. `iceberg.field.id`, `iceberg.field.optional`). This approach surfaces that metadata in the DataHub Properties tab without any schema changes, using the existing structured properties infrastructure that `schemaField` already supports.


## Test plan

- [ ] 5 new unit tests in `test_glue_source.py` cover: URN sanitization, definition deduplication, columns-without-params skipping, value assignment correctness, and cross-table definition caching
- [ ] All existing Glue unit tests still pass
- [ ] `lintFix` and pre-commit hooks pass

## Checklist

- [x] PR conforms to Contributing Guideline (PR Title Format)
- [x] Tests added/updated
- [x] Docs updated (`glue_post.md`)
- [ ] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)