### PR TITLE
feat(ingest/sigma): emit FineGrainedLineage on DM elements to warehouse

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
@@ -396,6 +396,17 @@ class WarehouseConnectionConfig(PlatformInstanceConfigMixin, EnvConfigMixin):
     produces dangling lineage for multi-env or multi-instance setups.
     """
 
+    default_database: Optional[str] = pydantic.Field(
+        default=None,
+        description=(
+            "Default database name for this connection. Required for platforms "
+            "where Sigma's /files path omits the database layer (e.g. Redshift: "
+            "'Connection Root/<SCHEMA>'). Set this to the database name the "
+            "warehouse connector uses so the emitted URNs match "
+            "(e.g. 'dev' to produce 'dev.public.table')."
+        ),
+    )
+
     convert_urns_to_lowercase: bool = pydantic.Field(
         default=True,
         description=(

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
@@ -404,7 +404,7 @@ class WarehouseConnectionConfig(PlatformInstanceConfigMixin, EnvConfigMixin):
         description=(
             "Default database name for this connection. Required for platforms "
             "where Sigma's /files path omits the database layer (e.g. Redshift: "
-            "'Connection Root/<SCHEMA>'). Set this to the database name the "
+            "'Connection Root/SCHEMA'). Set this to the database name the "
             "warehouse connector uses so the emitted URNs match "
             "(e.g. 'dev' to produce 'dev.public.table')."
         ),

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
@@ -303,31 +303,21 @@ class SigmaSourceReport(StaleEntityRemovalSourceReport):
     data_model_element_fgl_cross_dm_deferred: int = 0
     # Refs where element-name matches the element's own warehouse-table name
     # (e.g., element "data.csv" with formula "[data.csv/col]"). These are
-    # warehouse-passthrough passthroughs, not intra-DM self-edges; the actual
-    # upstream is the warehouse inode.  T4.B2 resolves most of these; the
-    # remainder (no warehouse source, unmappable connection) stay deferred.
+    # warehouse-passthrough refs, not intra-DM self-edges; the actual upstream
+    # is the warehouse inode.  Resolved via columnId when possible; remainder
+    # (no warehouse source, unmappable connection) stays deferred.
     data_model_element_fgl_warehouse_passthrough_deferred: int = 0
 
-    # T4.B2 — warehouse-passthrough FGL resolution.
-    # Emitted via columnId metadata (inode-<url_id>/<WAREHOUSE_COL> encoding).
+    # Warehouse-passthrough FGL resolution via columnId metadata.
+    # columnId encodes the warehouse column as inode-<url_id>/<WAREHOUSE_COL>.
     data_model_element_fgl_warehouse_resolved: int = 0
-    # Strategy B (trust bracket ref verbatim, no columnId) — not used on
-    # Snowflake/Redshift tenants where columnId is authoritative; reserved for
-    # future platforms where columnId may not encode the warehouse column.
-    data_model_element_fgl_warehouse_resolved_unvalidated: int = 0
-    # Strategy C rename path — reserved for future use if Sigma exposes an
-    # explicit sourceColumn field.
-    data_model_element_fgl_warehouse_resolved_via_rename: int = 0
-    # columnId decoded but column name absent from the warehouse schema —
-    # currently unused (columnId is trusted verbatim); reserved for strict mode.
-    data_model_element_fgl_warehouse_unknown_warehouse_column: int = 0
-    # Element's warehouse source connection is not in the registry or is
-    # is_mappable=False; FGL not emitted (separate from entity-level counter).
+    # Connection not in registry or is_mappable=False; FGL not emitted.
+    # Separate from the entity-level dm_element_warehouse_unknown_connection.
     data_model_element_fgl_warehouse_unmappable_connection: int = 0
     # Self-stripped ref but element has no warehouse-backed inode source
-    # (e.g., legacy SD-backed element with element name == SD name).
+    # (e.g., CSV-backed element whose name matches the formula source).
     data_model_element_fgl_warehouse_no_warehouse_source: int = 0
-    # Roll-up: resolved + resolved_unvalidated + resolved_via_rename.
+    # Roll-up of all successfully emitted warehouse-passthrough FGL entries.
     data_model_element_fgl_warehouse_emitted_total: int = 0
     # Refs whose source element is in this DM but not listed as an upstream by
     # /lineage; dropped to avoid orphan FGL the UI silently rejects.

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
@@ -304,21 +304,11 @@ class SigmaSourceReport(StaleEntityRemovalSourceReport):
     # Refs where element-name matches the element's own warehouse-table name
     # (e.g., element "data.csv" with formula "[data.csv/col]"). These are
     # warehouse-passthrough refs, not intra-DM self-edges; the actual upstream
-    # is the warehouse inode.  Equal to _no_warehouse_source +
-    # _unmappable_connection (all resolution failures land here).
+    # is the warehouse inode.  Non-zero when columnId doesn't encode a warehouse
+    # column or when the connection isn't in the registry.
     data_model_element_fgl_warehouse_passthrough_deferred: int = 0
-
     # Warehouse-passthrough FGL emitted via columnId (inode-<url_id>/<COL>).
     data_model_element_fgl_warehouse_resolved: int = 0
-    # Connection not in registry or is_mappable=False; FGL not emitted.
-    # Counted per column, not per source_id — differs in granularity from
-    # the entity-level dm_element_warehouse_unknown_connection counter.
-    data_model_element_fgl_warehouse_unmappable_connection: int = 0
-    # Self-stripped ref but no resolvable warehouse inode source (e.g.,
-    # CSV-backed element whose name matches the formula source, or /files miss).
-    data_model_element_fgl_warehouse_no_warehouse_source: int = 0
-    # Roll-up: equals _warehouse_resolved when no other paths are active.
-    data_model_element_fgl_warehouse_emitted_total: int = 0
     # Refs whose source element is in this DM but not listed as an upstream by
     # /lineage; dropped to avoid orphan FGL the UI silently rejects.
     data_model_element_fgl_dropped_orphan_upstream: int = 0

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
@@ -301,9 +301,12 @@ class SigmaSourceReport(StaleEntityRemovalSourceReport):
     data_model_element_fgl_collision_pick_first: int = 0
     # Refs whose source element is outside this DM; deferred to cross-DM resolution.
     data_model_element_fgl_cross_dm_deferred: int = 0
-    # Refs where the formula source name matches the element's own name (self-ref),
-    # indicating a warehouse-passthrough, but columnId-based resolution failed
-    # (e.g. CSV-backed element, /files lookup miss, unmappable connection).
+    # Warehouse-passthrough refs where columnId-based resolution failed.
+    # Fires for self-ref formulas (element name == formula source) AND for
+    # formulas where the source is the warehouse table name but resolution fails
+    # (e.g. inode-shaped columnId with /files miss or unmappable connection).
+    # Note: semantics changed in this release — previously this counter fired on
+    # every self-ref (a throughput signal); now it fires only on failure.
     data_model_element_fgl_warehouse_passthrough_deferred: int = 0
     # Warehouse-passthrough FGL emitted via columnId (inode-<url_id>/<COL>).
     # Covers both the self-ref case and the case where the formula source is

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
@@ -304,8 +304,31 @@ class SigmaSourceReport(StaleEntityRemovalSourceReport):
     # Refs where element-name matches the element's own warehouse-table name
     # (e.g., element "data.csv" with formula "[data.csv/col]"). These are
     # warehouse-passthrough passthroughs, not intra-DM self-edges; the actual
-    # upstream is the warehouse inode.
+    # upstream is the warehouse inode.  T4.B2 resolves most of these; the
+    # remainder (no warehouse source, unmappable connection) stay deferred.
     data_model_element_fgl_warehouse_passthrough_deferred: int = 0
+
+    # T4.B2 — warehouse-passthrough FGL resolution.
+    # Emitted via columnId metadata (inode-<url_id>/<WAREHOUSE_COL> encoding).
+    data_model_element_fgl_warehouse_resolved: int = 0
+    # Strategy B (trust bracket ref verbatim, no columnId) — not used on
+    # Snowflake/Redshift tenants where columnId is authoritative; reserved for
+    # future platforms where columnId may not encode the warehouse column.
+    data_model_element_fgl_warehouse_resolved_unvalidated: int = 0
+    # Strategy C rename path — reserved for future use if Sigma exposes an
+    # explicit sourceColumn field.
+    data_model_element_fgl_warehouse_resolved_via_rename: int = 0
+    # columnId decoded but column name absent from the warehouse schema —
+    # currently unused (columnId is trusted verbatim); reserved for strict mode.
+    data_model_element_fgl_warehouse_unknown_warehouse_column: int = 0
+    # Element's warehouse source connection is not in the registry or is
+    # is_mappable=False; FGL not emitted (separate from entity-level counter).
+    data_model_element_fgl_warehouse_unmappable_connection: int = 0
+    # Self-stripped ref but element has no warehouse-backed inode source
+    # (e.g., legacy SD-backed element with element name == SD name).
+    data_model_element_fgl_warehouse_no_warehouse_source: int = 0
+    # Roll-up: resolved + resolved_unvalidated + resolved_via_rename.
+    data_model_element_fgl_warehouse_emitted_total: int = 0
     # Refs whose source element is in this DM but not listed as an upstream by
     # /lineage; dropped to avoid orphan FGL the UI silently rejects.
     data_model_element_fgl_dropped_orphan_upstream: int = 0

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
@@ -304,20 +304,20 @@ class SigmaSourceReport(StaleEntityRemovalSourceReport):
     # Refs where element-name matches the element's own warehouse-table name
     # (e.g., element "data.csv" with formula "[data.csv/col]"). These are
     # warehouse-passthrough refs, not intra-DM self-edges; the actual upstream
-    # is the warehouse inode.  Resolved via columnId when possible; remainder
-    # (no warehouse source, unmappable connection) stays deferred.
+    # is the warehouse inode.  Equal to _no_warehouse_source +
+    # _unmappable_connection (all resolution failures land here).
     data_model_element_fgl_warehouse_passthrough_deferred: int = 0
 
-    # Warehouse-passthrough FGL resolution via columnId metadata.
-    # columnId encodes the warehouse column as inode-<url_id>/<WAREHOUSE_COL>.
+    # Warehouse-passthrough FGL emitted via columnId (inode-<url_id>/<COL>).
     data_model_element_fgl_warehouse_resolved: int = 0
     # Connection not in registry or is_mappable=False; FGL not emitted.
-    # Separate from the entity-level dm_element_warehouse_unknown_connection.
+    # Counted per column, not per source_id — differs in granularity from
+    # the entity-level dm_element_warehouse_unknown_connection counter.
     data_model_element_fgl_warehouse_unmappable_connection: int = 0
-    # Self-stripped ref but element has no warehouse-backed inode source
-    # (e.g., CSV-backed element whose name matches the formula source).
+    # Self-stripped ref but no resolvable warehouse inode source (e.g.,
+    # CSV-backed element whose name matches the formula source, or /files miss).
     data_model_element_fgl_warehouse_no_warehouse_source: int = 0
-    # Roll-up of all successfully emitted warehouse-passthrough FGL entries.
+    # Roll-up: equals _warehouse_resolved when no other paths are active.
     data_model_element_fgl_warehouse_emitted_total: int = 0
     # Refs whose source element is in this DM but not listed as an upstream by
     # /lineage; dropped to avoid orphan FGL the UI silently rejects.

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
@@ -301,13 +301,13 @@ class SigmaSourceReport(StaleEntityRemovalSourceReport):
     data_model_element_fgl_collision_pick_first: int = 0
     # Refs whose source element is outside this DM; deferred to cross-DM resolution.
     data_model_element_fgl_cross_dm_deferred: int = 0
-    # Refs where element-name matches the element's own warehouse-table name
-    # (e.g., element "data.csv" with formula "[data.csv/col]"). These are
-    # warehouse-passthrough refs, not intra-DM self-edges; the actual upstream
-    # is the warehouse inode.  Non-zero when columnId doesn't encode a warehouse
-    # column or when the connection isn't in the registry.
+    # Refs where the formula source name matches the element's own name (self-ref),
+    # indicating a warehouse-passthrough, but columnId-based resolution failed
+    # (e.g. CSV-backed element, /files lookup miss, unmappable connection).
     data_model_element_fgl_warehouse_passthrough_deferred: int = 0
     # Warehouse-passthrough FGL emitted via columnId (inode-<url_id>/<COL>).
+    # Covers both the self-ref case and the case where the formula source is
+    # the warehouse table name rather than the element name.
     data_model_element_fgl_warehouse_resolved: int = 0
     # Refs whose source element is in this DM but not listed as an upstream by
     # /lineage; dropped to avoid orphan FGL the UI silently rejects.

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -233,17 +233,17 @@ class _WarehouseTableRef:
     """Resolved warehouse table coordinates derived from a /files response."""
 
     connection_id: str
-    db: str
+    db: Optional[str]
     schema: str
     table: str
 
     def fq_name(self, platform: str, *, lowercase: bool = True) -> str:
-        # db is empty for platforms with a 2-segment /files path (e.g. Redshift:
+        # db is None for platforms with a 2-segment /files path (e.g. Redshift:
         # "Connection Root/<SCHEMA>"). In that case emit schema.table; otherwise
         # emit the full db.schema.table used by Snowflake and similar platforms.
         name = (
             f"{self.schema}.{self.table}"
-            if not self.db
+            if self.db is None
             else f"{self.db}.{self.schema}.{self.table}"
         )
         if platform.lower() in _WAREHOUSE_LOWERCASE_PLATFORMS and lowercase:
@@ -772,13 +772,11 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                 # first, then fall back to the connection registry's default_database.
                 conn_override = self.config.connection_to_platform_map.get(conn_id)
                 conn_record = self.connection_registry.get(conn_id)
-                db = (
-                    (conn_override.default_database if conn_override else None)
-                    or (conn_record.default_database if conn_record else None)
-                    or ""
+                db = (conn_override.default_database if conn_override else None) or (
+                    conn_record.default_database if conn_record else None
                 )
                 schema = parts[1]
-                if not db and conn_id not in self._missing_default_db_warned:
+                if db is None and conn_id not in self._missing_default_db_warned:
                     self._missing_default_db_warned.add(conn_id)
                     self.reporter.warning(
                         title="Sigma warehouse default_database not configured",
@@ -1575,8 +1573,8 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         name (e.g. "Customer Id") rather than the warehouse identifier
         ("CUSTOMER_ID" / "customer_id").
 
-        Returns a FineGrainedLineageClass on success; returns None and bumps a
-        failure counter on any resolution failure.  Dedup (emitted_pairs) is
+        Returns a FineGrainedLineageClass on success; returns None on any
+        resolution failure.  Counter bookkeeping and dedup (emitted_pairs) are
         the caller's responsibility so that None unambiguously means failure.
         """
         # Parse columnId → url_id + warehouse column name.
@@ -1630,7 +1628,162 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             confidenceScore=1.0,
         )
 
