### PR TITLE
feat(agent-context): add get_runs tool for DataJob and DataFlow run history

### DIFF
--- a/datahub-agent-context/src/datahub_agent_context/google_adk_tools/builder.py
+++ b/datahub-agent-context/src/datahub_agent_context/google_adk_tools/builder.py
@@ -27,6 +27,7 @@ from datahub_agent_context.mcp_tools.lineage import (
 )
 from datahub_agent_context.mcp_tools.owners import add_owners, remove_owners
 from datahub_agent_context.mcp_tools.queries import get_dataset_queries
+from datahub_agent_context.mcp_tools.runs import get_runs
 from datahub_agent_context.mcp_tools.save_document import save_document
 from datahub_agent_context.mcp_tools.search import search
 from datahub_agent_context.mcp_tools.tags import add_tags, remove_tags
@@ -78,6 +79,7 @@ def build_google_adk_tools(
         create_context_wrapper(get_lineage_paths_between, client),
         create_context_wrapper(get_dataset_queries, client),
         create_context_wrapper(get_dataset_assertions, client),
+        create_context_wrapper(get_runs, client),
         create_context_wrapper(search, client),
     ]
 

--- a/datahub-agent-context/src/datahub_agent_context/langchain_tools/builder.py
+++ b/datahub-agent-context/src/datahub_agent_context/langchain_tools/builder.py
@@ -36,6 +36,7 @@ from datahub_agent_context.mcp_tools.lineage import (
 )
 from datahub_agent_context.mcp_tools.owners import add_owners, remove_owners
 from datahub_agent_context.mcp_tools.queries import get_dataset_queries
+from datahub_agent_context.mcp_tools.runs import get_runs
 from datahub_agent_context.mcp_tools.save_document import save_document
 from datahub_agent_context.mcp_tools.search import search
 from datahub_agent_context.mcp_tools.tags import add_tags, remove_tags
