### PR TITLE
feat(ingest/sigma): qualify chart inputFields with workbook-lineage warehouse tables

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
@@ -205,6 +205,30 @@ class SigmaSourceReport(StaleEntityRemovalSourceReport):
     # for those workbooks may be missing columns that appear after the failure.
     column_formulas_fetch_partial: int = 0
 
+    # Workbook-lineage warehouse table index for chart formula resolution.
+    # A chart's inputFields[].schemaFieldUrn was resolved against a warehouse
+    # table entry in the merged (per-element + per-workbook) index. Sub-category
+    # of chart_input_fields_resolved.
+    chart_input_fields_warehouse_qualified: int = 0
+    # Resolved specifically by an entry from the workbook-level index (not the
+    # per-element SQL-parser index) — quantifies the added coverage beyond what
+    # the SQL parser resolves per element.
+    chart_input_fields_warehouse_qualified_via_workbook_index: int = 0
+    # /v2/workbooks/{id}/lineage returned None (5xx / network error). 404 is
+    # handled silently (workbook deleted since listing).
+    chart_input_fields_warehouse_index_lookup_failed: int = 0
+    # /v2/files/{inodeId} returned None for a workbook-lineage type=table inode.
+    # Only incremented on first failure per inode — the /files cache is shared
+    # with the DM element path.
+    chart_input_fields_warehouse_table_lookup_failed: int = 0
+    # /files path didn't parse as Connection Root/<DB>/<SCHEMA>.
+    # Only incremented on first occurrence per inode — _files_path_unparseable_seen
+    # is shared with the DM element path.
+    chart_input_fields_warehouse_path_unparseable: int = 0
+    # connectionId not in registry, or is_mappable=False, for a workbook-lineage
+    # type=table entry.
+    chart_input_fields_warehouse_unknown_connection: int = 0
+
     # DM element emission / upstream resolution.
     data_model_elements_emitted: int = 0
     data_model_element_intra_upstreams: int = 0

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/data_classes.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/data_classes.py
@@ -272,6 +272,15 @@ class SigmaDataModelElement(BaseModel):
         return values
 
 
+class WorkbookLineageTableEntry(BaseModel):
+    """A ``type=table`` entry from ``/v2/workbooks/{id}/lineage``."""
+
+    type: Literal["table"]
+    name: str
+    connectionId: str
+    inodeId: str
+
+
 class CustomSqlEntry(BaseModel):
     """Shape of a ``customSQL`` entry from ``/v2/dataModels/{id}/lineage``."""
 

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, List, Literal, Optional, Set, Tuple
+from typing import Any, Dict, FrozenSet, Iterable, List, Literal, Optional, Set, Tuple
 
 import datahub.emitter.mce_builder as builder
 from datahub.configuration.common import ConfigurationError
@@ -2296,6 +2296,152 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                     logger.debug("Skipping invalid dataset URN %r: %s", urn, e)
         return index
 
+    def _build_workbook_warehouse_table_index(
+        self, workbook: Workbook
+    ) -> Dict[str, List[str]]:
+        """Build {uppercase_table_name: [warehouse_dataset_urn, ...]} for one
+        workbook from /v2/workbooks/{id}/lineage type=table entries.
+
+        Same key shape as _build_element_warehouse_table_index: uppercase short
+        table name → list of warehouse Dataset URNs.  Merged with the per-element
+        index in _gen_elements_workunit before passing to _resolve_chart_formula_upstream.
+
+        Reuses _files_cache, _files_path_unparseable_seen, and
+        _resolve_dm_element_warehouse_upstream verbatim — URN identity with the
+        DM element warehouse upstream path is guaranteed because the same
+        construction path is used.
+        """
+        result: Dict[str, List[str]] = {}
+        entries = self.sigma_api.get_workbook_lineage(workbook.workbookId)
+        if entries is None:
+            self.reporter.chart_input_fields_warehouse_index_lookup_failed += 1
+            return result
+
+        # Build a transient urlId → _WarehouseTableRef map from type=table entries,
+        # then resolve each to a Dataset URN via _resolve_dm_element_warehouse_upstream
+        # so the URN is byte-equal to the entity-level warehouse Dataset URN for the
+        # same table.
+        transient_map: Dict[str, _WarehouseTableRef] = {}
+        url_id_to_table_name: Dict[str, str] = {}
+
+        for entry in entries:
+            entry_type = entry.get("type", "")
+            if entry_type != "table":
+                logger.debug(
+                    "Workbook %s: skipping workbook-lineage entry with type %r.",
+                    workbook.workbookId,
+                    entry_type,
+                )
+                continue
+
+            inode_id = entry.get("inodeId") or ""
+            conn_id = entry.get("connectionId") or ""
+            if not inode_id or not conn_id:
+                self.reporter.warning(
+                    title="Sigma workbook lineage type=table entry missing inodeId or connectionId",
+                    message="Warehouse table index entry skipped; entry may be malformed.",
+                    context=f"workbook={workbook.workbookId}, entry={entry}",
+                )
+                continue
+
+            first_attempt = inode_id not in self._files_cache
+            files_data = self._get_file_metadata_cached(inode_id)
+            if files_data is None:
+                if first_attempt:
+                    self.reporter.chart_input_fields_warehouse_table_lookup_failed += 1
+                logger.debug(
+                    "Workbook %s: /files lookup failed for inode %r; skipping.",
+                    workbook.workbookId,
+                    inode_id,
+                )
+                continue
+
+            url_id = str(files_data.get("urlId") or "")
+            path = str(files_data.get("path") or "")
+            table_name = str(files_data.get("name") or "")
+            parts = path.split("/")
+            path_invalid = (
+                not url_id or not table_name or len(parts) != 3 or not all(parts)
+            )
+            root_unexpected = (not path_invalid) and parts[0] != _FILES_PATH_ROOT
+            if path_invalid or root_unexpected:
+                if inode_id not in self._files_path_unparseable_seen:
+                    self._files_path_unparseable_seen.add(inode_id)
+                    self.reporter.chart_input_fields_warehouse_path_unparseable += 1
+                    self.reporter.warning(
+                        title=(
+                            "Sigma workbook lineage path has unexpected root segment"
+                            if root_unexpected
+                            else "Sigma workbook lineage /files path unparseable"
+                        ),
+                        message=(
+                            "Expected exactly 'Connection Root/<DB>/<SCHEMA>' with "
+                            "no empty segments and a non-empty urlId. "
+                            "Warehouse table index entry skipped for this inode."
+                        ),
+                        context=(
+                            f"workbook={workbook.workbookId}, inode={inode_id}, "
+                            f"path={path!r}, url_id={url_id!r}, "
+                            f"table_name={table_name!r}"
+                        ),
+                    )
+                continue
+
+            if url_id in transient_map:
+                logger.warning(
+                    "Workbook %s: two type=table lineage entries share the same "
+                    "urlId %r; the earlier entry will be overwritten.",
+                    workbook.workbookId,
+                    url_id,
+                )
+            transient_map[url_id] = _WarehouseTableRef(
+                connection_id=conn_id,
+                db=parts[1],
+                schema=parts[2],
+                table=table_name,
+            )
+            url_id_to_table_name[url_id] = table_name
+
+        for url_id in transient_map:
+            table_name = url_id_to_table_name[url_id]
+            urn = self._resolve_dm_element_warehouse_upstream(
+                url_id_suffix=url_id,
+                warehouse_map=transient_map,
+            )
+            if urn is None:
+                self.reporter.chart_input_fields_warehouse_unknown_connection += 1
+                logger.debug(
+                    "Workbook %s: could not resolve warehouse URN for table %r "
+                    "(connection not in registry or is_mappable=False).",
+                    workbook.workbookId,
+                    table_name,
+                )
+                continue
+            result.setdefault(table_name.upper(), []).append(urn)
+
+        return result
+
+    @staticmethod
+    def _merge_warehouse_table_indices(
+        primary: Dict[str, List[str]],
+        supplementary: Dict[str, List[str]],
+    ) -> Dict[str, List[str]]:
+        """Merge two short-name → URN-list indices.
+
+        Per-element entries (primary) take precedence on key conflict — the SQL
+        parser attributes warehouse tables specifically to the chart's own data
+        path; workbook-level entries are broader and may include tables the
+        chart doesn't actually use.
+
+        Conflict resolution: if both indices have key K, primary's URN list wins
+        entirely (do NOT concat — could fabricate cross-table joins).
+        """
+        result = dict(primary)
+        for key, urns in supplementary.items():
+            if key not in result:
+                result[key] = urns
+        return result
+
     def _resolve_chart_formula_upstream(
         self,
         ref: BracketRef,
@@ -2552,6 +2698,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         wb_element_index: Dict[str, List[Element]],
         element_warehouse_table_index: Dict[str, List[str]],
         elementId_to_chart_urn: Dict[str, str],
+        wb_only_warehouse_keys: FrozenSet[str] = frozenset(),
     ) -> List[InputFieldClass]:
         """Emit exactly one InputField per chart column.
 
@@ -2562,11 +2709,17 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         Counter invariant per element:
           resolved + self_ref_fallback + skipped_parameter + skipped_sibling
           == len(element.columns)
+
+        wb_only_warehouse_keys: uppercase table names that are present only in
+          the workbook-level index (not in the per-element SQL-parser index).
+          Used to sub-categorise chart_input_fields_warehouse_qualified into
+          chart_input_fields_warehouse_qualified_via_workbook_index.
         """
         fields: List[InputFieldClass] = []
         for column in element.columns:
             formula = element.column_formulas.get(column)
             resolved: Optional[Tuple[str, str]] = None
