### PR TITLE
chore(metadata-io): default coalesceBatchUpdates to false in V2 update strategy

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/service/UpdateIndicesV2Strategy.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/service/UpdateIndicesV2Strategy.java
@@ -110,14 +110,14 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
         idHashAlgo,
         semanticSearchConfig,
         indexConvention,
-        true);
+        false);
   }
 
   /**
    * Same as the 7-arg constructor, but allows toggling per-(urn, aspect) coalescing of batched
-   * updates. When {@code coalesceBatchUpdates} is true (default), N MCLs targeting the same (urn,
-   * aspect) within a batch produce a single ES upsert (last-write-wins, with predecessor runIds
-   * still appended). When false, the legacy per-event behavior is preserved as a rollback.
+   * updates. When {@code coalesceBatchUpdates} is true, N MCLs targeting the same (urn, aspect)
+   * within a batch produce a single ES upsert (last-write-wins, with predecessor runIds still
+   * appended). When false (default), the legacy per-event behavior is preserved.
    */
   public UpdateIndicesV2Strategy(
       @Nonnull EntityIndexVersionConfiguration v2Config,

--- a/metadata-io/src/main/java/com/linkedin/metadata/service/UpdateIndicesV2Strategy.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/service/UpdateIndicesV2Strategy.java
@@ -93,31 +93,10 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
    * @param idHashAlgo Hash algorithm for document IDs
    * @param semanticSearchConfig Semantic search configuration (null to disable dual-write)
    * @param indexConvention Index naming convention for deriving semantic index names (required)
-   */
-  public UpdateIndicesV2Strategy(
-      @Nonnull EntityIndexVersionConfiguration v2Config,
-      @Nonnull ElasticSearchService elasticSearchService,
-      @Nonnull SearchDocumentTransformer searchDocumentTransformer,
-      @Nonnull TimeseriesAspectService timeseriesAspectService,
-      @Nonnull String idHashAlgo,
-      @Nullable SemanticSearchConfiguration semanticSearchConfig,
-      @Nonnull IndexConvention indexConvention) {
-    this(
-        v2Config,
-        elasticSearchService,
-        searchDocumentTransformer,
-        timeseriesAspectService,
-        idHashAlgo,
-        semanticSearchConfig,
-        indexConvention,
-        false);
-  }
-
-  /**
-   * Same as the 7-arg constructor, but allows toggling per-(urn, aspect) coalescing of batched
-   * updates. When {@code coalesceBatchUpdates} is true, N MCLs targeting the same (urn, aspect)
-   * within a batch produce a single ES upsert (last-write-wins, with predecessor runIds still
-   * appended). When false (default), the legacy per-event behavior is preserved.
+   * @param coalesceBatchUpdates If true, coalesce multiple updates to the same (urn, aspect) in a
+   *     batch to a single update with the last state. This is a performance optimization that can
+   *     be disabled for more granular updates at the cost of more writes. Note: timeseries aspects
+   *     are always processed per-event and not coalesced.
    */
   public UpdateIndicesV2Strategy(
       @Nonnull EntityIndexVersionConfiguration v2Config,

--- a/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateIndicesServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateIndicesServiceTest.java
@@ -63,7 +63,8 @@ public class UpdateIndicesServiceTest {
             timeseriesAspectService,
             "MD5",
             null, // No semantic search config for this test
-            mock(IndexConvention.class));
+            mock(IndexConvention.class),
+            false);
 
     UpdateIndicesV3Strategy v3Strategy =
         new UpdateIndicesV3Strategy(

--- a/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateIndicesV2StrategyTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateIndicesV2StrategyTest.java
@@ -420,7 +420,8 @@ public class UpdateIndicesV2StrategyTest {
             timeseriesAspectService,
             "MD5",
             semanticConfig,
-            indexConvention);
+            indexConvention,
+            false);
 
     // Verify: Should not write to semantic index when not enabled
     assertFalse(
@@ -443,7 +444,8 @@ public class UpdateIndicesV2StrategyTest {
             timeseriesAspectService,
             "MD5",
             semanticConfig,
-            indexConvention);
+            indexConvention,
+            false);
 
     // Verify: Should not write to semantic index for dataset (not in enabled list)
     assertFalse(
@@ -469,7 +471,8 @@ public class UpdateIndicesV2StrategyTest {
             timeseriesAspectService,
             "MD5",
             semanticConfig,
-            indexConvention);
+            indexConvention,
+            false);
 
     // Verify: Should not write to semantic index when index doesn't exist
     assertFalse(strategyWithMissingIndex.shouldWriteToSemanticIndex(operationContext, "dataset"));
@@ -494,7 +497,8 @@ public class UpdateIndicesV2StrategyTest {
             timeseriesAspectService,
             "MD5",
             semanticConfig,
-            indexConvention);
+            indexConvention,
+            false);
 
     // Verify: Should write to semantic index when all conditions are met
     assertTrue(strategyWithAllConditions.shouldWriteToSemanticIndex(operationContext, "dataset"));