-    def _build_dm_element_fine_grained_lineages(  # noqa: C901
+    def _resolve_cross_dm_fgl(
+        self,
+        *,
+        ref: "BracketRef",
+        element: SigmaDataModelElement,
+        element_dataset_urn: str,
+        entity_level_upstream_urns: Set[str],
+        downstream_field: str,
+    ) -> Optional[FineGrainedLineageClass]:
+        """Resolve a formula ref against cross-DM sources and return an FGL.
+
+        Returns None (and bumps the appropriate deferred/dropped counter) when
+        resolution fails; counter bookkeeping for the success case is the
+        caller's responsibility.
+        """
+        # Cross-DM source_ids use the shape <dm-url-id>/<suffix>; intra-DM
+        # source_ids are bare elementIds (no "/"). Filter accordingly.
+        source_dm_url_ids = {
+            sid.partition("/")[0]
+            for sid in element.source_ids
+            if "/" in sid and not sid.startswith("inode-")
+        }
+        cross_dm_candidate_urns = sorted(
+            {
+                urn
+                for dm_url_id in source_dm_url_ids
+                for urn in self.dm_element_urn_by_name.get(dm_url_id, {}).get(
+                    ref.source.lower(), []
+                )
+                if urn != element_dataset_urn
+            }
+        )
+        if not cross_dm_candidate_urns:
+            self.reporter.data_model_element_fgl_cross_dm_deferred += 1
+            return None
+        if len(cross_dm_candidate_urns) > 1:
+            # Restrict to entity-level confirmed candidates whenever any exist.
+            confirmed = [
+                u for u in cross_dm_candidate_urns if u in entity_level_upstream_urns
+            ]
+            if confirmed:
+                cross_dm_candidate_urns = confirmed
+            if len(cross_dm_candidate_urns) > 1:
+                self.reporter.data_model_element_fgl_cross_dm_collision_pick_first += 1
+        chosen_upstream_urn = cross_dm_candidate_urns[0]
+        # dm_element_urn_to_cols is populated for every URN in
+        # dm_element_urn_by_name (same loop in _prepopulate_dm_bridge_maps),
+        # so this get() will only be None if a URN reaches this point
+        # without going through prepopulation — defensively handled.
+        upstream_cols = self.dm_element_urn_to_cols.get(chosen_upstream_urn)
+        if upstream_cols is None:
+            self.reporter.data_model_element_fgl_cross_dm_deferred += 1
+            return None
+        canonical_col = upstream_cols.get(ref.column.lower())
+        if canonical_col is None:
+            self.reporter.data_model_element_fgl_cross_dm_dropped_unknown_upstream_column += 1
+            return None
+        return FineGrainedLineageClass(
+            downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
+            downstreams=[downstream_field],
+            upstreamType=FineGrainedLineageUpstreamTypeClass.FIELD_SET,
+            upstreams=[
+                builder.make_schema_field_urn(chosen_upstream_urn, canonical_col)
+            ],
+            confidenceScore=1.0,
+        )
+
+    def _resolve_intra_dm_fgl(
+        self,
+        *,
+        ref: "BracketRef",
+        candidate_eids_after_self_strip: List[str],
+        elementId_to_dataset_urn: Dict[str, str],
+        entity_level_upstream_urns: Set[str],
+        urn_to_cols: Dict[str, Dict[str, str]],
+        downstream_field: str,
+        element: SigmaDataModelElement,
+        data_model: SigmaDataModel,
+        fgls: List[FineGrainedLineageClass],
+        emitted_pairs: Set[Tuple[str, str]],
+    ) -> None:
+        """Resolve a formula ref against intra-DM sibling elements.
+
+        Appends to fgls and emitted_pairs on success; bumps the appropriate
+        counter on any resolution failure.  Counter bookkeeping and dedup are
+        handled here so the caller needs no conditional on the result.
+        """
+        candidate_urns = sorted(
+            elementId_to_dataset_urn[eid]
+            for eid in candidate_eids_after_self_strip
+            if eid in elementId_to_dataset_urn
+        )
+        surviving_urns = sorted(
+            u for u in candidate_urns if u in entity_level_upstream_urns
+        )
+
+        if not surviving_urns:
+            # Intra-DM candidate(s) exist but none appear in /lineage.
+            # Rare on tenants where /lineage correctly reports intra-DM edges;
+            # keep counter for observability on future tenants.
+            self.reporter.data_model_element_fgl_dropped_orphan_upstream += 1
+            return
+
+        # Collision handling: multiple siblings passed /lineage filter.
+        # Pick sorted-first to match the collision policy used elsewhere
+        # in this connector and Sigma's server-side coalescing.
+        if len(surviving_urns) > 1:
+            self.reporter.data_model_element_fgl_collision_pick_first += 1
+            self.reporter.warning(
+                title="Ambiguous DM element name in formula ref",
+                message=(
+                    f"Formula ref {ref.raw!r} in element {element.elementId} "
+                    f"resolves to {len(surviving_urns)} elements with the same "
+                    f"display name — picking the lexicographically-first URN "
+                    f"({surviving_urns[0]!r}). Rename duplicate elements in "
+                    f"Data Model {data_model.dataModelId} to remove ambiguity."
+                ),
+                context=f"ref={ref.raw!r}, candidates={surviving_urns}",
+            )
+        chosen_upstream_urn = surviving_urns[0]
+
+        # Validate and normalise ref.column against the chosen upstream
+        # element's schema winners to avoid a dangling schemaField URN.
+        source_cols = urn_to_cols.get(chosen_upstream_urn, {})
+        canonical_col = source_cols.get(ref.column.lower())
+        if canonical_col is None:
+            self.reporter.data_model_element_fgl_dropped_unknown_upstream_column += 1
+            logger.debug(
+                "DM %s element %s: ref %r column %r not found in upstream "
+                "element %s schema winners; dropping FGL entry",
+                data_model.dataModelId,
+                element.elementId,
+                ref.raw,
+                ref.column,
+                chosen_upstream_urn,
+            )
+            return
+
+        upstream_field = builder.make_schema_field_urn(
+            chosen_upstream_urn, canonical_col
+        )
+        pair = (downstream_field, upstream_field)
+        if pair in emitted_pairs:
+            return
+        emitted_pairs.add(pair)
+        fgls.append(
+            FineGrainedLineageClass(
+                downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
+                downstreams=[downstream_field],
+                upstreamType=FineGrainedLineageUpstreamTypeClass.FIELD_SET,
+                upstreams=[upstream_field],
+                confidenceScore=1.0,
+            )
+        )
+
+    def _build_dm_element_fine_grained_lineages(
         self,
         *,
         element: SigmaDataModelElement,
@@ -1678,12 +1831,17 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             downstream_field = builder.make_schema_field_urn(
                 element_dataset_urn, column.name
             )
-            # Warehouse FGL is emitted at most once per column (based on columnId,
-            # which encodes a single warehouse column identity). Attempting it once
-            # per bracket ref would misfire for formulas with multiple refs —
-            # e.g. concat([T/a], [T/b]) would emit the same columnId-derived FGL
-            # for both refs, producing a spurious match on the second ref.
-            _warehouse_fgl_attempted = False
+            # Compute warehouse FGL once per column. columnId encodes a single
+            # warehouse column identity regardless of how many bracket refs the
+            # formula contains, so calling _try_emit per-ref would emit duplicates
+            # for multi-ref formulas like concat([T/a], [T/b]).
+            warehouse_fgl = self._try_emit_warehouse_passthrough_fgl(
+                column=column,
+                element=element,
+                downstream_field=downstream_field,
+                warehouse_url_id_map=warehouse_url_id_map,
+            )
+            warehouse_consumed = False
             for ref in extract_bracket_refs(column.formula):
                 if ref.is_parameter or ref.column is None:
                     # [P_*] parameter refs and bare [col] intra-element refs
@@ -1702,18 +1860,10 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
 
                 if not candidate_eids_after_self_strip:
                     if candidate_eids:
-                        # All candidates were self-references; actual upstream is a
-                        # warehouse table — attempt FGL resolution via columnId.
-                        # Guard: attempt at most once per column so formulas with
-                        # multiple self-ref bracket refs don't emit duplicate FGLs.
-                        if not _warehouse_fgl_attempted:
-                            _warehouse_fgl_attempted = True
-                            warehouse_fgl = self._try_emit_warehouse_passthrough_fgl(
-                                column=column,
-                                element=element,
-                                downstream_field=downstream_field,
-                                warehouse_url_id_map=warehouse_url_id_map,
-                            )
+                        # All candidates were self-references; actual upstream is the
+                        # warehouse table — use the pre-computed warehouse FGL.
+                        if not warehouse_consumed:
+                            warehouse_consumed = True
                             if warehouse_fgl is None:
                                 self.reporter.data_model_element_fgl_warehouse_passthrough_deferred += 1
                             else:
@@ -1729,16 +1879,10 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                     # the warehouse table name as the formula source (e.g.
                     # "[CUSTOMERS/col]" on an element that isn't named "CUSTOMERS")
                     # rather than the element name — columnId is authoritative.
-                    # H4: if columnId is warehouse-shaped but _try_emit fails,
+                    # If columnId is warehouse-shaped but resolution failed,
                     # count as warehouse-deferred rather than cross-DM-deferred.
-                    if not _warehouse_fgl_attempted:
-                        _warehouse_fgl_attempted = True
-                        warehouse_fgl = self._try_emit_warehouse_passthrough_fgl(
-                            column=column,
-                            element=element,
-                            downstream_field=downstream_field,
-                            warehouse_url_id_map=warehouse_url_id_map,
-                        )
+                    if not warehouse_consumed:
+                        warehouse_consumed = True
                         if warehouse_fgl is not None:
                             assert warehouse_fgl.upstreams
                             pair = (downstream_field, warehouse_fgl.upstreams[0])
@@ -1748,154 +1892,38 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                                 self.reporter.data_model_element_fgl_warehouse_resolved += 1
                             continue
                         if (column.columnId or "").startswith("inode-"):
-                            # Warehouse-shaped columnId but resolution failed
-                            # (e.g. /files miss, unmappable connection).
                             self.reporter.data_model_element_fgl_warehouse_passthrough_deferred += 1
                             continue
 
-                    # Source not in this DM — search only the DMs this element's
-                    # source_ids explicitly reference. This prevents formula refs
-                    # like [Orders/id] from linking to any ingested element named
-                    # "Orders" regardless of whether Sigma reported a lineage
-                    # relationship to that DM.
-                    # entity_level_upstream_urns is used as a collision tiebreaker
-                    # (not a hard gate) because Sigma's /lineage API does not always
-                    # surface cross-DM formula deps at the entity level.
-                    # Cross-DM source_ids use the shape <dm-url-id>/<suffix>;
-                    # intra-DM source_ids are bare elementIds (no "/").  So
-                    # source_dm_url_ids will never contain the consuming DM's
-                    # own url_id under normal Sigma API behaviour.
-                    source_dm_url_ids = {
-                        sid.partition("/")[0]
-                        for sid in element.source_ids
-                        if "/" in sid and not sid.startswith("inode-")
-                    }
-                    cross_dm_candidate_urns = sorted(
-                        {
-                            urn
-                            for dm_url_id in source_dm_url_ids
-                            for urn in self.dm_element_urn_by_name.get(
-                                dm_url_id, {}
-                            ).get(ref.source.lower(), [])
-                            if urn != element_dataset_urn
-                        }
+                    # Source not in this DM — resolve via cross-DM sources that
+                    # Sigma's /lineage explicitly reported for this element.
+                    cross_dm_fgl = self._resolve_cross_dm_fgl(
+                        ref=ref,
+                        element=element,
+                        element_dataset_urn=element_dataset_urn,
+                        entity_level_upstream_urns=entity_level_upstream_urns,
+                        downstream_field=downstream_field,
                     )
-                    if not cross_dm_candidate_urns:
-                        self.reporter.data_model_element_fgl_cross_dm_deferred += 1
-                        continue
-                    if len(cross_dm_candidate_urns) > 1:
-                        # Restrict to entity-level confirmed candidates whenever
-                        # any exist — even a subset of 2+ is better than
-                        # including unconfirmed URNs that sort earlier.
-                        confirmed = [
-                            u
-                            for u in cross_dm_candidate_urns
-                            if u in entity_level_upstream_urns
-                        ]
-                        if confirmed:
-                            cross_dm_candidate_urns = confirmed
-                        if len(cross_dm_candidate_urns) > 1:
-                            # Still ambiguous after filtering; pick sorted-first.
-                            self.reporter.data_model_element_fgl_cross_dm_collision_pick_first += 1
-                    chosen_upstream_urn = cross_dm_candidate_urns[0]
-                    # dm_element_urn_to_cols is populated for every URN in
-                    # dm_element_urn_by_name (same loop in _prepopulate_dm_bridge_maps),
-                    # so this get() will only be None if a URN reaches this point
-                    # without going through prepopulation — defensively handled.
-                    upstream_cols = self.dm_element_urn_to_cols.get(chosen_upstream_urn)
-                    if upstream_cols is None:
-                        self.reporter.data_model_element_fgl_cross_dm_deferred += 1
-                        continue
-                    canonical_col = upstream_cols.get(ref.column.lower())
-                    if canonical_col is None:
-                        self.reporter.data_model_element_fgl_cross_dm_dropped_unknown_upstream_column += 1
-                        continue
-                    upstream_field = builder.make_schema_field_urn(
-                        chosen_upstream_urn, canonical_col
-                    )
-                    pair = (downstream_field, upstream_field)
-                    if pair not in emitted_pairs:
-                        emitted_pairs.add(pair)
-                        cross_dm_fgls.append(
-                            FineGrainedLineageClass(
-                                downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
-                                downstreams=[downstream_field],
-                                upstreamType=FineGrainedLineageUpstreamTypeClass.FIELD_SET,
-                                upstreams=[upstream_field],
-                                confidenceScore=1.0,
-                            )
-                        )
-                        self.reporter.data_model_element_fgl_cross_dm_resolved += 1
+                    if cross_dm_fgl is not None:
+                        assert cross_dm_fgl.upstreams
+                        pair = (downstream_field, cross_dm_fgl.upstreams[0])
+                        if pair not in emitted_pairs:
+                            emitted_pairs.add(pair)
+                            cross_dm_fgls.append(cross_dm_fgl)
+                            self.reporter.data_model_element_fgl_cross_dm_resolved += 1
                     continue
 
-                # Map surviving elementIds to Dataset URNs and filter against
-                # /lineage's reported entity-level upstreams.
-                candidate_urns = sorted(
-                    elementId_to_dataset_urn[eid]
-                    for eid in candidate_eids_after_self_strip
-                    if eid in elementId_to_dataset_urn
-                )
-                surviving_urns = sorted(
-                    u for u in candidate_urns if u in entity_level_upstream_urns
-                )
-
-                if not surviving_urns:
-                    # Intra-DM candidate(s) exist but none appear in /lineage.
-                    # Rare on tenants where /lineage correctly reports intra-DM edges;
-                    # keep counter for observability on future tenants.
-                    self.reporter.data_model_element_fgl_dropped_orphan_upstream += 1
-                    continue
-
-                # Collision handling: multiple siblings passed /lineage filter.
-                # Pick sorted-first to match the collision policy used elsewhere
-                # in this connector and Sigma's server-side coalescing.
-                if len(surviving_urns) > 1:
-                    self.reporter.data_model_element_fgl_collision_pick_first += 1
-                    self.reporter.warning(
-                        title="Ambiguous DM element name in formula ref",
-                        message=(
-                            f"Formula ref {ref.raw!r} in element {element.elementId} "
-                            f"resolves to {len(surviving_urns)} elements with the same "
-                            f"display name — picking the lexicographically-first URN "
-                            f"({surviving_urns[0]!r}). Rename duplicate elements in "
-                            f"Data Model {data_model.dataModelId} to remove ambiguity."
-                        ),
-                        context=f"ref={ref.raw!r}, candidates={surviving_urns}",
-                    )
-                chosen_upstream_urn = surviving_urns[0]
-
-                # Validate and normalise ref.column against the chosen upstream
-                # element's schema winners to avoid a dangling schemaField URN.
-                source_cols = urn_to_cols.get(chosen_upstream_urn, {})
-                canonical_col = source_cols.get(ref.column.lower())
-                if canonical_col is None:
-                    self.reporter.data_model_element_fgl_dropped_unknown_upstream_column += 1
-                    logger.debug(
-                        "DM %s element %s: ref %r column %r not found in upstream "
-                        "element %s schema winners; dropping FGL entry",
-                        data_model.dataModelId,
-                        element.elementId,
-                        ref.raw,
-                        ref.column,
-                        chosen_upstream_urn,
-                    )
-                    continue
-
-                upstream_field = builder.make_schema_field_urn(
-                    chosen_upstream_urn, canonical_col
-                )
-                pair = (downstream_field, upstream_field)
-                if pair in emitted_pairs:
-                    continue
-                emitted_pairs.add(pair)
-                fgls.append(
-                    FineGrainedLineageClass(
-                        downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
-                        downstreams=[downstream_field],
-                        upstreamType=FineGrainedLineageUpstreamTypeClass.FIELD_SET,
-                        upstreams=[upstream_field],
-                        confidenceScore=1.0,
-                    )
+                self._resolve_intra_dm_fgl(
+                    ref=ref,
+                    candidate_eids_after_self_strip=candidate_eids_after_self_strip,
+                    elementId_to_dataset_urn=elementId_to_dataset_urn,
+                    entity_level_upstream_urns=entity_level_upstream_urns,
+                    urn_to_cols=urn_to_cols,
+                    downstream_field=downstream_field,
+                    element=element,
+                    data_model=data_model,
+                    fgls=fgls,
+                    emitted_pairs=emitted_pairs,
                 )
         # fgl_emitted is the umbrella count for intra-DM AND warehouse-passthrough
         # FGL (both appended to `fgls`). Cross-DM is tracked separately via

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -764,8 +764,15 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             if len(parts) == 3:
                 db, schema = parts[1], parts[2]
             else:
+                # No DB in path — resolve from connection_to_platform_map override
+                # first, then fall back to the connection registry's default_database.
+                conn_override = self.config.connection_to_platform_map.get(conn_id)
                 conn_record = self.connection_registry.get(conn_id)
-                db = (conn_record.default_database or "") if conn_record else ""
+                db = (
+                    (conn_override.default_database if conn_override else None)
+                    or (conn_record.default_database if conn_record else None)
+                    or ""
+                )
                 schema = parts[1]
             result[url_id] = _WarehouseTableRef(
                 connection_id=conn_id,

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -1535,7 +1535,8 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         ("CUSTOMER_ID" / "customer_id").
 
         Returns a FineGrainedLineageClass on success, None on any failure.
-        Bumps the appropriate T4.B2 counter before returning None.
+        Bumps a failure counter before returning None on resolution failure;
+        returns None silently on dedup (emitted_pairs hit).
         """
         # Parse columnId → url_id + warehouse column name.
         col_id = column.columnId or ""
@@ -1558,14 +1559,14 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         # Guard: url_id must resolve in the warehouse map (i.e. /files succeeded).
         wh_ref = warehouse_url_id_map.get(url_id)
         if wh_ref is None:
-            # /files lookup failed for this inode — T4.B already bumped
-            # dm_element_warehouse_table_lookup_failed.
+            # /files lookup failed for this inode; dm_element_warehouse_table_lookup_failed
+            # is already bumped by _build_dm_warehouse_url_id_map.
             self.reporter.data_model_element_fgl_warehouse_no_warehouse_source += 1
             return None
 
-        # Resolve the parent Dataset URN via T4.B's helper.  This is the ONLY
-        # allowed path for URN construction — avoids casing or platform-instance
-        # drift that would produce orphan schemaFields.
+        # Resolve the parent Dataset URN.  This is the only allowed path for
+        # URN construction — env, platform_instance, and casing all live here,
+        # so bypassing it risks orphan schemaFields on casing or instance drift.
         parent_urn = self._resolve_dm_element_warehouse_upstream(
             url_id_suffix=url_id,
             warehouse_map=warehouse_url_id_map,
@@ -1576,11 +1577,11 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             return None
 
         # Normalize column casing to match the platform convention used by the
-        # warehouse connector when emitting its own schemaField URNs.
+        # warehouse connector.  _resolve_dm_element_warehouse_upstream already
+        # resolved the registry record and override, so these lookups are cheap
+        # dict hits on the same objects.
         record = self.connection_registry.get(wh_ref.connection_id)
-        if record is None:
-            self.reporter.data_model_element_fgl_warehouse_unmappable_connection += 1
-            return None
+        assert record is not None  # guaranteed by parent_urn being non-None above
         conn_override = self.config.connection_to_platform_map.get(wh_ref.connection_id)
         lowercase = conn_override.convert_urns_to_lowercase if conn_override else True
         normalized_col = _normalize_warehouse_identifier(
@@ -1620,9 +1621,9 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         Self-references are stripped before resolution: when a DM element is named
         after its warehouse source (e.g., element "data.csv" with formula
         "[data.csv/col]"), the formula ref matches the element's own name and must
-        be filtered out to avoid self-referential FGL.  T4.B2 resolves these via
-        _try_emit_warehouse_passthrough_fgl; unresolved remainder is counted under
-        fgl_warehouse_passthrough_deferred.
+        be filtered out to avoid self-referential FGL.  Warehouse-passthrough
+        refs are resolved via _try_emit_warehouse_passthrough_fgl; unresolved
+        remainder is counted under fgl_warehouse_passthrough_deferred.
 
         When multiple sibling elements share a name and both pass the /lineage filter,
         the lexicographically-first URN is chosen (matching the collision policy
@@ -1670,7 +1671,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                 if not candidate_eids_after_self_strip:
                     if candidate_eids:
                         # All candidates were self-references; actual upstream is a
-                        # warehouse table.  T4.B2: attempt warehouse FGL resolution.
+                        # warehouse table — attempt FGL resolution via columnId.
                         warehouse_fgl = self._try_emit_warehouse_passthrough_fgl(
                             column=column,
                             element=element,

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -765,6 +765,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             # 3-segment path → DB + SCHEMA (e.g. Snowflake "Connection Root/<DB>/<SCHEMA>")
             # 2-segment path → SCHEMA only; fall back to connection's default_database
             # (e.g. Redshift "Connection Root/<SCHEMA>" where the DB lives in the connection)
+            db: Optional[str]
             if len(parts) == 3:
                 db, schema = parts[1], parts[2]
             else:
@@ -1643,6 +1644,9 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         resolution fails; counter bookkeeping for the success case is the
         caller's responsibility.
         """
+        assert (
+            ref.column is not None
+        )  # callers guard on ref.column is None before dispatching
         # Cross-DM source_ids use the shape <dm-url-id>/<suffix>; intra-DM
         # source_ids are bare elementIds (no "/"). Filter accordingly.
         source_dm_url_ids = {
@@ -1715,6 +1719,9 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         counter on any resolution failure.  Counter bookkeeping and dedup are
         handled here so the caller needs no conditional on the result.
         """
+        assert (
+            ref.column is not None
+        )  # callers guard on ref.column is None before dispatching
         candidate_urns = sorted(
             elementId_to_dataset_urn[eid]
             for eid in candidate_eids_after_self_strip

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -758,9 +758,15 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                     data_model.dataModelId,
                     url_id,
                 )
-            # 2-segment path → no DB layer (e.g. Redshift "Connection Root/<SCHEMA>")
             # 3-segment path → DB + SCHEMA (e.g. Snowflake "Connection Root/<DB>/<SCHEMA>")
-            db, schema = ("", parts[1]) if len(parts) == 2 else (parts[1], parts[2])
+            # 2-segment path → SCHEMA only; fall back to connection's default_database
+            # (e.g. Redshift "Connection Root/<SCHEMA>" where the DB lives in the connection)
+            if len(parts) == 3:
+                db, schema = parts[1], parts[2]
+            else:
+                conn_record = self.connection_registry.get(conn_id)
+                db = (conn_record.default_database or "") if conn_record else ""
+                schema = parts[1]
             result[url_id] = _WarehouseTableRef(
                 connection_id=conn_id,
                 db=db,

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -238,7 +238,14 @@ class _WarehouseTableRef:
     table: str
 
     def fq_name(self, platform: str, *, lowercase: bool = True) -> str:
-        name = f"{self.db}.{self.schema}.{self.table}"
+        # db is empty for platforms with a 2-segment /files path (e.g. Redshift:
+        # "Connection Root/<SCHEMA>"). In that case emit schema.table; otherwise
+        # emit the full db.schema.table used by Snowflake and similar platforms.
+        name = (
+            f"{self.schema}.{self.table}"
+            if not self.db
+            else f"{self.db}.{self.schema}.{self.table}"
+        )
         if platform.lower() in _WAREHOUSE_LOWERCASE_PLATFORMS and lowercase:
             return name.lower()
         return name
@@ -710,13 +717,13 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             # name field, which may be a display label or absent.
             table_name = str(files_data.get("name") or "")
             parts = path.split("/")
-            # Validate: exactly 3 non-empty segments and a non-empty urlId.
-            # Rejects "Acryl Workspace" (CSV uploads), "Connection Root//PUBLIC"
-            # (empty DB segment -> malformed URN), and >3 segments.
-            # H4 TODO: confirm with Sigma whether API path strings are localised;
-            # if so, relax the literal "Connection Root" check.
-            path_invalid = (
-                not url_id or not table_name or len(parts) != 3 or not all(parts)
+            # Accept 2–3 non-root segments (all non-empty) plus a non-empty urlId:
+            #   "Connection Root/<SCHEMA>"      — Redshift, MySQL (no DB layer)
+            #   "Connection Root/<DB>/<SCHEMA>" — Snowflake, Postgres
+            # Fewer segments (CSV uploads like "Acryl Workspace"), empty segments,
+            # or 4+ segments (not yet mapped) are all rejected.
+            path_invalid = not (
+                url_id and table_name and 2 <= len(parts) <= 3 and all(parts)
             )
             root_unexpected = (not path_invalid) and parts[0] != _FILES_PATH_ROOT
             if path_invalid or root_unexpected:
@@ -732,8 +739,9 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                             else "Sigma warehouse /files path unparseable"
                         ),
                         message=(
-                            "Expected exactly 'Connection Root/<DB>/<SCHEMA>' with "
-                            "no empty segments and a non-empty urlId. "
+                            "Expected 'Connection Root/<SCHEMA>' or "
+                            "'Connection Root/<DB>/<SCHEMA>' with no empty "
+                            "segments and a non-empty urlId. "
                             "Warehouse upstream skipped for this inode."
                         ),
                         context=(
@@ -750,10 +758,13 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                     data_model.dataModelId,
                     url_id,
                 )
+            # 2-segment path → no DB layer (e.g. Redshift "Connection Root/<SCHEMA>")
+            # 3-segment path → DB + SCHEMA (e.g. Snowflake "Connection Root/<DB>/<SCHEMA>")
+            db, schema = ("", parts[1]) if len(parts) == 2 else (parts[1], parts[2])
             result[url_id] = _WarehouseTableRef(
                 connection_id=conn_id,
-                db=parts[1],
-                schema=parts[2],
+                db=db,
+                schema=schema,
                 table=table_name,
             )
         return result

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -379,6 +379,9 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         # Inodes whose /files path already produced an unparseable warning;
         # prevents N identical warnings when the same inode spans N DMs (H3).
         self._files_path_unparseable_seen: Set[str] = set()
+        # Connections for which a "default_database not configured" warning has
+        # been emitted; dedup so multi-DM tenants don't flood the report.
+        self._missing_default_db_warned: Set[str] = set()
         # Once-per-run gate flags so noisy global conditions don't flood logs.
         self._registry_empty_warned: bool = False
         # Per-platform set: platforms for which we've emitted a "first emission"
@@ -717,11 +720,12 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             # name field, which may be a display label or absent.
             table_name = str(files_data.get("name") or "")
             parts = path.split("/")
-            # Accept 2–3 non-root segments (all non-empty) plus a non-empty urlId:
+            # Accept 2–3 total segments after splitting on "/" (1–2 non-root parts,
+            # all non-empty) plus a non-empty urlId:
             #   "Connection Root/<SCHEMA>"      — Redshift, MySQL (no DB layer)
             #   "Connection Root/<DB>/<SCHEMA>" — Snowflake, Postgres
-            # Fewer segments (CSV uploads like "Acryl Workspace"), empty segments,
-            # or 4+ segments (not yet mapped) are all rejected.
+            # Fewer total segments (e.g. "Acryl Workspace" = 1), empty segments,
+            # or 4+ total segments (not yet mapped) are all rejected.
             path_invalid = not (
                 url_id and table_name and 2 <= len(parts) <= 3 and all(parts)
             )
@@ -774,6 +778,20 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                     or ""
                 )
                 schema = parts[1]
+                if not db and conn_id not in self._missing_default_db_warned:
+                    self._missing_default_db_warned.add(conn_id)
+                    self.reporter.warning(
+                        title="Sigma warehouse default_database not configured",
+                        message=(
+                            "The /files path for this connection has no database layer "
+                            "(e.g. 'Connection Root/<SCHEMA>'). The emitted warehouse "
+                            "URN will use schema.table only, which will not match a "
+                            "connector that uses db.schema.table. Set "
+                            "connection_to_platform_map.<connectionId>.default_database "
+                            "in the recipe to fix the URN."
+                        ),
+                        context=f"connectionId={conn_id}, path={path!r}",
+                    )
             result[url_id] = _WarehouseTableRef(
                 connection_id=conn_id,
                 db=db,
@@ -1660,6 +1678,12 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             downstream_field = builder.make_schema_field_urn(
                 element_dataset_urn, column.name
             )
+            # Warehouse FGL is emitted at most once per column (based on columnId,
+            # which encodes a single warehouse column identity). Attempting it once
+            # per bracket ref would misfire for formulas with multiple refs —
+            # e.g. concat([T/a], [T/b]) would emit the same columnId-derived FGL
+            # for both refs, producing a spurious match on the second ref.
+            _warehouse_fgl_attempted = False
             for ref in extract_bracket_refs(column.formula):
                 if ref.is_parameter or ref.column is None:
                     # [P_*] parameter refs and bare [col] intra-element refs
@@ -1680,42 +1704,54 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                     if candidate_eids:
                         # All candidates were self-references; actual upstream is a
                         # warehouse table — attempt FGL resolution via columnId.
-                        warehouse_fgl = self._try_emit_warehouse_passthrough_fgl(
-                            column=column,
-                            element=element,
-                            downstream_field=downstream_field,
-                            warehouse_url_id_map=warehouse_url_id_map,
-                        )
-                        if warehouse_fgl is None:
-                            self.reporter.data_model_element_fgl_warehouse_passthrough_deferred += 1
-                        else:
-                            assert warehouse_fgl.upstreams
-                            pair = (downstream_field, warehouse_fgl.upstreams[0])
-                            if pair not in emitted_pairs:
-                                emitted_pairs.add(pair)
-                                fgls.append(warehouse_fgl)
-                                self.reporter.data_model_element_fgl_warehouse_resolved += 1
-                            # else: duplicate ref in same formula — silent, not a deferral
+                        # Guard: attempt at most once per column so formulas with
+                        # multiple self-ref bracket refs don't emit duplicate FGLs.
+                        if not _warehouse_fgl_attempted:
+                            _warehouse_fgl_attempted = True
+                            warehouse_fgl = self._try_emit_warehouse_passthrough_fgl(
+                                column=column,
+                                element=element,
+                                downstream_field=downstream_field,
+                                warehouse_url_id_map=warehouse_url_id_map,
+                            )
+                            if warehouse_fgl is None:
+                                self.reporter.data_model_element_fgl_warehouse_passthrough_deferred += 1
+                            else:
+                                assert warehouse_fgl.upstreams
+                                pair = (downstream_field, warehouse_fgl.upstreams[0])
+                                if pair not in emitted_pairs:
+                                    emitted_pairs.add(pair)
+                                    fgls.append(warehouse_fgl)
+                                    self.reporter.data_model_element_fgl_warehouse_resolved += 1
                         continue
                     # No intra-DM candidate. Before cross-DM search, try the
                     # warehouse path via columnId. Sigma elements sometimes use
                     # the warehouse table name as the formula source (e.g.
                     # "[CUSTOMERS/col]" on an element that isn't named "CUSTOMERS")
                     # rather than the element name — columnId is authoritative.
-                    warehouse_fgl = self._try_emit_warehouse_passthrough_fgl(
-                        column=column,
-                        element=element,
-                        downstream_field=downstream_field,
-                        warehouse_url_id_map=warehouse_url_id_map,
-                    )
-                    if warehouse_fgl is not None:
-                        assert warehouse_fgl.upstreams
-                        pair = (downstream_field, warehouse_fgl.upstreams[0])
-                        if pair not in emitted_pairs:
-                            emitted_pairs.add(pair)
-                            fgls.append(warehouse_fgl)
-                            self.reporter.data_model_element_fgl_warehouse_resolved += 1
-                        continue
+                    # H4: if columnId is warehouse-shaped but _try_emit fails,
+                    # count as warehouse-deferred rather than cross-DM-deferred.
+                    if not _warehouse_fgl_attempted:
+                        _warehouse_fgl_attempted = True
+                        warehouse_fgl = self._try_emit_warehouse_passthrough_fgl(
+                            column=column,
+                            element=element,
+                            downstream_field=downstream_field,
+                            warehouse_url_id_map=warehouse_url_id_map,
+                        )
+                        if warehouse_fgl is not None:
+                            assert warehouse_fgl.upstreams
+                            pair = (downstream_field, warehouse_fgl.upstreams[0])
+                            if pair not in emitted_pairs:
+                                emitted_pairs.add(pair)
+                                fgls.append(warehouse_fgl)
+                                self.reporter.data_model_element_fgl_warehouse_resolved += 1
+                            continue
+                        if (column.columnId or "").startswith("inode-"):
+                            # Warehouse-shaped columnId but resolution failed
+                            # (e.g. /files miss, unmappable connection).
+                            self.reporter.data_model_element_fgl_warehouse_passthrough_deferred += 1
+                            continue
 
                     # Source not in this DM — search only the DMs this element's
                     # source_ids explicitly reference. This prevents formula refs
@@ -1861,8 +1897,10 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                         confidenceScore=1.0,
                     )
                 )
-        # fgl_emitted tracks intra-DM FGL only; cross-DM is tracked separately
-        # via fgl_cross_dm_resolved so operators can see both buckets independently.
+        # fgl_emitted is the umbrella count for intra-DM AND warehouse-passthrough
+        # FGL (both appended to `fgls`). Cross-DM is tracked separately via
+        # fgl_cross_dm_resolved. Warehouse-passthrough is also sub-counted in
+        # fgl_warehouse_resolved (overlap intentional for independent triage).
         self.reporter.data_model_element_fgl_emitted += len(fgls)
         all_fgls = fgls + cross_dm_fgls
         all_fgls.sort(

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -1524,9 +1524,8 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         element: SigmaDataModelElement,
         downstream_field: str,
         warehouse_url_id_map: Dict[str, _WarehouseTableRef],
-        emitted_pairs: Set[Tuple[str, str]],
     ) -> Optional[FineGrainedLineageClass]:
-        """Attempt to emit a warehouse-passthrough FineGrainedLineage entry.
+        """Attempt to build a warehouse-passthrough FineGrainedLineage entry.
 
         Resolves the column's warehouse identity via the columnId field, which
         Sigma encodes as ``inode-<url_id>/<WAREHOUSE_COLUMN_NAME>``.  This is
@@ -1534,9 +1533,9 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         name (e.g. "Customer Id") rather than the warehouse identifier
         ("CUSTOMER_ID" / "customer_id").
 
-        Returns a FineGrainedLineageClass on success, None on any failure.
-        Bumps a failure counter before returning None on resolution failure;
-        returns None silently on dedup (emitted_pairs hit).
+        Returns a FineGrainedLineageClass on success; returns None and bumps a
+        failure counter on any resolution failure.  Dedup (emitted_pairs) is
+        the caller's responsibility so that None unambiguously means failure.
         """
         # Parse columnId → url_id + warehouse column name.
         col_id = column.columnId or ""
@@ -1581,21 +1580,16 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         # resolved the registry record and override, so these lookups are cheap
         # dict hits on the same objects.
         record = self.connection_registry.get(wh_ref.connection_id)
-        assert record is not None  # guaranteed by parent_urn being non-None above
+        if record is None:
+            # Should not happen when parent_urn is non-None, but degrade safely.
+            self.reporter.data_model_element_fgl_warehouse_unmappable_connection += 1
+            return None
         conn_override = self.config.connection_to_platform_map.get(wh_ref.connection_id)
         lowercase = conn_override.convert_urns_to_lowercase if conn_override else True
         normalized_col = _normalize_warehouse_identifier(
             warehouse_col, record.datahub_platform, lowercase
         )
-
         upstream_field = builder.make_schema_field_urn(parent_urn, normalized_col)
-        pair = (downstream_field, upstream_field)
-        if pair in emitted_pairs:
-            return None
-        emitted_pairs.add(pair)
-
-        self.reporter.data_model_element_fgl_warehouse_resolved += 1
-        self.reporter.data_model_element_fgl_warehouse_emitted_total += 1
         return FineGrainedLineageClass(
             downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
             downstreams=[downstream_field],
@@ -1677,12 +1671,18 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                             element=element,
                             downstream_field=downstream_field,
                             warehouse_url_id_map=warehouse_url_id_map,
-                            emitted_pairs=emitted_pairs,
                         )
-                        if warehouse_fgl is not None:
-                            fgls.append(warehouse_fgl)
-                        else:
+                        if warehouse_fgl is None:
                             self.reporter.data_model_element_fgl_warehouse_passthrough_deferred += 1
+                        else:
+                            assert warehouse_fgl.upstreams
+                            pair = (downstream_field, warehouse_fgl.upstreams[0])
+                            if pair not in emitted_pairs:
+                                emitted_pairs.add(pair)
+                                fgls.append(warehouse_fgl)
+                                self.reporter.data_model_element_fgl_warehouse_resolved += 1
+                                self.reporter.data_model_element_fgl_warehouse_emitted_total += 1
+                            # else: duplicate ref in same formula — silent, not a deferral
                         continue
                     # Source not in this DM — search only the DMs this element's
                     # source_ids explicitly reference. This prevents formula refs

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -1540,27 +1540,21 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         # Parse columnId → url_id + warehouse column name.
         col_id = column.columnId or ""
         if not col_id.startswith("inode-"):
-            self.reporter.data_model_element_fgl_warehouse_no_warehouse_source += 1
             return None
         suffix = col_id[len("inode-") :]
         url_id, sep, warehouse_col = suffix.partition("/")
         if not sep or not warehouse_col:
-            self.reporter.data_model_element_fgl_warehouse_no_warehouse_source += 1
             return None
 
         # Verify this url_id is one of the element's declared warehouse sources.
         # Mismatches can occur if a column belongs to a different element's inode
         # (shouldn't happen with well-formed API data, but guards against drift).
         if f"inode-{url_id}" not in element.source_ids:
-            self.reporter.data_model_element_fgl_warehouse_no_warehouse_source += 1
             return None
 
         # Guard: url_id must resolve in the warehouse map (i.e. /files succeeded).
         wh_ref = warehouse_url_id_map.get(url_id)
         if wh_ref is None:
-            # /files lookup failed for this inode; dm_element_warehouse_table_lookup_failed
-            # is already bumped by _build_dm_warehouse_url_id_map.
-            self.reporter.data_model_element_fgl_warehouse_no_warehouse_source += 1
             return None
 
         # Resolve the parent Dataset URN.  This is the only allowed path for
@@ -1571,8 +1565,6 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             warehouse_map=warehouse_url_id_map,
         )
         if parent_urn is None:
-            # Connection not in registry or is_mappable=False.
-            self.reporter.data_model_element_fgl_warehouse_unmappable_connection += 1
             return None
 
         # Normalize column casing to match the platform convention used by the
@@ -1581,8 +1573,6 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         # dict hits on the same objects.
         record = self.connection_registry.get(wh_ref.connection_id)
         if record is None:
-            # Should not happen when parent_urn is non-None, but degrade safely.
-            self.reporter.data_model_element_fgl_warehouse_unmappable_connection += 1
             return None
         conn_override = self.config.connection_to_platform_map.get(wh_ref.connection_id)
         lowercase = conn_override.convert_urns_to_lowercase if conn_override else True
@@ -1681,7 +1671,6 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                                 emitted_pairs.add(pair)
                                 fgls.append(warehouse_fgl)
                                 self.reporter.data_model_element_fgl_warehouse_resolved += 1
-                                self.reporter.data_model_element_fgl_warehouse_emitted_total += 1
                             # else: duplicate ref in same formula — silent, not a deferral
                         continue
                     # Source not in this DM — search only the DMs this element's

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -1673,6 +1673,26 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                                 self.reporter.data_model_element_fgl_warehouse_resolved += 1
                             # else: duplicate ref in same formula — silent, not a deferral
                         continue
+                    # No intra-DM candidate. Before cross-DM search, try the
+                    # warehouse path via columnId. Sigma elements sometimes use
+                    # the warehouse table name as the formula source (e.g.
+                    # "[CUSTOMERS/col]" on an element that isn't named "CUSTOMERS")
+                    # rather than the element name — columnId is authoritative.
+                    warehouse_fgl = self._try_emit_warehouse_passthrough_fgl(
+                        column=column,
+                        element=element,
+                        downstream_field=downstream_field,
+                        warehouse_url_id_map=warehouse_url_id_map,
+                    )
+                    if warehouse_fgl is not None:
+                        assert warehouse_fgl.upstreams
+                        pair = (downstream_field, warehouse_fgl.upstreams[0])
+                        if pair not in emitted_pairs:
+                            emitted_pairs.add(pair)
+                            fgls.append(warehouse_fgl)
+                            self.reporter.data_model_element_fgl_warehouse_resolved += 1
+                        continue
+
                     # Source not in this DM — search only the DMs this element's
                     # source_ids explicitly reference. This prevents formula refs
                     # like [Orders/id] from linking to any ingested element named

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -217,6 +217,17 @@ _WAREHOUSE_LOWERCASE_PLATFORMS: frozenset[str] = frozenset({"snowflake"})
 _FILES_PATH_ROOT = "Connection Root"
 
 
+def _normalize_warehouse_identifier(name: str, platform: str, lowercase: bool) -> str:
+    """Apply platform-appropriate casing to a warehouse identifier (table or column).
+
+    Mirrors _WarehouseTableRef.fq_name's casing logic so table and column
+    identifiers in schemaField URNs use the same convention.
+    """
+    if platform.lower() in _WAREHOUSE_LOWERCASE_PLATFORMS and lowercase:
+        return name.lower()
+    return name
+
+
 @dataclass(frozen=True)
 class _WarehouseTableRef:
     """Resolved warehouse table coordinates derived from a /files response."""
@@ -1438,6 +1449,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             elementId_to_dataset_urn=elementId_to_dataset_urn,
             entity_level_upstream_urns=set(upstream_urns),
             data_model=data_model,
+            warehouse_url_id_map=warehouse_url_id_map,
         )
         return UpstreamLineage(
             upstreams=[
@@ -1505,7 +1517,93 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             entityUrn=element_dataset_urn, aspect=schema_metadata
         ).as_workunit()
 
-    def _build_dm_element_fine_grained_lineages(
+    def _try_emit_warehouse_passthrough_fgl(
+        self,
+        *,
+        column: SigmaDataModelColumn,
+        element: SigmaDataModelElement,
+        downstream_field: str,
+        warehouse_url_id_map: Dict[str, _WarehouseTableRef],
+        emitted_pairs: Set[Tuple[str, str]],
+    ) -> Optional[FineGrainedLineageClass]:
+        """Attempt to emit a warehouse-passthrough FineGrainedLineage entry.
+
+        Resolves the column's warehouse identity via the columnId field, which
+        Sigma encodes as ``inode-<url_id>/<WAREHOUSE_COLUMN_NAME>``.  This is
+        more reliable than the formula bracket ref, which carries the DM display
+        name (e.g. "Customer Id") rather than the warehouse identifier
+        ("CUSTOMER_ID" / "customer_id").
+
+        Returns a FineGrainedLineageClass on success, None on any failure.
+        Bumps the appropriate T4.B2 counter before returning None.
+        """
+        # Parse columnId → url_id + warehouse column name.
+        col_id = column.columnId or ""
+        if not col_id.startswith("inode-"):
+            self.reporter.data_model_element_fgl_warehouse_no_warehouse_source += 1
+            return None
+        suffix = col_id[len("inode-") :]
+        url_id, sep, warehouse_col = suffix.partition("/")
+        if not sep or not warehouse_col:
+            self.reporter.data_model_element_fgl_warehouse_no_warehouse_source += 1
+            return None
+
+        # Verify this url_id is one of the element's declared warehouse sources.
+        # Mismatches can occur if a column belongs to a different element's inode
+        # (shouldn't happen with well-formed API data, but guards against drift).
+        if f"inode-{url_id}" not in element.source_ids:
+            self.reporter.data_model_element_fgl_warehouse_no_warehouse_source += 1
+            return None
+
+        # Guard: url_id must resolve in the warehouse map (i.e. /files succeeded).
+        wh_ref = warehouse_url_id_map.get(url_id)
+        if wh_ref is None:
+            # /files lookup failed for this inode — T4.B already bumped
+            # dm_element_warehouse_table_lookup_failed.
+            self.reporter.data_model_element_fgl_warehouse_no_warehouse_source += 1
+            return None
+
+        # Resolve the parent Dataset URN via T4.B's helper.  This is the ONLY
+        # allowed path for URN construction — avoids casing or platform-instance
+        # drift that would produce orphan schemaFields.
+        parent_urn = self._resolve_dm_element_warehouse_upstream(
+            url_id_suffix=url_id,
+            warehouse_map=warehouse_url_id_map,
+        )
+        if parent_urn is None:
+            # Connection not in registry or is_mappable=False.
+            self.reporter.data_model_element_fgl_warehouse_unmappable_connection += 1
+            return None
+
+        # Normalize column casing to match the platform convention used by the
+        # warehouse connector when emitting its own schemaField URNs.
+        record = self.connection_registry.get(wh_ref.connection_id)
+        if record is None:
+            self.reporter.data_model_element_fgl_warehouse_unmappable_connection += 1
+            return None
+        conn_override = self.config.connection_to_platform_map.get(wh_ref.connection_id)
+        lowercase = conn_override.convert_urns_to_lowercase if conn_override else True
+        normalized_col = _normalize_warehouse_identifier(
+            warehouse_col, record.datahub_platform, lowercase
+        )
+
+        upstream_field = builder.make_schema_field_urn(parent_urn, normalized_col)
+        pair = (downstream_field, upstream_field)
+        if pair in emitted_pairs:
+            return None
+        emitted_pairs.add(pair)
+
+        self.reporter.data_model_element_fgl_warehouse_resolved += 1
+        self.reporter.data_model_element_fgl_warehouse_emitted_total += 1
+        return FineGrainedLineageClass(
+            downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
+            downstreams=[downstream_field],
+            upstreamType=FineGrainedLineageUpstreamTypeClass.FIELD_SET,
+            upstreams=[upstream_field],
+            confidenceScore=1.0,
+        )
+
+    def _build_dm_element_fine_grained_lineages(  # noqa: C901
         self,
         *,
         element: SigmaDataModelElement,
@@ -1514,6 +1612,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         elementId_to_dataset_urn: Dict[str, str],
         entity_level_upstream_urns: Set[str],
         data_model: SigmaDataModel,
+        warehouse_url_id_map: Dict[str, _WarehouseTableRef],
     ) -> List[FineGrainedLineageClass]:
         """Build FineGrainedLineage entries for intra-DM [ElementName/col] refs.
 
@@ -1521,8 +1620,9 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         Self-references are stripped before resolution: when a DM element is named
         after its warehouse source (e.g., element "data.csv" with formula
         "[data.csv/col]"), the formula ref matches the element's own name and must
-        be filtered out to avoid self-referential FGL.  These are counted under
-        fgl_warehouse_passthrough_deferred and left for warehouse-external resolution.
+        be filtered out to avoid self-referential FGL.  T4.B2 resolves these via
+        _try_emit_warehouse_passthrough_fgl; unresolved remainder is counted under
+        fgl_warehouse_passthrough_deferred.
 
         When multiple sibling elements share a name and both pass the /lineage filter,
         the lexicographically-first URN is chosen (matching the collision policy
@@ -1570,8 +1670,18 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                 if not candidate_eids_after_self_strip:
                     if candidate_eids:
                         # All candidates were self-references; actual upstream is a
-                        # warehouse table.
-                        self.reporter.data_model_element_fgl_warehouse_passthrough_deferred += 1
+                        # warehouse table.  T4.B2: attempt warehouse FGL resolution.
+                        warehouse_fgl = self._try_emit_warehouse_passthrough_fgl(
+                            column=column,
+                            element=element,
+                            downstream_field=downstream_field,
+                            warehouse_url_id_map=warehouse_url_id_map,
+                            emitted_pairs=emitted_pairs,
+                        )
+                        if warehouse_fgl is not None:
+                            fgls.append(warehouse_fgl)
+                        else:
+                            self.reporter.data_model_element_fgl_warehouse_passthrough_deferred += 1
                         continue
                     # Source not in this DM — search only the DMs this element's
                     # source_ids explicitly reference. This prevents formula refs

--- a/metadata-ingestion/tests/integration/sigma/golden_test_sigma_dm_element_warehouse_fgl.json
+++ b/metadata-ingestion/tests/integration/sigma/golden_test_sigma_dm_element_warehouse_fgl.json
@@ -1,0 +1,2131 @@
+[
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,49HFLTr6xytgrPly3PFsNC,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227367,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,49HFLTr6xytgrPly3PFsNC,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "datasetId": "8891fd40-5470-4ff2-a74f-6e61ee44d3fc",
+                "path": "Acryl Data"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/b/49HFLTr6xytgrPly3PFsNC",
+            "name": "PETS",
+            "qualifiedName": "PETS",
+            "description": "",
+            "created": {
+                "time": 1713188592664
+            },
+            "lastModified": {
+                "time": 1713188592664
+            },
+            "tags": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227367,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,49HFLTr6xytgrPly3PFsNC,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227367,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,49HFLTr6xytgrPly3PFsNC,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:john.doe@example.com",
+                    "type": "DATAOWNER"
+                }
+            ],
+            "ownerTypes": {},
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227368,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,49HFLTr6xytgrPly3PFsNC,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Sigma Dataset"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227368,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,49HFLTr6xytgrPly3PFsNC,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227368,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,5LqGLu14qUnqh3cN6wRJBd,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227370,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,5LqGLu14qUnqh3cN6wRJBd,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "datasetId": "bd6b86e8-cd4a-4b25-ab65-f258c2a68a8f",
+                "path": "Acryl Data/New Folder"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/b/5LqGLu14qUnqh3cN6wRJBd",
+            "name": "PET_PROFILES_JOINED_DYNAMIC",
+            "qualifiedName": "PET_PROFILES_JOINED_DYNAMIC",
+            "description": "",
+            "created": {
+                "time": 1713189068019
+            },
+            "lastModified": {
+                "time": 1713189068019
+            },
+            "tags": [
+                "Deprecated"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227370,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,5LqGLu14qUnqh3cN6wRJBd,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227370,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,5LqGLu14qUnqh3cN6wRJBd,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:john.doe@example.com",
+                    "type": "DATAOWNER"
+                }
+            ],
+            "ownerTypes": {},
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227371,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,5LqGLu14qUnqh3cN6wRJBd,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Sigma Dataset"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227371,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,5LqGLu14qUnqh3cN6wRJBd,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "globalTags",
+    "aspect": {
+        "json": {
+            "tags": [
+                {
+                    "tag": "urn:li:tag:Deprecated"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227371,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,5LqGLu14qUnqh3cN6wRJBd,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "New Folder"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227371,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:818113c9d17a14105fa03b045b7b0def",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227372,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:818113c9d17a14105fa03b045b7b0def",
+    "changeType": "UPSERT",
+    "aspectName": "containerProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "platform": "sigma",
+                "dataModelId": "81e9980c-3ec8-4bbf-a38e-78f9fe472ce0",
+                "dataModelUrlId": "Acme-Snowflake-DM-fixture01",
+                "latestVersion": "1",
+                "path": "Acryl Data"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/dm/Acme-Snowflake-DM-fixture01",
+            "name": "Acme Snowflake DM",
+            "description": "Integration fixture for warehouse-backed DM element",
+            "created": {
+                "time": 1777852800000
+            },
+            "lastModified": {
+                "time": 1777852800000
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227372,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:818113c9d17a14105fa03b045b7b0def",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227372,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:818113c9d17a14105fa03b045b7b0def",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:sigma"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227372,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:818113c9d17a14105fa03b045b7b0def",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Sigma Data Model"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227373,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:818113c9d17a14105fa03b045b7b0def",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227373,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,81e9980c-3ec8-4bbf-a38e-78f9fe472ce0.byF6DckhFw,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227377,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,81e9980c-3ec8-4bbf-a38e-78f9fe472ce0.byF6DckhFw,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dataModelId": "81e9980c-3ec8-4bbf-a38e-78f9fe472ce0",
+                "dataModelUrlId": "Acme-Snowflake-DM-fixture01",
+                "elementId": "byF6DckhFw",
+                "type": "table"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/dm/Acme-Snowflake-DM-fixture01?:nodeId=byF6DckhFw",
+            "name": "CUSTOMERS",
+            "qualifiedName": "Acme Snowflake DM/CUSTOMERS",
+            "tags": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227377,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,81e9980c-3ec8-4bbf-a38e-78f9fe472ce0.byF6DckhFw,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Sigma Data Model Element"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227378,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,81e9980c-3ec8-4bbf-a38e-78f9fe472ce0.byF6DckhFw,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "CUSTOMERS",
+            "platform": "urn:li:dataPlatform:sigma",
+            "version": 0,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.OtherSchema": {
+                    "rawSchema": ""
+                }
+            },
+            "fields": [
+                {
+                    "fieldPath": "Customer Id",
+                    "nullable": false,
+                    "description": "Customer Id",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NullType": {}
+                        }
+                    },
+                    "nativeDataType": "unknown",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "Email",
+                    "nullable": false,
+                    "description": "Email",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NullType": {}
+                        }
+                    },
+                    "nativeDataType": "unknown",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "First Name",
+                    "nullable": false,
+                    "description": "First Name",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NullType": {}
+                        }
+                    },
+                    "nativeDataType": "unknown",
+                    "recursive": false,
+                    "isPartOfKey": false
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227378,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,81e9980c-3ec8-4bbf-a38e-78f9fe472ce0.byF6DckhFw,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:818113c9d17a14105fa03b045b7b0def"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227378,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,81e9980c-3ec8-4bbf-a38e-78f9fe472ce0.byF6DckhFw,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "upstreamLineage",
+    "aspect": {
+        "json": {
+            "upstreams": [
+                {
+                    "auditStamp": {
+                        "time": 0,
+                        "actor": "urn:li:corpuser:unknown"
+                    },
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,warehouse_coffee_company.public.customers,PROD)",
+                    "type": "TRANSFORMED"
+                }
+            ],
+            "fineGrainedLineages": [
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,warehouse_coffee_company.public.customers,PROD),customer_id)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:sigma,81e9980c-3ec8-4bbf-a38e-78f9fe472ce0.byF6DckhFw,PROD),Customer Id)"
+                    ],
+                    "confidenceScore": 1.0
+                },
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,warehouse_coffee_company.public.customers,PROD),email)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:sigma,81e9980c-3ec8-4bbf-a38e-78f9fe472ce0.byF6DckhFw,PROD),Email)"
+                    ],
+                    "confidenceScore": 1.0
+                },
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,warehouse_coffee_company.public.customers,PROD),first_name)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:sigma,81e9980c-3ec8-4bbf-a38e-78f9fe472ce0.byF6DckhFw,PROD),First Name)"
+                    ],
+                    "confidenceScore": 1.0
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227379,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,81e9980c-3ec8-4bbf-a38e-78f9fe472ce0.byF6DckhFw,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "urn:li:container:818113c9d17a14105fa03b045b7b0def",
+                    "urn": "urn:li:container:818113c9d17a14105fa03b045b7b0def"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227379,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227379,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+    "changeType": "UPSERT",
+    "aspectName": "dashboardInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "path": "Acryl Data",
+                "latestVersion": "2"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/workbook/4JRFW1HThPI1K3YTjouXI7",
+            "title": "Acryl Workbook",
+            "description": "",
+            "charts": [],
+            "datasets": [],
+            "dashboards": [
+                {
+                    "sourceUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+                    "destinationUrn": "urn:li:dashboard:(sigma,OSnGLBzL1i)"
+                },
+                {
+                    "sourceUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+                    "destinationUrn": "urn:li:dashboard:(sigma,DFSieiAcgo)"
+                }
+            ],
+            "lastModified": {
+                "created": {
+                    "time": 1713188691477,
+                    "actor": "urn:li:corpuser:datahub"
+                },
+                "lastModified": {
+                    "time": 1713189117302,
+                    "actor": "urn:li:corpuser:datahub"
+                }
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227380,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Sigma Workbook"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227380,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:john.doe@example.com",
+                    "type": "DATAOWNER"
+                }
+            ],
+            "ownerTypes": {},
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227380,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+    "changeType": "UPSERT",
+    "aspectName": "globalTags",
+    "aspect": {
+        "json": {
+            "tags": [
+                {
+                    "tag": "urn:li:tag:Warning"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227380,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227380,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "Acryl Workbook"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227380,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,OSnGLBzL1i)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227381,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,OSnGLBzL1i)",
+    "changeType": "UPSERT",
+    "aspectName": "dashboardInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "ElementsCount": "2"
+            },
+            "title": "Page 1",
+            "description": "",
+            "charts": [
+                "urn:li:chart:(sigma,kH0MeihtGs)",
+                "urn:li:chart:(sigma,Ml9C5ezT5W)"
+            ],
+            "datasets": [],
+            "dashboards": [],
+            "lastModified": {
+                "created": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227381,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,OSnGLBzL1i)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "Acryl Workbook"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227381,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,kH0MeihtGs)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227396,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,kH0MeihtGs)",
+    "changeType": "UPSERT",
+    "aspectName": "chartInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "VizualizationType": "levelTable",
+                "type": "table"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/workbook/4JRFW1HThPI1K3YTjouXI7?:nodeId=kH0MeihtGs&:fullScreen=true",
+            "title": "ADOPTIONS",
+            "description": "",
+            "lastModified": {
+                "created": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            },
+            "inputs": [
+                {
+                    "string": "urn:li:dataset:(urn:li:dataPlatform:snowflake,long_tail_companions.adoption.adoptions,PROD)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227396,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,kH0MeihtGs)",
+    "changeType": "UPSERT",
+    "aspectName": "inputFields",
+    "aspect": {
+        "json": {
+            "fields": [
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Pk)",
+                    "schemaField": {
+                        "fieldPath": "Pk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Pet Fk)",
+                    "schemaField": {
+                        "fieldPath": "Pet Fk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Human Fk)",
+                    "schemaField": {
+                        "fieldPath": "Human Fk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Status)",
+                    "schemaField": {
+                        "fieldPath": "Status",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Created At)",
+                    "schemaField": {
+                        "fieldPath": "Created At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Updated At)",
+                    "schemaField": {
+                        "fieldPath": "Updated At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227396,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,kH0MeihtGs)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "Acryl Workbook"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227397,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,Ml9C5ezT5W)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227404,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,Ml9C5ezT5W)",
+    "changeType": "UPSERT",
+    "aspectName": "chartInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "VizualizationType": "bar",
+                "type": "visualization"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/workbook/4JRFW1HThPI1K3YTjouXI7?:nodeId=Ml9C5ezT5W&:fullScreen=true",
+            "title": "Count of Profile Id by Status",
+            "description": "",
+            "lastModified": {
+                "created": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            },
+            "inputs": [
+                {
+                    "string": "urn:li:dataset:(urn:li:dataPlatform:sigma,49HFLTr6xytgrPly3PFsNC,PROD)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227404,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,Ml9C5ezT5W)",
+    "changeType": "UPSERT",
+    "aspectName": "inputFields",
+    "aspect": {
+        "json": {
+            "fields": [
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Pk)",
+                    "schemaField": {
+                        "fieldPath": "Pk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Profile Id)",
+                    "schemaField": {
+                        "fieldPath": "Profile Id",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Status)",
+                    "schemaField": {
+                        "fieldPath": "Status",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Created At)",
+                    "schemaField": {
+                        "fieldPath": "Created At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Updated At)",
+                    "schemaField": {
+                        "fieldPath": "Updated At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Count of Profile Id)",
+                    "schemaField": {
+                        "fieldPath": "Count of Profile Id",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227404,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,Ml9C5ezT5W)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "Acryl Workbook"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227405,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,OSnGLBzL1i)",
+    "changeType": "UPSERT",
+    "aspectName": "inputFields",
+    "aspect": {
+        "json": {
+            "fields": [
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Pk)",
+                    "schemaField": {
+                        "fieldPath": "Pk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Pet Fk)",
+                    "schemaField": {
+                        "fieldPath": "Pet Fk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Human Fk)",
+                    "schemaField": {
+                        "fieldPath": "Human Fk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Status)",
+                    "schemaField": {
+                        "fieldPath": "Status",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Created At)",
+                    "schemaField": {
+                        "fieldPath": "Created At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Updated At)",
+                    "schemaField": {
+                        "fieldPath": "Updated At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Pk)",
+                    "schemaField": {
+                        "fieldPath": "Pk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Profile Id)",
+                    "schemaField": {
+                        "fieldPath": "Profile Id",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Status)",
+                    "schemaField": {
+                        "fieldPath": "Status",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Created At)",
+                    "schemaField": {
+                        "fieldPath": "Created At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Updated At)",
+                    "schemaField": {
+                        "fieldPath": "Updated At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Count of Profile Id)",
+                    "schemaField": {
+                        "fieldPath": "Count of Profile Id",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227405,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,DFSieiAcgo)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227406,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,DFSieiAcgo)",
+    "changeType": "UPSERT",
+    "aspectName": "dashboardInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "ElementsCount": "1"
+            },
+            "title": "Page 2",
+            "description": "",
+            "charts": [
+                "urn:li:chart:(sigma,tQJu5N1l81)"
+            ],
+            "datasets": [],
+            "dashboards": [],
+            "lastModified": {
+                "created": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227406,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,DFSieiAcgo)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "Acryl Workbook"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227406,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,tQJu5N1l81)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227414,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,tQJu5N1l81)",
+    "changeType": "UPSERT",
+    "aspectName": "chartInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "VizualizationType": "levelTable",
+                "type": "table"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/workbook/4JRFW1HThPI1K3YTjouXI7?:nodeId=tQJu5N1l81&:fullScreen=true",
+            "title": "PETS ADOPTIONS JOIN",
+            "description": "",
+            "lastModified": {
+                "created": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            },
+            "inputs": [
+                {
+                    "string": "urn:li:dataset:(urn:li:dataPlatform:sigma,49HFLTr6xytgrPly3PFsNC,PROD)"
+                },
+                {
+                    "string": "urn:li:dataset:(urn:li:dataPlatform:snowflake,long_tail_companions.adoption.adoptions,PROD)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227415,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,tQJu5N1l81)",
+    "changeType": "UPSERT",
+    "aspectName": "inputFields",
+    "aspect": {
+        "json": {
+            "fields": [
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Pk)",
+                    "schemaField": {
+                        "fieldPath": "Pk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Profile Id)",
+                    "schemaField": {
+                        "fieldPath": "Profile Id",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Status)",
+                    "schemaField": {
+                        "fieldPath": "Status",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Created At)",
+                    "schemaField": {
+                        "fieldPath": "Created At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Updated At)",
+                    "schemaField": {
+                        "fieldPath": "Updated At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Pk %28ADOPTIONS%29)",
+                    "schemaField": {
+                        "fieldPath": "Pk (ADOPTIONS)",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Pet Fk)",
+                    "schemaField": {
+                        "fieldPath": "Pet Fk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Human Fk)",
+                    "schemaField": {
+                        "fieldPath": "Human Fk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Status %28ADOPTIONS%29)",
+                    "schemaField": {
+                        "fieldPath": "Status (ADOPTIONS)",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Created At %28ADOPTIONS%29)",
+                    "schemaField": {
+                        "fieldPath": "Created At (ADOPTIONS)",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Updated At %28ADOPTIONS%29)",
+                    "schemaField": {
+                        "fieldPath": "Updated At (ADOPTIONS)",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227415,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,tQJu5N1l81)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "Acryl Workbook"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227416,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,DFSieiAcgo)",
+    "changeType": "UPSERT",
+    "aspectName": "inputFields",
+    "aspect": {
+        "json": {
+            "fields": [
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Pk)",
+                    "schemaField": {
+                        "fieldPath": "Pk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Profile Id)",
+                    "schemaField": {
+                        "fieldPath": "Profile Id",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Status)",
+                    "schemaField": {
+                        "fieldPath": "Status",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Created At)",
+                    "schemaField": {
+                        "fieldPath": "Created At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Updated At)",
+                    "schemaField": {
+                        "fieldPath": "Updated At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Pk %28ADOPTIONS%29)",
+                    "schemaField": {
+                        "fieldPath": "Pk (ADOPTIONS)",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Pet Fk)",
+                    "schemaField": {
+                        "fieldPath": "Pet Fk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Human Fk)",
+                    "schemaField": {
+                        "fieldPath": "Human Fk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Status %28ADOPTIONS%29)",
+                    "schemaField": {
+                        "fieldPath": "Status (ADOPTIONS)",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Created At %28ADOPTIONS%29)",
+                    "schemaField": {
+                        "fieldPath": "Created At (ADOPTIONS)",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Updated At %28ADOPTIONS%29)",
+                    "schemaField": {
+                        "fieldPath": "Updated At (ADOPTIONS)",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227416,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+    "changeType": "UPSERT",
+    "aspectName": "containerProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "platform": "sigma",
+                "workspaceId": "3ee61405-3be2-4000-ba72-60d36757b95b"
+            },
+            "name": "Acryl Data",
+            "created": {
+                "time": 1710232264826
+            },
+            "lastModified": {
+                "time": 1710232264826
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227417,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227417,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:sigma"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227417,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Sigma Workspace"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227417,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:john.doe@example.com",
+                    "type": "DATAOWNER"
+                }
+            ],
+            "ownerTypes": {},
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227417,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227418,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,49HFLTr6xytgrPly3PFsNC,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "upstreamLineage",
+    "aspect": {
+        "json": {
+            "upstreams": [
+                {
+                    "auditStamp": {
+                        "time": 0,
+                        "actor": "urn:li:corpuser:unknown"
+                    },
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,long_tail_companions.adoption.pets,PROD)",
+                    "type": "COPY"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227418,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "tag",
+    "entityUrn": "urn:li:tag:Deprecated",
+    "changeType": "UPSERT",
+    "aspectName": "tagKey",
+    "aspect": {
+        "json": {
+            "name": "Deprecated"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227418,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "tag",
+    "entityUrn": "urn:li:tag:Warning",
+    "changeType": "UPSERT",
+    "aspectName": "tagKey",
+    "aspect": {
+        "json": {
+            "name": "Warning"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1778094227418,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+}
+]

--- a/metadata-ingestion/tests/integration/sigma/test_sigma.py
+++ b/metadata-ingestion/tests/integration/sigma/test_sigma.py
@@ -7234,7 +7234,6 @@ def test_sigma_ingest_data_models_dm_element_warehouse_fgl(
     assert report.data_model_element_fgl_warehouse_resolved == 3, (
         f"expected 3 warehouse FGL resolved; got {report.data_model_element_fgl_warehouse_resolved}"
     )
-    assert report.data_model_element_fgl_warehouse_emitted_total == 3
     assert report.data_model_element_fgl_warehouse_passthrough_deferred == 0
 
     expected_warehouse_urn = (

--- a/metadata-ingestion/tests/integration/sigma/test_sigma.py
+++ b/metadata-ingestion/tests/integration/sigma/test_sigma.py
@@ -7144,3 +7144,130 @@ def test_sigma_chart_input_fields_warehouse_qualified(
         output_path=output_path,
         golden_path=f"{test_resources_dir}/golden_test_sigma_chart_warehouse_qualified.json",
     )
+
+
+def _get_warehouse_dm_fgl_overrides() -> Dict[str, Dict]:
+    """Extends the warehouse-upstream DM fixture with passthrough formula columns.
+
+    Three columns on element CUSTOMERS (byF6DckhFw):
+      - Customer Id  -> columnId=inode-<url_id>/CUSTOMER_ID  formula=[CUSTOMERS/Customer Id]
+      - Email        -> columnId=inode-<url_id>/EMAIL         formula=[CUSTOMERS/Email]
+      - First Name   -> columnId=inode-<url_id>/FIRST_NAME    formula=[CUSTOMERS/First Name]
+
+    All three resolve to warehouse schemaField URNs via columnId-based FGL resolution.
+    """
+    overrides = _get_warehouse_dm_overrides()
+    # Replace the columns endpoint with passthrough formula columns.
+    overrides[
+        f"https://aws-api.sigmacomputing.com/v2/dataModels/{_WH_DM_ID}/columns"
+    ] = {
+        "method": "GET",
+        "status_code": 200,
+        "json": {
+            "entries": [
+                {
+                    "columnId": f"inode-{_WH_URL_ID}/CUSTOMER_ID",
+                    "name": "Customer Id",
+                    "elementId": _WH_ELEMENT_ID,
+                    "label": "Customer Id",
+                    "formula": "[CUSTOMERS/Customer Id]",
+                    "type": {"type": "text"},
+                },
+                {
+                    "columnId": f"inode-{_WH_URL_ID}/EMAIL",
+                    "name": "Email",
+                    "elementId": _WH_ELEMENT_ID,
+                    "label": "Email",
+                    "formula": "[CUSTOMERS/Email]",
+                    "type": {"type": "text"},
+                },
+                {
+                    "columnId": f"inode-{_WH_URL_ID}/FIRST_NAME",
+                    "name": "First Name",
+                    "elementId": _WH_ELEMENT_ID,
+                    "label": "First Name",
+                    "formula": "[CUSTOMERS/First Name]",
+                    "type": {"type": "text"},
+                },
+            ],
+            "total": 3,
+            "nextPage": None,
+        },
+    }
+    return overrides
+
+
+@pytest.mark.integration
+def test_sigma_ingest_data_models_dm_element_warehouse_fgl(
+    pytestconfig, tmp_path, requests_mock
+):
+    """DM element with warehouse-passthrough formula columns emits FineGrainedLineage.
+
+    Uses the warehouse-upstream DM fixture with columns updated to include
+    passthrough formulas like [CUSTOMERS/Email]. The columnId field encodes
+    the warehouse column identity (inode-<url_id>/<WAREHOUSE_COL>).
+
+    Assertions:
+      - 3 FineGrainedLineage entries on the DM-element child Dataset
+      - Upstream schemaField parent URN matches the entity-level warehouse URN
+      - warehouse_resolved == 3; warehouse_passthrough_deferred == 0
+      - No new entity-level Upstream entries (FGL-only)
+    """
+    test_resources_dir = pytestconfig.rootpath / "tests/integration/sigma"
+
+    override_data = _get_warehouse_dm_fgl_overrides()
+    register_mock_api(request_mock=requests_mock, override_data=override_data)
+
+    output_path = f"{tmp_path}/sigma_dm_element_warehouse_fgl_mces.json"
+    pipeline = Pipeline.create(
+        _minimal_sigma_pipeline_config(output_path, ingest_data_models=True)
+    )
+    pipeline.run()
+    pipeline.raise_from_status()
+
+    report = _sigma_report(pipeline)
+    # Warehouse-upstream counters must be clean.
+    assert report.dm_element_warehouse_upstream_emitted == 1
+    assert report.dm_element_warehouse_table_lookup_failed == 0
+    assert report.dm_element_warehouse_unknown_connection == 0
+    # Warehouse FGL counters.
+    assert report.data_model_element_fgl_warehouse_resolved == 3, (
+        f"expected 3 warehouse FGL resolved; got {report.data_model_element_fgl_warehouse_resolved}"
+    )
+    assert report.data_model_element_fgl_warehouse_emitted_total == 3
+    assert report.data_model_element_fgl_warehouse_passthrough_deferred == 0
+
+    expected_warehouse_urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,"
+        "warehouse_coffee_company.public.customers,PROD)"
+    )
+    element_urn = (
+        f"urn:li:dataset:(urn:li:dataPlatform:sigma,{_WH_DM_ID}.{_WH_ELEMENT_ID},PROD)"
+    )
+    with open(output_path) as f:
+        mces = json.load(f)
+    ul_aspects = [
+        mce
+        for mce in mces
+        if mce.get("entityUrn") == element_urn
+        and mce.get("aspectName") == "upstreamLineage"
+    ]
+    assert len(ul_aspects) == 1
+    fgls = ul_aspects[0]["aspect"]["json"].get("fineGrainedLineages", [])
+    assert len(fgls) == 3, f"expected 3 FGL entries; got {len(fgls)}: {fgls}"
+    # Each FGL upstream must be a schemaField on the warehouse dataset.
+    for fgl in fgls:
+        for upstream in fgl.get("upstreams", []):
+            assert upstream.startswith(
+                f"urn:li:schemaField:({expected_warehouse_urn},"
+            ), f"unexpected upstream: {upstream}"
+    # Entity-level upstreams unchanged (1 warehouse table, no new entries).
+    upstreams = ul_aspects[0]["aspect"]["json"]["upstreams"]
+    assert len(upstreams) == 1
+    assert upstreams[0]["dataset"] == expected_warehouse_urn
+
+    mce_helpers.check_golden_file(
+        pytestconfig,
+        output_path=output_path,
+        golden_path=f"{test_resources_dir}/golden_test_sigma_dm_element_warehouse_fgl.json",
+    )

--- a/metadata-ingestion/tests/unit/sigma/test_dm_element_fgl.py
+++ b/metadata-ingestion/tests/unit/sigma/test_dm_element_fgl.py
@@ -86,6 +86,7 @@ def _build(
         elementId_to_dataset_urn=elementId_to_dataset_urn or {},
         entity_level_upstream_urns=entity_level_upstream_urns or set(),
         data_model=_data_model(all_elements),
+        warehouse_url_id_map={},
     )
 
 

--- a/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_fgl.py
+++ b/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_fgl.py
@@ -298,6 +298,7 @@ class TestTryEmitResolution:
         result = _try_emit(source, col, elem, _SF_WAREHOUSE_MAP)
 
         assert result is not None
+        assert result.upstreams is not None
         assert len(result.upstreams) == 1
         expected_upstream = builder.make_schema_field_urn(_SF_DATASET_URN, "email")
         assert result.upstreams[0] == expected_upstream
@@ -312,6 +313,7 @@ class TestTryEmitResolution:
         result = _try_emit(source, col, elem, _RS_WAREHOUSE_MAP)
 
         assert result is not None
+        assert result.upstreams is not None
         expected_upstream = builder.make_schema_field_urn(_RS_DATASET_URN, "age")
         assert result.upstreams[0] == expected_upstream
         assert source.reporter.data_model_element_fgl_warehouse_resolved == 1
@@ -328,6 +330,7 @@ class TestTryEmitResolution:
         result = _try_emit(source, col, elem, _SF_WAREHOUSE_MAP)
 
         assert result is not None
+        assert result.upstreams is not None
         # With lowercase=False the dataset URN also preserves case (UPPERCASE for
         # Snowflake since that's what Sigma's API returns in the /files path).
         uppercase_dataset_urn = (
@@ -384,6 +387,7 @@ class TestTryEmitResolution:
         result = _try_emit(source, col, elem, _SF_WAREHOUSE_MAP)
 
         assert result is not None
+        assert result.upstreams is not None
         # The schemaField URN is urn:li:schemaField:(parent_urn, col).
         # Extract the parent URN by reading the upstream and deriving the Dataset.
         upstream_field_urn = result.upstreams[0]
@@ -478,10 +482,10 @@ class TestBuildFglWarehouseIntegration:
 
         assert len(fgls) == 2
         assert source.reporter.data_model_element_fgl_warehouse_resolved == 2
-        upstream_fields = {fgl.upstreams[0] for fgl in fgls}
+        upstream_fields = {fgl.upstreams[0] for fgl in fgls if fgl.upstreams}
         # Same upstream schemaField for both
         assert len(upstream_fields) == 1
-        downstream_fields = {fgl.downstreams[0] for fgl in fgls}
+        downstream_fields = {fgl.downstreams[0] for fgl in fgls if fgl.downstreams}
         assert len(downstream_fields) == 2
 
     def test_same_ref_repeated_in_formula_deduplicated(self):
@@ -595,6 +599,8 @@ class TestBuildFglWarehouseIntegration:
         )
         # Upstream column names are lowercased (Snowflake)
         upstream_cols = {
-            fgl.upstreams[0].rsplit(",", 1)[-1].rstrip(")") for fgl in fgls
+            fgl.upstreams[0].rsplit(",", 1)[-1].rstrip(")")
+            for fgl in fgls
+            if fgl.upstreams
         }
         assert upstream_cols == {"email", "first_name", "customer_id"}

--- a/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_fgl.py
+++ b/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_fgl.py
@@ -1,4 +1,4 @@
-"""Unit tests for T4.B2 — DM element warehouse-passthrough FineGrainedLineage.
+"""Unit tests for warehouse-passthrough FineGrainedLineage on DM elements.
 
 Coverage:
   - _try_emit_warehouse_passthrough_fgl: all pre-flight failure modes
@@ -9,7 +9,7 @@ Coverage:
   - _build_dm_element_fine_grained_lineages: diamond case (two downstream columns,
     same upstream schemaField → two FGLs, one upstream)
   - _build_dm_element_fine_grained_lineages: mixed intra-DM + warehouse refs
-  - URN identity: parent Dataset URN inside schemaField URN == T4.B entity-level URN
+  - URN identity: schemaField parent Dataset URN matches entity-level warehouse URN
 
 Counters verified:
   data_model_element_fgl_warehouse_resolved
@@ -89,7 +89,7 @@ _SF_REF = _WarehouseTableRef(
 )
 _SF_WAREHOUSE_MAP: Dict[str, _WarehouseTableRef] = {_SF_URL_ID: _SF_REF}
 
-# Expected entity-level URN (same as T4.B emits for this ref)
+# Expected entity-level URN emitted by the warehouse-upstream resolver
 _SF_DATASET_URN = (
     "urn:li:dataset:(urn:li:dataPlatform:snowflake,"
     "warehouse_coffee_company.public.customers,PROD)"
@@ -378,9 +378,9 @@ class TestTryEmitResolution:
         assert result is None
         assert source.reporter.data_model_element_fgl_warehouse_resolved == 0
 
-    def test_urn_identity_with_t4b(self):
-        """Parent Dataset URN inside T4.B2's schemaField URN must equal T4.B's
-        entity-level warehouse Dataset URN for the same fixture inode."""
+    def test_urn_identity_with_entity_level_upstream(self):
+        """The parent Dataset URN inside the schemaField URN must equal the
+        entity-level warehouse Dataset URN emitted for the same fixture inode."""
         source = _make_source()
         col = _column(f"inode-{_SF_URL_ID}/EMAIL", "Email", "[CUSTOMERS/Email]")
         elem = _element("el-1", "CUSTOMERS", [col], [_SF_INODE_SOURCE])
@@ -397,7 +397,7 @@ class TestTryEmitResolution:
         # Split from the right: last comma-separated token is the field name
         last_comma = inner.rfind(",")
         parent_urn_in_schema_field = inner[:last_comma]
-        # Verify byte-equality with T4.B's entity-level URN
+        # Verify byte-equality with the entity-level warehouse Dataset URN
         assert parent_urn_in_schema_field == _SF_DATASET_URN
 
 

--- a/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_fgl.py
+++ b/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_fgl.py
@@ -513,7 +513,6 @@ class TestBuildFglWarehouseIntegration:
 
         assert len(fgls) == 3
         assert source.reporter.data_model_element_fgl_warehouse_resolved == 3
-        assert source.reporter.data_model_element_fgl_warehouse_resolved == 3
         assert (
             source.reporter.data_model_element_fgl_warehouse_passthrough_deferred == 0
         )
@@ -524,3 +523,39 @@ class TestBuildFglWarehouseIntegration:
             if fgl.upstreams
         }
         assert upstream_cols == {"email", "first_name", "customer_id"}
+
+    def test_formula_source_is_warehouse_table_name_not_element_name(self):
+        """Element named differently from its warehouse table still resolves
+        via columnId when formula uses the warehouse table name as source.
+
+        e.g. element "CUSTOMER Summary" with formula "[CUSTOMERS/Email]" where
+        "CUSTOMERS" is the warehouse table name, not the element name.
+        """
+        source = _make_source()
+        col = _column(
+            f"inode-{_SF_URL_ID}/EMAIL",
+            "Email",
+            "[CUSTOMERS/Email]",  # source = warehouse table name, not element name
+        )
+        elem = _element(
+            "el-summary",
+            "CUSTOMER Summary",  # element name differs from formula source
+            [col],
+            [_SF_INODE_SOURCE],
+        )
+        # No DM element named "CUSTOMERS" exists — candidate_eids will be empty
+        name_to_eids = {"customer summary": [elem.elementId]}
+
+        fgls = _build_fgls(
+            source,
+            elem,
+            warehouse_map=_SF_WAREHOUSE_MAP,
+            element_name_to_eids=name_to_eids,
+        )
+
+        assert len(fgls) == 1
+        assert source.reporter.data_model_element_fgl_warehouse_resolved == 1
+        assert source.reporter.data_model_element_fgl_cross_dm_deferred == 0
+        assert fgls[0].upstreams is not None
+        expected_upstream = builder.make_schema_field_urn(_SF_DATASET_URN, "email")
+        assert fgls[0].upstreams[0] == expected_upstream

--- a/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_fgl.py
+++ b/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_fgl.py
@@ -20,7 +20,7 @@ Counters verified:
 """
 
 import datetime as dt
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Set
 from unittest.mock import patch
 
 from datahub.emitter import mce_builder as builder
@@ -192,7 +192,6 @@ def _try_emit(
     element: SigmaDataModelElement,
     warehouse_map: Dict[str, _WarehouseTableRef],
     downstream_field: Optional[str] = None,
-    emitted_pairs: Optional[Set[Tuple[str, str]]] = None,
 ) -> Optional[FineGrainedLineageClass]:
     elem_urn = f"urn:li:dataset:(urn:li:dataPlatform:sigma,{element.elementId},PROD)"
     return source._try_emit_warehouse_passthrough_fgl(
@@ -201,7 +200,6 @@ def _try_emit(
         downstream_field=downstream_field
         or builder.make_schema_field_urn(elem_urn, column.name),
         warehouse_url_id_map=warehouse_map,
-        emitted_pairs=emitted_pairs if emitted_pairs is not None else set(),
     )
 
 
@@ -302,8 +300,6 @@ class TestTryEmitResolution:
         assert len(result.upstreams) == 1
         expected_upstream = builder.make_schema_field_urn(_SF_DATASET_URN, "email")
         assert result.upstreams[0] == expected_upstream
-        assert source.reporter.data_model_element_fgl_warehouse_resolved == 1
-        assert source.reporter.data_model_element_fgl_warehouse_emitted_total == 1
 
     def test_redshift_preserves_lowercase_column(self):
         """Redshift columnId is already lowercase; no double-lowercasing."""
@@ -316,7 +312,6 @@ class TestTryEmitResolution:
         assert result.upstreams is not None
         expected_upstream = builder.make_schema_field_urn(_RS_DATASET_URN, "age")
         assert result.upstreams[0] == expected_upstream
-        assert source.reporter.data_model_element_fgl_warehouse_resolved == 1
 
     def test_convert_urns_to_lowercase_false_preserves_case(self):
         """When convert_urns_to_lowercase=False, both the dataset and column
@@ -362,20 +357,19 @@ class TestTryEmitResolution:
         assert result.downstreamType == FineGrainedLineageDownstreamTypeClass.FIELD
         assert result.upstreamType == FineGrainedLineageUpstreamTypeClass.FIELD_SET
 
-    def test_dedup_via_emitted_pairs(self):
-        """Same (downstream, upstream) pair must not be emitted twice."""
+    def test_resolved_once_per_pair(self):
+        """_try_emit resolves every call independently; dedup and counter
+        bumps are the caller's responsibility."""
         source = _make_source()
-        elem_urn = "urn:li:dataset:(urn:li:dataPlatform:sigma,el-1,PROD)"
         col = _column(f"inode-{_SF_URL_ID}/EMAIL", "Email", "[CUSTOMERS/Email]")
         elem = _element("el-1", "CUSTOMERS", [col], [_SF_INODE_SOURCE])
-        downstream = builder.make_schema_field_urn(elem_urn, "Email")
-        upstream = builder.make_schema_field_urn(_SF_DATASET_URN, "email")
-        already_emitted: Set[Tuple[str, str]] = {(downstream, upstream)}
 
-        result = _try_emit(
-            source, col, elem, _SF_WAREHOUSE_MAP, downstream, already_emitted
-        )
-        assert result is None
+        result1 = _try_emit(source, col, elem, _SF_WAREHOUSE_MAP)
+        result2 = _try_emit(source, col, elem, _SF_WAREHOUSE_MAP)
+
+        assert result1 is not None
+        assert result2 is not None
+        # Counters are bumped by the caller, not by _try_emit.
         assert source.reporter.data_model_element_fgl_warehouse_resolved == 0
 
     def test_urn_identity_with_entity_level_upstream(self):
@@ -515,6 +509,10 @@ class TestBuildFglWarehouseIntegration:
 
         assert len(fgls) == 1
         assert source.reporter.data_model_element_fgl_warehouse_resolved == 1
+        # Dedup must not inflate _passthrough_deferred.
+        assert (
+            source.reporter.data_model_element_fgl_warehouse_passthrough_deferred == 0
+        )
 
     def test_mixed_intra_dm_and_warehouse_refs(self):
         """An element with one intra-DM ref and one warehouse-passthrough ref

--- a/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_fgl.py
+++ b/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_fgl.py
@@ -13,10 +13,7 @@ Coverage:
 
 Counters verified:
   data_model_element_fgl_warehouse_resolved
-  data_model_element_fgl_warehouse_emitted_total
   data_model_element_fgl_warehouse_passthrough_deferred
-  data_model_element_fgl_warehouse_no_warehouse_source
-  data_model_element_fgl_warehouse_unmappable_connection
 """
 
 import datetime as dt
@@ -58,8 +55,8 @@ _SF_RECORD = SigmaConnectionRecord(
     name="Prod Snowflake",
     sigma_type="snowflake",
     datahub_platform="snowflake",
-    host="acme.snowflakecomputing.com",
-    account="acme",
+    host="example.snowflakecomputing.com",
+    account="example",
     is_mappable=True,
 )
 _RS_RECORD = SigmaConnectionRecord(
@@ -83,7 +80,7 @@ _SF_URL_ID = "7k3e6T4RK9oix71Nm2umE6"
 _SF_INODE_SOURCE = f"inode-{_SF_URL_ID}"
 _SF_REF = _WarehouseTableRef(
     connection_id=_SF_CONN_ID,
-    db="WAREHOUSE_COFFEE_COMPANY",
+    db="PROD_DB",
     schema="PUBLIC",
     table="CUSTOMERS",
 )
@@ -91,8 +88,7 @@ _SF_WAREHOUSE_MAP: Dict[str, _WarehouseTableRef] = {_SF_URL_ID: _SF_REF}
 
 # Expected entity-level URN emitted by the warehouse-upstream resolver
 _SF_DATASET_URN = (
-    "urn:li:dataset:(urn:li:dataPlatform:snowflake,"
-    "warehouse_coffee_company.public.customers,PROD)"
+    "urn:li:dataset:(urn:li:dataPlatform:snowflake,prod_db.public.customers,PROD)"
 )
 
 # Redshift warehouse table fixture
@@ -213,35 +209,26 @@ class TestTryEmitPreflightFailures:
         source = _make_source()
         col = _column("bare-col-id", "email", "[CUSTOMERS/Email]")
         elem = _element("el-1", "CUSTOMERS", [col], [_SF_INODE_SOURCE])
-        result = _try_emit(source, col, elem, _SF_WAREHOUSE_MAP)
-        assert result is None
-        assert source.reporter.data_model_element_fgl_warehouse_no_warehouse_source == 1
+        assert _try_emit(source, col, elem, _SF_WAREHOUSE_MAP) is None
 
     def test_column_id_no_slash(self):
         source = _make_source()
         col = _column(f"inode-{_SF_URL_ID}", "email", "[CUSTOMERS/Email]")
         elem = _element("el-1", "CUSTOMERS", [col], [_SF_INODE_SOURCE])
-        result = _try_emit(source, col, elem, _SF_WAREHOUSE_MAP)
-        assert result is None
-        assert source.reporter.data_model_element_fgl_warehouse_no_warehouse_source == 1
+        assert _try_emit(source, col, elem, _SF_WAREHOUSE_MAP) is None
 
     def test_column_id_url_id_not_in_source_ids(self):
         source = _make_source()
-        # columnId references a different url_id than what's in source_ids
         col = _column("inode-OTHER_URL_ID/EMAIL", "email", "[CUSTOMERS/Email]")
         elem = _element("el-1", "CUSTOMERS", [col], [_SF_INODE_SOURCE])
-        result = _try_emit(source, col, elem, _SF_WAREHOUSE_MAP)
-        assert result is None
-        assert source.reporter.data_model_element_fgl_warehouse_no_warehouse_source == 1
+        assert _try_emit(source, col, elem, _SF_WAREHOUSE_MAP) is None
 
     def test_url_id_not_in_warehouse_map(self):
         """url_id matches source_ids but /files lookup failed (not in map)."""
         source = _make_source()
         col = _column(f"inode-{_SF_URL_ID}/EMAIL", "email", "[CUSTOMERS/Email]")
         elem = _element("el-1", "CUSTOMERS", [col], [_SF_INODE_SOURCE])
-        result = _try_emit(source, col, elem, {})  # empty map = lookup failed
-        assert result is None
-        assert source.reporter.data_model_element_fgl_warehouse_no_warehouse_source == 1
+        assert _try_emit(source, col, elem, {}) is None
 
     def test_unmappable_connection(self):
         source = _make_source()
@@ -256,11 +243,7 @@ class TestTryEmitPreflightFailures:
         }
         col = _column(f"inode-{url_id}/COL", "col", "[TBL/col]")
         elem = _element("el-1", "TBL", [col], [f"inode-{url_id}"])
-        result = _try_emit(source, col, elem, wh_map)
-        assert result is None
-        assert (
-            source.reporter.data_model_element_fgl_warehouse_unmappable_connection == 1
-        )
+        assert _try_emit(source, col, elem, wh_map) is None
 
     def test_connection_not_in_registry(self):
         source = _make_source()
@@ -275,11 +258,7 @@ class TestTryEmitPreflightFailures:
         }
         col = _column(f"inode-{url_id}/COL", "col", "[TBL/col]")
         elem = _element("el-1", "TBL", [col], [f"inode-{url_id}"])
-        result = _try_emit(source, col, elem, wh_map)
-        assert result is None
-        assert (
-            source.reporter.data_model_element_fgl_warehouse_unmappable_connection == 1
-        )
+        assert _try_emit(source, col, elem, wh_map) is None
 
 
 # ---------------------------------------------------------------------------
@@ -330,69 +309,12 @@ class TestTryEmitResolution:
         # Snowflake since that's what Sigma's API returns in the /files path).
         uppercase_dataset_urn = (
             "urn:li:dataset:(urn:li:dataPlatform:snowflake,"
-            "WAREHOUSE_COFFEE_COMPANY.PUBLIC.CUSTOMERS,PROD)"
+            "PROD_DB.PUBLIC.CUSTOMERS,PROD)"
         )
         expected_upstream = builder.make_schema_field_urn(
             uppercase_dataset_urn, "EMAIL"
         )
         assert result.upstreams[0] == expected_upstream
-
-    def test_fgl_shape(self):
-        """Emitted FineGrainedLineageClass has correct type + confidenceScore."""
-        source = _make_source()
-        elem_urn = "urn:li:dataset:(urn:li:dataPlatform:sigma,el-1,PROD)"
-        col = _column(f"inode-{_SF_URL_ID}/EMAIL", "Email", "[CUSTOMERS/Email]")
-        elem = _element("el-1", "CUSTOMERS", [col], [_SF_INODE_SOURCE])
-        downstream_field = builder.make_schema_field_urn(elem_urn, "Email")
-        result = _try_emit(source, col, elem, _SF_WAREHOUSE_MAP, downstream_field)
-
-        assert result is not None
-        assert result.downstreams == [downstream_field]
-        assert result.confidenceScore == 1.0
-        from datahub.metadata.com.linkedin.pegasus2avro.dataset import (
-            FineGrainedLineageDownstreamTypeClass,
-            FineGrainedLineageUpstreamTypeClass,
-        )
-
-        assert result.downstreamType == FineGrainedLineageDownstreamTypeClass.FIELD
-        assert result.upstreamType == FineGrainedLineageUpstreamTypeClass.FIELD_SET
-
-    def test_resolved_once_per_pair(self):
-        """_try_emit resolves every call independently; dedup and counter
-        bumps are the caller's responsibility."""
-        source = _make_source()
-        col = _column(f"inode-{_SF_URL_ID}/EMAIL", "Email", "[CUSTOMERS/Email]")
-        elem = _element("el-1", "CUSTOMERS", [col], [_SF_INODE_SOURCE])
-
-        result1 = _try_emit(source, col, elem, _SF_WAREHOUSE_MAP)
-        result2 = _try_emit(source, col, elem, _SF_WAREHOUSE_MAP)
-
-        assert result1 is not None
-        assert result2 is not None
-        # Counters are bumped by the caller, not by _try_emit.
-        assert source.reporter.data_model_element_fgl_warehouse_resolved == 0
-
-    def test_urn_identity_with_entity_level_upstream(self):
-        """The parent Dataset URN inside the schemaField URN must equal the
-        entity-level warehouse Dataset URN emitted for the same fixture inode."""
-        source = _make_source()
-        col = _column(f"inode-{_SF_URL_ID}/EMAIL", "Email", "[CUSTOMERS/Email]")
-        elem = _element("el-1", "CUSTOMERS", [col], [_SF_INODE_SOURCE])
-        result = _try_emit(source, col, elem, _SF_WAREHOUSE_MAP)
-
-        assert result is not None
-        assert result.upstreams is not None
-        # The schemaField URN is urn:li:schemaField:(parent_urn, col).
-        # Extract the parent URN by reading the upstream and deriving the Dataset.
-        upstream_field_urn = result.upstreams[0]
-        # schemaField URN shape: urn:li:schemaField:(dataset_urn, field)
-        assert upstream_field_urn.startswith("urn:li:schemaField:(")
-        inner = upstream_field_urn[len("urn:li:schemaField:(") : -1]
-        # Split from the right: last comma-separated token is the field name
-        last_comma = inner.rfind(",")
-        parent_urn_in_schema_field = inner[:last_comma]
-        # Verify byte-equality with the entity-level warehouse Dataset URN
-        assert parent_urn_in_schema_field == _SF_DATASET_URN
 
 
 # ---------------------------------------------------------------------------
@@ -425,7 +347,7 @@ class TestBuildFglWarehouseIntegration:
 
         assert len(fgls) == 1
         assert source.reporter.data_model_element_fgl_warehouse_resolved == 1
-        assert source.reporter.data_model_element_fgl_warehouse_emitted_total == 1
+        assert source.reporter.data_model_element_fgl_warehouse_resolved == 1
         assert (
             source.reporter.data_model_element_fgl_warehouse_passthrough_deferred == 0
         )
@@ -591,7 +513,7 @@ class TestBuildFglWarehouseIntegration:
 
         assert len(fgls) == 3
         assert source.reporter.data_model_element_fgl_warehouse_resolved == 3
-        assert source.reporter.data_model_element_fgl_warehouse_emitted_total == 3
+        assert source.reporter.data_model_element_fgl_warehouse_resolved == 3
         assert (
             source.reporter.data_model_element_fgl_warehouse_passthrough_deferred == 0
         )

--- a/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_fgl.py
+++ b/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_fgl.py
@@ -347,7 +347,6 @@ class TestBuildFglWarehouseIntegration:
 
         assert len(fgls) == 1
         assert source.reporter.data_model_element_fgl_warehouse_resolved == 1
-        assert source.reporter.data_model_element_fgl_warehouse_resolved == 1
         assert (
             source.reporter.data_model_element_fgl_warehouse_passthrough_deferred == 0
         )

--- a/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_fgl.py
+++ b/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_fgl.py
@@ -1,0 +1,600 @@
+"""Unit tests for T4.B2 — DM element warehouse-passthrough FineGrainedLineage.
+
+Coverage:
+  - _try_emit_warehouse_passthrough_fgl: all pre-flight failure modes
+  - _try_emit_warehouse_passthrough_fgl: Snowflake and Redshift resolution
+  - _try_emit_warehouse_passthrough_fgl: convert_urns_to_lowercase=False override
+  - _try_emit_warehouse_passthrough_fgl: dedup via emitted_pairs
+  - _build_dm_element_fine_grained_lineages: counter shift (deferred → resolved)
+  - _build_dm_element_fine_grained_lineages: diamond case (two downstream columns,
+    same upstream schemaField → two FGLs, one upstream)
+  - _build_dm_element_fine_grained_lineages: mixed intra-DM + warehouse refs
+  - URN identity: parent Dataset URN inside schemaField URN == T4.B entity-level URN
+
+Counters verified:
+  data_model_element_fgl_warehouse_resolved
+  data_model_element_fgl_warehouse_emitted_total
+  data_model_element_fgl_warehouse_passthrough_deferred
+  data_model_element_fgl_warehouse_no_warehouse_source
+  data_model_element_fgl_warehouse_unmappable_connection
+"""
+
+import datetime as dt
+from typing import Dict, List, Optional, Set, Tuple
+from unittest.mock import patch
+
+from datahub.emitter import mce_builder as builder
+from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.source.sigma.config import (
+    SigmaSourceConfig,
+    WarehouseConnectionConfig,
+)
+from datahub.ingestion.source.sigma.connection_registry import (
+    SigmaConnectionRecord,
+    SigmaConnectionRegistry,
+)
+from datahub.ingestion.source.sigma.data_classes import (
+    SigmaDataModel,
+    SigmaDataModelColumn,
+    SigmaDataModelElement,
+)
+from datahub.ingestion.source.sigma.sigma import (
+    SigmaSource,
+    _WarehouseTableRef,
+)
+from datahub.ingestion.source.sigma.sigma_api import SigmaAPI
+from datahub.metadata.com.linkedin.pegasus2avro.dataset import FineGrainedLineageClass
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_SF_CONN_ID = "conn-sf-001"
+_RS_CONN_ID = "conn-rs-001"
+_UNMAPPABLE_CONN_ID = "conn-oracle-001"
+
+_SF_RECORD = SigmaConnectionRecord(
+    connection_id=_SF_CONN_ID,
+    name="Prod Snowflake",
+    sigma_type="snowflake",
+    datahub_platform="snowflake",
+    host="acme.snowflakecomputing.com",
+    account="acme",
+    is_mappable=True,
+)
+_RS_RECORD = SigmaConnectionRecord(
+    connection_id=_RS_CONN_ID,
+    name="Prod Redshift",
+    sigma_type="redshift",
+    datahub_platform="redshift",
+    host="cluster.redshift.amazonaws.com",
+    is_mappable=True,
+)
+_UNMAPPABLE_RECORD = SigmaConnectionRecord(
+    connection_id=_UNMAPPABLE_CONN_ID,
+    name="Oracle (unsupported)",
+    sigma_type="oracle",
+    datahub_platform="",
+    is_mappable=False,
+)
+
+# Snowflake warehouse table fixture
+_SF_URL_ID = "7k3e6T4RK9oix71Nm2umE6"
+_SF_INODE_SOURCE = f"inode-{_SF_URL_ID}"
+_SF_REF = _WarehouseTableRef(
+    connection_id=_SF_CONN_ID,
+    db="WAREHOUSE_COFFEE_COMPANY",
+    schema="PUBLIC",
+    table="CUSTOMERS",
+)
+_SF_WAREHOUSE_MAP: Dict[str, _WarehouseTableRef] = {_SF_URL_ID: _SF_REF}
+
+# Expected entity-level URN (same as T4.B emits for this ref)
+_SF_DATASET_URN = (
+    "urn:li:dataset:(urn:li:dataPlatform:snowflake,"
+    "warehouse_coffee_company.public.customers,PROD)"
+)
+
+# Redshift warehouse table fixture
+_RS_URL_ID = "3KaiZnkNI1mqAKABVqD6Vy"
+_RS_INODE_SOURCE = f"inode-{_RS_URL_ID}"
+_RS_REF = _WarehouseTableRef(
+    connection_id=_RS_CONN_ID,
+    db="analytics",
+    schema="demo_schema",
+    table="base_table",
+)
+_RS_WAREHOUSE_MAP: Dict[str, _WarehouseTableRef] = {_RS_URL_ID: _RS_REF}
+_RS_DATASET_URN = (
+    "urn:li:dataset:(urn:li:dataPlatform:redshift,"
+    "analytics.demo_schema.base_table,PROD)"
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_source(
+    extra_records: Optional[List[SigmaConnectionRecord]] = None,
+    conn_overrides: Optional[Dict[str, WarehouseConnectionConfig]] = None,
+) -> SigmaSource:
+    config = SigmaSourceConfig.model_validate(
+        {"client_id": "test", "client_secret": "test"}
+    )
+    if conn_overrides:
+        config.connection_to_platform_map = conn_overrides
+    ctx = PipelineContext(run_id="t4b2-unit")
+    with patch.object(SigmaAPI, "_generate_token"):
+        source = SigmaSource(config=config, ctx=ctx)
+    records = [_SF_RECORD, _RS_RECORD, _UNMAPPABLE_RECORD] + (extra_records or [])
+    source.connection_registry = SigmaConnectionRegistry(
+        by_id={r.connection_id: r for r in records}
+    )
+    return source
+
+
+def _column(column_id: str, name: str, formula: Optional[str]) -> SigmaDataModelColumn:
+    return SigmaDataModelColumn(columnId=column_id, name=name, formula=formula)
+
+
+def _element(
+    element_id: str,
+    name: str,
+    columns: List[SigmaDataModelColumn],
+    source_ids: Optional[List[str]] = None,
+) -> SigmaDataModelElement:
+    return SigmaDataModelElement(
+        elementId=element_id,
+        name=name,
+        columns=[c.model_dump() for c in columns],
+        source_ids=source_ids or [],
+    )
+
+
+def _dm(elements: Optional[List[SigmaDataModelElement]] = None) -> SigmaDataModel:
+    now = dt.datetime.now(dt.timezone.utc)
+    return SigmaDataModel(
+        dataModelId="dm-test",
+        name="Test DM",
+        createdAt=now,
+        updatedAt=now,
+        elements=elements or [],
+    )
+
+
+def _build_fgls(
+    source: SigmaSource,
+    element: SigmaDataModelElement,
+    warehouse_map: Optional[Dict[str, _WarehouseTableRef]] = None,
+    element_name_to_eids: Optional[Dict[str, List[str]]] = None,
+    elementId_to_dataset_urn: Optional[Dict[str, str]] = None,
+    entity_level_upstream_urns: Optional[Set[str]] = None,
+    upstream_elements: Optional[List[SigmaDataModelElement]] = None,
+) -> List[FineGrainedLineageClass]:
+    all_elements = [element] + (upstream_elements or [])
+    urn = f"urn:li:dataset:(urn:li:dataPlatform:sigma,{element.elementId},PROD)"
+    return source._build_dm_element_fine_grained_lineages(
+        element=element,
+        element_dataset_urn=urn,
+        element_name_to_eids=element_name_to_eids or {},
+        elementId_to_dataset_urn=elementId_to_dataset_urn or {},
+        entity_level_upstream_urns=entity_level_upstream_urns or set(),
+        data_model=_dm(all_elements),
+        warehouse_url_id_map=warehouse_map or {},
+    )
+
+
+def _try_emit(
+    source: SigmaSource,
+    column: SigmaDataModelColumn,
+    element: SigmaDataModelElement,
+    warehouse_map: Dict[str, _WarehouseTableRef],
+    downstream_field: Optional[str] = None,
+    emitted_pairs: Optional[Set[Tuple[str, str]]] = None,
+) -> Optional[FineGrainedLineageClass]:
+    elem_urn = f"urn:li:dataset:(urn:li:dataPlatform:sigma,{element.elementId},PROD)"
+    return source._try_emit_warehouse_passthrough_fgl(
+        column=column,
+        element=element,
+        downstream_field=downstream_field
+        or builder.make_schema_field_urn(elem_urn, column.name),
+        warehouse_url_id_map=warehouse_map,
+        emitted_pairs=emitted_pairs if emitted_pairs is not None else set(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pre-flight failure tests
+# ---------------------------------------------------------------------------
+
+
+class TestTryEmitPreflightFailures:
+    def test_column_id_no_inode_prefix(self):
+        source = _make_source()
+        col = _column("bare-col-id", "email", "[CUSTOMERS/Email]")
+        elem = _element("el-1", "CUSTOMERS", [col], [_SF_INODE_SOURCE])
+        result = _try_emit(source, col, elem, _SF_WAREHOUSE_MAP)
+        assert result is None
+        assert source.reporter.data_model_element_fgl_warehouse_no_warehouse_source == 1
+
+    def test_column_id_no_slash(self):
+        source = _make_source()
+        col = _column(f"inode-{_SF_URL_ID}", "email", "[CUSTOMERS/Email]")
+        elem = _element("el-1", "CUSTOMERS", [col], [_SF_INODE_SOURCE])
+        result = _try_emit(source, col, elem, _SF_WAREHOUSE_MAP)
+        assert result is None
+        assert source.reporter.data_model_element_fgl_warehouse_no_warehouse_source == 1
+
+    def test_column_id_url_id_not_in_source_ids(self):
+        source = _make_source()
+        # columnId references a different url_id than what's in source_ids
+        col = _column("inode-OTHER_URL_ID/EMAIL", "email", "[CUSTOMERS/Email]")
+        elem = _element("el-1", "CUSTOMERS", [col], [_SF_INODE_SOURCE])
+        result = _try_emit(source, col, elem, _SF_WAREHOUSE_MAP)
+        assert result is None
+        assert source.reporter.data_model_element_fgl_warehouse_no_warehouse_source == 1
+
+    def test_url_id_not_in_warehouse_map(self):
+        """url_id matches source_ids but /files lookup failed (not in map)."""
+        source = _make_source()
+        col = _column(f"inode-{_SF_URL_ID}/EMAIL", "email", "[CUSTOMERS/Email]")
+        elem = _element("el-1", "CUSTOMERS", [col], [_SF_INODE_SOURCE])
+        result = _try_emit(source, col, elem, {})  # empty map = lookup failed
+        assert result is None
+        assert source.reporter.data_model_element_fgl_warehouse_no_warehouse_source == 1
+
+    def test_unmappable_connection(self):
+        source = _make_source()
+        url_id = "unmappable-url-id"
+        wh_map = {
+            url_id: _WarehouseTableRef(
+                connection_id=_UNMAPPABLE_CONN_ID,
+                db="DB",
+                schema="SCH",
+                table="TBL",
+            )
+        }
+        col = _column(f"inode-{url_id}/COL", "col", "[TBL/col]")
+        elem = _element("el-1", "TBL", [col], [f"inode-{url_id}"])
+        result = _try_emit(source, col, elem, wh_map)
+        assert result is None
+        assert (
+            source.reporter.data_model_element_fgl_warehouse_unmappable_connection == 1
+        )
+
+    def test_connection_not_in_registry(self):
+        source = _make_source()
+        url_id = "unknown-conn-url"
+        wh_map = {
+            url_id: _WarehouseTableRef(
+                connection_id="conn-not-in-registry",
+                db="DB",
+                schema="SCH",
+                table="TBL",
+            )
+        }
+        col = _column(f"inode-{url_id}/COL", "col", "[TBL/col]")
+        elem = _element("el-1", "TBL", [col], [f"inode-{url_id}"])
+        result = _try_emit(source, col, elem, wh_map)
+        assert result is None
+        assert (
+            source.reporter.data_model_element_fgl_warehouse_unmappable_connection == 1
+        )
+
+
+# ---------------------------------------------------------------------------
+# Resolution tests
+# ---------------------------------------------------------------------------
+
+
+class TestTryEmitResolution:
+    def test_snowflake_lowercases_column(self):
+        """Snowflake columnId is UPPERCASE; emitted schemaField must be lowercase."""
+        source = _make_source()
+        col = _column(f"inode-{_SF_URL_ID}/EMAIL", "Email", "[CUSTOMERS/Email]")
+        elem = _element("el-1", "CUSTOMERS", [col], [_SF_INODE_SOURCE])
+        result = _try_emit(source, col, elem, _SF_WAREHOUSE_MAP)
+
+        assert result is not None
+        assert len(result.upstreams) == 1
+        expected_upstream = builder.make_schema_field_urn(_SF_DATASET_URN, "email")
+        assert result.upstreams[0] == expected_upstream
+        assert source.reporter.data_model_element_fgl_warehouse_resolved == 1
+        assert source.reporter.data_model_element_fgl_warehouse_emitted_total == 1
+
+    def test_redshift_preserves_lowercase_column(self):
+        """Redshift columnId is already lowercase; no double-lowercasing."""
+        source = _make_source()
+        col = _column(f"inode-{_RS_URL_ID}/age", "Age", "[base_table/Age]")
+        elem = _element("el-1", "base_table", [col], [_RS_INODE_SOURCE])
+        result = _try_emit(source, col, elem, _RS_WAREHOUSE_MAP)
+
+        assert result is not None
+        expected_upstream = builder.make_schema_field_urn(_RS_DATASET_URN, "age")
+        assert result.upstreams[0] == expected_upstream
+        assert source.reporter.data_model_element_fgl_warehouse_resolved == 1
+
+    def test_convert_urns_to_lowercase_false_preserves_case(self):
+        """When convert_urns_to_lowercase=False, both the dataset and column
+        identifiers preserve their original casing from the API."""
+        override = WarehouseConnectionConfig.model_validate(
+            {"convert_urns_to_lowercase": False}
+        )
+        source = _make_source(conn_overrides={_SF_CONN_ID: override})
+        col = _column(f"inode-{_SF_URL_ID}/EMAIL", "Email", "[CUSTOMERS/Email]")
+        elem = _element("el-1", "CUSTOMERS", [col], [_SF_INODE_SOURCE])
+        result = _try_emit(source, col, elem, _SF_WAREHOUSE_MAP)
+
+        assert result is not None
+        # With lowercase=False the dataset URN also preserves case (UPPERCASE for
+        # Snowflake since that's what Sigma's API returns in the /files path).
+        uppercase_dataset_urn = (
+            "urn:li:dataset:(urn:li:dataPlatform:snowflake,"
+            "WAREHOUSE_COFFEE_COMPANY.PUBLIC.CUSTOMERS,PROD)"
+        )
+        expected_upstream = builder.make_schema_field_urn(
+            uppercase_dataset_urn, "EMAIL"
+        )
+        assert result.upstreams[0] == expected_upstream
+
+    def test_fgl_shape(self):
+        """Emitted FineGrainedLineageClass has correct type + confidenceScore."""
+        source = _make_source()
+        elem_urn = "urn:li:dataset:(urn:li:dataPlatform:sigma,el-1,PROD)"
+        col = _column(f"inode-{_SF_URL_ID}/EMAIL", "Email", "[CUSTOMERS/Email]")
+        elem = _element("el-1", "CUSTOMERS", [col], [_SF_INODE_SOURCE])
+        downstream_field = builder.make_schema_field_urn(elem_urn, "Email")
+        result = _try_emit(source, col, elem, _SF_WAREHOUSE_MAP, downstream_field)
+
+        assert result is not None
+        assert result.downstreams == [downstream_field]
+        assert result.confidenceScore == 1.0
+        from datahub.metadata.com.linkedin.pegasus2avro.dataset import (
+            FineGrainedLineageDownstreamTypeClass,
+            FineGrainedLineageUpstreamTypeClass,
+        )
+
+        assert result.downstreamType == FineGrainedLineageDownstreamTypeClass.FIELD
+        assert result.upstreamType == FineGrainedLineageUpstreamTypeClass.FIELD_SET
+
+    def test_dedup_via_emitted_pairs(self):
+        """Same (downstream, upstream) pair must not be emitted twice."""
+        source = _make_source()
+        elem_urn = "urn:li:dataset:(urn:li:dataPlatform:sigma,el-1,PROD)"
+        col = _column(f"inode-{_SF_URL_ID}/EMAIL", "Email", "[CUSTOMERS/Email]")
+        elem = _element("el-1", "CUSTOMERS", [col], [_SF_INODE_SOURCE])
+        downstream = builder.make_schema_field_urn(elem_urn, "Email")
+        upstream = builder.make_schema_field_urn(_SF_DATASET_URN, "email")
+        already_emitted: Set[Tuple[str, str]] = {(downstream, upstream)}
+
+        result = _try_emit(
+            source, col, elem, _SF_WAREHOUSE_MAP, downstream, already_emitted
+        )
+        assert result is None
+        assert source.reporter.data_model_element_fgl_warehouse_resolved == 0
+
+    def test_urn_identity_with_t4b(self):
+        """Parent Dataset URN inside T4.B2's schemaField URN must equal T4.B's
+        entity-level warehouse Dataset URN for the same fixture inode."""
+        source = _make_source()
+        col = _column(f"inode-{_SF_URL_ID}/EMAIL", "Email", "[CUSTOMERS/Email]")
+        elem = _element("el-1", "CUSTOMERS", [col], [_SF_INODE_SOURCE])
+        result = _try_emit(source, col, elem, _SF_WAREHOUSE_MAP)
+
+        assert result is not None
+        # The schemaField URN is urn:li:schemaField:(parent_urn, col).
+        # Extract the parent URN by reading the upstream and deriving the Dataset.
+        upstream_field_urn = result.upstreams[0]
+        # schemaField URN shape: urn:li:schemaField:(dataset_urn, field)
+        assert upstream_field_urn.startswith("urn:li:schemaField:(")
+        inner = upstream_field_urn[len("urn:li:schemaField:(") : -1]
+        # Split from the right: last comma-separated token is the field name
+        last_comma = inner.rfind(",")
+        parent_urn_in_schema_field = inner[:last_comma]
+        # Verify byte-equality with T4.B's entity-level URN
+        assert parent_urn_in_schema_field == _SF_DATASET_URN
+
+
+# ---------------------------------------------------------------------------
+# Integration with _build_dm_element_fine_grained_lineages
+# ---------------------------------------------------------------------------
+
+
+class TestBuildFglWarehouseIntegration:
+    def test_counter_shift_resolved_not_deferred(self):
+        """Successful resolution bumps _warehouse_resolved and does NOT bump
+        _warehouse_passthrough_deferred."""
+        source = _make_source()
+        col = _column(f"inode-{_SF_URL_ID}/EMAIL", "Email", "[CUSTOMERS/Email]")
+        elem = _element(
+            "el-customers",
+            "CUSTOMERS",
+            [col],
+            [_SF_INODE_SOURCE],
+        )
+        # element_name_to_eids must include the element itself so the self-strip
+        # logic fires (candidate_eids non-empty, all equal element.elementId).
+        name_to_eids = {"customers": [elem.elementId]}
+
+        fgls = _build_fgls(
+            source,
+            elem,
+            warehouse_map=_SF_WAREHOUSE_MAP,
+            element_name_to_eids=name_to_eids,
+        )
+
+        assert len(fgls) == 1
+        assert source.reporter.data_model_element_fgl_warehouse_resolved == 1
+        assert source.reporter.data_model_element_fgl_warehouse_emitted_total == 1
+        assert (
+            source.reporter.data_model_element_fgl_warehouse_passthrough_deferred == 0
+        )
+
+    def test_deferred_when_no_warehouse_source(self):
+        """When the element has no warehouse-backed inode, deferred counter bumps."""
+        source = _make_source()
+        col = _column("bare-col-id", "Email", "[CUSTOMERS/Email]")
+        elem = _element("el-customers", "CUSTOMERS", [col], [])  # no source_ids
+        name_to_eids = {"customers": [elem.elementId]}
+
+        fgls = _build_fgls(
+            source,
+            elem,
+            warehouse_map={},
+            element_name_to_eids=name_to_eids,
+        )
+
+        assert fgls == []
+        assert (
+            source.reporter.data_model_element_fgl_warehouse_passthrough_deferred == 1
+        )
+        assert source.reporter.data_model_element_fgl_warehouse_resolved == 0
+
+    def test_diamond_two_downstream_columns_same_upstream(self):
+        """Two columns on the same element both reference the same warehouse column.
+        Each produces a distinct FGL (different downstream schemaField), but the
+        upstream schemaField URN is the same — emitted_pairs must not suppress."""
+        source = _make_source()
+        col_a = _column(f"inode-{_SF_URL_ID}/EMAIL", "Email", "[CUSTOMERS/Email]")
+        col_b = _column(
+            f"inode-{_SF_URL_ID}/EMAIL", "Contact Email", "[CUSTOMERS/Email]"
+        )
+        elem = _element(
+            "el-customers",
+            "CUSTOMERS",
+            [col_a, col_b],
+            [_SF_INODE_SOURCE],
+        )
+        name_to_eids = {"customers": [elem.elementId]}
+
+        fgls = _build_fgls(
+            source,
+            elem,
+            warehouse_map=_SF_WAREHOUSE_MAP,
+            element_name_to_eids=name_to_eids,
+        )
+
+        assert len(fgls) == 2
+        assert source.reporter.data_model_element_fgl_warehouse_resolved == 2
+        upstream_fields = {fgl.upstreams[0] for fgl in fgls}
+        # Same upstream schemaField for both
+        assert len(upstream_fields) == 1
+        downstream_fields = {fgl.downstreams[0] for fgl in fgls}
+        assert len(downstream_fields) == 2
+
+    def test_same_ref_repeated_in_formula_deduplicated(self):
+        """Multiple bracket refs to the same [CUSTOMERS/Email] in one formula
+        produce only one FGL entry (dedup via emitted_pairs)."""
+        source = _make_source()
+        # Formula references the same column three times
+        col = _column(
+            f"inode-{_SF_URL_ID}/EMAIL",
+            "Email",
+            'If([CUSTOMERS/Email] = "", "unknown", [CUSTOMERS/Email])',
+        )
+        elem = _element(
+            "el-customers",
+            "CUSTOMERS",
+            [col],
+            [_SF_INODE_SOURCE],
+        )
+        name_to_eids = {"customers": [elem.elementId]}
+
+        fgls = _build_fgls(
+            source,
+            elem,
+            warehouse_map=_SF_WAREHOUSE_MAP,
+            element_name_to_eids=name_to_eids,
+        )
+
+        assert len(fgls) == 1
+        assert source.reporter.data_model_element_fgl_warehouse_resolved == 1
+
+    def test_mixed_intra_dm_and_warehouse_refs(self):
+        """An element with one intra-DM ref and one warehouse-passthrough ref
+        produces both an intra-DM FGL and a warehouse FGL."""
+        source = _make_source()
+        # Upstream intra-DM element
+        upstream_id = "el-upstream"
+        upstream_urn = "urn:li:dataset:(urn:li:dataPlatform:sigma,el-upstream,PROD)"
+        upstream_elem = _element(
+            upstream_id,
+            "UPSTREAM",
+            [_column("up-x", "x", None)],
+        )
+        # Column a: intra-DM ref → [UPSTREAM/x]
+        col_intra = _column("col-a", "a", "[UPSTREAM/x]")
+        # Column b: warehouse-passthrough → [CUSTOMERS/Email]
+        col_wh = _column(f"inode-{_SF_URL_ID}/EMAIL", "Email", "[CUSTOMERS/Email]")
+        elem = _element(
+            "el-customers",
+            "CUSTOMERS",
+            [col_intra, col_wh],
+            [_SF_INODE_SOURCE],
+        )
+        name_to_eids = {
+            "customers": [elem.elementId],
+            "upstream": [upstream_id],
+        }
+        id_to_urn = {upstream_id: upstream_urn}
+
+        fgls = _build_fgls(
+            source,
+            elem,
+            warehouse_map=_SF_WAREHOUSE_MAP,
+            element_name_to_eids=name_to_eids,
+            elementId_to_dataset_urn=id_to_urn,
+            entity_level_upstream_urns={upstream_urn},
+            upstream_elements=[upstream_elem],
+        )
+
+        # One intra-DM FGL + one warehouse FGL
+        assert len(fgls) == 2
+        assert source.reporter.data_model_element_fgl_warehouse_resolved == 1
+        # data_model_element_fgl_emitted counts ALL FGLs (intra-DM + warehouse)
+        assert source.reporter.data_model_element_fgl_emitted == 2
+
+    def test_multiple_columns_all_resolved(self):
+        """All columns on a warehouse-passthrough element emit FGL entries."""
+        source = _make_source()
+        columns = [
+            _column(f"inode-{_SF_URL_ID}/EMAIL", "Email", "[CUSTOMERS/Email]"),
+            _column(
+                f"inode-{_SF_URL_ID}/FIRST_NAME",
+                "First Name",
+                "[CUSTOMERS/First Name]",
+            ),
+            _column(
+                f"inode-{_SF_URL_ID}/CUSTOMER_ID",
+                "Customer Id",
+                "[CUSTOMERS/Customer Id]",
+            ),
+        ]
+        elem = _element(
+            "el-customers",
+            "CUSTOMERS",
+            columns,
+            [_SF_INODE_SOURCE],
+        )
+        name_to_eids = {"customers": [elem.elementId]}
+
+        fgls = _build_fgls(
+            source,
+            elem,
+            warehouse_map=_SF_WAREHOUSE_MAP,
+            element_name_to_eids=name_to_eids,
+        )
+
+        assert len(fgls) == 3
+        assert source.reporter.data_model_element_fgl_warehouse_resolved == 3
+        assert source.reporter.data_model_element_fgl_warehouse_emitted_total == 3
+        assert (
+            source.reporter.data_model_element_fgl_warehouse_passthrough_deferred == 0
+        )
+        # Upstream column names are lowercased (Snowflake)
+        upstream_cols = {
+            fgl.upstreams[0].rsplit(",", 1)[-1].rstrip(")") for fgl in fgls
+        }
+        assert upstream_cols == {"email", "first_name", "customer_id"}

--- a/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_upstream.py
+++ b/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_upstream.py
@@ -841,10 +841,10 @@ class TestWarehouseTableRefFqName:
         ref = _WarehouseTableRef(connection_id="c", db="DB", schema="SCH", table="TBL")
         assert ref.fq_name("snowflake", lowercase=False) == "DB.SCH.TBL"
 
-    def test_empty_db_omits_db_prefix(self):
-        # 2-segment /files path (e.g. Redshift "Connection Root/<SCHEMA>") sets
-        # db="" and fq_name must emit schema.table without the leading ".".
-        ref = _WarehouseTableRef(connection_id="c", db="", schema="public", table="t")
+    def test_none_db_omits_db_prefix(self):
+        # 2-segment /files path (e.g. Redshift "Connection Root/<SCHEMA>") leaves
+        # db=None and fq_name must emit schema.table without the leading ".".
+        ref = _WarehouseTableRef(connection_id="c", db=None, schema="public", table="t")
         assert ref.fq_name("redshift") == "public.t"
 
 
@@ -929,7 +929,7 @@ class TestTwoSegmentPathDefaultDatabase:
     def test_empty_db_emits_warning(self):
         source = _make_source_with_override()  # no default_database anywhere
         result = self._build_map(source)
-        assert result["rsUrlId001"].db == ""
+        assert result["rsUrlId001"].db is None
         assert any(
             "default_database" in (w.title or "") for w in source.reporter.warnings
         )

--- a/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_upstream.py
+++ b/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_upstream.py
@@ -840,3 +840,119 @@ class TestWarehouseTableRefFqName:
         # operators match a Snowflake connector run with that flag disabled.
         ref = _WarehouseTableRef(connection_id="c", db="DB", schema="SCH", table="TBL")
         assert ref.fq_name("snowflake", lowercase=False) == "DB.SCH.TBL"
+
+    def test_empty_db_omits_db_prefix(self):
+        # 2-segment /files path (e.g. Redshift "Connection Root/<SCHEMA>") sets
+        # db="" and fq_name must emit schema.table without the leading ".".
+        ref = _WarehouseTableRef(connection_id="c", db="", schema="public", table="t")
+        assert ref.fq_name("redshift") == "public.t"
+
+
+# ---------------------------------------------------------------------------
+# Tests: 2-segment /files path + default_database resolution
+# ---------------------------------------------------------------------------
+
+
+_REDSHIFT_CONN_ID = "conn-rs-001"
+_REDSHIFT_CONN_RECORD = SigmaConnectionRecord(
+    connection_id=_REDSHIFT_CONN_ID,
+    name="Prod Redshift",
+    sigma_type="redshift",
+    datahub_platform="redshift",
+    host="cluster.redshift.amazonaws.com",
+    default_database="dev",
+    is_mappable=True,
+)
+_TWO_SEG_FILES = {
+    "id": "inode-rs-001",
+    "urlId": "rsUrlId001",
+    "name": "base_table",
+    "type": "table",
+    "path": "Connection Root/public",
+}
+
+
+def _make_source_with_override(
+    override_default_db: Optional[str] = None,
+    registry_default_db: Optional[str] = None,
+) -> SigmaSource:
+    conn_override = (
+        WarehouseConnectionConfig.model_validate(
+            {"default_database": override_default_db}
+        )
+        if override_default_db is not None
+        else None
+    )
+    config = SigmaSourceConfig.model_validate(
+        {"client_id": "test", "client_secret": "test"}
+    )
+    if conn_override:
+        config.connection_to_platform_map = {_REDSHIFT_CONN_ID: conn_override}
+    ctx = PipelineContext(run_id="t4b-unit")
+    with patch.object(SigmaAPI, "_generate_token"):
+        source = SigmaSource(config=config, ctx=ctx)
+    record = SigmaConnectionRecord(
+        connection_id=_REDSHIFT_CONN_ID,
+        name="Prod Redshift",
+        sigma_type="redshift",
+        datahub_platform="redshift",
+        host="cluster.redshift.amazonaws.com",
+        default_database=registry_default_db,
+        is_mappable=True,
+    )
+    source.connection_registry = SigmaConnectionRegistry(
+        by_id={_REDSHIFT_CONN_ID: record}
+    )
+    return source
+
+
+class TestTwoSegmentPathDefaultDatabase:
+    def _build_map(self, source: SigmaSource) -> dict:
+        dm = _make_dm_with_inodes({"inode-rs-001": {"connectionId": _REDSHIFT_CONN_ID}})
+        with patch.object(
+            source.sigma_api, "get_file_metadata", return_value=_TWO_SEG_FILES
+        ):
+            return source._build_dm_warehouse_url_id_map(dm)
+
+    def test_override_default_database_wins(self):
+        source = _make_source_with_override(
+            override_default_db="staging", registry_default_db="dev"
+        )
+        result = self._build_map(source)
+        assert result["rsUrlId001"].db == "staging"
+
+    def test_registry_default_database_fallback(self):
+        source = _make_source_with_override(registry_default_db="dev")
+        result = self._build_map(source)
+        assert result["rsUrlId001"].db == "dev"
+
+    def test_empty_db_emits_warning(self):
+        source = _make_source_with_override()  # no default_database anywhere
+        result = self._build_map(source)
+        assert result["rsUrlId001"].db == ""
+        warnings = [w["title"] for w in source.reporter.warnings]
+        assert any("default_database" in w for w in warnings)
+
+    def test_empty_db_warning_deduped_across_dms(self):
+        source = _make_source_with_override()
+        dm1 = _make_dm_with_inodes(
+            {"inode-rs-001": {"connectionId": _REDSHIFT_CONN_ID}}
+        )
+        dm2 = _make_dm_with_inodes(
+            {"inode-rs-001": {"connectionId": _REDSHIFT_CONN_ID}}
+        )
+        with patch.object(
+            source.sigma_api, "get_file_metadata", return_value=_TWO_SEG_FILES
+        ):
+            source._build_dm_warehouse_url_id_map(dm1)
+            source._build_dm_warehouse_url_id_map(dm2)
+        warnings = [
+            w for w in source.reporter.warnings if "default_database" in w["title"]
+        ]
+        assert len(warnings) == 1
+
+    def test_fq_name_with_registry_db(self):
+        source = _make_source_with_override(registry_default_db="dev")
+        result = self._build_map(source)
+        ref = result["rsUrlId001"]
+        assert ref.fq_name("redshift") == "dev.public.base_table"

--- a/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_upstream.py
+++ b/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_upstream.py
@@ -930,8 +930,7 @@ class TestTwoSegmentPathDefaultDatabase:
         source = _make_source_with_override()  # no default_database anywhere
         result = self._build_map(source)
         assert result["rsUrlId001"].db == ""
-        warnings = [w["title"] for w in source.reporter.warnings]
-        assert any("default_database" in w for w in warnings)
+        assert any("default_database" in w.title for w in source.reporter.warnings)
 
     def test_empty_db_warning_deduped_across_dms(self):
         source = _make_source_with_override()
@@ -947,7 +946,7 @@ class TestTwoSegmentPathDefaultDatabase:
             source._build_dm_warehouse_url_id_map(dm1)
             source._build_dm_warehouse_url_id_map(dm2)
         warnings = [
-            w for w in source.reporter.warnings if "default_database" in w["title"]
+            w for w in source.reporter.warnings if "default_database" in w.title
         ]
         assert len(warnings) == 1
 

--- a/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_upstream.py
+++ b/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_upstream.py
@@ -930,7 +930,9 @@ class TestTwoSegmentPathDefaultDatabase:
         source = _make_source_with_override()  # no default_database anywhere
         result = self._build_map(source)
         assert result["rsUrlId001"].db == ""
-        assert any("default_database" in w.title for w in source.reporter.warnings)
+        assert any(
+            "default_database" in (w.title or "") for w in source.reporter.warnings
+        )
 
     def test_empty_db_warning_deduped_across_dms(self):
         source = _make_source_with_override()
@@ -946,7 +948,7 @@ class TestTwoSegmentPathDefaultDatabase:
             source._build_dm_warehouse_url_id_map(dm1)
             source._build_dm_warehouse_url_id_map(dm2)
         warnings = [
-            w for w in source.reporter.warnings if "default_database" in w.title
+            w for w in source.reporter.warnings if "default_database" in (w.title or "")
         ]
         assert len(warnings) == 1
 


### PR DESCRIPTION
`fineGrainedLineages` for the same elements.

Resolution uses `columnId` (format: `inode-<url_id>/<WAREHOUSE_COL>`) which
encodes the actual warehouse column name. The formula bracket ref carries the
display name (e.g. "Customer Id"), not the identifier ("customer_id"), so
  trusting it verbatim would produce orphan schemaFields.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
