### PR TITLE
feat: Add severity support to assertion result APIs

### DIFF
--- a/metadata-ingestion/src/datahub/api/graphql/assertion.py
+++ b/metadata-ingestion/src/datahub/api/graphql/assertion.py
@@ -36,11 +36,21 @@ query dataset($urn: String!, $start: Int, $count: Int, $status: AssertionRunStat
             result {
               __typename
               type
+              severity
               rowCount
               missingCount
               unexpectedCount
               actualAggValue
               externalUrl
+              nativeResults {
+                value
+              }
+              error {
+                type
+                properties {
+                  value
+                }
+              }
             }
             assertionUrn
           }

--- a/metadata-ingestion/src/datahub/ingestion/graph/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/client.py
@@ -1614,6 +1614,7 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
         fragment: str = """
              fragment assertionResult on AssertionResult {
                  type
+                 severity
                  rowCount
                  missingCount
                  unexpectedCount
@@ -1899,6 +1900,7 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
         external_url: Optional[str] = None,
         error_type: Optional[str] = None,
         error_message: Optional[str] = None,
+        severity: Optional[Literal["LOW", "MEDIUM", "HIGH"]] = None,
     ) -> bool:
         graph_query: str = """
             mutation reportAssertionResult(
@@ -1908,6 +1910,7 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
                 $properties: [StringMapEntryInput!],
                 $externalUrl: String,
                 $error: AssertionResultErrorInput,
+                $severity: AssertionResultSeverity,
             ) {
                 reportAssertionResult(urn: $assertionUrn, result: {
                     timestampMillis: $timestampMillis
@@ -1915,6 +1918,7 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
                     properties: $properties
                     externalUrl: $externalUrl
                     error: $error
+                    severity: $severity
                 })
             }
         """
@@ -1928,6 +1932,7 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
             "error": (
                 {"type": error_type, "message": error_message} if error_type else None
             ),
+            "severity": severity,
         }
 
         res = self.execute_graphql(

--- a/metadata-ingestion/tests/unit/sdk/test_run_assertions.py
+++ b/metadata-ingestion/tests/unit/sdk/test_run_assertions.py
@@ -215,3 +215,71 @@ class TestRunAssertionsForAsset:
             param_dict = {p["key"]: p["value"] for p in variables["parameters"]}
             assert param_dict["threshold"] == "50"
             assert param_dict["window"] == "24h"
+
+
+class TestAssertionResultFragmentIncludesSeverity:
+    """The shared assertionResult fragment must expose severity to read callers."""
+
+    def test_run_assertion_query_includes_severity(self, mock_graph):
+        with patch.object(mock_graph, "execute_graphql") as mock_execute:
+            mock_execute.return_value = {"runAssertion": {"type": "SUCCESS"}}
+            mock_graph.run_assertion(urn="urn:li:assertion:test123")
+
+            query = mock_execute.call_args.kwargs["query"]
+            assert "fragment assertionResult on AssertionResult" in query
+            assert "severity" in query
+
+    def test_run_assertions_query_includes_severity(self, mock_graph):
+        with patch.object(mock_graph, "execute_graphql") as mock_execute:
+            mock_execute.return_value = {"runAssertions": {"passingCount": 0}}
+            mock_graph.run_assertions(urns=["urn:li:assertion:test1"])
+
+            query = mock_execute.call_args.kwargs["query"]
+            assert "fragment assertionResult on AssertionResult" in query
+            assert "severity" in query
+
+    def test_run_assertions_for_asset_query_includes_severity(self, mock_graph):
+        with patch.object(mock_graph, "execute_graphql") as mock_execute:
+            mock_execute.return_value = {"runAssertionsForAsset": {"passingCount": 0}}
+            mock_graph.run_assertions_for_asset(
+                urn="urn:li:dataset:(urn:li:dataPlatform:mysql,db.table,PROD)"
+            )
+
+            query = mock_execute.call_args.kwargs["query"]
+            assert "fragment assertionResult on AssertionResult" in query
+            assert "severity" in query
+
+
+class TestReportAssertionResult:
+    """Tests for the report_assertion_result method."""
+
+    def test_report_assertion_result_without_severity(self, mock_graph):
+        with patch.object(mock_graph, "execute_graphql") as mock_execute:
+            mock_execute.return_value = {"reportAssertionResult": True}
+
+            mock_graph.report_assertion_result(
+                urn="urn:li:assertion:test123",
+                timestamp_millis=1700000000000,
+                type="SUCCESS",
+            )
+
+            query = mock_execute.call_args.kwargs["query"]
+            variables = mock_execute.call_args.kwargs["variables"]
+            assert "$severity: AssertionResultSeverity" in query
+            assert "severity: $severity" in query
+            assert variables["severity"] is None
+
+    def test_report_assertion_result_with_severity(self, mock_graph):
+        with patch.object(mock_graph, "execute_graphql") as mock_execute:
+            mock_execute.return_value = {"reportAssertionResult": True}
+
+            mock_graph.report_assertion_result(
+                urn="urn:li:assertion:test123",
+                timestamp_millis=1700000000000,
+                type="FAILURE",
+                severity="HIGH",
+            )
+
+            variables = mock_execute.call_args.kwargs["variables"]
+            assert variables["severity"] == "HIGH"
+            assert variables["type"] == "FAILURE"


### PR DESCRIPTION
## Summary
Add support for the `severity` field in assertion result APIs, allowing callers to specify and retrieve assertion result severity levels (LOW, MEDIUM, HIGH).

## Changes
- **GraphQL Client (`client.py`)**:
  - Added `severity` parameter to `report_assertion_result()` method with type `Optional[Literal["LOW", "MEDIUM", "HIGH"]]`
  - Updated GraphQL mutation to include `$severity: AssertionResultSeverity` variable and pass it to the `reportAssertionResult` mutation
  - Added `severity` field to the shared `assertionResult` fragment to expose it to read callers

- **Assertion API (`assertion.py`)**:
  - Added `severity` field to the assertion result query
  - Enhanced result object to include `nativeResults` and `error` fields with their nested properties for better error reporting

- **Tests (`test_run_assertions.py`)**:
  - Added `TestAssertionResultFragmentIncludesSeverity` class with 3 tests verifying that `severity` is included in the GraphQL queries for `run_assertion()`, `run_assertions()`, and `run_assertions_for_asset()` methods
  - Added `TestReportAssertionResult` class with 2 tests verifying that `report_assertion_result()` correctly handles severity parameter (both with and without severity specified)

## Testing
- Added comprehensive unit tests covering:
  - Severity field inclusion in assertion result queries
  - Severity parameter handling in `report_assertion_result()` with and without values
  - Proper GraphQL variable and query construction

All new tests pass and validate the severity field is properly integrated into the assertion result APIs.

https://claude.ai/code/session_013gC8bUj37Xiio2c9HFE2DM