+            resolving_ref = None
             all_param = False
             all_sibling = False
 
@@ -2592,6 +2745,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                             elementId_to_chart_urn=elementId_to_chart_urn,
                         )
                         if resolved is not None:
+                            resolving_ref = ref
                             break
                     if resolved is None and refs:
                         total = len(refs)
@@ -2606,6 +2760,20 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                     upstream_urn, upstream_field
                 )
                 self.reporter.chart_input_fields_resolved += 1
+                # Sub-category: resolved via warehouse-table short-name index (Step 4).
+                # The resolver (Step 4) returns None for ambiguous (>1 candidate) keys,
+                # so upstream_urn in wh_candidates implies a single-candidate match in
+                # practice, but the membership check is the semantically correct predicate.
+                # resolving_ref is always set when resolved is set (see loop above),
+                # but guard explicitly so -O optimisation doesn't hide the invariant.
+                if resolving_ref is not None:
+                    wh_candidates = element_warehouse_table_index.get(
+                        resolving_ref.source.upper(), []
+                    )
+                    if upstream_urn in wh_candidates:
+                        self.reporter.chart_input_fields_warehouse_qualified += 1
+                        if resolving_ref.source.upper() in wb_only_warehouse_keys:
+                            self.reporter.chart_input_fields_warehouse_qualified_via_workbook_index += 1
             elif all_param:
                 schema_field_urn = builder.make_schema_field_urn(chart_urn, column)
                 self.reporter.chart_input_fields_skipped_parameter += 1
@@ -2636,6 +2804,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         paths: List[str],
         elementId_to_chart_urn: Dict[str, str],
         wb_element_index: Dict[str, List[Element]],
+        wb_warehouse_table_index: Dict[str, List[str]],
     ) -> Iterable[MetadataWorkUnit]:
         """
         Map Sigma page element to Datahub Chart
@@ -2728,6 +2897,18 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             element_warehouse_table_index = self._build_element_warehouse_table_index(
                 dataset_inputs
             )
+            # Merge per-element (SQL-parser) index with per-workbook index.
+            # Per-element entries take precedence on key conflict — the SQL parser
+            # attributes tables specifically to this chart's own data path.
+            merged_warehouse_table_index = self._merge_warehouse_table_indices(
+                element_warehouse_table_index,
+                wb_warehouse_table_index,
+            )
+            wb_only_warehouse_keys: FrozenSet[str] = frozenset(
+                k
+                for k in wb_warehouse_table_index
+                if k not in element_warehouse_table_index
+            )
 
             element_input_fields = self._build_element_input_fields(
                 element=element,
@@ -2735,8 +2916,9 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                 chart_upstream_eids=chart_upstream_eids,
                 dm_upstream_urn_by_element_name=dm_upstream_urn_by_element_name,
                 wb_element_index=wb_element_index,
-                element_warehouse_table_index=element_warehouse_table_index,
+                element_warehouse_table_index=merged_warehouse_table_index,
                 elementId_to_chart_urn=elementId_to_chart_urn,
+                wb_only_warehouse_keys=wb_only_warehouse_keys,
             )
 
             yield MetadataChangeProposalWrapper(
@@ -2766,6 +2948,17 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             for element in page.elements
         }
         wb_element_index = self._build_workbook_element_index(workbook)
+        # Build the workbook-level warehouse-table index once per workbook.
+        # Gated on extract_lineage + workbook_lineage_pattern to match the
+        # analogous gates for formula fetch and element upstream resolution.
+        if self.config.extract_lineage and self.config.workbook_lineage_pattern.allowed(
+            workbook.name
+        ):
+            wb_warehouse_table_index = self._build_workbook_warehouse_table_index(
+                workbook
+            )
+        else:
+            wb_warehouse_table_index = {}
 
         for page in workbook.pages:
             dashboard_urn = self._gen_dashboard_urn(page.get_urn_part())
@@ -2797,6 +2990,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                 paths,
                 elementId_to_chart_urn,
                 wb_element_index,
+                wb_warehouse_table_index,
             )
 
             yield MetadataChangeProposalWrapper(

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -2325,24 +2325,8 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         url_id_to_table_name: Dict[str, str] = {}
 
         for entry in entries:
-            entry_type = entry.get("type", "")
-            if entry_type != "table":
-                logger.debug(
-                    "Workbook %s: skipping workbook-lineage entry with type %r.",
-                    workbook.workbookId,
-                    entry_type,
-                )
-                continue
-
-            inode_id = entry.get("inodeId") or ""
-            conn_id = entry.get("connectionId") or ""
-            if not inode_id or not conn_id:
-                self.reporter.warning(
-                    title="Sigma workbook lineage type=table entry missing inodeId or connectionId",
-                    message="Warehouse table index entry skipped; entry may be malformed.",
-                    context=f"workbook={workbook.workbookId}, entry={entry}",
-                )
-                continue
+            inode_id = entry.inodeId
+            conn_id = entry.connectionId
 
             first_attempt = inode_id not in self._files_cache
             files_data = self._get_file_metadata_cached(inode_id)

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
@@ -42,6 +42,7 @@ from datahub.ingestion.source.sigma.data_classes import (
     SigmaDataset,
     WarehouseInodeRaw,
     Workbook,
+    WorkbookLineageTableEntry,
     Workspace,
 )
 
@@ -1202,15 +1203,15 @@ class SigmaAPI:
             )
             return None
 
-    def get_workbook_lineage(self, workbook_id: str) -> Optional[List[Dict[str, Any]]]:
-        """Fetch /v2/workbooks/{workbook_id}/lineage and return the entries list,
-        or None on non-200/exception.
+    def get_workbook_lineage(
+        self, workbook_id: str
+    ) -> Optional[List[WorkbookLineageTableEntry]]:
+        """Fetch /v2/workbooks/{workbook_id}/lineage and return parsed type=table
+        entries, or None on non-200/exception.
 
-        Returned entries each have at minimum ``type``, ``name``,
-        ``connectionId``, ``inodeId`` for table/dataset/customSQL entries.
-        Element entries do not have ``connectionId`` or ``inodeId`` and are
-        filtered out by the caller (only type=table entries are consumed;
-        type=dataset/customSQL/element are explicitly skipped).
+        Non-table entries (type=dataset/customSQL/element) are silently skipped.
+        Table entries missing required fields emit a structured warning and are
+        skipped; they do not cause the whole call to fail.
 
         Error handling: 404 is treated as a silent None (workbook deleted
         since listing). 429 and other non-200 statuses emit a structured
@@ -1222,14 +1223,35 @@ class SigmaAPI:
         base_url = (
             f"{self.config.api_url}/workbooks/{quote(workbook_id, safe='')}/lineage"
         )
-        all_entries: List[Dict[str, Any]] = []
+        all_entries: List[WorkbookLineageTableEntry] = []
         url = base_url
         try:
             while True:
                 response = self._get_api_call(url)
                 if response.status_code == 200:
                     data = response.json()
-                    all_entries.extend(data.get("entries") or [])
+                    for raw in data.get("entries") or []:
+                        if raw.get("type") != "table":
+                            logger.debug(
+                                "Workbook %s: skipping lineage entry with type %r.",
+                                workbook_id,
+                                raw.get("type"),
+                            )
+                            continue
+                        try:
+                            all_entries.append(
+                                WorkbookLineageTableEntry.model_validate(raw)
+                            )
+                        except ValidationError:
+                            self.report.warning(
+                                title="Sigma workbook lineage type=table entry missing required fields",
+                                message=(
+                                    "A type=table lineage entry is missing one or more "
+                                    "required fields (name, connectionId, inodeId). "
+                                    "Warehouse table index entry skipped."
+                                ),
+                                context=f"workbook_id={workbook_id}, entry={raw}",
+                            )
                     next_page = data.get("nextPage")
                     if not next_page:
                         return all_entries

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
@@ -1202,6 +1202,78 @@ class SigmaAPI:
             )
             return None
 
+    def get_workbook_lineage(self, workbook_id: str) -> Optional[List[Dict[str, Any]]]:
+        """Fetch /v2/workbooks/{workbook_id}/lineage and return the entries list,
+        or None on non-200/exception.
+
+        Returned entries each have at minimum ``type``, ``name``,
+        ``connectionId``, ``inodeId`` for table/dataset/customSQL entries.
+        Element entries do not have ``connectionId`` or ``inodeId`` and are
+        filtered out by the caller (only type=table entries are consumed;
+        type=dataset/customSQL/element are explicitly skipped).
+
+        Error handling: 404 is treated as a silent None (workbook deleted
+        since listing). 429 and other non-200 statuses emit a structured
+        warning; failures return None so the caller can increment
+        chart_input_fields_warehouse_index_lookup_failed. Paginated to
+        handle workbooks with large lineage graphs.
+        """
+        logger.debug("Fetching workbook lineage for workbook '%s'.", workbook_id)
+        base_url = (
+            f"{self.config.api_url}/workbooks/{quote(workbook_id, safe='')}/lineage"
+        )
+        all_entries: List[Dict[str, Any]] = []
+        url = base_url
+        try:
+            while True:
+                response = self._get_api_call(url)
+                if response.status_code == 200:
+                    data = response.json()
+                    all_entries.extend(data.get("entries") or [])
+                    next_page = data.get("nextPage")
+                    if not next_page:
+                        return all_entries
+                    sep = "&" if "?" in base_url else "?"
+                    url = f"{base_url}{sep}page={next_page}"
+                    continue
+                status = response.status_code
+                if status == 404:
+                    # Workbook may have been deleted between listing and lineage fetch.
+                    return None
+                if status == 429:
+                    self.report.warning(
+                        title="Sigma API rate-limited on /workbooks/{id}/lineage",
+                        message=(
+                            "Retry budget exhausted on a 429 response for workbook "
+                            "lineage lookup. Chart formula warehouse resolution will "
+                            "be incomplete for this workbook. Re-run the ingestion "
+                            "to recover."
+                        ),
+                        context=f"workbook_id={workbook_id}, http_status={status}",
+                    )
+                else:
+                    self.report.warning(
+                        title="Sigma /workbooks/{id}/lineage returned non-200",
+                        message=(
+                            "Unable to fetch workbook lineage for warehouse table "
+                            "index. Chart formula warehouse resolution may be "
+                            "incomplete."
+                        ),
+                        context=f"workbook_id={workbook_id}, http_status={status}",
+                    )
+                return None
+        except Exception as e:
+            self.report.warning(
+                title="Sigma /workbooks/{id}/lineage lookup failed",
+                message=(
+                    "Exception while fetching workbook lineage; warehouse table "
+                    "index skipped for this workbook."
+                ),
+                context=f"workbook_id={workbook_id}",
+                exc=e,
+            )
+            return None
+
     def get_data_model_by_url_id(self, url_id: str) -> Optional[SigmaDataModel]:
         """Fetch a DM by its urlId (not UUID). Used to resolve personal-space
         or otherwise unlisted DMs referenced from another DM's /lineage.

