### PR TITLE
fix(re-index-loop): prevent perpetual ES8 reindex loop in graph index…

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/index/entity/v2/V2MappingsBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/index/entity/v2/V2MappingsBuilder.java
@@ -23,6 +23,7 @@ import com.linkedin.metadata.models.annotation.SearchableAnnotation.FieldType;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.search.elasticsearch.index.MappingsBuilder;
 import com.linkedin.metadata.search.utils.ESUtils;
+import com.linkedin.metadata.utils.elasticsearch.SearchClientShim.SearchEngineType;
 import com.linkedin.structured.StructuredPropertyDefinition;
 import com.linkedin.util.Pair;
 import io.datahubproject.metadata.context.OperationContext;
@@ -36,20 +37,30 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class V2MappingsBuilder implements MappingsBuilder {
 
-  private static final Map<String, String> PARTIAL_NGRAM_CONFIG =
+  // ES7/OpenSearch silently accept doc_values=false on search_as_you_type and persist it.
+  // ES8+ strips it from stored mappings on round-trip, which causes a perpetual mapping diff and a
+  // reindex loop.
+  private static final Map<String, String> PARTIAL_NGRAM_CONFIG_LEGACY =
       ImmutableMap.of(
           TYPE, "search_as_you_type",
           MAX_SHINGLE_SIZE, "4",
           DOC_VALUES, "false");
 
-  private static Map<String, String> getPartialNgramConfigWithOverrides(
-      Map<String, String> overrides) {
-    return Stream.concat(PARTIAL_NGRAM_CONFIG.entrySet().stream(), overrides.entrySet().stream())
+  private static final Map<String, String> PARTIAL_NGRAM_CONFIG_ES8 =
+      ImmutableMap.of(
+          TYPE, "search_as_you_type",
+          MAX_SHINGLE_SIZE, "4");
+
+  private final Map<String, String> partialNgramConfig;
+
+  private Map<String, String> getPartialNgramConfigWithOverrides(Map<String, String> overrides) {
+    return Stream.concat(partialNgramConfig.entrySet().stream(), overrides.entrySet().stream())
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
@@ -76,7 +87,17 @@ public class V2MappingsBuilder implements MappingsBuilder {
   private final EntityIndexConfiguration entityIndexConfiguration;
 
   public V2MappingsBuilder(@Nonnull EntityIndexConfiguration entityIndexConfiguration) {
+    this(entityIndexConfiguration, null);
+  }
+
+  public V2MappingsBuilder(
+      @Nonnull EntityIndexConfiguration entityIndexConfiguration,
+      @Nullable SearchEngineType engineType) {
     this.entityIndexConfiguration = entityIndexConfiguration;
+    this.partialNgramConfig =
+        (engineType != null && engineType.requiresEs8JavaClient())
+            ? PARTIAL_NGRAM_CONFIG_ES8
+            : PARTIAL_NGRAM_CONFIG_LEGACY;
   }
 
   @Override
@@ -226,7 +247,7 @@ public class V2MappingsBuilder implements MappingsBuilder {
     return ImmutableMap.of(PROPERTIES, mappings);
   }
 
-  private static Map<String, Object> getMappingsForUrn() {
+  private Map<String, Object> getMappingsForUrn() {
     Map<String, Object> subFields = new HashMap<>();
     subFields.put(
         DELIMITED,
@@ -287,7 +308,7 @@ public class V2MappingsBuilder implements MappingsBuilder {
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
-  private static Map<String, Object> getMappingsForField(
+  private Map<String, Object> getMappingsForField(
       @Nonnull final SearchableFieldSpec searchableFieldSpec) {
     FieldType fieldType = searchableFieldSpec.getSearchableAnnotation().getFieldType();
 
@@ -381,7 +402,7 @@ public class V2MappingsBuilder implements MappingsBuilder {
     return mappingForField;
   }
 
-  private static Map<String, Object> getMappingsForSearchText(FieldType fieldType) {
+  private Map<String, Object> getMappingsForSearchText(FieldType fieldType) {
     Map<String, Object> mappingForField = new HashMap<>();
     mappingForField.put(TYPE, ESUtils.KEYWORD_FIELD_TYPE);
     mappingForField.put(NORMALIZER, KEYWORD_NORMALIZER);
@@ -423,7 +444,7 @@ public class V2MappingsBuilder implements MappingsBuilder {
         ImmutableMap.of(TYPE, ESUtils.DOUBLE_FIELD_TYPE));
   }
 
-  private static Map<String, Object> getMappingForSearchableRefField(
+  private Map<String, Object> getMappingForSearchableRefField(
       @Nonnull EntityRegistry entityRegistry,
       @Nonnull final SearchableRefFieldSpec searchableRefFieldSpec,
       final int depth) {

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ReindexConfig.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ReindexConfig.java
@@ -2,6 +2,7 @@ package com.linkedin.metadata.search.elasticsearch.indexbuilder;
 
 import static com.linkedin.metadata.Constants.*;
 import static com.linkedin.metadata.search.utils.ESUtils.PROPERTIES;
+import static com.linkedin.metadata.search.utils.ESUtils.TYPE;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.StreamReadConstraints;
@@ -192,13 +193,18 @@ public class ReindexConfig {
       if (input == null) {
         return new TreeMap<>();
       }
-      return input.entrySet().stream()
-          .collect(
-              Collectors.toMap(
-                  Map.Entry::getKey,
-                  e -> normalizeObjectForComparison(e.getValue()),
-                  (oldValue, newValue) -> newValue,
-                  TreeMap::new));
+      TreeMap<String, Object> result =
+          input.entrySet().stream()
+              .collect(
+                  Collectors.toMap(
+                      Map.Entry::getKey,
+                      e -> normalizeObjectForComparison(e.getValue()),
+                      (oldValue, newValue) -> newValue,
+                      TreeMap::new));
+      if (result.containsKey(PROPERTIES) && !result.containsKey(TYPE)) {
+        result.put(TYPE, "object");
+      }
+      return result;
     }
 
     private static List<Object> normalizeListForComparison(List<?> input) {

--- a/metadata-io/src/main/java/com/linkedin/metadata/service/UpdateIndicesV2Strategy.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/service/UpdateIndicesV2Strategy.java
@@ -27,6 +27,7 @@ import com.linkedin.metadata.search.transformer.SearchDocumentTransformer;
 import com.linkedin.metadata.timeseries.TimeseriesAspectService;
 import com.linkedin.metadata.timeseries.transformer.TimeseriesAspectTransformer;
 import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
+import com.linkedin.metadata.utils.elasticsearch.SearchClientShim.SearchEngineType;
 import com.linkedin.mxe.SystemMetadata;
 import com.linkedin.structured.StructuredPropertyDefinition;
 import com.linkedin.util.Pair;
@@ -110,7 +111,8 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
         idHashAlgo,
         semanticSearchConfig,
         indexConvention,
-        true);
+        true,
+        null);
   }
 
   /**
@@ -127,7 +129,8 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
       @Nonnull String idHashAlgo,
       @Nullable SemanticSearchConfiguration semanticSearchConfig,
       @Nonnull IndexConvention indexConvention,
-      boolean coalesceBatchUpdates) {
+      boolean coalesceBatchUpdates,
+      @Nullable SearchEngineType engineType) {
     this.v2Config = v2Config;
     this.elasticSearchService = elasticSearchService;
     this.searchDocumentTransformer = searchDocumentTransformer;
@@ -140,7 +143,8 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
         new V2MappingsBuilder(
             com.linkedin.metadata.config.search.EntityIndexConfiguration.builder()
                 .v2(v2Config)
-                .build());
+                .build(),
+            engineType);
     this.semanticIndexExistsCache =
         CacheBuilder.newBuilder()
             .expireAfterWrite(SEMANTIC_INDEX_CACHE_TTL_MINUTES, TimeUnit.MINUTES)

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/index/entity/v2/V2MappingsBuilderTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/index/entity/v2/V2MappingsBuilderTest.java
@@ -19,6 +19,7 @@ import com.linkedin.metadata.models.registry.ConfigEntityRegistry;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.search.elasticsearch.index.MappingsBuilder.IndexMapping;
 import com.linkedin.metadata.search.query.request.TestSearchFieldConfig;
+import com.linkedin.metadata.utils.elasticsearch.SearchClientShim.SearchEngineType;
 import com.linkedin.structured.StructuredPropertyDefinition;
 import com.linkedin.util.Pair;
 import io.datahubproject.metadata.context.OperationContext;
@@ -734,5 +735,167 @@ public class V2MappingsBuilderTest {
         TestSearchFieldConfig.class
             .getClassLoader()
             .getResourceAsStream("test-entity-registry.yaml"));
+  }
+
+  // ES7 / OpenSearch silently accept and persist doc_values=false on search_as_you_type ngram
+  // subfields,
+  // ES8+ strips it on round-trip, which causes a perpetual mapping diff and reindex loop.
+  /** Recursively collects every value found under any "ngram" key in a mappings tree. */
+  private List<Map<String, Object>> findAllNgramSubfields(Map<String, Object> root) {
+    List<Map<String, Object>> found = new java.util.ArrayList<>();
+    collectNgramSubfields(root, found);
+    return found;
+  }
+
+  @SuppressWarnings("unchecked")
+  private void collectNgramSubfields(Object node, List<Map<String, Object>> found) {
+    if (!(node instanceof Map)) {
+      return;
+    }
+    Map<String, Object> map = (Map<String, Object>) node;
+    for (Map.Entry<String, Object> entry : map.entrySet()) {
+      if ("ngram".equals(entry.getKey()) && entry.getValue() instanceof Map) {
+        found.add((Map<String, Object>) entry.getValue());
+      }
+      collectNgramSubfields(entry.getValue(), found);
+    }
+  }
+
+  private Collection<IndexMapping> buildAllMappings(SearchEngineType engineType) {
+    V2MappingsBuilder builder = new V2MappingsBuilder(entityIndexConfiguration, engineType);
+    return builder.getIndexMappings(operationContext);
+  }
+
+  private List<Map<String, Object>> collectAllNgramSubfields(SearchEngineType engineType) {
+    Collection<IndexMapping> mappings = buildAllMappings(engineType);
+    assertNotNull(mappings, "Mappings should not be null");
+    assertFalse(mappings.isEmpty(), "Test entity registry must produce at least one mapping");
+
+    List<Map<String, Object>> all = new java.util.ArrayList<>();
+    for (IndexMapping mapping : mappings) {
+      all.addAll(findAllNgramSubfields(mapping.getMappings()));
+    }
+    return all;
+  }
+
+  private void assertLegacyNgramShape(List<Map<String, Object>> ngrams, SearchEngineType type) {
+    assertFalse(
+        ngrams.isEmpty(),
+        "Expected at least one ngram subfield for engine type " + type + " — test setup is broken");
+    for (Map<String, Object> ngram : ngrams) {
+      assertEquals(
+          ngram.get("type"), "search_as_you_type", "ngram type should be search_as_you_type");
+      assertEquals(ngram.get("max_shingle_size"), "4", "max_shingle_size should be preserved");
+      assertEquals(
+          ngram.get("doc_values"),
+          "false",
+          "Legacy engine type "
+              + type
+              + " must continue to emit doc_values=false to avoid a transitional reindex of"
+              + " existing ES7/OpenSearch indexes");
+    }
+  }
+
+  private void assertEs8NgramShape(List<Map<String, Object>> ngrams, SearchEngineType type) {
+    assertFalse(
+        ngrams.isEmpty(),
+        "Expected at least one ngram subfield for engine type " + type + " — test setup is broken");
+    for (Map<String, Object> ngram : ngrams) {
+      assertEquals(
+          ngram.get("type"), "search_as_you_type", "ngram type should be search_as_you_type");
+      assertEquals(ngram.get("max_shingle_size"), "4", "max_shingle_size should be preserved");
+      assertFalse(
+          ngram.containsKey("doc_values"),
+          "ES8+ engine type "
+              + type
+              + " must omit doc_values — ES8 strips it on round-trip and including it causes a"
+              + " perpetual mapping diff (PFP-3594)");
+    }
+  }
+
+  @Test
+  public void testNgramHasDocValuesForLegacyNullEngineType() {
+    // null is the backward-compat path used by tests and pre-fix callers; must preserve legacy.
+    assertLegacyNgramShape(collectAllNgramSubfields(null), null);
+  }
+
+  @Test
+  public void testNgramHasDocValuesForElasticsearch7() {
+    assertLegacyNgramShape(
+        collectAllNgramSubfields(SearchEngineType.ELASTICSEARCH_7),
+        SearchEngineType.ELASTICSEARCH_7);
+  }
+
+  @Test
+  public void testNgramHasDocValuesForOpenSearch2() {
+    assertLegacyNgramShape(
+        collectAllNgramSubfields(SearchEngineType.OPENSEARCH_2), SearchEngineType.OPENSEARCH_2);
+  }
+
+  @Test
+  public void testNgramOmitsDocValuesForElasticsearch8() {
+    assertEs8NgramShape(
+        collectAllNgramSubfields(SearchEngineType.ELASTICSEARCH_8),
+        SearchEngineType.ELASTICSEARCH_8);
+  }
+
+  @Test
+  public void testNgramOmitsDocValuesForElasticsearch9() {
+    assertEs8NgramShape(
+        collectAllNgramSubfields(SearchEngineType.ELASTICSEARCH_9),
+        SearchEngineType.ELASTICSEARCH_9);
+  }
+
+  @Test
+  public void testSingleArgConstructorDefaultsToLegacyBehavior() {
+    // Backward-compat: callers that don't know the engine type (tests, older code) must keep
+    // emitting the legacy form so they don't break ES7/OpenSearch deployments.
+    V2MappingsBuilder builder = new V2MappingsBuilder(entityIndexConfiguration);
+    Collection<IndexMapping> mappings = builder.getIndexMappings(operationContext);
+
+    List<Map<String, Object>> ngrams = new java.util.ArrayList<>();
+    for (IndexMapping mapping : mappings) {
+      ngrams.addAll(findAllNgramSubfields(mapping.getMappings()));
+    }
+    assertLegacyNgramShape(ngrams, null);
+  }
+
+  @Test
+  public void testEngineTypeDoesNotChangeOtherStructure() {
+    // Sanity check: switching engine type must NOT alter top-level fields like urn, runId,
+    // systemCreated, or the analyzer wiring. We only expect the ngram doc_values flag to differ.
+    Collection<IndexMapping> legacy = buildAllMappings(SearchEngineType.ELASTICSEARCH_7);
+    Collection<IndexMapping> es8 = buildAllMappings(SearchEngineType.ELASTICSEARCH_8);
+    assertEquals(legacy.size(), es8.size(), "Same number of indexes regardless of engine type");
+
+    // For each index, verify top-level field key sets are identical.
+    java.util.Iterator<IndexMapping> legacyIt = legacy.iterator();
+    java.util.Iterator<IndexMapping> es8It = es8.iterator();
+    while (legacyIt.hasNext() && es8It.hasNext()) {
+      Map<String, Object> legacyProps =
+          (Map<String, Object>) legacyIt.next().getMappings().get("properties");
+      Map<String, Object> es8Props =
+          (Map<String, Object>) es8It.next().getMappings().get("properties");
+      assertEquals(
+          legacyProps.keySet(),
+          es8Props.keySet(),
+          "Top-level field set must be identical between engine types");
+    }
+  }
+
+  @Test
+  public void testNgramAnalyzerOverridesAreApplied() {
+    // The fix replaced static config with instance-based config. Verify that overrides
+    // (analyzer name) still apply correctly after the refactor — different code paths use
+    // different analyzers (PARTIAL_URN_COMPONENT vs PARTIAL_ANALYZER).
+    List<Map<String, Object>> ngrams = collectAllNgramSubfields(SearchEngineType.ELASTICSEARCH_8);
+    assertFalse(ngrams.isEmpty(), "Should produce ngram subfields");
+    for (Map<String, Object> ngram : ngrams) {
+      assertNotNull(ngram.get("analyzer"), "Every ngram subfield must specify an analyzer");
+      String analyzer = (String) ngram.get("analyzer");
+      assertTrue(
+          analyzer.startsWith("partial"),
+          "Analyzer should be a partial analyzer variant, got: " + analyzer);
+    }
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/indexbuilder/ReindexConfigTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/indexbuilder/ReindexConfigTest.java
@@ -237,6 +237,515 @@ public class ReindexConfigTest {
   }
 
   @Test
+  void testImplicitObjectTypeNormalizedAcrossSides() {
+    // ES8 echoes "type":"object" back for any field that has "properties"; ES7 / OpenSearch
+    // omit it. Mapping builders that don't emit the explicit type must not cause a perpetual
+    // mapping diff (and therefore a perpetual reindex loop) when running against ES8.
+    Map<String, Object> currentMappings = new HashMap<>();
+    Map<String, Object> currentProperties = new HashMap<>();
+    Map<String, Object> currentObjectField = new HashMap<>();
+    currentObjectField.put(TYPE_KEY, "object");
+    currentObjectField.put(
+        PROPERTIES_KEY,
+        ImmutableMap.of(
+            "partition", ImmutableMap.of("type", "keyword"),
+            "timePartition", ImmutableMap.of("type", "keyword")));
+    currentProperties.put("partitionSpec", currentObjectField);
+    currentMappings.put(PROPERTIES_KEY, currentProperties);
+
+    Map<String, Object> targetMappings = new HashMap<>();
+    Map<String, Object> targetProperties = new HashMap<>();
+    targetProperties.put(
+        "partitionSpec",
+        ImmutableMap.of(
+            PROPERTIES_KEY,
+            ImmutableMap.of(
+                "partition", ImmutableMap.of("type", "keyword"),
+                "timePartition", ImmutableMap.of("type", "keyword"))));
+    targetMappings.put(PROPERTIES_KEY, targetProperties);
+
+    ReindexConfig config =
+        ReindexConfig.builder()
+            .name(TEST_INDEX_NAME)
+            .exists(true)
+            .currentMappings(currentMappings)
+            .targetMappings(targetMappings)
+            .currentSettings(Settings.EMPTY)
+            .targetSettings(new HashMap<>())
+            .enableIndexMappingsReindex(true)
+            .build();
+
+    Assert.assertFalse(
+        config.requiresApplyMappings(),
+        "Implicit vs explicit type:object on a properties-bearing sub-mapping must not be"
+            + " treated as a diff");
+    Assert.assertFalse(config.requiresReindex());
+  }
+
+  @Test
+  void testImplicitObjectTypeNormalized_TargetExplicit_CurrentImplicit() {
+    // Symmetric to testImplicitObjectTypeNormalizedAcrossSides: confirm normalization works
+    // when current is implicit and target is explicit.
+    Map<String, Object> currentMappings = new HashMap<>();
+    currentMappings.put(
+        PROPERTIES_KEY,
+        ImmutableMap.of(
+            "partitionSpec",
+            ImmutableMap.of(
+                PROPERTIES_KEY, ImmutableMap.of("partition", ImmutableMap.of("type", "keyword")))));
+
+    Map<String, Object> targetMappings = new HashMap<>();
+    targetMappings.put(
+        PROPERTIES_KEY,
+        ImmutableMap.of(
+            "partitionSpec",
+            ImmutableMap.of(
+                TYPE_KEY,
+                "object",
+                PROPERTIES_KEY,
+                ImmutableMap.of("partition", ImmutableMap.of("type", "keyword")))));
+
+    ReindexConfig config =
+        ReindexConfig.builder()
+            .name(TEST_INDEX_NAME)
+            .exists(true)
+            .currentMappings(currentMappings)
+            .targetMappings(targetMappings)
+            .currentSettings(Settings.EMPTY)
+            .targetSettings(new HashMap<>())
+            .enableIndexMappingsReindex(true)
+            .build();
+
+    Assert.assertFalse(
+        config.requiresApplyMappings(),
+        "Normalization must be symmetric: current implicit + target explicit should match");
+    Assert.assertFalse(config.requiresReindex());
+  }
+
+  @Test
+  void testBothSidesImplicitObjectMatch() {
+    // Defensive: when both sides emit implicit object (properties only, no type),
+    // they should still compare equal after normalization.
+    Map<String, Object> mappings = new HashMap<>();
+    mappings.put(
+        PROPERTIES_KEY,
+        ImmutableMap.of(
+            "partitionSpec",
+            ImmutableMap.of(
+                PROPERTIES_KEY, ImmutableMap.of("partition", ImmutableMap.of("type", "keyword")))));
+
+    ReindexConfig config =
+        ReindexConfig.builder()
+            .name(TEST_INDEX_NAME)
+            .exists(true)
+            .currentMappings(mappings)
+            .targetMappings(mappings)
+            .currentSettings(Settings.EMPTY)
+            .targetSettings(new HashMap<>())
+            .enableIndexMappingsReindex(true)
+            .build();
+
+    Assert.assertFalse(config.requiresApplyMappings(), "Both sides implicit object — should match");
+  }
+
+  @Test
+  void testNestedTypeNotNormalizedToObject() {
+    // type:nested has properties but explicit type — normalization must skip it
+    // (TYPE is already present, condition is false).
+    Map<String, Object> mappings = new HashMap<>();
+    mappings.put(
+        PROPERTIES_KEY,
+        ImmutableMap.of(
+            "tags",
+            ImmutableMap.of(
+                TYPE_KEY,
+                "nested",
+                PROPERTIES_KEY,
+                ImmutableMap.of("name", ImmutableMap.of("type", "keyword")))));
+
+    ReindexConfig config =
+        ReindexConfig.builder()
+            .name(TEST_INDEX_NAME)
+            .exists(true)
+            .currentMappings(mappings)
+            .targetMappings(mappings)
+            .currentSettings(Settings.EMPTY)
+            .targetSettings(new HashMap<>())
+            .enableIndexMappingsReindex(true)
+            .build();
+
+    Assert.assertFalse(
+        config.requiresApplyMappings(),
+        "Identical nested mappings should match without object normalization interfering");
+  }
+
+  @Test
+  void testObjectToNestedTransitionDetected() {
+    // Real change: implicit object → explicit nested. The fix must NOT hide this diff
+    // by normalizing both sides to type:object.
+    Map<String, Object> currentMappings = new HashMap<>();
+    currentMappings.put(
+        PROPERTIES_KEY,
+        ImmutableMap.of(
+            "tags",
+            ImmutableMap.of(
+                PROPERTIES_KEY, ImmutableMap.of("name", ImmutableMap.of("type", "keyword")))));
+
+    Map<String, Object> targetMappings = new HashMap<>();
+    targetMappings.put(
+        PROPERTIES_KEY,
+        ImmutableMap.of(
+            "tags",
+            ImmutableMap.of(
+                TYPE_KEY,
+                "nested",
+                PROPERTIES_KEY,
+                ImmutableMap.of("name", ImmutableMap.of("type", "keyword")))));
+
+    ReindexConfig config =
+        ReindexConfig.builder()
+            .name(TEST_INDEX_NAME)
+            .exists(true)
+            .currentMappings(currentMappings)
+            .targetMappings(targetMappings)
+            .currentSettings(Settings.EMPTY)
+            .targetSettings(new HashMap<>())
+            .enableIndexMappingsReindex(true)
+            .build();
+
+    Assert.assertTrue(
+        config.requiresApplyMappings(),
+        "object→nested transition is a real schema change — normalization must not hide it");
+    Assert.assertTrue(config.requiresReindex());
+  }
+
+  @Test
+  void testMultiFieldsNotAffected() {
+    // Multi-fields use the 'fields' key (not 'properties'), so the normalization
+    // condition is false. Comparison should work normally.
+    Map<String, Object> mappings = new HashMap<>();
+    mappings.put(
+        PROPERTIES_KEY,
+        ImmutableMap.of(
+            "name",
+            ImmutableMap.of(
+                TYPE_KEY,
+                "text",
+                "fields",
+                ImmutableMap.of("keyword", ImmutableMap.of("type", "keyword")))));
+
+    ReindexConfig config =
+        ReindexConfig.builder()
+            .name(TEST_INDEX_NAME)
+            .exists(true)
+            .currentMappings(mappings)
+            .targetMappings(mappings)
+            .currentSettings(Settings.EMPTY)
+            .targetSettings(new HashMap<>())
+            .enableIndexMappingsReindex(true)
+            .build();
+
+    Assert.assertFalse(
+        config.requiresApplyMappings(),
+        "Multi-fields ('fields' key, not 'properties') should be unaffected by object normalization");
+  }
+
+  @Test
+  void testFieldAliasNotAffected() {
+    // Field aliases have type:alias and path, but no properties. Normalization
+    // should leave them alone.
+    Map<String, Object> mappings = new HashMap<>();
+    mappings.put(
+        PROPERTIES_KEY,
+        ImmutableMap.of(
+            "_entityName",
+            ImmutableMap.of(TYPE_KEY, "alias", "path", "name"),
+            "name",
+            ImmutableMap.of(TYPE_KEY, "keyword")));
+
+    ReindexConfig config =
+        ReindexConfig.builder()
+            .name(TEST_INDEX_NAME)
+            .exists(true)
+            .currentMappings(mappings)
+            .targetMappings(mappings)
+            .currentSettings(Settings.EMPTY)
+            .targetSettings(new HashMap<>())
+            .enableIndexMappingsReindex(true)
+            .build();
+
+    Assert.assertFalse(
+        config.requiresApplyMappings(),
+        "Field aliases have a type but no properties — normalization must not affect them");
+  }
+
+  @Test
+  void testCombinedTypeAndPropertyChangeStillDetected() {
+    // Combined change: current is implicit object, target is explicit nested with a new field.
+    // Both the type change AND the property addition must be detected — the object-type
+    // injection must not mask either signal.
+    Map<String, Object> currentMappings = new HashMap<>();
+    currentMappings.put(
+        PROPERTIES_KEY,
+        ImmutableMap.of(
+            "tags",
+            ImmutableMap.of(
+                PROPERTIES_KEY, ImmutableMap.of("name", ImmutableMap.of("type", "keyword")))));
+
+    Map<String, Object> targetMappings = new HashMap<>();
+    targetMappings.put(
+        PROPERTIES_KEY,
+        ImmutableMap.of(
+            "tags",
+            ImmutableMap.of(
+                TYPE_KEY,
+                "nested",
+                PROPERTIES_KEY,
+                ImmutableMap.of(
+                    "name", ImmutableMap.of("type", "keyword"),
+                    "color", ImmutableMap.of("type", "keyword")))));
+
+    ReindexConfig config =
+        ReindexConfig.builder()
+            .name(TEST_INDEX_NAME)
+            .exists(true)
+            .currentMappings(currentMappings)
+            .targetMappings(targetMappings)
+            .currentSettings(Settings.EMPTY)
+            .targetSettings(new HashMap<>())
+            .enableIndexMappingsReindex(true)
+            .build();
+
+    Assert.assertTrue(
+        config.requiresApplyMappings(),
+        "Combined type+property change must be detected even when current is implicit object");
+    Assert.assertTrue(config.requiresReindex());
+    Assert.assertFalse(
+        config.isPureMappingsAddition(),
+        "Type change makes this non-additive; should require reindex");
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Engine-type round-trip simulations
+  //
+  // ReindexConfig.normalizeMapForComparison applies its type:object injection universally — it
+  // does not depend on engineType. These tests document the mapping shape each search engine
+  // typically returns during a round-trip and verify the universal normalization handles all
+  // three engines correctly. The "code" side is always assumed to emit implicit-object form
+  // (no explicit type when properties is present) — matching V2MappingsBuilder's output.
+  // ---------------------------------------------------------------------------------------------
+
+  /**
+   * Builds a code-emitted (target) mapping that uses the implicit-object form (no `type` key on
+   * properties-bearing nodes). This mirrors what V2MappingsBuilder produces.
+   */
+  private static Map<String, Object> implicitObjectMapping() {
+    Map<String, Object> mappings = new HashMap<>();
+    mappings.put(
+        PROPERTIES_KEY,
+        ImmutableMap.of(
+            "partitionSpec",
+            ImmutableMap.of(
+                PROPERTIES_KEY,
+                ImmutableMap.of(
+                    "partition", ImmutableMap.of("type", "keyword"),
+                    "timePartition", ImmutableMap.of("type", "keyword")))));
+    return mappings;
+  }
+
+  /**
+   * Builds a stored mapping in the explicit-object shape (ES8-style) — every properties-bearing
+   * node has an explicit `"type": "object"` added by ES8's round-trip behaviour.
+   */
+  private static Map<String, Object> explicitObjectMapping() {
+    Map<String, Object> mappings = new HashMap<>();
+    Map<String, Object> partitionSpec = new HashMap<>();
+    partitionSpec.put(TYPE_KEY, "object");
+    partitionSpec.put(
+        PROPERTIES_KEY,
+        ImmutableMap.of(
+            "partition", ImmutableMap.of("type", "keyword"),
+            "timePartition", ImmutableMap.of("type", "keyword")));
+    mappings.put(PROPERTIES_KEY, ImmutableMap.of("partitionSpec", partitionSpec));
+    return mappings;
+  }
+
+  @Test
+  void testEngineRoundTrip_ES7_PreservesImplicitObject() {
+    // ES7 round-trip: stored mapping looks the same as what was sent.
+    // Both sides remain implicit-object form. Comparison must report no diff.
+    ReindexConfig config =
+        ReindexConfig.builder()
+            .name(TEST_INDEX_NAME)
+            .exists(true)
+            .currentMappings(implicitObjectMapping())
+            .targetMappings(implicitObjectMapping())
+            .currentSettings(Settings.EMPTY)
+            .targetSettings(new HashMap<>())
+            .enableIndexMappingsReindex(true)
+            .build();
+
+    Assert.assertFalse(
+        config.requiresApplyMappings(),
+        "ES7 preserves implicit-object form on round-trip — both sides should match");
+    Assert.assertFalse(config.requiresReindex());
+  }
+
+  @Test
+  void testEngineRoundTrip_OpenSearch_PreservesImplicitObject() {
+    // OpenSearch behaves like ES7 on object round-trips: implicit form preserved.
+    // The universal normalization should be a no-op (both sides already match).
+    ReindexConfig config =
+        ReindexConfig.builder()
+            .name(TEST_INDEX_NAME)
+            .exists(true)
+            .currentMappings(implicitObjectMapping())
+            .targetMappings(implicitObjectMapping())
+            .currentSettings(Settings.EMPTY)
+            .targetSettings(new HashMap<>())
+            .enableIndexMappingsReindex(true)
+            .build();
+
+    Assert.assertFalse(
+        config.requiresApplyMappings(),
+        "OpenSearch preserves implicit-object form on round-trip — both sides should match");
+    Assert.assertFalse(config.requiresReindex());
+  }
+
+  @Test
+  void testEngineRoundTrip_ES8_AddsExplicitTypeObject_ResolvedByNormalization() {
+    // ES8 round-trip: stored mapping gains "type":"object" automatically.
+    // Code still emits implicit-object form. Without the universal fix this would be a
+    // perpetual diff (the PFP-3594 loop). With the fix, normalization adds type:object to
+    // the implicit (target) side, making them equivalent.
+    ReindexConfig config =
+        ReindexConfig.builder()
+            .name(TEST_INDEX_NAME)
+            .exists(true)
+            .currentMappings(explicitObjectMapping()) // ES8-style stored shape
+            .targetMappings(implicitObjectMapping()) // code-emitted shape
+            .currentSettings(Settings.EMPTY)
+            .targetSettings(new HashMap<>())
+            .enableIndexMappingsReindex(true)
+            .build();
+
+    Assert.assertFalse(
+        config.requiresApplyMappings(),
+        "PFP-3594 fix: ES8 round-trip drift must NOT produce a synthetic mapping diff");
+    Assert.assertFalse(
+        config.requiresReindex(), "No real schema change — must not trigger reindex on ES8");
+  }
+
+  @Test
+  void testEngineRoundTrip_ES8_RealMappingChangeStillDetected() {
+    // Even with the ES8 round-trip drift in play, a real schema change underneath must still
+    // be detected. Here current (ES8 stored) has explicit type:object + one inner field, but
+    // target (code) has implicit + an additional inner field. The added field must surface.
+    Map<String, Object> currentEs8 = new HashMap<>();
+    Map<String, Object> currentPartitionSpec = new HashMap<>();
+    currentPartitionSpec.put(TYPE_KEY, "object");
+    currentPartitionSpec.put(
+        PROPERTIES_KEY, ImmutableMap.of("partition", ImmutableMap.of("type", "keyword")));
+    currentEs8.put(PROPERTIES_KEY, ImmutableMap.of("partitionSpec", currentPartitionSpec));
+
+    Map<String, Object> targetCode = new HashMap<>();
+    targetCode.put(
+        PROPERTIES_KEY,
+        ImmutableMap.of(
+            "partitionSpec",
+            ImmutableMap.of(
+                PROPERTIES_KEY,
+                ImmutableMap.of(
+                    "partition", ImmutableMap.of("type", "keyword"),
+                    "timePartition", ImmutableMap.of("type", "keyword") // new field
+                    ))));
+
+    ReindexConfig config =
+        ReindexConfig.builder()
+            .name(TEST_INDEX_NAME)
+            .exists(true)
+            .currentMappings(currentEs8)
+            .targetMappings(targetCode)
+            .currentSettings(Settings.EMPTY)
+            .targetSettings(new HashMap<>())
+            .enableIndexMappingsReindex(true)
+            .build();
+
+    Assert.assertTrue(
+        config.requiresApplyMappings(),
+        "Real schema change (new inner field) must still be detected on ES8 even when "
+            + "the type:object round-trip drift would otherwise mask it");
+  }
+
+  @Test
+  void testEngineRoundTrip_ES7_RealMappingChangeStillDetected() {
+    // Sanity check that the universal normalization does not inadvertently mask real changes
+    // on ES7/OpenSearch either.
+    Map<String, Object> currentEs7 = implicitObjectMapping();
+
+    Map<String, Object> targetCode = new HashMap<>();
+    targetCode.put(
+        PROPERTIES_KEY,
+        ImmutableMap.of(
+            "partitionSpec",
+            ImmutableMap.of(
+                PROPERTIES_KEY,
+                ImmutableMap.of(
+                    "partition", ImmutableMap.of("type", "keyword"),
+                    "timePartition", ImmutableMap.of("type", "keyword"),
+                    "extra", ImmutableMap.of("type", "long") // new field
+                    ))));
+
+    ReindexConfig config =
+        ReindexConfig.builder()
+            .name(TEST_INDEX_NAME)
+            .exists(true)
+            .currentMappings(currentEs7)
+            .targetMappings(targetCode)
+            .currentSettings(Settings.EMPTY)
+            .targetSettings(new HashMap<>())
+            .enableIndexMappingsReindex(true)
+            .build();
+
+    Assert.assertTrue(
+        config.requiresApplyMappings(),
+        "Real schema change must still be detected on ES7/OpenSearch — universal "
+            + "normalization is mathematically incapable of masking a content diff");
+  }
+
+  @Test
+  void testEngineRoundTrip_ES8_NestedTypeNotMisIdentified() {
+    // ES8 returns "type":"nested" for nested fields just as it was sent. The universal
+    // normalization must not misclassify a nested field as object even when both sides have
+    // properties.
+    Map<String, Object> nestedMapping = new HashMap<>();
+    nestedMapping.put(
+        PROPERTIES_KEY,
+        ImmutableMap.of(
+            "tags",
+            ImmutableMap.of(
+                TYPE_KEY,
+                "nested",
+                PROPERTIES_KEY,
+                ImmutableMap.of("name", ImmutableMap.of("type", "keyword")))));
+
+    ReindexConfig config =
+        ReindexConfig.builder()
+            .name(TEST_INDEX_NAME)
+            .exists(true)
+            .currentMappings(nestedMapping)
+            .targetMappings(nestedMapping)
+            .currentSettings(Settings.EMPTY)
+            .targetSettings(new HashMap<>())
+            .enableIndexMappingsReindex(true)
+            .build();
+
+    Assert.assertFalse(
+        config.requiresApplyMappings(),
+        "type:nested fields must remain nested through normalization — must not be auto-promoted to object");
+  }
+
+  @Test
   void testSettingsComparison() {
     // Arrange
     Settings currentSettings =

--- a/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateIndicesV2StrategyTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateIndicesV2StrategyTest.java
@@ -870,7 +870,8 @@ public class UpdateIndicesV2StrategyTest {
             "MD5",
             null,
             mock(IndexConvention.class),
-            false);
+            false,
+            null);
 
     AspectSpec ownershipSpec = mock(AspectSpec.class);
     when(ownershipSpec.getName()).thenReturn("ownership");

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entity/update/indices/UpdateIndicesStrategyFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entity/update/indices/UpdateIndicesStrategyFactory.java
@@ -12,6 +12,7 @@ import com.linkedin.metadata.service.UpdateIndicesV2Strategy;
 import com.linkedin.metadata.service.UpdateIndicesV3Strategy;
 import com.linkedin.metadata.timeseries.TimeseriesAspectService;
 import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
+import com.linkedin.metadata.utils.elasticsearch.SearchClientShim;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -35,6 +36,7 @@ public class UpdateIndicesStrategyFactory {
       TimeseriesAspectService timeseriesAspectService,
       ConfigurationProvider configProvider,
       @Qualifier(IndexConventionFactory.INDEX_CONVENTION_BEAN) IndexConvention indexConvention,
+      @Qualifier("searchClientShim") SearchClientShim<?> searchClient,
       @Value("${elasticsearch.idHashAlgo}") String idHashAlgo,
       @Value("${elasticsearch.entityIndex.v2.cleanup:false}") boolean v2Cleanup,
       @Value("${elasticsearch.entityIndex.v2.coalesceBatchUpdates:true}")
@@ -73,7 +75,8 @@ public class UpdateIndicesStrategyFactory {
         idHashAlgo,
         semanticSearchConfig,
         indexConvention,
-        coalesceBatchUpdates);
+        coalesceBatchUpdates,
+        searchClient.getEngineType());
   }
 
   @Bean("updateIndicesV3Strategy")

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/search/MappingsBuilderFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/search/MappingsBuilderFactory.java
@@ -30,10 +30,12 @@ public class MappingsBuilderFactory {
   @Bean("legacyMappingsBuilder")
   @ConditionalOnProperty(name = "elasticsearch.entityIndex.v2.enabled", havingValue = "true")
   @Nonnull
-  protected MappingsBuilder createLegacyMappingsBuilder(ConfigurationProvider configProvider) {
+  protected MappingsBuilder createLegacyMappingsBuilder(
+      ConfigurationProvider configProvider,
+      @Qualifier("searchClientShim") SearchClientShim<?> searchClient) {
     EntityIndexConfiguration entityIndexConfig = configProvider.getElasticSearch().getEntityIndex();
-    log.info("Creating LegacyMappingsBuilder bean");
-    return new V2MappingsBuilder(entityIndexConfig);
+    log.info("Creating LegacyMappingsBuilder bean (engineType={})", searchClient.getEngineType());
+    return new V2MappingsBuilder(entityIndexConfig, searchClient.getEngineType());
   }
 
   @Bean("multiEntityMappingsBuilder")

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/search/DisabledCustomSearchTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/search/DisabledCustomSearchTest.java
@@ -9,6 +9,7 @@ import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.search.elasticsearch.ElasticSearchService;
 import com.linkedin.metadata.search.elasticsearch.index.SettingsBuilder;
 import com.linkedin.metadata.search.elasticsearch.query.filter.QueryFilterRewriteChain;
+import com.linkedin.metadata.utils.elasticsearch.SearchClientShim;
 import com.linkedin.metadata.utils.metrics.MetricUtils;
 import io.datahubproject.metadata.context.ObjectMapperContext;
 import io.datahubproject.metadata.context.OperationContext;
@@ -69,6 +70,16 @@ public class DisabledCustomSearchTest extends AbstractTestNGSpringContextTests {
         @Qualifier("systemOperationContext") OperationContext systemOperationContext) {
       return systemOperationContext.getEntityRegistry();
     }
+  }
+
+  @Bean(name = "searchClientShim")
+  @Primary
+  @SuppressWarnings("unchecked")
+  public SearchClientShim<?> searchClientShim() {
+    SearchClientShim<?> mock = Mockito.mock(SearchClientShim.class);
+    Mockito.when(mock.getEngineType())
+        .thenReturn(SearchClientShim.SearchEngineType.ELASTICSEARCH_8);
+    return mock;
   }
 
   @Autowired


### PR DESCRIPTION
… (PFP-3594)

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->


On ES8, the mapping diff comparator` (ReindexConfig.java:238–246) `continuously flagged for reindexing during every system update cycle.

Logs showed entriesDiffering for the source, destination, and properties fields:

```
left (ES stored): {properties: {...}, type=object} // includes explicit type
right (DataHub code): {properties: {...}} // missing type
```

Elasticsearch 8 returns mappings with an explicit type: **object** for object fields.
However, DataHub’s GraphRelationshipMappingsBuilder previously omitted this, relying on **Elasticsearch’s implicit** default.

This mismatch caused the mapping comparison to **fail on every round trip**, triggering a reindex on each cycle without ever converging.

  **Summary**

  - ES8+ silently strips doc_values: false from search_as_you_type fields on round-trip, while ES7/OpenSearch persist it. This caused V2MappingsBuilder to emit a config that never matched what the cluster
  returned — every diff flagged a change and triggered a fresh reindex on every restart.
  - V2MappingsBuilder now selects the partial-ngram config based on SearchEngineType: ES8+ omits doc_values: false; legacy engines keep it. engineType is plumbed through MappingsBuilderFactory,
  UpdateIndicesStrategyFactory, and UpdateIndicesV2Strategy.
  - ReindexConfig.normalizeObjectForComparison now injects the implicit type: "object" ES adds for any node containing properties, eliminating another spurious-diff source that fed the same loop.

  **Changes**

  - `V2MappingsBuilder.java` — engine-aware PARTIAL_NGRAM_CONFIG_LEGACY vs PARTIAL_NGRAM_CONFIG_ES8; static methods → instance methods.
  - `ReindexConfig.java `— add implicit type: object during normalization when properties is present without type.
  - `UpdateIndicesV2Strategy.java`, UpdateIndicesStrategyFactory.java, MappingsBuilderFactory.java — propagate SearchEngineType to the mappings builder.
  - Tests added/updated in V2MappingsBuilderTest, ReindexConfigTest, UpdateIndicesV2StrategyTest, UpdateIndicesHookTest, UpdateIndicesServiceTest, DisabledCustomSearchTest.