### PR TITLE
feat(ingest): env-var default for tcp_keepalive on REST sink/client

### DIFF
--- a/metadata-ingestion/src/datahub/configuration/env_vars.py
+++ b/metadata-ingestion/src/datahub/configuration/env_vars.py
@@ -134,6 +134,11 @@ def get_rest_sink_default_mode() -> Optional[str]:
     return os.getenv("DATAHUB_REST_SINK_DEFAULT_MODE")
 
 
+def get_rest_sink_default_tcp_keepalive() -> bool:
+    """Default value for tcp_keepalive on the REST sink / DataHub client"""
+    return os.getenv("DATAHUB_REST_SINK_DEFAULT_TCP_KEEPALIVE", "").lower() == "true"
+
+
 # ============================================================================
 # Telemetry & Monitoring
 # ============================================================================

--- a/metadata-ingestion/src/datahub/emitter/rest_emitter.py
+++ b/metadata-ingestion/src/datahub/emitter/rest_emitter.py
@@ -53,6 +53,7 @@ from datahub.configuration.env_vars import (
     get_rest_emitter_default_pool_connections,
     get_rest_emitter_default_pool_maxsize,
     get_rest_emitter_default_retry_max_times,
+    get_rest_sink_default_tcp_keepalive,
 )
 from datahub.emitter.generic_emitter import Emitter
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
@@ -99,6 +100,7 @@ _DEFAULT_RETRY_METHODS = ["HEAD", "GET", "POST", "PUT", "DELETE", "OPTIONS", "TR
 _DEFAULT_RETRY_MAX_TIMES = int(get_rest_emitter_default_retry_max_times())
 _DEFAULT_POOL_CONNECTIONS = get_rest_emitter_default_pool_connections()
 _DEFAULT_POOL_MAXSIZE = get_rest_emitter_default_pool_maxsize()
+_DEFAULT_TCP_KEEPALIVE = get_rest_sink_default_tcp_keepalive()
 
 # Multiplier to increase number of retries on 429s
 _429_RETRY_MULTIPLIER = get_rest_emitter_429_retry_multiplier()
@@ -305,7 +307,7 @@ class RequestsSessionConfig(ConfigModel):
     client_mode: Optional[ClientMode] = _DEFAULT_CLIENT_MODE
     datahub_component: Optional[str] = None
 
-    tcp_keepalive: bool = False
+    tcp_keepalive: bool = _DEFAULT_TCP_KEEPALIVE
 
     def build_session(self) -> requests.Session:
         session = requests.Session()
@@ -482,7 +484,7 @@ class DataHubRestEmitter(Closeable, Emitter):
         client_mode: Optional[ClientMode] = None,
         datahub_component: Optional[str] = None,
         server_config_refresh_interval: Optional[int] = None,
-        tcp_keepalive: bool = False,
+        tcp_keepalive: Optional[bool] = None,
     ):
         if not gms_server:
             raise ConfigurationError("gms server is required")
@@ -553,7 +555,7 @@ class DataHubRestEmitter(Closeable, Emitter):
             disable_ssl_verification=disable_ssl_verification,
             client_mode=client_mode,
             datahub_component=datahub_component,
-            tcp_keepalive=tcp_keepalive,
+            tcp_keepalive=get_or_else(tcp_keepalive, _DEFAULT_TCP_KEEPALIVE),
         )
 
         self._session = self._session_config.build_session()

--- a/metadata-ingestion/src/datahub/ingestion/graph/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/config.py
@@ -4,7 +4,10 @@ from typing import Dict, List, Optional
 from pydantic import ConfigDict
 
 from datahub.configuration.common import ConfigModel
-from datahub.configuration.env_vars import get_datahub_component
+from datahub.configuration.env_vars import (
+    get_datahub_component,
+    get_rest_sink_default_tcp_keepalive,
+)
 
 
 class ClientMode(Enum):
@@ -14,6 +17,7 @@ class ClientMode(Enum):
 
 
 DATAHUB_COMPONENT_ENV: str = get_datahub_component().lower()
+_DEFAULT_TCP_KEEPALIVE: bool = get_rest_sink_default_tcp_keepalive()
 
 
 class DatahubClientConfig(ConfigModel):
@@ -34,9 +38,6 @@ class DatahubClientConfig(ConfigModel):
     client_mode: Optional[ClientMode] = None
     datahub_component: Optional[str] = None
     server_config_refresh_interval: Optional[int] = None
