### PR TITLE
fix(ingest/glue): fix schemaField URN and definition ordering for extract_column_parameters

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
@@ -2016,8 +2016,16 @@ class GlueSource(StatefulIngestionSourceBase):
                 params = column.get("Parameters")
                 if not params:
                     continue
+                schema_fields = get_schema_fields_for_hive_column(
+                    hive_column_name=column["Name"],
+                    hive_column_type=column.get("Type", "string"),
+                    description=column.get("Comment"),
+                    default_nullable=True,
+                )
+                if not schema_fields:
+                    continue
                 field_urn = mce_builder.make_schema_field_urn(
-                    dataset_urn, column["Name"]
+                    dataset_urn, schema_fields[0].fieldPath
                 )
                 assignments = []
                 for key, value in params.items():
@@ -2026,7 +2034,7 @@ class GlueSource(StatefulIngestionSourceBase):
                         "urn:li:structuredProperty:"
                     )
                     if property_urn not in self._seen_column_param_urns:
-                        yield MetadataChangeProposalWrapper(
+                        definition_mcp = MetadataChangeProposalWrapper(
                             entityUrn=property_urn,
                             aspect=StructuredPropertyDefinitionClass(
                                 qualifiedName=qualified_name,
@@ -2034,9 +2042,15 @@ class GlueSource(StatefulIngestionSourceBase):
                                 valueType="urn:li:dataType:datahub.string",
                                 entityTypes=["urn:li:entityType:datahub.schemaField"],
                             ),
-                        ).as_workunit()
-                        # Only cache after successful yield so a dropped MCP
-                        # (network blip, GMS rejection) doesn't prevent retry.
+                        )
+                        if self.ctx.graph is not None:
+                            # Emit synchronously so GMS persists the definition
+                            # before the structuredProperties MCP below is
+                            # validated — GMS rejects assignments that reference
+                            # a definition not yet in the database.
+                            self.ctx.graph.emit_mcp(definition_mcp)
+                        else:
+                            yield definition_mcp.as_workunit()
                         self._seen_column_param_urns.add(property_urn)
                     assignments.append(
                         StructuredPropertyValueAssignmentClass(

--- a/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
@@ -2048,7 +2048,7 @@ class GlueSource(StatefulIngestionSourceBase):
                             # before the structuredProperties MCP below is
                             # validated — GMS rejects assignments that reference
                             # a definition not yet in the database.
-                            self.ctx.graph.emit_mcp(definition_mcp)
+                            self.ctx.graph.emit_mcp(definition_mcp, emit_mode=EmitMode.SYNC_PRIMARY)
                         else:
                             yield definition_mcp.as_workunit()
                         self._seen_column_param_urns.add(property_urn)

--- a/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
@@ -47,6 +47,7 @@ from datahub.emitter.mcp_builder import (
     add_domain_to_entity_wu,
     gen_containers,
 )
+from datahub.emitter.rest_emitter import EmitMode
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.api.decorators import (
     SourceCapability,
@@ -2048,7 +2049,9 @@ class GlueSource(StatefulIngestionSourceBase):
                             # before the structuredProperties MCP below is
                             # validated — GMS rejects assignments that reference
                             # a definition not yet in the database.
-                            self.ctx.graph.emit_mcp(definition_mcp, emit_mode=EmitMode.SYNC_PRIMARY)
+                            self.ctx.graph.emit_mcp(
+                                definition_mcp, emit_mode=EmitMode.SYNC_PRIMARY
+                            )
                         else:
                             yield definition_mcp.as_workunit()
                         self._seen_column_param_urns.add(property_urn)

--- a/metadata-ingestion/tests/unit/glue/test_glue_source.py
+++ b/metadata-ingestion/tests/unit/glue/test_glue_source.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple, Type, cast
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pydantic
 import pytest
@@ -1675,8 +1675,8 @@ def test_get_column_param_workunits_values_assigned_correctly() -> None:
 
     workunits = list(source._get_column_param_workunits(table, dataset_urn))
 
-    # Find the StructuredProperties workunit for col_a
-    col_a_urn = "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:glue,test_db.test_table,PROD),col_a)"
+    # Find the StructuredProperties workunit for col_a (v2 typed field path)
+    col_a_urn = "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:glue,test_db.test_table,PROD),[version=2.0].[type=string].col_a)"
     col_a_props_wu = next(
         (
             wu
@@ -1728,3 +1728,64 @@ def test_seen_definitions_not_re_emitted_across_tables() -> None:
     ]
     assert len(first_defs) > 0
     assert second_defs == []
+
+
+def test_get_column_param_workunits_uses_v2_field_path() -> None:
+    """schemaField URNs must use the v2 typed path from get_schema_fields_for_hive_column."""
+    source = _make_glue_source_with_column_params()
+    table = _make_table_with_column_params()
+    dataset_urn = "urn:li:dataset:(urn:li:dataPlatform:glue,test_db.test_table,PROD)"
+
+    workunits = list(source._get_column_param_workunits(table, dataset_urn))
+
+    assignment_urns = {
+        wu.get_urn()
+        for wu in workunits
+        if wu.get_aspect_of_type(models.StructuredPropertiesClass) is not None
+    }
+    # v2 typed paths must be used
+    assert (
+        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:glue,test_db.test_table,PROD),[version=2.0].[type=string].col_a)"
+        in assignment_urns
+    )
+    # bare column names must not appear as field paths
+    assert (
+        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:glue,test_db.test_table,PROD),col_a)"
+        not in assignment_urns
+    )
+
+
+def test_get_column_param_definitions_emitted_via_graph() -> None:
+    """When ctx.graph is set, definitions are emitted synchronously via emit_mcp, not as workunits."""
+    pipeline_context = PipelineContext(run_id="test-graph-emit")
+    pipeline_context.graph = MagicMock(spec=DataHubGraph)
+    source = GlueSource(
+        ctx=pipeline_context,
+        config=GlueSourceConfig(
+            aws_region="us-west-2",
+            extract_transforms=False,
+            use_s3_bucket_tags=False,
+            use_s3_object_tags=False,
+            extract_column_parameters=True,
+        ),
+    )
+    table = _make_table_with_column_params()
+    dataset_urn = "urn:li:dataset:(urn:li:dataPlatform:glue,test_db.test_table,PROD)"
+
+    workunits = list(source._get_column_param_workunits(table, dataset_urn))
+
+    # definitions go to graph.emit_mcp, not into the workunit stream
+    assert pipeline_context.graph.emit_mcp.called
+    definition_wus = [
+        wu
+        for wu in workunits
+        if wu.get_aspect_of_type(models.StructuredPropertyDefinitionClass) is not None
+    ]
+    assert definition_wus == []
+    # assignment workunits still flow through the pipeline normally
+    assignment_wus = [
+        wu
+        for wu in workunits
+        if wu.get_aspect_of_type(models.StructuredPropertiesClass) is not None
+    ]
+    assert len(assignment_wus) > 0