@@ -519,7 +523,8 @@ public class UpdateIndicesV2StrategyTest {
             timeseriesAspectService,
             "MD5",
             semanticConfig,
-            indexConvention);
+            indexConvention,
+            false);
 
     // Call shouldWriteToSemanticIndex multiple times
     assertTrue(strategyWithCaching.shouldWriteToSemanticIndex(operationContext, "dataset"));
@@ -549,7 +554,8 @@ public class UpdateIndicesV2StrategyTest {
             timeseriesAspectService,
             "MD5",
             semanticConfig,
-            indexConvention);
+            indexConvention,
+            false);
 
     // Setup mocks for document transformation
     when(searchDocumentTransformer.transformAspect(
@@ -641,7 +647,8 @@ public class UpdateIndicesV2StrategyTest {
             timeseriesAspectService,
             "MD5",
             semanticConfig,
-            indexConvention);
+            indexConvention,
+            false);
 
     // Execute with isKeyAspect = true (full delete)
     strategyWithSemantic.deleteSearchData(

--- a/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateIndicesV2StrategyTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateIndicesV2StrategyTest.java
@@ -113,7 +113,8 @@ public class UpdateIndicesV2StrategyTest {
             timeseriesAspectService,
             "MD5",
             null, // No semantic search config for basic tests
-            mock(IndexConvention.class));
+            mock(IndexConvention.class),
+            true);
   }
 
   @Test

--- a/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHookTest.java
+++ b/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHookTest.java
@@ -143,7 +143,8 @@ public class UpdateIndicesHookTest {
             mockTimeseriesAspectService,
             "MD5",
             null,
-            mock(IndexConvention.class));
+            mock(IndexConvention.class),
+            false);
 
     updateIndicesService =
         new UpdateIndicesService(
@@ -260,7 +261,8 @@ public class UpdateIndicesHookTest {
             mockTimeseriesAspectService,
             "MD5",
             null,
-            mock(IndexConvention.class));
+            mock(IndexConvention.class),
+            false);
 
     updateIndicesService =
         new UpdateIndicesService(
@@ -892,7 +894,8 @@ public class UpdateIndicesHookTest {
               mockTimeseriesAspectService,
               "MD5",
               null, // No semantic search config for this test
-              mock(IndexConvention.class));
+              mock(IndexConvention.class),
+              false);
       strategies.add(v2Strategy);
     }
 

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -395,7 +395,7 @@ elasticsearch:
     v2:
       enabled: ${ELASTICSEARCH_ENTITY_INDEX_V2_ENABLED:true}
       cleanup: ${ELASTICSEARCH_ENTITY_INDEX_V2_CLEANUP:true}
-      coalesceBatchUpdates: ${ELASTICSEARCH_ENTITY_INDEX_V2_COALESCE_BATCH_UPDATES:true}
+      coalesceBatchUpdates: ${ELASTICSEARCH_ENTITY_INDEX_V2_COALESCE_BATCH_UPDATES:false}
     v3:
       enabled: ${ELASTICSEARCH_ENTITY_INDEX_V3_ENABLED:false}
       cleanup: ${ELASTICSEARCH_ENTITY_INDEX_V3_CLEANUP:false}

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entity/update/indices/UpdateIndicesStrategyFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entity/update/indices/UpdateIndicesStrategyFactory.java
@@ -37,7 +37,7 @@ public class UpdateIndicesStrategyFactory {
       @Qualifier(IndexConventionFactory.INDEX_CONVENTION_BEAN) IndexConvention indexConvention,
       @Value("${elasticsearch.idHashAlgo}") String idHashAlgo,
       @Value("${elasticsearch.entityIndex.v2.cleanup:false}") boolean v2Cleanup,
-      @Value("${elasticsearch.entityIndex.v2.coalesceBatchUpdates:true}")
+      @Value("${elasticsearch.entityIndex.v2.coalesceBatchUpdates:false}")
           boolean coalesceBatchUpdates) {
 
     EntityIndexVersionConfiguration v2Config =

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/graphql/GraphQLEngineFactoryTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/graphql/GraphQLEngineFactoryTest.java
@@ -116,7 +116,7 @@ public class GraphQLEngineFactoryTest extends AbstractTestNGSpringContextTests {
   @Qualifier("graphClient")
   private GraphClient graphClient;
 
-  @Autowired
+  @MockitoBean
   @Qualifier("entityService")
   private EntityService<?> entityService;
 


### PR DESCRIPTION
## Summary

Switches the default for `elasticsearch.entityIndex.v2.coalesceBatchUpdates` from `true` to `false`, making MCL coalescing in `UpdateIndicesV2Strategy` opt-in. Operators can re-enable the per-(urn, aspect) batch dedup behavior with `ELASTICSEARCH_ENTITY_INDEX_V2_COALESCE_BATCH_UPDATES=true`.

Changes:
- `application.yaml`: env-var default `true` → `false`
- `UpdateIndicesStrategyFactory`: Spring `@Value` default `true` → `false`
- `UpdateIndicesV2Strategy`: 7-arg convenience constructor delegates with `false` to match the production default; Javadoc updated accordingly
- `UpdateIndicesV2StrategyTest`: setup now explicitly passes `true` so the existing `Coalesce*` tests continue to exercise the coalescing path