### PR TITLE
fix(ingest/kafka-connect): avoid duplicated schema segment in sink lineage URNs

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/sink_connectors.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/sink_connectors.py
@@ -1243,8 +1243,16 @@ class JdbcSinkConnector(BaseConnector):
                 if parser.schema_name and has_three_level_hierarchy(
                     parser.target_platform
                 ):
-                    # Platform supports schema hierarchy: database.schema.table
-                    table_with_schema = f"{parser.schema_name}.{table_name}"
+                    schema_prefix = f"{parser.schema_name}."
+                    if table_name.startswith(schema_prefix):
+                        # Topic-derived table name already encodes the schema
+                        # (e.g. topic "public.clm" with schema_name="public"
+                        # and the default table.name.format="${topic}").
+                        # Prepending the schema again would duplicate the
+                        # segment in the lineage URN.
+                        table_with_schema = table_name
+                    else:
+                        table_with_schema = f"{parser.schema_name}.{table_name}"
                     target_dataset = get_dataset_name(
                         parser.database_name, table_with_schema
                     )

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/sink_connectors.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/sink_connectors.py
@@ -1066,26 +1066,46 @@ class JdbcSinkConnector(BaseConnector):
             self.connector_manifest, self.platform
         )
 
-    def get_table_name_from_topic(self, topic: str, table_format: str) -> str:
+    def get_table_name_from_topic(
+        self,
+        topic: str,
+        table_format: str,
+        schema_name: Optional[str] = None,
+    ) -> str:
         """
         Extract table name from topic using connector configuration.
 
         Uses the table.name.format config or defaults to topic name.
         Common format: "${topic}" means table name = topic name
 
+        If `schema_name` is provided and the derived table name already starts
+        with `{schema_name}.`, that prefix is stripped — otherwise the caller's
+        downstream `f"{schema_name}.{table_name}"` concatenation would duplicate
+        the schema segment in the lineage URN (e.g. `mydb.public.public.clm`
+        for topic `public.clm` with `schema_name="public"`).
+
         Args:
             topic: The Kafka topic name
             table_format: Table name format from configuration
+            schema_name: Optional schema name to strip from the prefix if the
+                topic-derived table name already encodes it
 
         Returns:
-            Table name derived from topic
+            Table name derived from topic, without any duplicated schema prefix
         """
         # Replace ${topic} placeholder with actual topic name
         if "${topic}" in table_format:
-            return table_format.replace("${topic}", topic)
+            table_name = table_format.replace("${topic}", topic)
+        else:
+            # If no ${topic} placeholder, assume format IS the table name
+            table_name = table_format
 
