### PR TITLE
fix(ingest/mode): gate chart fetch on chart_count, not explorations_count

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/mode.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/mode.py
@@ -1159,6 +1159,7 @@ class ModeSource(StatefulIngestionSourceBase):
                     "last_run_id",
                     "data_source_id",
                     "explorations_count",
+                    "chart_count",
                     "report_imports_count",
                     "dbt_metric_id",
                 ],
@@ -1937,8 +1938,9 @@ class ModeSource(StatefulIngestionSourceBase):
                         chart_fields.setdefault(field.fieldPath, field)
                 yield wu
 
-            # Skip chart API call when the query has 0 explorations.
-            if query.get("explorations_count", None) == 0:
+            # Gate on chart_count (published charts), not explorations_count
+            # (private user analyses), to avoid silently dropping report charts.
+            if query.get("chart_count", 0) == 0:
                 charts: List[dict] = []
                 with self.report._lock:
                     self.report.chart_api_calls_skipped += 1

--- a/metadata-ingestion/tests/integration/mode/mode_mces_golden.json
+++ b/metadata-ingestion/tests/integration/mode/mode_mces_golden.json
@@ -102,7 +102,8 @@
                 "updated_at": "2021-12-10T23:12:53.273Z",
                 "last_run_id": "1897576958",
                 "data_source_id": "34499",
-                "explorations_count": "1"
+                "explorations_count": "1",
+                "chart_count": "1"
             },
             "externalUrl": "https://app.mode.com/acryl/reports/9d2da37fa91e/details/queries/6e26a9f3d4e2",
             "name": "Customer and staff",

--- a/metadata-ingestion/tests/integration/mode/setup/queries.json
+++ b/metadata-ingestion/tests/integration/mode/setup/queries.json
@@ -15,6 +15,7 @@
       "last_run_id": 1897576958,
       "data_source_id": 34499,
       "explorations_count": 1,
+      "chart_count": 1,
       "_links": {
         "self": {
           "href": "/api/acryltest/reports/9d2da37fa91e/queries/6e26a9f3d4e2"

--- a/metadata-ingestion/tests/unit/test_mode_source.py
+++ b/metadata-ingestion/tests/unit/test_mode_source.py
@@ -664,13 +664,14 @@ class TestChartFetchGating:
         report = {"token": "rtok", "id": 1, "name": "r", "_links": {}}
 
         chart_calls: List[tuple] = []
+
+        def fake_get_charts(report_token: str, query_token: str) -> List[dict]:
+            chart_calls.append((report_token, query_token))
+            return []
+
         with (
             patch.object(source, "_get_queries", return_value=[query]),
-            patch.object(
-                source,
-                "_get_charts",
-                side_effect=lambda r, q: chart_calls.append((r, q)) or [],
-            ),
+            patch.object(source, "_get_charts", side_effect=fake_get_charts),
             patch.object(source, "construct_query_or_dataset", return_value=iter([])),
             patch.object(source, "construct_dashboard", return_value=None),
         ):

--- a/metadata-ingestion/tests/unit/test_mode_source.py
+++ b/metadata-ingestion/tests/unit/test_mode_source.py
@@ -639,3 +639,50 @@ class TestExcludePersonalCollections:
 
         assert "tok1" in result
         assert "tok2" not in result
+
+
+class TestChartFetchGating:
+    """The connector previously gated chart fetching on explorations_count
+    (private user analyses), silently dropping charts and lineage for any
+    report whose queries had explorations_count=0 but real published charts.
+    See ZD #7475."""
+
+    @staticmethod
+    def _drive(source: ModeSource, *, explorations_count: int, chart_count: int) -> int:
+        """Run _process_report_inner against one fake query and return the
+        number of times _get_charts was called."""
+        query = {
+            "id": 1,
+            "token": "qtok",
+            "name": "q",
+            "data_source_id": 1,
+            "last_run_id": 1,
+            "explorations_count": explorations_count,
+            "chart_count": chart_count,
+            "_links": {"creator": {"href": "/api/modeuser"}},
+        }
+        report = {"token": "rtok", "id": 1, "name": "r", "_links": {}}
+
+        chart_calls: List[tuple] = []
+        with (
+            patch.object(source, "_get_queries", return_value=[query]),
+            patch.object(
+                source,
+                "_get_charts",
+                side_effect=lambda r, q: chart_calls.append((r, q)) or [],
+            ),
+            patch.object(source, "construct_query_or_dataset", return_value=iter([])),
+            patch.object(source, "construct_dashboard", return_value=None),
+        ):
+            list(source._process_report_inner(space_token="s", report=report))
+        return len(chart_calls)
+
+    def test_fetches_charts_when_explorations_zero_but_chart_count_positive(self):
+        source = _make_source()
+        assert self._drive(source, explorations_count=0, chart_count=1) == 1
+        assert source.report.chart_api_calls_skipped == 0
+
+    def test_skips_chart_api_when_chart_count_zero(self):
+        source = _make_source()
+        assert self._drive(source, explorations_count=5, chart_count=0) == 0
+        assert source.report.chart_api_calls_skipped == 1


### PR DESCRIPTION
## Summary

The Mode connector had a perf optimization that skipped calling the chart API when a query's `explorations_count` was 0. In Mode's API, explorations are private user-level analyses, unrelated to the charts published on a report — the right field is `chart_count`. For any report whose queries had `explorations_count: 0` but real published charts, the connector silently:

- emitted `dashboardInfo` with `charts: []`
- never wrote chart entities for those charts
- never wrote chart-level `upstreamLineage`

so the lineage chain `Dashboard → Charts → Query → Upstream tables` broke and the UI's Lineage tab looked empty.

This PR switches the gate to `chart_count`, exposes `chart_count` in query custom properties for observability, updates the integration fixture to include `chart_count` (mirroring real Mode API responses), and adds focused regression tests.

## Root cause

`mode.py` `_process_report_inner`:

```python
# before
if query.get("explorations_count", None) == 0:
    charts = []
    self.report.chart_api_calls_skipped += 1
else:
    charts = self._get_charts(...)
```

`explorations_count` was introduced in #16300 (Mar 2026) as the gate. The test fixture `tests/integration/mode/setup/queries.json` had `explorations_count: 1`, so the skip path was never exercised in tests.

## Change

```python
# after
# Gate on chart_count (published charts), not explorations_count
# (private user analyses), to avoid silently dropping report charts.
if query.get("chart_count", 0) == 0:
    charts = []
    self.report.chart_api_calls_skipped += 1
else:
    charts = self._get_charts(...)
```

## Refs
- Linear CUS-8603 / ING-2323