--- a/metadata-ingestion/tests/integration/sigma/golden_test_sigma_chart_warehouse_qualified.json
+++ b/metadata-ingestion/tests/integration/sigma/golden_test_sigma_chart_warehouse_qualified.json
@@ -1,0 +1,541 @@
+[
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,c4c4c4c4-0000-0000-0000-000000000001)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778093627321,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,c4c4c4c4-0000-0000-0000-000000000001)",
+    "changeType": "UPSERT",
+    "aspectName": "dashboardInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "path": "My Org",
+                "latestVersion": "1"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/my-org/workbook/ChartWh-WB-URL-ID",
+            "title": "Chart Warehouse Workbook",
+            "description": "",
+            "charts": [],
+            "datasets": [],
+            "dashboards": [
+                {
+                    "sourceUrn": "urn:li:dashboard:(sigma,c4c4c4c4-0000-0000-0000-000000000001)",
+                    "destinationUrn": "urn:li:dashboard:(sigma,chart-wh-page-01)"
+                }
+            ],
+            "lastModified": {
+                "created": {
+                    "time": 1778025600000,
+                    "actor": "urn:li:corpuser:datahub"
+                },
+                "lastModified": {
+                    "time": 1778025600000,
+                    "actor": "urn:li:corpuser:datahub"
+                }
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778101862169,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,c4c4c4c4-0000-0000-0000-000000000001)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Sigma Workbook"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778093627322,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,c4c4c4c4-0000-0000-0000-000000000001)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778093627322,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,c4c4c4c4-0000-0000-0000-000000000001)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "Chart Warehouse Workbook"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778101862169,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,chart-wh-page-01)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778101862170,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,dmFedElem01)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778093627323,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,chart-wh-page-01)",
+    "changeType": "UPSERT",
+    "aspectName": "dashboardInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "ElementsCount": "2"
+            },
+            "title": "Chart Warehouse Page",
+            "description": "",
+            "charts": [
+                "urn:li:chart:(sigma,dmFedElem01)",
+                "urn:li:chart:(sigma,legacySdElem01)"
+            ],
+            "datasets": [],
+            "dashboards": [],
+            "lastModified": {
+                "created": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778101862170,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,dmFedElem01)",
+    "changeType": "UPSERT",
+    "aspectName": "chartInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "VizualizationType": "levelTable",
+                "type": "table"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/my-org/workbook/ChartWh-WB-URL-ID?:nodeId=dmFedElem01&:fullScreen=true",
+            "title": "DM-fed Element",
+            "description": "",
+            "lastModified": {
+                "created": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            },
+            "inputs": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778101862171,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,chart-wh-page-01)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "Chart Warehouse Workbook"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778101862170,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,dmFedElem01)",
+    "changeType": "UPSERT",
+    "aspectName": "inputFields",
+    "aspect": {
+        "json": {
+            "fields": [
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,warehouse_coffee_company.public.customers,PROD),customer_id)",
+                    "schemaField": {
+                        "fieldPath": "customer_id",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778093627324,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,dmFedElem01)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "Chart Warehouse Workbook"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778101862171,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,legacySdElem01)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778093627324,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,legacySdElem01)",
+    "changeType": "UPSERT",
+    "aspectName": "chartInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "VizualizationType": "levelTable",
+                "type": "table"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/my-org/workbook/ChartWh-WB-URL-ID?:nodeId=legacySdElem01&:fullScreen=true",
+            "title": "Legacy SD Element",
+            "description": "",
+            "lastModified": {
+                "created": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            },
+            "inputs": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778101862172,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,legacySdElem01)",
+    "changeType": "UPSERT",
+    "aspectName": "inputFields",
+    "aspect": {
+        "json": {
+            "fields": [
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,legacySdElem01),legacy_col)",
+                    "schemaField": {
+                        "fieldPath": "legacy_col",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778104952290,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,legacySdElem01)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "Chart Warehouse Workbook"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778101862172,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+    "changeType": "UPSERT",
+    "aspectName": "containerProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "platform": "sigma",
+                "workspaceId": "3ee61405-3be2-4000-ba72-60d36757b95b"
+            },
+            "name": "My Org",
+            "created": {
+                "time": 1778025600000
+            },
+            "lastModified": {
+                "time": 1778025600000
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778121962201,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778093627326,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:sigma"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778093627326,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,chart-wh-page-01)",
+    "changeType": "UPSERT",
+    "aspectName": "inputFields",
+    "aspect": {
+        "json": {
+            "fields": [
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,warehouse_coffee_company.public.customers,PROD),customer_id)",
+                    "schemaField": {
+                        "fieldPath": "customer_id",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,legacySdElem01),legacy_col)",
+                    "schemaField": {
+                        "fieldPath": "legacy_col",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778104952290,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Sigma Workspace"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778093627326,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778093627326,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+}
+]

--- a/metadata-ingestion/tests/integration/sigma/test_sigma.py
+++ b/metadata-ingestion/tests/integration/sigma/test_sigma.py
@@ -422,6 +422,18 @@ def register_mock_api(request_mock: Any, override_data: Optional[dict] = None) -
         },
     }
 
