### PR TITLE
fix(agent-context): use Dataset inline spread for QuerySubject.dataset.name

### DIFF
--- a/datahub-agent-context/src/datahub_agent_context/mcp_tools/gql/queries.gql
+++ b/datahub-agent-context/src/datahub_agent_context/mcp_tools/gql/queries.gql
@@ -29,7 +29,10 @@ fragment query on QueryEntity {
   subjects {
     dataset {
       urn
-      name
+      type
+      ... on Dataset {
+        name
+      }
     }
     schemaField {
       urn

--- a/datahub-agent-context/src/datahub_agent_context/mcp_tools/gql/query_entity.gql
+++ b/datahub-agent-context/src/datahub_agent_context/mcp_tools/gql/query_entity.gql
@@ -23,7 +23,10 @@ query GetQueryEntity($urn: String!) {
       subjects {
         dataset {
           urn
-          name
+          type
+          ... on Dataset {
+            name
+          }
         }
         schemaField {
           urn


### PR DESCRIPTION
## Summary

The MCP tool GraphQL fragments in `datahub-agent-context` select `name` directly on `QuerySubject.dataset`. This works against OSS GMS today (where the field is typed `Dataset!`), but fails GraphQL validation against deployments where `QuerySubject.dataset` has been widened to the `Entity` interface — e.g. for view-authorization restricted-entity flows — with:

> `Field 'name' in type 'Entity' is undefined`

This wraps `name` in a `... on Dataset` inline spread so the fragment is valid against both schema shapes. Same pattern as the existing React frontend fragment in `datahub-web-react/src/graphql/query.graphql`:

```graphql
dataset {
  urn
  type
  ... on Dataset {
    name
  }
}
```

The change is a no-op against the current OSS schema (the inline spread on the same concrete type doesn't filter anything) and fixes the validation failure on schemas that have widened the field.

## Affected operations

- `GetQueryEntity` in `query_entity.gql` — used by `get_entities` on Query URNs
- `listQueries` in `queries.gql` — used by `get_dataset_queries`

## Checklist

- [x] PR conforms to the Contributing Guideline (PR title format)
- [x] No related issue (driver was a downstream regression in DataHub Cloud)
- [ ] No tests added — `datahub-agent-context` doesn't currently have integration tests against a live GMS for these fragments. Happy to add one if there's an established pattern you'd prefer.
- [x] No docs changes needed
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)