@@ -86,6 +87,7 @@ def build_langchain_tools(
 
     tools.append(tool(create_context_wrapper(get_dataset_queries, client)))
     tools.append(tool(create_context_wrapper(get_dataset_assertions, client)))
+    tools.append(tool(create_context_wrapper(get_runs, client)))
     tools.append(tool(create_context_wrapper(search, client)))
 
     if include_mutations:

--- a/datahub-agent-context/src/datahub_agent_context/mcp_tools/__init__.py
+++ b/datahub-agent-context/src/datahub_agent_context/mcp_tools/__init__.py
@@ -16,6 +16,7 @@ from datahub_agent_context.mcp_tools.lineage import (
 )
 from datahub_agent_context.mcp_tools.owners import add_owners, remove_owners
 from datahub_agent_context.mcp_tools.queries import get_dataset_queries
+from datahub_agent_context.mcp_tools.runs import get_runs
 from datahub_agent_context.mcp_tools.save_document import save_document
 from datahub_agent_context.mcp_tools.search import search
 from datahub_agent_context.mcp_tools.structured_properties import (
@@ -36,6 +37,7 @@ __all__ = [
     "get_lineage_paths_between",
     "get_dataset_queries",
     "get_dataset_assertions",
+    "get_runs",
     "search_documents",
     "grep_documents",
     "add_tags",

--- a/datahub-agent-context/src/datahub_agent_context/mcp_tools/runs.py
+++ b/datahub-agent-context/src/datahub_agent_context/mcp_tools/runs.py
@@ -1,0 +1,236 @@
+"""Tools for getting pipeline run history for DataJobs and DataFlows."""
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from datahub_agent_context.context import get_graph
+from datahub_agent_context.mcp_tools.base import clean_gql_response, execute_graphql
+
+logger = logging.getLogger(__name__)
+
+GET_RUNS_QUERY = """
+query GetEntityRuns($urn: String!, $start: Int!, $count: Int!) {
+    entity(urn: $urn) {
+        ... on DataJob {
+            runs(start: $start, count: $count) {
+                total
+                start
+                count
+                runs {
+                    urn
+                    externalUrl
+                    properties {
+                        name
+                        externalUrl
+                        created {
+                            time
+                        }
+                    }
+                    state(limit: 2) {
+                        status
+                        timestampMillis
+                        durationMillis
+                        attempt
+                        result {
+                            resultType
+                            nativeResultType
+                        }
+                    }
+                }
+            }
+        }
+        ... on DataFlow {
+            runs(start: $start, count: $count) {
+                total
+                start
+                count
+                runs {
+                    urn
+                    externalUrl
+                    properties {
+                        name
+                        externalUrl
+                        created {
+                            time
+                        }
+                    }
+                    state(limit: 2) {
+                        status
+                        timestampMillis
+                        durationMillis
+                        attempt
+                        result {
+                            resultType
+                            nativeResultType
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+"""
+
+DEFAULT_COUNT = 10
+MAX_COUNT = 50
+
+
+def _millis_to_iso(millis: Optional[int]) -> Optional[str]:
+    if millis is None:
+        return None
+    return datetime.fromtimestamp(millis / 1000, tz=timezone.utc).isoformat()
+
+
+def _summarize_run(run: dict[str, Any]) -> dict[str, Any]:
+    """Convert a raw DataProcessInstance into a concise summary."""
+    props = run.get("properties") or {}
+    state_events = run.get("state") or []
+
+    # state events are returned newest-first; pick the terminal COMPLETE event
+    # if present, otherwise fall back to the first (most recent) event.
+    complete_event = next(
+        (e for e in state_events if e.get("status") == "COMPLETE"), None
+    )
+    latest_event = complete_event or (state_events[0] if state_events else None)
+
+    result_type: Optional[str] = None
+    native_result: Optional[str] = None
+    finished_at: Optional[str] = None
+    duration_ms: Optional[int] = None
+
+    if latest_event:
+        result_obj = latest_event.get("result") or {}
+        result_type = result_obj.get("resultType")
+        native_result = result_obj.get("nativeResultType")
+        finished_at = _millis_to_iso(latest_event.get("timestampMillis"))
+        duration_ms = latest_event.get("durationMillis")
+
+    created_time: Optional[str] = None
+    created = props.get("created") or {}
+    if created.get("time"):
+        created_time = _millis_to_iso(created["time"])
+
+    summary: dict[str, Any] = {
+        "urn": run.get("urn"),
+        "name": props.get("name"),
+        "startedAt": created_time,
+        "finishedAt": finished_at,
+        "status": result_type,
+        "nativeStatus": native_result,
+        "durationMs": duration_ms,
+        "externalUrl": run.get("externalUrl") or props.get("externalUrl"),
+    }
+    # Drop None values for cleaner output
+    return {k: v for k, v in summary.items() if v is not None}
+
+
+def get_runs(
+    urn: str,
+    start: int = 0,
+    count: int = DEFAULT_COUNT,
+) -> dict[str, Any]:
+    """Get the execution run history for a DataJob (task) or DataFlow (DAG/pipeline).
+
+    Returns a list of recent runs ordered newest-first, with timestamp, status,
+    and duration for each run. Use this to answer questions like:
+    - "When did this task last run?"
+    - "Did the pipeline succeed today?"
+    - "What was the last run status of this task?"
+
+    Args:
+        urn: URN of a DataJob (task) or DataFlow (pipeline/DAG).
+            Examples:
+            - DataJob:  urn:li:dataJob:(urn:li:dataFlow:(airflow,my_dag,prod),my_task)
+            - DataFlow: urn:li:dataFlow:(airflow,my_dag,prod)
+        start: Pagination offset (default 0)
+        count: Number of runs to return (default 10, max 50)
+
+    Returns:
+        Dictionary with:
+        - success: Whether the request was successful
+        - data: Contains start, count, total, and runs list
+        - message: Summary message with last-run status
+
+    Each run includes:
+        - urn: Unique identifier for this run instance
+        - name: Run ID / name as reported by the orchestrator
+        - startedAt: ISO-8601 UTC timestamp when the run started
+        - finishedAt: ISO-8601 UTC timestamp when the run completed (if available)
+        - status: Outcome — SUCCESS, FAILURE, SKIPPED, or UP_FOR_RETRY
+        - nativeStatus: Raw status string from the source system (e.g. "success")
+        - durationMs: Run duration in milliseconds (if available)
+        - externalUrl: Link to view the run in the source orchestrator
+
+    Examples:
+        # Get last 10 runs for an Airflow task
+        get_runs(urn="urn:li:dataJob:(urn:li:dataFlow:(airflow,my_dag,prod),my_task)")
+
+        # Get last 5 runs for a DAG
+        get_runs(
+            urn="urn:li:dataFlow:(airflow,my_dag,prod)",
+            count=5,
+        )
+
+        # Paginate through run history
+        get_runs(urn="urn:li:dataJob:(...)", start=10, count=10)
+
+    Example:
+        from datahub_agent_context.context import DataHubContext
+
+        with DataHubContext(client.graph):
+            result = get_runs(
+                urn="urn:li:dataJob:(urn:li:dataFlow:(airflow,my_dag,prod),my_task)"
+            )
+    """
+    graph = get_graph()
+
+    start = max(0, start)
+    count = max(1, min(count, MAX_COUNT))
+
+    try:
+        result = execute_graphql(
+            graph,
+            query=GET_RUNS_QUERY,
+            variables={"urn": urn, "start": start, "count": count},
+            operation_name="GetEntityRuns",
+        )
+
+        entity = result.get("entity") or {}
+        runs_result = entity.get("runs")
+
+        if runs_result is None:
+            return {
+                "success": False,
+                "data": {"start": start, "count": 0, "total": 0, "runs": []},
+                "message": (
+                    "No run history found. The entity may not be a DataJob or DataFlow, "
+                    "or no runs have been recorded yet."
+                ),
+            }
+
+        raw_runs = runs_result.get("runs") or []
+        total = runs_result.get("total", 0)
+        summaries = [_summarize_run(clean_gql_response(r)) for r in raw_runs]
+
+        latest = summaries[0] if summaries else None
+        if latest:
+            last_run_at = latest.get("finishedAt") or latest.get("startedAt", "unknown")
+            last_status = latest.get("status", "UNKNOWN")
+            message = f"Last run: {last_run_at} — {last_status}. Total runs available: {total}."
+        else:
+            message = f"No runs found (total recorded: {total})."
+
+        return {
+            "success": True,
+            "data": {
+                "start": runs_result.get("start", start),
+                "count": len(summaries),
+                "total": total,
+                "runs": summaries,
+            },
+            "message": message,
+        }
+
+    except Exception as e:
+        raise RuntimeError(f"Error fetching run history for {urn}: {e}") from e

--- a/datahub-agent-context/tests/unit/mcp_tools/test_runs.py
+++ b/datahub-agent-context/tests/unit/mcp_tools/test_runs.py
@@ -1,0 +1,206 @@
+"""Tests for pipeline run history tool."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from datahub_agent_context.context import DataHubContext
+from datahub_agent_context.mcp_tools.runs import (
+    _millis_to_iso,
+    _summarize_run,
+    get_runs,
+)
+
+DATAJOB_URN = "urn:li:dataJob:(urn:li:dataFlow:(airflow,my_dag,prod),my_task)"
+
+
+def _make_run(
+    urn: str = "urn:li:dataProcessInstance:abc123",
+    name: str = "my_dag_my_task_run_2026-05-07",
+    created_time: int = 1746614400000,  # 2026-05-07T12:00:00Z
+    finished_time: int = 1746614700000,  # 2026-05-07T12:05:00Z
+    duration_ms: int = 300000,
+    status: str = "SUCCESS",
+    external_url: str = "https://airflow.example.com/runs/1",
+) -> dict:
+    return {
+        "urn": urn,
+        "externalUrl": external_url,
+        "properties": {
+            "name": name,
+            "externalUrl": None,
+            "created": {"time": created_time},
+        },
+        "state": [
+            {
+                "status": "COMPLETE",
+                "timestampMillis": finished_time,
+                "durationMillis": duration_ms,
+                "attempt": 1,
+                "result": {
+                    "resultType": status,
+                    "nativeResultType": "airflow",
+                },
+            }
+        ],
+    }
+
+
+def _make_gql_response(runs: list, total: int = None) -> dict:
+    return {
+        "entity": {
+            "runs": {
+                "total": total if total is not None else len(runs),
+                "start": 0,
+                "count": len(runs),
+                "runs": runs,
+            }
+        }
+    }
+
+
+# --- Unit tests for helper functions ---
+
+
+def test_millis_to_iso_valid():
+    result = _millis_to_iso(1746614400000)
+    assert result == "2026-05-07T12:00:00+00:00"
+
+
+def test_millis_to_iso_none():
+    assert _millis_to_iso(None) is None
+
+
+def test_summarize_run_success():
+    raw = _make_run()
+    summary = _summarize_run(raw)
+
+    assert summary["urn"] == "urn:li:dataProcessInstance:abc123"
+    assert summary["name"] == "my_dag_my_task_run_2026-05-07"
+    assert summary["status"] == "SUCCESS"
+    assert summary["startedAt"] == "2026-05-07T12:00:00+00:00"
+    assert summary["finishedAt"] == "2026-05-07T12:05:00+00:00"
+    assert summary["durationMs"] == 300000
+    assert summary["externalUrl"] == "https://airflow.example.com/runs/1"
+
+
+def test_summarize_run_prefers_complete_state_event():
+    """COMPLETE event should be preferred over STARTED event for status."""
+    raw = _make_run()
+    raw["state"] = [
+        {
+            "status": "STARTED",
+            "timestampMillis": 1746614400000,
+            "durationMillis": None,
+            "attempt": 1,
+            "result": None,
+        },
+        {
+            "status": "COMPLETE",
+            "timestampMillis": 1746614700000,
+            "durationMillis": 300000,
+            "attempt": 1,
+            "result": {"resultType": "SUCCESS", "nativeResultType": "airflow"},
+        },
+    ]
+    summary = _summarize_run(raw)
+    assert summary["status"] == "SUCCESS"
+    assert summary["durationMs"] == 300000
+
+
+def test_summarize_run_no_state():
+    """Run with no state events should still return basic info."""
+    raw = _make_run()
+    raw["state"] = []
+    summary = _summarize_run(raw)
+
+    assert summary["urn"] == "urn:li:dataProcessInstance:abc123"
+    assert "status" not in summary
+    assert "finishedAt" not in summary
+
+
+def test_summarize_run_strips_none_values():
+    raw = _make_run()
+    raw["externalUrl"] = None
+    raw["properties"]["externalUrl"] = None
+    summary = _summarize_run(raw)
+    assert "externalUrl" not in summary
+
+
+# --- Integration-style tests for get_runs ---
+
+
+def _mock_graph():
+    graph = MagicMock()
+    graph.frontend_base_url = None
+    return graph
+
+
+def test_get_runs_datajob_success():
+    run = _make_run()
+    mock_response = _make_gql_response([run], total=1)
+
+    with patch(
+        "datahub_agent_context.mcp_tools.runs.execute_graphql",
+        return_value=mock_response,
+    ), DataHubContext(_mock_graph()):
+        result = get_runs(urn=DATAJOB_URN, count=5)
+
+    assert result["success"] is True
+    assert result["data"]["total"] == 1
+    assert result["data"]["count"] == 1
+    runs = result["data"]["runs"]
+    assert len(runs) == 1
+    assert runs[0]["status"] == "SUCCESS"
+    assert "Last run:" in result["message"]
+    assert "SUCCESS" in result["message"]
+
+
+def test_get_runs_empty():
+    mock_response = _make_gql_response([], total=0)
+
+    with patch(
+        "datahub_agent_context.mcp_tools.runs.execute_graphql",
+        return_value=mock_response,
+    ), DataHubContext(_mock_graph()):
+        result = get_runs(urn=DATAJOB_URN)
+
+    assert result["success"] is True
+    assert result["data"]["total"] == 0
+    assert result["data"]["runs"] == []
+
+
+def test_get_runs_entity_not_datajob():
+    """Non-DataJob/DataFlow entity returns failure response."""
+    mock_response = {"entity": {}}
+
+    with patch(
+        "datahub_agent_context.mcp_tools.runs.execute_graphql",
+        return_value=mock_response,
+    ), DataHubContext(_mock_graph()):
+        result = get_runs(urn="urn:li:dataset:(urn:li:dataPlatform:snowflake,db.t,PROD)")
+
+    assert result["success"] is False
+    assert result["data"]["runs"] == []
+
+
+def test_get_runs_clamps_count():
+    mock_response = _make_gql_response([], total=0)
+
+    with patch(
+        "datahub_agent_context.mcp_tools.runs.execute_graphql",
+        return_value=mock_response,
+    ) as mock_gql, DataHubContext(_mock_graph()):
+        get_runs(urn=DATAJOB_URN, count=999)
+
+    variables = mock_gql.call_args.kwargs["variables"]
+    assert variables["count"] == 50  # MAX_COUNT
+
+
+def test_get_runs_propagates_error():
+    with patch(
+        "datahub_agent_context.mcp_tools.runs.execute_graphql",
+        side_effect=Exception("GMS unavailable"),
+    ), DataHubContext(_mock_graph()):
+        with pytest.raises(RuntimeError, match="Error fetching run history"):
+            get_runs(urn=DATAJOB_URN)


### PR DESCRIPTION
## Summary

- Adds a new `get_runs` MCP tool to `datahub-agent-context` that queries execution run history for **DataJob** (task) and **DataFlow** (DAG/pipeline) entities.
- Closes a gap where AI agents could not answer common questions like *when did this pipeline last run?* or *did the task succeed today?*, even though the data exists in DataHub via the Runs tab in the UI.
- Registers the tool in `mcp_tools/__init__.py`, `langchain_tools/builder.py`, and `google_adk_tools/builder.py`.

## How it works

Uses the `runs(start, count)` GraphQL field already defined on `DataJob` and `DataFlow` (via `runs.graphql`) to return a paginated list of `DataProcessInstance` records ordered newest-first. Each run includes `startedAt`, `finishedAt`, `status` (SUCCESS/FAILURE/SKIPPED/UP_FOR_RETRY), `durationMs`, and `externalUrl`.

## Test plan

- [x] Unit tests added in `tests/unit/mcp_tools/test_runs.py` covering success, empty results, non-DataJob entities, count clamping, and error propagation.

Made with [Cursor](https://cursor.com)