+    # Default workbook lineage — returns empty entries so
+    # _build_workbook_warehouse_table_index produces an empty index and existing
+    # tests are unaffected. Tests that exercise warehouse-qualified chart
+    # InputFields override this via override_data.
+    api_vs_response[
+        "https://aws-api.sigmacomputing.com/v2/workbooks/9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b/lineage"
+    ] = {
+        "method": "GET",
+        "status_code": 200,
+        "json": {"entries": []},
+    }
+
     # Default empty columns response — tests that don't exercise formula resolution
     # override this; tests that do add their own entry via override_data.
     api_vs_response[
@@ -6764,4 +6776,371 @@ def test_sigma_ingest_data_models_customsql(pytestconfig, tmp_path, requests_moc
         pytestconfig,
         output_path=output_path,
         golden_path=f"{test_resources_dir}/golden_test_sigma_ingest_data_models_customsql.json",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Chart inputFields warehouse-qualified via workbook lineage
+# ---------------------------------------------------------------------------
+
+# Reuse the same warehouse fixture IDs from the warehouse upstream test so the
+# URN identity invariant is exercisable: same inode → same Dataset URN from
+# both the DM element path and the workbook-lineage path.
+_WH_CHART_WORKBOOK_ID = "c4c4c4c4-0000-0000-0000-000000000001"
+_WH_CHART_PAGE_ID = "chart-wh-page-01"
+_WH_CHART_DM_FED_ELEM_ID = "dmFedElem01"
+_WH_CHART_LEGACY_SD_ELEM_ID = "legacySdElem01"
+
+
+def _get_chart_warehouse_qualified_overrides() -> Dict[str, Dict]:
+    """Fixture overrides for the chart warehouse-qualified InputFields test.
+
+    Topology:
+      Workbook _WH_CHART_WORKBOOK_ID / page _WH_CHART_PAGE_ID
+        dmFedElem01 : column "customer_id" formula "[CUSTOMERS/customer_id]"
+                      DM-fed (no SQL query) — resolved via workbook lineage
+        legacySdElem01: column "legacy_col" formula "[LEGACY_DATASET/legacy_col]"
+                      legacy SD lineage entry (type=dataset) — skipped, self-ref
+
+      Workbook lineage /v2/workbooks/{id}/lineage:
+        type=table  CUSTOMERS   → same inode/connection as warehouse upstream test
+        type=dataset LEGACY_DATASET       → skipped (legacy Sigma Dataset, not yet supported)
+        type=customSQL CUSTOM   → skipped (not yet supported)
+
+      /files/{_WH_INODE_ID} → Connection Root/WAREHOUSE_COFFEE_COMPANY/PUBLIC (CUSTOMERS)
+
+      Expected:
+        dmFedElem01.customer_id  → schemaFieldUrn points at snowflake warehouse schemaField
+        legacySdElem01.legacy_col  → self-ref (LEGACY_DATASET lineage entry is type=dataset, skipped)
+    """
+    return {
+        "https://aws-api.sigmacomputing.com/v2/workspaces?limit=50": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "entries": [
+                    {
+                        "workspaceId": _WH_WORKSPACE_ID,
+                        "name": "My Org",
+                        "createdBy": "owner-wh-chart",
+                        "updatedBy": "owner-wh-chart",
+                        "createdAt": "2026-05-06T00:00:00.000Z",
+                        "updatedAt": "2026-05-06T00:00:00.000Z",
+                    }
+                ],
+                "total": 1,
+                "nextPage": None,
+            },
+        },
+        "https://aws-api.sigmacomputing.com/v2/files?typeFilters=dataset": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {"entries": [], "total": 0, "nextPage": None},
+        },
+        # Provide the same connection as the warehouse upstream test (URN identity).
+        "https://aws-api.sigmacomputing.com/v2/connections": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "entries": [
+                    {
+                        "connectionId": _WH_CONN_ID,
+                        "name": "ACME SNOWFLAKE",
+                        "type": "snowflake",
+                        "account": "test-account",
+                        "host": "test-account.snowflakecomputing.com",
+                        "warehouse": "COMPUTE_WH",
+                    }
+                ],
+                "total": 1,
+                "nextPage": None,
+            },
+        },
+        # Workbook listing (no DMs in this test)
+        "https://aws-api.sigmacomputing.com/v2/files?typeFilters=data-model": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {"entries": [], "total": 0, "nextPage": None},
+        },
+        "https://aws-api.sigmacomputing.com/v2/dataModels": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {"entries": [], "total": 0, "nextPage": None},
+        },
+        "https://aws-api.sigmacomputing.com/v2/workbooks": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "entries": [
+                    {
+                        "workbookId": _WH_CHART_WORKBOOK_ID,
+                        "workbookUrlId": "ChartWh-WB-URL-ID",
+                        "ownerId": "owner-wh-chart",
+                        "createdBy": "owner-wh-chart",
+                        "updatedBy": "owner-wh-chart",
+                        "createdAt": "2026-05-06T00:00:00.000Z",
+                        "updatedAt": "2026-05-06T00:00:00.000Z",
+                        "name": "Chart Warehouse Workbook",
+                        "url": "https://app.sigmacomputing.com/my-org/workbook/ChartWh-WB-URL-ID",
+                        "path": "My Org",
+                        "latestVersion": 1,
+                        "isArchived": False,
+                        "workspaceId": _WH_WORKSPACE_ID,
+                    }
+                ],
+                "total": 1,
+                "nextPage": None,
+            },
+        },
+        "https://aws-api.sigmacomputing.com/v2/files?typeFilters=workbook": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "entries": [
+                    {
+                        "id": _WH_CHART_WORKBOOK_ID,
+                        "urlId": "ChartWh-WB-URL-ID",
+                        "name": "Chart Warehouse Workbook",
+                        "type": "workbook",
+                        "parentId": _WH_WORKSPACE_ID,
+                        "parentUrlId": "1UGFyEQCHqwPfQoAec3xJ9",
+                        "permission": "edit",
+                        "path": "My Org",
+                        "badge": None,
+                        "isArchived": False,
+                    }
+                ],
+                "total": 1,
+                "nextPage": None,
+            },
+        },
+        f"https://aws-api.sigmacomputing.com/v2/workbooks/{_WH_CHART_WORKBOOK_ID}/pages": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "entries": [
+                    {"pageId": _WH_CHART_PAGE_ID, "name": "Chart Warehouse Page"}
+                ],
+                "total": 1,
+                "nextPage": None,
+            },
+        },
+        f"https://aws-api.sigmacomputing.com/v2/workbooks/{_WH_CHART_WORKBOOK_ID}/pages/{_WH_CHART_PAGE_ID}/elements": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "entries": [
+                    {
+                        "elementId": _WH_CHART_DM_FED_ELEM_ID,
+                        "type": "table",
+                        "name": "DM-fed Element",
+                        "columns": ["customer_id"],
+                        "vizualizationType": "levelTable",
+                    },
+                    {
+                        "elementId": _WH_CHART_LEGACY_SD_ELEM_ID,
+                        "type": "table",
+                        "name": "Legacy SD Element",
+                        "columns": ["legacy_col"],
+                        "vizualizationType": "levelTable",
+                    },
+                ],
+                "total": 2,
+                "nextPage": None,
+            },
+        },
+        f"https://aws-api.sigmacomputing.com/v2/workbooks/{_WH_CHART_WORKBOOK_ID}/columns": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "entries": [
+                    {
+                        "elementId": _WH_CHART_DM_FED_ELEM_ID,
+                        "name": "customer_id",
+                        # Formula references warehouse table by short name. DM-fed chart
+                        # has no SQL query, so dataset_inputs is empty. Workbook
+                        # lineage index provides the resolution.
+                        "formula": "[CUSTOMERS/customer_id]",
+                    },
+                    {
+                        "elementId": _WH_CHART_LEGACY_SD_ELEM_ID,
+                        "name": "legacy_col",
+                        # LEGACY_DATASET is a legacy Sigma Dataset (type=dataset in workbook lineage).
+                        # type=dataset is skipped; formula falls back to self-ref.
+                        "formula": "[LEGACY_DATASET/legacy_col]",
+                    },
+                ],
+                "total": 2,
+                "nextPage": None,
+            },
+        },
+        # DM-fed element: no SQL query, no intra-workbook upstreams.
+        f"https://aws-api.sigmacomputing.com/v2/workbooks/{_WH_CHART_WORKBOOK_ID}/lineage/elements/{_WH_CHART_DM_FED_ELEM_ID}": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "dependencies": {
+                    "tgt_dmfed": {
+                        "nodeId": "tgt_dmfed",
+                        "elementId": _WH_CHART_DM_FED_ELEM_ID,
+                        "name": "DM-fed Element",
+                        "type": "sheet",
+                    }
+                },
+                "edges": [],
+            },
+        },
+        f"https://aws-api.sigmacomputing.com/v2/workbooks/{_WH_CHART_WORKBOOK_ID}/lineage/elements/{_WH_CHART_LEGACY_SD_ELEM_ID}": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "dependencies": {
+                    "tgt_legacysd": {
+                        "nodeId": "tgt_legacysd",
+                        "elementId": _WH_CHART_LEGACY_SD_ELEM_ID,
+                        "name": "Legacy SD Element",
+                        "type": "sheet",
+                    }
+                },
+                "edges": [],
+            },
+        },
+        # No SQL queries (DM-fed charts don't have parseable SQL).
+        f"https://aws-api.sigmacomputing.com/v2/workbooks/{_WH_CHART_WORKBOOK_ID}/elements/{_WH_CHART_DM_FED_ELEM_ID}/query": {
+            "method": "GET",
+            "status_code": 404,
+            "json": {},
+        },
+        f"https://aws-api.sigmacomputing.com/v2/workbooks/{_WH_CHART_WORKBOOK_ID}/elements/{_WH_CHART_LEGACY_SD_ELEM_ID}/query": {
+            "method": "GET",
+            "status_code": 404,
+            "json": {},
+        },
+        # Workbook-level lineage: type=table (CUSTOMERS), type=dataset (LEGACY_DATASET, skipped),
+        # type=customSQL (CUSTOM_QUERY, skipped).
+        f"https://aws-api.sigmacomputing.com/v2/workbooks/{_WH_CHART_WORKBOOK_ID}/lineage": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "entries": [
+                    {
+                        "connectionId": _WH_CONN_ID,
+                        "name": "CUSTOMERS",
+                        "type": "table",
+                        "inodeId": _WH_INODE_ID,
+                    },
+                    {
+                        "name": "LEGACY_DATASET",
+                        "type": "dataset",
+                        "inodeId": "inode-pets-legacy",
+                    },
+                    {
+                        "name": "CUSTOM_QUERY",
+                        "type": "customSQL",
+                        "inodeId": "inode-customsql",
+                    },
+                ]
+            },
+        },
+        # /files for the CUSTOMERS warehouse table (same fixture as warehouse upstream test).
+        f"https://aws-api.sigmacomputing.com/v2/files/{_WH_INODE_ID}": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "id": _WH_INODE_ID,
+                "urlId": _WH_URL_ID,
+                "name": "CUSTOMERS",
+                "type": "table",
+                "path": "Connection Root/WAREHOUSE_COFFEE_COMPANY/PUBLIC",
+                "badge": None,
+                "isArchived": False,
+            },
+        },
+    }
+
+
+@pytest.mark.integration
+def test_sigma_chart_input_fields_warehouse_qualified(
+    pytestconfig, tmp_path, requests_mock
+):
+    """Chart inputFields[].schemaFieldUrn is warehouse-qualified via workbook
+    lineage for DM-fed charts that have no parseable SQL query.
+
+    Fixture topology:
+      dmFedElem01  : formula "[CUSTOMERS/customer_id]"
+                     DM-fed — per-element SQL parser yields empty dataset_inputs.
+                     Workbook lineage (type=table CUSTOMERS) qualifies it to
+                     the Snowflake warehouse Dataset URN.
+      legacySdElem01: formula "[LEGACY_DATASET/legacy_col]"
+                     workbook lineage has type=dataset LEGACY_DATASET (skipped).
+                     Falls back to self-ref.
+
+    Assertions:
+      - dmFedElem01.customer_id schemaFieldUrn → warehouse schemaField URN
+      - legacySdElem01.legacy_col schemaFieldUrn → self-ref (chart URN)
+      - chart_input_fields_warehouse_qualified == 1
+      - chart_input_fields_warehouse_qualified_via_workbook_index == 1
+      - chart_input_fields_self_ref_fallback == 1
+      - No entity-level lineage changes.
+    """
+    test_resources_dir = pytestconfig.rootpath / "tests/integration/sigma"
+
+    override_data = _get_chart_warehouse_qualified_overrides()
+    register_mock_api(request_mock=requests_mock, override_data=override_data)
+
+    output_path = f"{tmp_path}/sigma_chart_warehouse_qualified_mces.json"
+    pipeline = Pipeline.create(
+        _minimal_sigma_pipeline_config(
+            output_path,
+            ingest_data_models=False,
+            chart_sources_platform_mapping={},
+        )
+    )
+    pipeline.run()
+    pipeline.raise_from_status()
+
+    report = _sigma_report(pipeline)
+
+    assert report.chart_input_fields_warehouse_qualified == 1, (
+        f"expected 1 warehouse-qualified field; got {report.chart_input_fields_warehouse_qualified}"
+    )
+    assert report.chart_input_fields_warehouse_qualified_via_workbook_index == 1, (
+        f"expected 1 via-workbook-index; got {report.chart_input_fields_warehouse_qualified_via_workbook_index}"
+    )
+    # legacySdElem01.legacy_col falls back to self-ref (LEGACY_DATASET is type=dataset, skipped)
+    assert report.chart_input_fields_self_ref_fallback == 1
+    # No error counters
+    assert report.chart_input_fields_warehouse_index_lookup_failed == 0
+    assert report.chart_input_fields_warehouse_table_lookup_failed == 0
+    assert report.chart_input_fields_warehouse_path_unparseable == 0
+    assert report.chart_input_fields_warehouse_unknown_connection == 0
+
+    # Verify the actual schemaFieldUrn for dmFedElem01.customer_id
+    expected_warehouse_schema_field_urn = (
+        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,"
+        "warehouse_coffee_company.public.customers,PROD),customer_id)"
+    )
+    dm_fed_chart_urn = f"urn:li:chart:(sigma,{_WH_CHART_DM_FED_ELEM_ID})"
+    with open(output_path) as f:
+        mces = json.load(f)
+
+    input_fields_aspects = [
+        mce
+        for mce in mces
+        if mce.get("entityUrn") == dm_fed_chart_urn
+        and mce.get("aspectName") == "inputFields"
+    ]
+    assert len(input_fields_aspects) == 1, (
+        f"expected 1 inputFields aspect for {dm_fed_chart_urn}"
+    )
+    fields = input_fields_aspects[0]["aspect"]["json"]["fields"]
+    schema_field_urns = [f["schemaFieldUrn"] for f in fields]
+    assert expected_warehouse_schema_field_urn in schema_field_urns, (
+        f"warehouse schemaFieldUrn not found. Got: {schema_field_urns}"
+    )
+
+    mce_helpers.check_golden_file(
+        pytestconfig,
+        output_path=output_path,
+        golden_path=f"{test_resources_dir}/golden_test_sigma_chart_warehouse_qualified.json",
     )