-    # Enables TCP keepalive on the underlying HTTP session, which prevents idle
-    # connections from being silently dropped by intermediaries (e.g. NAT
-    # gateways) and surfacing as SSLEOFError on reuse.
-    tcp_keepalive: bool = False
+    tcp_keepalive: bool = _DEFAULT_TCP_KEEPALIVE
 
     model_config = ConfigDict(extra="ignore")

--- a/metadata-ingestion/tests/unit/configuration/test_env_vars.py
+++ b/metadata-ingestion/tests/unit/configuration/test_env_vars.py
@@ -1,7 +1,10 @@
 import os
 from unittest.mock import patch
 
-from datahub.configuration.env_vars import is_ci
+from datahub.configuration.env_vars import (
+    get_rest_sink_default_tcp_keepalive,
+    is_ci,
+)
 
 
 def test_is_ci_with_ci_true():
@@ -80,3 +83,17 @@ def test_is_ci_with_ci_and_github_actions_both_true():
     """Test that is_ci() returns True when both CI and GITHUB_ACTIONS are true"""
     with patch.dict(os.environ, {"CI": "true", "GITHUB_ACTIONS": "true"}, clear=True):
         assert is_ci() is True
+
+
+def test_get_rest_sink_default_tcp_keepalive() -> None:
+    """Only the literal string 'true' (case-insensitive) enables the default."""
+    with patch.dict(
+        os.environ, {"DATAHUB_REST_SINK_DEFAULT_TCP_KEEPALIVE": "true"}, clear=True
+    ):
+        assert get_rest_sink_default_tcp_keepalive() is True
+    with patch.dict(
+        os.environ, {"DATAHUB_REST_SINK_DEFAULT_TCP_KEEPALIVE": "1"}, clear=True
+    ):
+        assert get_rest_sink_default_tcp_keepalive() is False
+    with patch.dict(os.environ, {}, clear=True):
+        assert get_rest_sink_default_tcp_keepalive() is False

--- a/metadata-ingestion/tests/unit/sdk/test_rest_emitter.py
+++ b/metadata-ingestion/tests/unit/sdk/test_rest_emitter.py
@@ -2526,6 +2526,39 @@ class TestDataHubGraphTcpKeepalive:
         )
 
 
+class TestTcpKeepaliveModuleDefaultResolution:
+    """DataHubRestEmitter.__init__ resolves an unset `tcp_keepalive` arg via
+    `get_or_else(arg, _DEFAULT_TCP_KEEPALIVE)`, where the module constant is
+    seeded from DATAHUB_REST_SINK_DEFAULT_TCP_KEEPALIVE at import. We patch
+    the constant directly to verify the resolution; the env-var -> constant
+    mapping is covered separately in tests/unit/configuration/test_env_vars.py.
+    """
+
+    @pytest.mark.parametrize(
+        "module_default,explicit_arg,expected_keepalive",
+        [
+            (True, None, True),  # default applies when arg omitted
+            (False, None, False),  # default applies when arg omitted
+            (True, False, False),  # explicit False wins over True default
+            (False, True, True),  # explicit True wins over False default
+        ],
+    )
+    def test_emitter_keepalive_resolution(
+        self, module_default, explicit_arg, expected_keepalive
+    ):
+        from datahub.emitter import rest_emitter
+
+        kwargs = {} if explicit_arg is None else {"tcp_keepalive": explicit_arg}
+        with patch.object(rest_emitter, "_DEFAULT_TCP_KEEPALIVE", module_default):
+            emitter = DataHubRestEmitter("http://localhost:8080", **kwargs)
+
+        adapter = emitter._session.get_adapter("https://example.com")
+        if expected_keepalive:
+            assert isinstance(adapter, _KeepAliveHTTPAdapter)
+        else:
+            assert type(adapter) is HTTPAdapter
+
+
 class TestWeightedRetry:
     """Tests for the WeightedRetry class that provides weighted retry logic for 429 responses."""
 


### PR DESCRIPTION
## Summary
Adds `DATAHUB_REST_SINK_DEFAULT_TCP_KEEPALIVE`, an environment variable that flips the default value of `tcp_keepalive` on the DataHub REST sink and underlying HTTP client. Operators can now enable TCP keepalive fleet-wide (e.g. via Helm `extraEnvs` on the Remote Executor) without having to edit every recipe, while explicit recipe values continue to win.

## Motivation
TCP keepalive on the executor's HTTP client to GMS prevents long-running ingestions from failing with `SSLEOFError` and similar connection errors when an idle TCP connection is silently dropped by an intermediary (NAT gateway, load balancer, corporate firewall) and then reused.

The recipe-level `tcp_keepalive: true` knob already exists, but in deployments with many recipes spread across many sources it's impractical to enable on each one individually. The natural place to set this is at the executor itself, so every recipe inherits the safer default with zero per-recipe edits required.

