### PR TITLE
fix(graphql): add missing SIT and SBX FabricType enum values

### DIFF
--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -3124,6 +3124,16 @@ enum FabricType {
   Designates alternative spelling TEST
   """
   TST
+
+  """
+  System Integration Testing
+  """
+  SIT
+
+  """
+  Alternative spelling for sandbox
+  """
+  SBX
 }
 
 """


### PR DESCRIPTION
These were added to the PDL model in #13842 (June 2025) but the GraphQL schema was never updated to match, causing BAD_REQUEST errors when querying entities with SIT or SBX environment fabrics.