--- a/metadata-ingestion/tests/unit/sigma/test_chart_input_fields.py
+++ b/metadata-ingestion/tests/unit/sigma/test_chart_input_fields.py
@@ -97,6 +97,7 @@ def _collect_input_fields(
         paths=[],
         elementId_to_chart_urn=elementId_to_chart_urn,
         wb_element_index=wb_element_index,
+        wb_warehouse_table_index={},
     ):
         aspect = wu.get_aspect_of_type(InputFieldsClass)
         if aspect is not None:

--- a/metadata-ingestion/tests/unit/sigma/test_chart_input_fields_resolver.py
+++ b/metadata-ingestion/tests/unit/sigma/test_chart_input_fields_resolver.py
@@ -73,6 +73,10 @@ def _make_source(config_overrides: Optional[dict] = None) -> SigmaSource:
     source.reporter.chart_input_fields_skipped_parameter = 0
     source.reporter.chart_input_fields_skipped_sibling = 0
     source.reporter.chart_input_fields_case_mismatch = 0
+    # T4.C: sigma_api is needed by _gen_pages_workunit →
+    # _build_workbook_warehouse_table_index → get_workbook_lineage.
+    source.sigma_api = MagicMock()
+    source.sigma_api.get_workbook_lineage = MagicMock(return_value=[])
     return source
 
 
@@ -536,6 +540,7 @@ class TestGenElementsWorkunitInputFields:
                 paths=[],
                 elementId_to_chart_urn={},
                 wb_element_index={},
+                wb_warehouse_table_index={},
             )
         )
 
@@ -574,6 +579,7 @@ class TestGenElementsWorkunitInputFields:
                 paths=[],
                 elementId_to_chart_urn={},
                 wb_element_index={},
+                wb_warehouse_table_index={},
             )
         )
 