## Changes Overview

**New Features**
- New env var `DATAHUB_REST_SINK_DEFAULT_TCP_KEEPALIVE`. When set to `"true"` (case-insensitive), the default value of `tcp_keepalive` becomes `True` everywhere it's not explicitly set.
- Helper `get_rest_sink_default_tcp_keepalive()` in `datahub.configuration.env_vars`, following the existing `get_rest_sink_default_*` naming pattern.

**Modifications**
- `RequestsSessionConfig.tcp_keepalive` and `DatahubClientConfig.tcp_keepalive` field defaults are now seeded from the env var (via a module-level `_DEFAULT_TCP_KEEPALIVE` constant), instead of being hard-coded to `False`.
- `DataHubRestEmitter.__init__` now accepts `tcp_keepalive: Optional[bool] = None` and resolves it via `get_or_else(arg, _DEFAULT_TCP_KEEPALIVE)`, so callers that pass `None` (or omit the kwarg) pick up the env-driven default.

## Architecture / Design Notes

**Precedence (highest first):**
1. Explicit value supplied by recipe / kwarg.
2. `DATAHUB_REST_SINK_DEFAULT_TCP_KEEPALIVE` (if set to `"true"`, case-insensitive).
3. `False`.

The env var is read **once at module import** and cached on a module-level constant. This is intentional: the constant seeds Pydantic field defaults (which are evaluated at class definition time), keeping a single source of truth across both the imperative emitter API and the declarative config models. For tests, the constant is patched directly.

The env-var name and helper name align with the existing `get_rest_sink_default_max_threads` / `DATAHUB_REST_SINK_DEFAULT_MODE` family for discoverability and consistency.

## Testing

**Unit tests added/updated:**
- `tests/unit/configuration/test_env_vars.py::test_get_rest_sink_default_tcp_keepalive` — verifies the helper only treats the literal string `"true"` (case-insensitive) as truthy; values like `"1"` and unset/empty resolve to `False`.
- `tests/unit/sdk/test_rest_emitter.py::TestTcpKeepaliveModuleDefaultResolution::test_emitter_keepalive_resolution` — parametrized test that patches the module constant and verifies `DataHubRestEmitter.__init__` correctly applies the default when `tcp_keepalive` is omitted, and that an explicit `True`/`False` kwarg always wins over the module default.

**Manual verification** of the full layering matrix (env unset / `"true"`, recipe omitted / `true` / `false`, on both `DatahubClientConfig` and `DatahubRestSinkConfig`) confirmed the precedence above and that the explicit recipe value always wins when both an env var and a recipe value are present.

The pre-existing `tcp_keepalive` end-to-end test coverage in `test_rest_emitter.py` (HTTP adapter selection, socket option resolution, `to_graph()` propagation) is unchanged and continues to pass.

## Impact Assessment

**Affected components**
- `datahub.configuration.env_vars`
- `datahub.emitter.rest_emitter` (`RequestsSessionConfig`, `DataHubRestEmitter`)
- `datahub.ingestion.graph.config` (`DatahubClientConfig`)

**Breaking changes** — None.
- When `DATAHUB_REST_SINK_DEFAULT_TCP_KEEPALIVE` is unset, every code path resolves to `False`, identical to pre-change behavior.
- Existing recipes with `tcp_keepalive: true` or `tcp_keepalive: false` are unaffected; explicit values bypass the env-driven default.
- The signature change on `DataHubRestEmitter.__init__` (`bool` → `Optional[bool]`, default `None`) is source- and runtime-compatible: callers passing `True`/`False`/nothing all behave the same as before when the env var is unset.

**Risk level:** Low. Behavior change is opt-in via env var; default code paths are unchanged.

## Deployment Notes

**To enable fleet-wide on the Remote Executor (Helm):**

```yaml
extraEnvs:
  - name: DATAHUB_REST_SINK_DEFAULT_TCP_KEEPALIVE
    value: "true"
```

**Equivalent for Docker:**

```bash
docker run --env DATAHUB_REST_SINK_DEFAULT_TCP_KEEPALIVE=true ...
```

When enabled, the executor sets `SO_KEEPALIVE` along with platform-specific `TCP_KEEPIDLE` / `TCP_KEEPINTVL` / `TCP_KEEPCNT` socket options on every HTTP connection it opens to GMS. The keepalive cadence is intentionally aggressive (probes every ~60s) to stay well under typical NAT idle-connection timeouts.

No DB migration, no feature flag, no coordinated deployment required. Rollback = unset the env var.