### PR DESCRIPTION
## Summary

Follow-up to #17325. Two bugs found during testing that prevented `extract_column_parameters` from working:

- **Wrong schemaField URN**: `_get_column_param_workunits` was calling `make_schema_field_urn(dataset_urn, column["Name"])`, using the bare column name (e.g. `emp_std_id`) as the field path. The actual `schemaField` entity in DataHub uses the v2 typed path generated by `get_schema_fields_for_hive_column` (e.g. `[version=2.0].[type=string].emp_std_id`). This meant all `structuredProperties` MCPs were written to shadow entities that don't correspond to any visible schema field in the UI. Fix: derive `field_path` from `schema_fields[0].fieldPath`, exactly as `_get_schema_metadata` does.

- **Batch ordering**: `StructuredPropertyDefinition` and `structuredProperties` MCPs were both yielded as pipeline workunits and landed in the same async batch to GMS. GMS validates assignments against the current DB state (pre-batch), so definitions submitted in the same batch are not visible when assignments are validated — resulting in 422 rejections for all `structuredProperties` MCPs. Fix: emit definitions synchronously via `ctx.graph` when available, ensuring they are persisted in GMS before the assignment MCPs arrive. Falls back to yielding as a workunit when `ctx.graph` is `None` (file sink, dry-run).

## Test plan

- [x] E2e tested against a real Glue catalog + local DataHub instance: all column `Parameters` now appear as structured properties on the correct `schemaField` entities in the Properties tab
- [x] `./gradlew :metadata-ingestion:lintFix` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)