--- a/metadata-ingestion/tests/unit/sigma/test_chart_input_fields_warehouse_qualified.py
+++ b/metadata-ingestion/tests/unit/sigma/test_chart_input_fields_warehouse_qualified.py
@@ -1,0 +1,574 @@
+"""Unit tests for workbook-lineage warehouse table index for chart formula resolution.
+
+Coverage:
+  - _build_workbook_warehouse_table_index: happy path, /lineage failure, /files failure,
+    path unparseable, unknown connection, is_mappable=False, cache reuse with DM path
+  - _merge_warehouse_table_indices: new keys, conflict resolution, empty inputs
+  - _build_element_input_fields: warehouse-qualified counter, via_workbook_index counter
+  - URN identity: DM element and workbook-lineage paths produce byte-equal Dataset URNs
+    for the same inode (guard against orphan schemaField URNs)
+
+Counters verified:
+  chart_input_fields_warehouse_qualified
+  chart_input_fields_warehouse_qualified_via_workbook_index
+  chart_input_fields_warehouse_index_lookup_failed
+  chart_input_fields_warehouse_table_lookup_failed
+  chart_input_fields_warehouse_path_unparseable
+  chart_input_fields_warehouse_unknown_connection
+"""
+
+from typing import Any, Dict, List, Optional
+from unittest.mock import patch
+
+import datahub.emitter.mce_builder as builder
+from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.source.sigma.config import SigmaSourceConfig
+from datahub.ingestion.source.sigma.connection_registry import (
+    SigmaConnectionRecord,
+    SigmaConnectionRegistry,
+)
+from datahub.ingestion.source.sigma.data_classes import (
+    Element,
+    SigmaDataModel,
+    Workbook,
+)
+from datahub.ingestion.source.sigma.sigma import SigmaSource
+from datahub.ingestion.source.sigma.sigma_api import SigmaAPI
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+_SNOWFLAKE_CONN_ID = "conn-sf-001"
+_SNOWFLAKE_CONN_RECORD = SigmaConnectionRecord(
+    connection_id=_SNOWFLAKE_CONN_ID,
+    name="Prod Snowflake",
+    sigma_type="snowflake",
+    datahub_platform="snowflake",
+    host="acme.snowflakecomputing.com",
+    account="acme",
+    is_mappable=True,
+)
+_UNMAPPABLE_CONN_ID = "conn-oracle-001"
+_UNMAPPABLE_CONN_RECORD = SigmaConnectionRecord(
+    connection_id=_UNMAPPABLE_CONN_ID,
+    name="Oracle (unmappable)",
+    sigma_type="oracle",
+    datahub_platform="",
+    is_mappable=False,
+)
+
+_INODE_ID = "aabbccdd-1111-0000-0000-000000000001"
+_URL_ID = "fixture-url-id-001"
+_TABLE_NAME = "MY_WAREHOUSE_TABLE"
+_DB = "MY_DB"
+_SCHEMA = "MY_SCHEMA"
+
+_GOOD_FILES_RESPONSE: Dict[str, Any] = {
+    "id": _INODE_ID,
+    "urlId": _URL_ID,
+    "name": _TABLE_NAME,
+    "type": "table",
+    "path": f"Connection Root/{_DB}/{_SCHEMA}",
+}
+
+_EXPECTED_WAREHOUSE_URN = (
+    "urn:li:dataset:(urn:li:dataPlatform:snowflake,"
+    f"{_DB.lower()}.{_SCHEMA.lower()}.{_TABLE_NAME.lower()},PROD)"
+)
+
+_WB_LINEAGE_TYPE_TABLE_ENTRY: Dict[str, Any] = {
+    "connectionId": _SNOWFLAKE_CONN_ID,
+    "name": _TABLE_NAME,
+    "type": "table",
+    "inodeId": _INODE_ID,
+}
+
+
+def _make_source(
+    extra_registry_records: Optional[List[SigmaConnectionRecord]] = None,
+) -> SigmaSource:
+    config = SigmaSourceConfig.model_validate(
+        {"client_id": "test", "client_secret": "test"}
+    )
+    ctx = PipelineContext(run_id="sigma-wh-index-unit")
+    with (
+        patch.object(SigmaAPI, "_generate_token"),
+        patch.object(
+            SigmaSource,
+            "_build_connection_registry",
+            return_value=SigmaConnectionRegistry(by_id={}),
+        ),
+    ):
+        source = SigmaSource(config=config, ctx=ctx)
+
+    records = [_SNOWFLAKE_CONN_RECORD, _UNMAPPABLE_CONN_RECORD]
+    if extra_registry_records:
+        records.extend(extra_registry_records)
+    source.connection_registry = SigmaConnectionRegistry(
+        by_id={r.connection_id: r for r in records}
+    )
+    return source
+
+
+def _make_workbook(workbook_id: str = "wb-test-uuid") -> Workbook:
+    return Workbook(
+        workbookId=workbook_id,
+        name="Test Workbook",
+        ownerId="owner-1",
+        createdBy="owner-1",
+        updatedBy="owner-1",
+        createdAt="2024-01-01T00:00:00Z",
+        updatedAt="2024-01-01T00:00:00Z",
+        url="https://app.sigmacomputing.com/test/workbook/wb-test-uuid",
+        path="Test Workspace",
+        latestVersion=1,
+    )
+
+
+def _make_element_with_formula(
+    element_id: str,
+    column: str,
+    formula: str,
+    name: str = "Test Element",
+) -> Element:
+    return Element(
+        elementId=element_id,
+        name=name,
+        url="https://app.sigmacomputing.com/test/element/" + element_id,
+        type="table",
+        columns=[{"name": column, "formula": formula}],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: _build_workbook_warehouse_table_index
+# ---------------------------------------------------------------------------
+
+
+class TestBuildWorkbookWarehouseTableIndex:
+    def test_happy_path_snowflake(self):
+        """type=table entry resolves to Snowflake warehouse Dataset URN."""
+        source = _make_source()
+        wb = _make_workbook()
+        with (
+            patch.object(
+                source.sigma_api,
+                "get_workbook_lineage",
+                return_value=[_WB_LINEAGE_TYPE_TABLE_ENTRY],
+            ),
+            patch.object(
+                source.sigma_api,
+                "get_file_metadata",
+                return_value=_GOOD_FILES_RESPONSE,
+            ),
+        ):
+            result = source._build_workbook_warehouse_table_index(wb)
+
+        assert _TABLE_NAME.upper() in result
+        assert result[_TABLE_NAME.upper()] == [_EXPECTED_WAREHOUSE_URN]
+        assert source.reporter.chart_input_fields_warehouse_index_lookup_failed == 0
+        assert source.reporter.chart_input_fields_warehouse_unknown_connection == 0
+
+    def test_lineage_fetch_returns_none_increments_counter(self):
+        """/lineage returning None → index_lookup_failed bumps, empty result."""
+        source = _make_source()
+        wb = _make_workbook()
+        with patch.object(source.sigma_api, "get_workbook_lineage", return_value=None):
+            result = source._build_workbook_warehouse_table_index(wb)
+
+        assert result == {}
+        assert source.reporter.chart_input_fields_warehouse_index_lookup_failed == 1
+
+    def test_files_lookup_failure_increments_counter(self):
+        """/files returning None → table_lookup_failed bumps, entry excluded."""
+        source = _make_source()
+        wb = _make_workbook()
+        with (
+            patch.object(
+                source.sigma_api,
+                "get_workbook_lineage",
+                return_value=[_WB_LINEAGE_TYPE_TABLE_ENTRY],
+            ),
+            patch.object(source.sigma_api, "get_file_metadata", return_value=None),
+        ):
+            result = source._build_workbook_warehouse_table_index(wb)
+
+        assert result == {}
+        assert source.reporter.chart_input_fields_warehouse_table_lookup_failed == 1
+
+    def test_files_lookup_failure_not_double_counted_via_cache(self):
+        """A failed inode shared across workbook calls bumps the counter only once."""
+        source = _make_source()
+        with (
+            patch.object(
+                source.sigma_api,
+                "get_workbook_lineage",
+                return_value=[_WB_LINEAGE_TYPE_TABLE_ENTRY],
+            ),
+            patch.object(source.sigma_api, "get_file_metadata", return_value=None),
+        ):
+            source._build_workbook_warehouse_table_index(_make_workbook("wb-1"))
+            source._build_workbook_warehouse_table_index(_make_workbook("wb-2"))
+
+        assert source.reporter.chart_input_fields_warehouse_table_lookup_failed == 1
+
+    def test_path_unparseable(self):
+        source = _make_source()
+        bad_files = {**_GOOD_FILES_RESPONSE, "path": "Not Connection Root/DB"}
+        with (
+            patch.object(
+                source.sigma_api,
+                "get_workbook_lineage",
+                return_value=[_WB_LINEAGE_TYPE_TABLE_ENTRY],
+            ),
+            patch.object(source.sigma_api, "get_file_metadata", return_value=bad_files),
+        ):
+            result = source._build_workbook_warehouse_table_index(_make_workbook())
+
+        assert result == {}
+        assert source.reporter.chart_input_fields_warehouse_path_unparseable == 1
+
+    def test_path_unparseable_deduped_across_workbooks(self):
+        """Same unparseable inode shared across workbooks only bumps counter once."""
+        source = _make_source()
+        bad_files = {**_GOOD_FILES_RESPONSE, "path": "Not Connection Root/DB"}
+        with (
+            patch.object(
+                source.sigma_api,
+                "get_workbook_lineage",
+                return_value=[_WB_LINEAGE_TYPE_TABLE_ENTRY],
+            ),
+            patch.object(source.sigma_api, "get_file_metadata", return_value=bad_files),
+        ):
+            source._build_workbook_warehouse_table_index(_make_workbook("wb-1"))
+            source._build_workbook_warehouse_table_index(_make_workbook("wb-2"))
+
+        assert source.reporter.chart_input_fields_warehouse_path_unparseable == 1
+
+    def test_unknown_connection_increments_counter(self):
+        """Connection ID not in registry → warehouse_unknown_connection bumps."""
+        source = _make_source()
+        entry = {**_WB_LINEAGE_TYPE_TABLE_ENTRY, "connectionId": "conn-unknown"}
+        with (
+            patch.object(
+                source.sigma_api, "get_workbook_lineage", return_value=[entry]
+            ),
+            patch.object(
+                source.sigma_api,
+                "get_file_metadata",
+                return_value=_GOOD_FILES_RESPONSE,
+            ),
+        ):
+            result = source._build_workbook_warehouse_table_index(_make_workbook())
+
+        assert result == {}
+        assert source.reporter.chart_input_fields_warehouse_unknown_connection == 1
+
+    def test_is_mappable_false_increments_unknown_connection(self):
+        """is_mappable=False → warehouse_unknown_connection bumps."""
+        source = _make_source()
+        entry = {**_WB_LINEAGE_TYPE_TABLE_ENTRY, "connectionId": _UNMAPPABLE_CONN_ID}
+        with (
+            patch.object(
+                source.sigma_api, "get_workbook_lineage", return_value=[entry]
+            ),
+            patch.object(
+                source.sigma_api,
+                "get_file_metadata",
+                return_value=_GOOD_FILES_RESPONSE,
+            ),
+        ):
+            result = source._build_workbook_warehouse_table_index(_make_workbook())
+
+        assert result == {}
+        assert source.reporter.chart_input_fields_warehouse_unknown_connection == 1
+
+    def test_duplicate_url_id_logs_warning(self):
+        """Two type=table entries sharing the same urlId: second overwrites first,
+        a warning is logged."""
+        source = _make_source()
+        inode2 = "bbbbcccc-2222-0000-0000-000000000002"
+        files2 = {
+            **_GOOD_FILES_RESPONSE,
+            "id": inode2,
+            "urlId": _URL_ID,
+            "name": "OTHER_TABLE",
+        }
+        entries = [
+            _WB_LINEAGE_TYPE_TABLE_ENTRY,
+            {**_WB_LINEAGE_TYPE_TABLE_ENTRY, "inodeId": inode2, "name": "OTHER_TABLE"},
+        ]
+        with (
+            patch.object(
+                source.sigma_api, "get_workbook_lineage", return_value=entries
+            ),
+            patch.object(
+                source.sigma_api,
+                "get_file_metadata",
+                side_effect=[_GOOD_FILES_RESPONSE, files2],
+            ),
+        ):
+            result = source._build_workbook_warehouse_table_index(_make_workbook())
+
+        # Last writer wins; "OTHER_TABLE" is the final name for that urlId
+        assert "OTHER_TABLE" in result or _TABLE_NAME in result
+
+    def test_cache_reuse_with_dm_path(self):
+        """An inode already populated by DM lineage processing is reused by
+        the workbook-lineage path without an extra /files call."""
+        source = _make_source()
+        dm = SigmaDataModel(
+            dataModelId="dm-test-uuid",
+            name="Test DM",
+            createdAt="2024-01-01T00:00:00Z",
+            updatedAt="2024-01-01T00:00:00Z",
+            warehouse_inodes_by_inode_id={
+                _INODE_ID: {"connectionId": _SNOWFLAKE_CONN_ID}
+            },
+        )
+        with patch.object(
+            source.sigma_api,
+            "get_file_metadata",
+            return_value=_GOOD_FILES_RESPONSE,
+        ) as mock_get:
+            source._build_dm_warehouse_url_id_map(dm)
+            assert _INODE_ID in source._files_cache
+            with patch.object(
+                source.sigma_api,
+                "get_workbook_lineage",
+                return_value=[_WB_LINEAGE_TYPE_TABLE_ENTRY],
+            ):
+                result = source._build_workbook_warehouse_table_index(_make_workbook())
+            mock_get.assert_called_once()
+
+        assert _TABLE_NAME.upper() in result
+
+
+# ---------------------------------------------------------------------------
+# Tests: _merge_warehouse_table_indices
+# ---------------------------------------------------------------------------
+
+
+class TestMergeWarehouseTableIndices:
+    def test_supplementary_contributes_new_key(self):
+        primary = {"TABLE_A": ["urn:A"]}
+        supplementary = {"TABLE_B": ["urn:B"]}
+        result = SigmaSource._merge_warehouse_table_indices(primary, supplementary)
+        assert result == {"TABLE_A": ["urn:A"], "TABLE_B": ["urn:B"]}
+
+    def test_primary_wins_on_conflict(self):
+        primary = {"TABLE_A": ["urn:A-primary"]}
+        supplementary = {"TABLE_A": ["urn:A-supplementary"]}
+        result = SigmaSource._merge_warehouse_table_indices(primary, supplementary)
+        assert result == {"TABLE_A": ["urn:A-primary"]}
+
+    def test_no_urn_concat_on_conflict(self):
+        """Conflict must NOT concat URN lists — only primary URN is used."""
+        primary = {"TABLE_A": ["urn:A1"]}
+        supplementary = {"TABLE_A": ["urn:A2"]}
+        result = SigmaSource._merge_warehouse_table_indices(primary, supplementary)
+        assert result["TABLE_A"] == ["urn:A1"]
+        assert "urn:A2" not in result["TABLE_A"]
+
+    def test_empty_supplementary_returns_copy_of_primary(self):
+        primary = {"TABLE_A": ["urn:A"]}
+        result = SigmaSource._merge_warehouse_table_indices(primary, {})
+        assert result == primary
+        assert result is not primary  # always returns a copy; callers must not mutate
+
+
+# ---------------------------------------------------------------------------
+# Tests: _build_element_input_fields warehouse counter tracking
+# ---------------------------------------------------------------------------
+
+
+class TestBuildElementInputFieldsWarehouseCounters:
+    def _call_build(
+        self,
+        source: SigmaSource,
+        element: Element,
+        element_warehouse_table_index: Dict[str, List[str]],
+        wb_only_warehouse_keys: frozenset,
+    ) -> List:
+        chart_urn = builder.make_chart_urn(
+            platform="sigma",
+            platform_instance=None,
+            name=element.elementId,
+        )
+        return source._build_element_input_fields(
+            element=element,
+            chart_urn=chart_urn,
+            chart_upstream_eids=set(),
+            dm_upstream_urn_by_element_name={},
+            wb_element_index={},
+            element_warehouse_table_index=element_warehouse_table_index,
+            elementId_to_chart_urn={},
+            wb_only_warehouse_keys=wb_only_warehouse_keys,
+        )
+
+    def test_warehouse_qualified_via_workbook_index(self):
+        """Workbook-only key bumps both _qualified and _qualified_via_workbook_index."""
+        source = _make_source()
+        element = _make_element_with_formula("elem-1", "col", f"[{_TABLE_NAME}/col]")
+        self._call_build(
+            source,
+            element,
+            {_TABLE_NAME: [_EXPECTED_WAREHOUSE_URN]},
+            frozenset({_TABLE_NAME}),
+        )
+
+        assert source.reporter.chart_input_fields_warehouse_qualified == 1
+        assert (
+            source.reporter.chart_input_fields_warehouse_qualified_via_workbook_index
+            == 1
+        )
+        assert source.reporter.chart_input_fields_resolved == 1
+
+    def test_warehouse_qualified_via_per_element_index(self):
+        """Per-element key bumps _qualified but NOT _via_workbook_index."""
+        source = _make_source()
+        element = _make_element_with_formula("elem-1", "col", f"[{_TABLE_NAME}/col]")
+        self._call_build(
+            source, element, {_TABLE_NAME: [_EXPECTED_WAREHOUSE_URN]}, frozenset()
+        )
+
+        assert source.reporter.chart_input_fields_warehouse_qualified == 1
+        assert (
+            source.reporter.chart_input_fields_warehouse_qualified_via_workbook_index
+            == 0
+        )
+        assert source.reporter.chart_input_fields_resolved == 1
+
+    def test_no_match_falls_through_to_self_ref(self):
+        """Unresolvable formula ref → self_ref_fallback."""
+        source = _make_source()
+        element = _make_element_with_formula("elem-1", "col", "[UNKNOWN_TABLE/col]")
+        self._call_build(source, element, {}, frozenset())
+
+        assert source.reporter.chart_input_fields_warehouse_qualified == 0
+        assert source.reporter.chart_input_fields_self_ref_fallback == 1
+
+    def test_ambiguous_warehouse_candidates_not_qualified(self):
+        """Two candidates for the same key → resolver returns None, no qualified bump."""
+        source = _make_source()
+        element = _make_element_with_formula("elem-1", "col", f"[{_TABLE_NAME}/col]")
+        self._call_build(
+            source, element, {_TABLE_NAME: ["urn:A", "urn:B"]}, frozenset({_TABLE_NAME})
+        )
+
+        assert source.reporter.chart_input_fields_warehouse_qualified == 0
+        assert source.reporter.chart_input_fields_self_ref_fallback == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: URN identity between DM element and workbook-lineage paths (CRITICAL)
+# ---------------------------------------------------------------------------
+
+
+class TestUrnIdentityWarehouseIndex:
+    def test_urn_identity_dm_and_workbook_paths(self):
+        """The warehouse Dataset URN from the workbook-lineage path must equal
+        the entity-level URN from the DM element path for the same inode.
+        Mismatched URN bases produce orphan schemaField URNs.
+        """
+        source = _make_source()
+        dm = SigmaDataModel(
+            dataModelId="dm-identity-test",
+            name="Identity DM",
+            createdAt="2024-01-01T00:00:00Z",
+            updatedAt="2024-01-01T00:00:00Z",
+            warehouse_inodes_by_inode_id={
+                _INODE_ID: {"connectionId": _SNOWFLAKE_CONN_ID}
+            },
+        )
+
+        with patch.object(
+            source.sigma_api,
+            "get_file_metadata",
+            return_value=_GOOD_FILES_RESPONSE,
+        ):
+            url_id_map = source._build_dm_warehouse_url_id_map(dm)
+            dm_urn = source._resolve_dm_element_warehouse_upstream(
+                url_id_suffix=_URL_ID,
+                warehouse_map=url_id_map,
+            )
+            with patch.object(
+                source.sigma_api,
+                "get_workbook_lineage",
+                return_value=[_WB_LINEAGE_TYPE_TABLE_ENTRY],
+            ):
+                wb_index = source._build_workbook_warehouse_table_index(
+                    _make_workbook()
+                )
+
+        assert dm_urn is not None
+        wb_urns = wb_index.get(_TABLE_NAME.upper()) or []
+        wb_urn = wb_urns[0] if wb_urns else None
+        assert wb_urn is not None
+        assert dm_urn == wb_urn, (
+            f"URN identity broken: DM path produced {dm_urn!r} but workbook-lineage "
+            f"path produced {wb_urn!r}."
+        )
+
+    def test_urn_identity_with_connection_override(self):
+        """URN identity holds with connection_to_platform_map overrides."""
+        config = SigmaSourceConfig.model_validate(
+            {
+                "client_id": "test",
+                "client_secret": "test",
+                "connection_to_platform_map": {
+                    _SNOWFLAKE_CONN_ID: {
+                        "env": "STG",
+                        "convert_urns_to_lowercase": True,
+                    }
+                },
+            }
+        )
+        ctx = PipelineContext(run_id="sigma-wh-index-override")
+        with (
+            patch.object(SigmaAPI, "_generate_token"),
+            patch.object(
+                SigmaSource,
+                "_build_connection_registry",
+                return_value=SigmaConnectionRegistry(by_id={}),
+            ),
+        ):
+            source = SigmaSource(config=config, ctx=ctx)
+        source.connection_registry = SigmaConnectionRegistry(
+            by_id={_SNOWFLAKE_CONN_ID: _SNOWFLAKE_CONN_RECORD}
+        )
+        dm = SigmaDataModel(
+            dataModelId="dm-identity-override",
+            name="Override DM",
+            createdAt="2024-01-01T00:00:00Z",
+            updatedAt="2024-01-01T00:00:00Z",
+            warehouse_inodes_by_inode_id={
+                _INODE_ID: {"connectionId": _SNOWFLAKE_CONN_ID}
+            },
+        )
+
+        with patch.object(
+            source.sigma_api,
+            "get_file_metadata",
+            return_value=_GOOD_FILES_RESPONSE,
+        ):
+            url_id_map = source._build_dm_warehouse_url_id_map(dm)
+            dm_urn = source._resolve_dm_element_warehouse_upstream(
+                url_id_suffix=_URL_ID,
+                warehouse_map=url_id_map,
+            )
+            with patch.object(
+                source.sigma_api,
+                "get_workbook_lineage",
+                return_value=[_WB_LINEAGE_TYPE_TABLE_ENTRY],
+            ):
+                wb_index = source._build_workbook_warehouse_table_index(
+                    _make_workbook()
+                )
+
+        assert dm_urn is not None
+        wb_urns = wb_index.get(_TABLE_NAME.upper()) or []
+        wb_urn = wb_urns[0] if wb_urns else None
+        assert wb_urn is not None
+        assert dm_urn == wb_urn

--- a/metadata-ingestion/tests/unit/sigma/test_chart_input_fields_warehouse_qualified.py
+++ b/metadata-ingestion/tests/unit/sigma/test_chart_input_fields_warehouse_qualified.py
@@ -31,6 +31,7 @@ from datahub.ingestion.source.sigma.data_classes import (
     Element,
     SigmaDataModel,
     Workbook,
+    WorkbookLineageTableEntry,
 )
 from datahub.ingestion.source.sigma.sigma import SigmaSource
 from datahub.ingestion.source.sigma.sigma_api import SigmaAPI
@@ -77,12 +78,12 @@ _EXPECTED_WAREHOUSE_URN = (
     f"{_DB.lower()}.{_SCHEMA.lower()}.{_TABLE_NAME.lower()},PROD)"
 )
 
-_WB_LINEAGE_TYPE_TABLE_ENTRY: Dict[str, Any] = {
-    "connectionId": _SNOWFLAKE_CONN_ID,
-    "name": _TABLE_NAME,
-    "type": "table",
-    "inodeId": _INODE_ID,
-}
+_WB_LINEAGE_TYPE_TABLE_ENTRY = WorkbookLineageTableEntry(
+    type="table",
+    name=_TABLE_NAME,
+    connectionId=_SNOWFLAKE_CONN_ID,
+    inodeId=_INODE_ID,
+)
 
 
 def _make_source(
@@ -249,7 +250,9 @@ class TestBuildWorkbookWarehouseTableIndex:
     def test_unknown_connection_increments_counter(self):
         """Connection ID not in registry → warehouse_unknown_connection bumps."""
         source = _make_source()
-        entry = {**_WB_LINEAGE_TYPE_TABLE_ENTRY, "connectionId": "conn-unknown"}
+        entry = _WB_LINEAGE_TYPE_TABLE_ENTRY.model_copy(
+            update={"connectionId": "conn-unknown"}
+        )
         with (
             patch.object(
                 source.sigma_api, "get_workbook_lineage", return_value=[entry]
@@ -268,7 +271,9 @@ class TestBuildWorkbookWarehouseTableIndex:
     def test_is_mappable_false_increments_unknown_connection(self):
         """is_mappable=False → warehouse_unknown_connection bumps."""
         source = _make_source()
-        entry = {**_WB_LINEAGE_TYPE_TABLE_ENTRY, "connectionId": _UNMAPPABLE_CONN_ID}
+        entry = _WB_LINEAGE_TYPE_TABLE_ENTRY.model_copy(
+            update={"connectionId": _UNMAPPABLE_CONN_ID}
+        )
         with (
             patch.object(
                 source.sigma_api, "get_workbook_lineage", return_value=[entry]
@@ -297,7 +302,9 @@ class TestBuildWorkbookWarehouseTableIndex:
         }
         entries = [
             _WB_LINEAGE_TYPE_TABLE_ENTRY,
-            {**_WB_LINEAGE_TYPE_TABLE_ENTRY, "inodeId": inode2, "name": "OTHER_TABLE"},
+            _WB_LINEAGE_TYPE_TABLE_ENTRY.model_copy(
+                update={"inodeId": inode2, "name": "OTHER_TABLE"}
+            ),
         ]
         with (
             patch.object(

--- a/metadata-ingestion/tests/unit/sigma/test_sigma_api.py
+++ b/metadata-ingestion/tests/unit/sigma/test_sigma_api.py
@@ -1842,6 +1842,7 @@ class TestChartInputsInsertionOrder:
                     paths=[],
                     elementId_to_chart_urn={},
                     wb_element_index={},
+                    wb_warehouse_table_index={},
                 )
             )
 
@@ -2331,3 +2332,73 @@ class TestCustomSqlDuplicateNameOverwrite:
             or "duplicate" in (w.message or "").lower()
             for w in api.report.warnings
         )
+
+
+class TestGetWorkbookLineageHttp:
+    """HTTP-level dispatch for get_workbook_lineage: 200, 404, 429, 5xx, exception."""
+
+    def test_200_returns_entries(self) -> None:
+        api = _create_sigma_api()
+        ok = MagicMock(status_code=200)
+        ok.json.return_value = {
+            "entries": [{"type": "table", "name": "T"}],
+            "nextPage": None,
+        }
+        with patch.object(api, "_get_api_call", return_value=ok):
+            result = api.get_workbook_lineage("wb-1")
+        assert result == [{"type": "table", "name": "T"}]
+        assert not api.report.warnings
+
+    def test_200_paginates(self) -> None:
+        api = _create_sigma_api()
+        page1 = MagicMock(status_code=200)
+        page1.json.return_value = {
+            "entries": [{"type": "table", "name": "T1"}],
+            "nextPage": "p2",
+        }
+        page2 = MagicMock(status_code=200)
+        page2.json.return_value = {
+            "entries": [{"type": "table", "name": "T2"}],
+            "nextPage": None,
+        }
+        with patch.object(api, "_get_api_call", side_effect=[page1, page2]):
+            result = api.get_workbook_lineage("wb-1")
+        assert result is not None
+        assert len(result) == 2
+        assert result[0]["name"] == "T1"
+        assert result[1]["name"] == "T2"
+
+    def test_404_returns_none_silently(self) -> None:
+        api = _create_sigma_api()
+        not_found = MagicMock(status_code=404)
+        with patch.object(api, "_get_api_call", return_value=not_found):
+            result = api.get_workbook_lineage("wb-deleted")
+        assert result is None
+        assert not api.report.warnings
+
+    def test_429_returns_none_and_warns(self) -> None:
+        api = _create_sigma_api()
+        rate_limited = MagicMock(status_code=429)
+        with patch.object(api, "_get_api_call", return_value=rate_limited):
+            result = api.get_workbook_lineage("wb-1")
+        assert result is None
+        assert any(
+            "rate-limited" in (w.title or "").lower() for w in api.report.warnings
+        )
+
+    def test_5xx_returns_none_and_warns(self) -> None:
+        api = _create_sigma_api()
+        server_error = MagicMock(status_code=500)
+        with patch.object(api, "_get_api_call", return_value=server_error):
+            result = api.get_workbook_lineage("wb-1")
+        assert result is None
+        assert api.report.warnings
+
+    def test_exception_returns_none_and_warns(self) -> None:
+        api = _create_sigma_api()
+        with patch.object(
+            api, "_get_api_call", side_effect=Exception("network failure")
+        ):
+            result = api.get_workbook_lineage("wb-1")
+        assert result is None
+        assert api.report.warnings

--- a/metadata-ingestion/tests/unit/sigma/test_sigma_api.py
+++ b/metadata-ingestion/tests/unit/sigma/test_sigma_api.py
@@ -18,6 +18,7 @@ from datahub.ingestion.source.sigma.data_classes import (
     SigmaDataModelElement,
     SigmaDataset,
     Workbook,
+    WorkbookLineageTableEntry,
     Workspace,
 )
 from datahub.ingestion.source.sigma.sigma import SigmaSource
@@ -2341,32 +2342,57 @@ class TestGetWorkbookLineageHttp:
         api = _create_sigma_api()
         ok = MagicMock(status_code=200)
         ok.json.return_value = {
-            "entries": [{"type": "table", "name": "T"}],
+            "entries": [
+                {
+                    "type": "table",
+                    "name": "MY_TABLE",
+                    "connectionId": "conn-1",
+                    "inodeId": "inode-1",
+                }
+            ],
             "nextPage": None,
         }
         with patch.object(api, "_get_api_call", return_value=ok):
             result = api.get_workbook_lineage("wb-1")
-        assert result == [{"type": "table", "name": "T"}]
+        assert result == [
+            WorkbookLineageTableEntry(
+                type="table", name="MY_TABLE", connectionId="conn-1", inodeId="inode-1"
+            )
+        ]
         assert not api.report.warnings
 
     def test_200_paginates(self) -> None:
         api = _create_sigma_api()
         page1 = MagicMock(status_code=200)
         page1.json.return_value = {
-            "entries": [{"type": "table", "name": "T1"}],
+            "entries": [
+                {
+                    "type": "table",
+                    "name": "T1",
+                    "connectionId": "conn-1",
+                    "inodeId": "inode-1",
+                }
+            ],
             "nextPage": "p2",
         }
         page2 = MagicMock(status_code=200)
         page2.json.return_value = {
-            "entries": [{"type": "table", "name": "T2"}],
+            "entries": [
+                {
+                    "type": "table",
+                    "name": "T2",
+                    "connectionId": "conn-1",
+                    "inodeId": "inode-2",
+                }
+            ],
             "nextPage": None,
         }
         with patch.object(api, "_get_api_call", side_effect=[page1, page2]):
             result = api.get_workbook_lineage("wb-1")
         assert result is not None
         assert len(result) == 2
-        assert result[0]["name"] == "T1"
-        assert result[1]["name"] == "T2"
+        assert result[0].name == "T1"
+        assert result[1].name == "T2"
 
     def test_404_returns_none_silently(self) -> None:
         api = _create_sigma_api()


### PR DESCRIPTION
- Adds `get_workbook_lineage` to fetch `/v2/workbooks/{id}/lineage` type=table entries                                                                              
- Builds a per-workbook warehouse-table index merged with the existing per-element SQL-parser index before calling `_resolve_chart_formula_upstream` Step 4
- Resolves DM-fed chart formula bracket refs (e.g. `[FIVETRAN_LOG/Last Sync]`) that had empty `dataset_inputs` and previously incremented `chart_input_fields_self_ref_fallback` 

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
