### PR TITLE
perf(ingest/teradata): filter tables-and-views query by configured databases to reduce peak memory

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/teradata.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/teradata.py
@@ -829,7 +829,7 @@ class TeradataSource(TwoTierSQLAlchemySource):
     ORDER BY "timestamp", "query_id", "row_no"
     """.strip()
 
-    TABLES_AND_VIEWS_QUERY: str = f"""
+    _TABLES_AND_VIEWS_QUERY_TEMPLATE: str = """
 SELECT
     t.DataBaseName,
     t.TableName as name,
@@ -846,12 +846,33 @@ SELECT
     t.LastAlterName,
     t.LastAlterTimeStamp,
     t.RequestText,
-    t.CreatorName  -- User who created the table/view, used for ownership extraction
+    t.CreatorName
 FROM dbc.TablesV t
-WHERE DataBaseName NOT IN ({",".join([f"'{db}'" for db in EXCLUDED_DATABASES])})
+WHERE DataBaseName NOT IN ({excluded_dbs}){db_allowlist}
 AND t.TableKind in ('T', 'V', 'Q', 'O')
 ORDER by DataBaseName, TableName;
-     """.strip()
+""".strip()
+
+    def _build_tables_and_views_query(self) -> str:
+        excluded_dbs = ",".join([f"'{db}'" for db in EXCLUDED_DATABASES])
+
+        # When config.databases is set push filtering into SQL so we only fetch
+        # metadata for the configured databases. Without this, a Teradata system
+        # with thousands of databases loads ALL their table/view metadata into
+        # _tables_cache even though only a small subset will ever be processed.
+        # On large installations this is the primary driver of OOM crashes.
+        db_allowlist = ""
+        if self.config.databases:
+            # Teradata identifiers cannot contain single quotes; strip defensively.
+            safe_names = [db.replace("'", "") for db in self.config.databases]
+            db_allowlist = "\nAND DataBaseName IN ({})".format(
+                ",".join(f"'{db}'" for db in safe_names)
+            )
+
+        return self._TABLES_AND_VIEWS_QUERY_TEMPLATE.format(
+            excluded_dbs=excluded_dbs,
+            db_allowlist=db_allowlist,
+        )
 
     _tables_cache: MutableMapping[str, List[TeradataTable]] = defaultdict(list)
     # Cache mapping (schema, entity_name) -> creator_name for table/view ownership
@@ -1554,7 +1575,7 @@ ORDER by DataBaseName, TableName;
                         "Tables/views with LastAlterTimeStamp before the watermark will be skipped."
                     )
 
-                for entry in engine.execute(self.TABLES_AND_VIEWS_QUERY):
+                for entry in engine.execute(self._build_tables_and_views_query()):
                     table = TeradataTable(
                         database=entry.DataBaseName.strip(),
                         name=entry.name.strip(),

--- a/metadata-ingestion/tests/unit/test_teradata_performance.py
+++ b/metadata-ingestion/tests/unit/test_teradata_performance.py
@@ -525,8 +525,7 @@ class TestQueryOptimizations:
             ):
                 source = TeradataSource(config, PipelineContext(run_id="test"))
 
-            # Test TABLES_AND_VIEWS_QUERY structure
-            query = source.TABLES_AND_VIEWS_QUERY
+            query = source._build_tables_and_views_query()
 
             # Should exclude system databases efficiently
             assert "NOT IN" in query
@@ -534,6 +533,33 @@ class TestQueryOptimizations:
 
             # Should only select necessary table types
             assert "t.TableKind in ('T', 'V', 'Q', 'O')" in query
+
+            # No allowlist clause when config.databases is not set
+            assert "AND DataBaseName IN" not in query
+
+    def test_tables_query_database_filter(self):
+        """When config.databases is set, the query must include an IN clause to avoid
+        loading the entire Teradata installation into memory (primary OOM driver)."""
+        config = TeradataConfig.model_validate(
+            {**_base_config(), "databases": ["DB_A", "DB_B", "DB_C"]}
+        )
+
+        with patch(
+            "datahub.ingestion.source.sql.teradata.SqlParsingAggregator"
+        ) as mock_aggregator_class:
+            mock_aggregator = MagicMock()
+            mock_aggregator_class.return_value = mock_aggregator
+
+            with patch(
+                "datahub.ingestion.source.sql.teradata.TeradataSource.cache_tables_and_views"
+            ):
+                source = TeradataSource(config, PipelineContext(run_id="test"))
+
+        query = source._build_tables_and_views_query()
+
+        assert "AND DataBaseName IN ('DB_A','DB_B','DB_C')" in query
+        # System database exclusion still present
+        assert "NOT IN" in query
 
     def test_usexviews_optimization(self):
         """Test that usexviews configuration optimizes queries."""


### PR DESCRIPTION
## Summary

- `cache_tables_and_views()` previously issued a query that loaded **all** tables/views from every user database on the Teradata installation into `_tables_cache`, regardless of what the recipe was configured to ingest. On large enterprise systems with thousands of databases this is the primary driver of OOM crashes — the cache grows proportional to the entire system, not the recipe scope.
- When `config.databases` is explicitly set, this PR pushes an `AND DataBaseName IN (...)` clause into the query so only the configured databases are fetched. This reduces `_tables_cache` size from O(system) to O(recipe), which can be a 10–100× memory reduction on large installations.
- When `config.databases` is not set, behaviour is unchanged — all databases are loaded as before.

## Why it's safe

Non-recipe database entries in `_tables_cache` were never read: the cache is only accessed for schemas currently being iterated, and only recipe databases pass the `database_pattern` filter. Cross-database view lineage resolution uses the `schema_resolver` (not `_tables_cache`) and was already limited to recipe databases. `_make_lineage_queries()` uses `self.config.databases` directly when that field is set, bypassing `_tables_cache` entirely.

## Test plan

- [ ] Added `test_tables_query_database_filter` — verifies that setting `config.databases` produces a query with an `IN` clause containing exactly those databases
- [ ] Existing `test_query_structure_optimization` updated — now calls `_build_tables_and_views_query()` and additionally asserts no `IN` clause is added when `config.databases` is unset
- [ ] All 110 existing Teradata unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)