-        # If no ${topic} placeholder, assume format IS the table name
-        return table_format
+        if schema_name:
+            schema_prefix = f"{schema_name}."
+            if table_name.startswith(schema_prefix):
+                table_name = table_name[len(schema_prefix) :]
+
+        return table_name
 
     def get_topics_from_config(self) -> List[str]:
         """
@@ -1234,25 +1254,21 @@ class JdbcSinkConnector(BaseConnector):
             for original_topic, transformed_topic in zip(
                 topic_list, transformed_topics, strict=False
             ):
-                # Get table name using format from config
+                # Get table name using format from config — passing schema_name
+                # so any pre-existing schema prefix in the topic-derived name is
+                # stripped, preventing a duplicated schema segment in the URN.
                 table_name = self.get_table_name_from_topic(
-                    transformed_topic, parser.table_name_format
+                    transformed_topic,
+                    parser.table_name_format,
+                    parser.schema_name,
                 )
 
                 # Build fully qualified dataset name using helper function
                 if parser.schema_name and has_three_level_hierarchy(
                     parser.target_platform
                 ):
-                    schema_prefix = f"{parser.schema_name}."
-                    if table_name.startswith(schema_prefix):
-                        # Topic-derived table name already encodes the schema
-                        # (e.g. topic "public.clm" with schema_name="public"
-                        # and the default table.name.format="${topic}").
-                        # Prepending the schema again would duplicate the
-                        # segment in the lineage URN.
-                        table_with_schema = table_name
-                    else:
-                        table_with_schema = f"{parser.schema_name}.{table_name}"
+                    # Platform supports schema hierarchy: database.schema.table
+                    table_with_schema = f"{parser.schema_name}.{table_name}"
                     target_dataset = get_dataset_name(
                         parser.database_name, table_with_schema
                     )

--- a/metadata-ingestion/tests/integration/kafka_connect/confluent-cloud/kafka_connect_confluent_cloud_mces_golden.json
+++ b/metadata-ingestion/tests/integration/kafka_connect/confluent-cloud/kafka_connect_confluent_cloud_mces_golden.json
@@ -148,7 +148,7 @@
           "urn:li:dataset:(urn:li:dataPlatform:kafka,public.customer_profiles,PROD)"
         ],
         "outputDatasets": [
-          "urn:li:dataset:(urn:li:dataPlatform:postgres,reporting_db.public.public.customer_profiles,PROD)"
+          "urn:li:dataset:(urn:li:dataPlatform:postgres,reporting_db.public.customer_profiles,PROD)"
         ]
       }
     },
@@ -494,7 +494,7 @@
           "urn:li:dataset:(urn:li:dataPlatform:kafka,public.product_catalog,PROD)"
         ],
         "outputDatasets": [
-          "urn:li:dataset:(urn:li:dataPlatform:postgres,reporting_db.public.public.product_catalog,PROD)"
+          "urn:li:dataset:(urn:li:dataPlatform:postgres,reporting_db.public.product_catalog,PROD)"
         ]
       }
     },

--- a/metadata-ingestion/tests/unit/test_kafka_connect_double_schema_prefix.py
+++ b/metadata-ingestion/tests/unit/test_kafka_connect_double_schema_prefix.py
@@ -1,0 +1,209 @@
+"""Regression tests for kafka-connect double schema prefix in lineage URNs.
+
+When a topic name encodes a schema (e.g. `public.users`) and the destination
+sink connector is configured with the same `db.schema` value, sinks that
+build a 3-tier URN can produce a doubled schema segment — e.g.
+`mydb.public.public.users`.
+
+These tests cover two areas:
+
+1. (JDBC sink, e.g. Postgres / SQL Server / Oracle) Topic name already
+   contains the schema (`public.users` with `schema_name="public"`) and the
+   default `table.name.format="${topic}"`. Without a guard, the lineage URN
+   becomes `mydb.public.public.users`. The fix in `JdbcSinkConnector`
+   detects that `table_name` already starts with `schema_name.` and skips
+   the duplicate prepend.
+
+2. (Snowflake sink, pinned-current-behavior) Two cases pinned: with and
+   without `snowflake.topic2table.map`. The Snowflake URN must always match
+   the actual Snowflake table that will be created by the connector (the
+   default `re.sub` substitution is documented Snowflake behavior, not a
+   bug to "prettify").
+"""
+
+from unittest.mock import Mock
+
+from datahub.ingestion.source.kafka_connect.common import (
+    ConnectorManifest,
+    KafkaConnectSourceConfig,
+    KafkaConnectSourceReport,
+)
+from datahub.ingestion.source.kafka_connect.sink_connectors import (
+    JdbcSinkConnector,
+    SnowflakeSinkConnector,
+)
+
+
+def _make_kafka_connect_config_mock() -> Mock:
+    config = Mock(spec=KafkaConnectSourceConfig)
+    config.use_schema_resolver = False
+    config.schema_resolver_finegrained_lineage = False
+    config.env = "PROD"
+    config.connect_to_platform_map = None
+    config.platform_instance_map = None
+    config.convert_lineage_urns_to_lowercase = True
+    return config
+
+
+def test_jdbc_sink_with_schema_qualified_topic_does_not_double_schema() -> None:
+    """JDBC sink must not duplicate the schema when the topic name already
+    encodes the schema.
+
+    When a topic is named `public.users` and the sink connector is
+    configured with `db.schema=public` (or the postgres default `public`)
+    and the default `table.name.format="${topic}"`, the lineage target URN
+    must be `mydb.public.users` — not `mydb.public.public.users`.
+    """
+    manifest = ConnectorManifest(
+        name="test-postgres-sink",
+        type="sink",
+        config={
+            "connector.class": "PostgresSink",
+            "topics": "public.users",
+            "connection.host": "db.example.invalid",
+            "connection.port": "5432",
+            "db.name": "mydb",
+            "db.schema": "public",
+        },
+        tasks=[],
+        topic_names=["public.users"],
+    )
+
+    config = _make_kafka_connect_config_mock()
+    report = Mock(spec=KafkaConnectSourceReport)
+
+    connector = JdbcSinkConnector(manifest, config, report, platform="postgres")
+
+    lineages = connector.extract_lineages()
+    assert len(lineages) == 1
+    lineage = lineages[0]
+
+    assert lineage.source_dataset == "public.users"
+    assert lineage.target_dataset == "mydb.public.users", (
+        f"JDBC sink must not duplicate the schema when the topic already "
+        f"encodes it; got {lineage.target_dataset!r}"
+    )
+
+
+def test_jdbc_sink_without_schema_qualified_topic_still_prepends_schema() -> None:
+    """Sanity check: when the topic does NOT start with the configured
+    schema, the JDBC sink must still prepend the schema as before.
+
+    Topic `users` (no schema prefix) with `db.schema=public` should yield
+    target URN `mydb.public.users`. This guards against the dedup fix
+    accidentally stripping a legitimate schema prepend for unprefixed
+    topic names.
+    """
+    manifest = ConnectorManifest(
+        name="test-postgres-sink",
+        type="sink",
+        config={
+            "connector.class": "PostgresSink",
+            "topics": "users",
+            "connection.host": "db.example.invalid",
+            "connection.port": "5432",
+            "db.name": "mydb",
+            "db.schema": "public",
+        },
+        tasks=[],
+        topic_names=["users"],
+    )
+
+    config = _make_kafka_connect_config_mock()
+    report = Mock(spec=KafkaConnectSourceReport)
+
+    connector = JdbcSinkConnector(manifest, config, report, platform="postgres")
+
+    lineages = connector.extract_lineages()
+    assert len(lineages) == 1
+    assert lineages[0].target_dataset == "mydb.public.users"
+
+
+def test_snowflake_sink_default_naming_uses_native_table_name() -> None:
+    """Without `snowflake.topic2table.map`, Snowflake's default rule
+    replaces non-alphanumeric chars in the topic with `_`. Topic
+    `public.users` becomes the Snowflake table `public_users` in the
+    configured schema. DataHub's URN must reflect that real table.
+
+    This is *not* a bug. A future "prettification" PR that emits
+    `target_db.public.users` would orphan the URN — Snowflake has no such
+    table unless `snowflake.topic2table.map` is configured.
+    """
+    manifest = ConnectorManifest(
+        name="test-snowflake-sink",
+        type="sink",
+        config={
+            "connector.class": "SnowflakeSinkConnector",
+            "topics": "public.users",
+            "snowflake.database.name": "target_db",
+            "snowflake.schema.name": "public",
+        },
+        tasks=[],
+        topic_names=["public.users"],
+    )
+
+    config = _make_kafka_connect_config_mock()
+    report = Mock(spec=KafkaConnectSourceReport)
+
+    connector = SnowflakeSinkConnector(
+        connector_manifest=manifest,
+        config=config,
+        report=report,
+    )
+
+    lineages = connector.extract_lineages()
+    assert len(lineages) == 1
+    lineage = lineages[0]
+
+    assert lineage.source_dataset == "public.users"
+    assert lineage.target_dataset == "target_db.public.public_users", (
+        "Snowflake sink URN must match the actual Snowflake table name "
+        "(topic dots replaced with underscores per Snowflake connector "
+        f"default); got {lineage.target_dataset!r}. If you are intentionally "
+        "changing this, ensure the new URN points to a Snowflake table that "
+        "actually exists — e.g. via snowflake.topic2table.map."
+    )
+
+
+def test_snowflake_sink_with_topic2table_map_uses_mapped_table_name() -> None:
+    """With `snowflake.topic2table.map` configured, the URN must point to
+    the explicitly-mapped table name — *not* the default `_`-substituted
+    name.
+
+    For topic `public.users` and `snowflake.topic2table.map=public.users:users`,
+    the actual Snowflake table is `target_db.public.users`, and the URN
+    must match. The existing code already handles this; this test pins
+    that behavior so it doesn't silently regress.
+    """
+    manifest = ConnectorManifest(
+        name="test-snowflake-sink",
+        type="sink",
+        config={
+            "connector.class": "SnowflakeSinkConnector",
+            "topics": "public.users",
+            "snowflake.database.name": "target_db",
+            "snowflake.schema.name": "public",
+            "snowflake.topic2table.map": "public.users:users",
+        },
+        tasks=[],
+        topic_names=["public.users"],
+    )
+
+    config = _make_kafka_connect_config_mock()
+    report = Mock(spec=KafkaConnectSourceReport)
+
+    connector = SnowflakeSinkConnector(
+        connector_manifest=manifest,
+        config=config,
+        report=report,
+    )
+
+    lineages = connector.extract_lineages()
+    assert len(lineages) == 1
+    lineage = lineages[0]
+
+    assert lineage.source_dataset == "public.users"
+    assert lineage.target_dataset == "target_db.public.users", (
+        f"with snowflake.topic2table.map configured, URN must use the "
+        f"mapped table name; got {lineage.target_dataset!r}"
+    )


### PR DESCRIPTION
## Summary

`JdbcSinkConnector.extract_lineages` builds the target URN as `{db}.{schema}.{schema}.{table}` when the topic name already encodes the schema. For a topic named `public.users` with `db.schema=public` and the default `table.name.format=${topic}`, this produces a URN like `mydb.public.public.users` — pointing to a phantom dataset and orphaning lineage.

This PR detects when `table_name` already starts with `{schema_name}.` and skips the duplicate prepend, so the lineage URN matches the actual destination table the sink writes to. Affects 3-tier JDBC sinks (Postgres, SQL Server, Oracle).

The Snowflake sink path is unchanged: `SnowflakeSinkConnector` already handles `snowflake.topic2table.map` correctly in both branches (mapped and default `re.sub` substitution). Pin tests for both branches are included so this doesn't silently regress.

## Changes

- `metadata-ingestion/src/datahub/ingestion/source/kafka_connect/sink_connectors.py` — `JdbcSinkConnector.extract_lineages` deduplicates the schema prepend.
- `metadata-ingestion/tests/unit/test_kafka_connect_double_schema_prefix.py` — 3 new regression tests.

## Test plan

- [x] `pytest tests/unit/test_kafka_connect_double_schema_prefix.py` — 4 pass
- [x] `pytest -k kafka_connect tests/unit/` — 510 pass, 0 regressions
- [x] `./gradlew :metadata-ingestion:lintFix` — clean

## Scope

| Sink | Affected? | Notes |
|---|---|---|
| `JdbcSinkConnector` (Postgres, SQL Server, Oracle) | **Yes** — fixed | 3-tier; topic with `.` + default `${topic}` |
| `JdbcSinkConnector` (MySQL) | No | 2-tier — no schema prepend |
| `SnowflakeSinkConnector` | No (already correct) | `topic2table.map` handled; pin tests added |
| `BigQuerySinkConnector` | Theoretical edge case only | Not touched |
| `ClickHouseSinkConnector` | No | 2-tier |
| `ConfluentS3SinkConnector` | No | Path-based URN |

## Caveat

The fix assumes the Kafka Connect sink connector strips the schema prefix from the topic before writing (e.g. via `RegexRouter` SMT) — which is the common pattern. For an unusual setup where the destination table is *literally* named `public.users` (with a dot in the name), the URN would be incorrect, but no such case is known in practice.