### PR TITLE
docs(slack): document optional Slack bot scopes and bot-relay limitations

### DIFF
--- a/docs/managed-datahub/slack/saas-slack-setup.md
+++ b/docs/managed-datahub/slack/saas-slack-setup.md
@@ -57,60 +57,62 @@ Now proceed to [connect your Slack account](#connect-your-slack-account) so you 
 
 ### DataHub Slack Bot Permissions
 
-The DataHub Slack bot requires a certain set of Slack scopes to function properly. Some scopes are
-**optional** — the bot will install successfully without them, but specific features will be
-degraded. See [Optional scopes and trade-offs](#optional-scopes-and-trade-offs) below for what you
-lose if you decline them.
+The DataHub Slack bot requires a certain set of Slack scopes to function properly. By default, all
+scopes listed below — including the four message-history scopes — are **required** at install time.
+If your security or compliance team objects to granting broad message-read access, the four
+`*:history` scopes can be made optional for your instance; see
+[Optional scopes and trade-offs](#optional-scopes-and-trade-offs) below.
 
 <details>
-<summary>View all Slack bot scopes</summary>
+<summary>View all required Slack bot scopes</summary>
 
-| Scope                   | Required?                                                 | Purpose                                                                                         |
-| ----------------------- | --------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| `commands`              | Required                                                  | Required for slash commands / shortcuts                                                         |
-| `app_mentions:read`     | Required                                                  | Required to get @DataHub messages                                                               |
-| `chat:write`            | Required                                                  | Required to send messages as @DataHub                                                           |
-| `chat:write.public`     | Required                                                  | Required to post in public channels the bot hasn't joined                                       |
-| `chat:write.customize`  | Required                                                  | Allows using a custom icon so messages display the DataHub Cloud logo                           |
-| `channels:history`      | **Optional** ([details](#optional-scopes-and-trade-offs)) | Read message history in public channels (used as conversational context for **Ask DataHub**)    |
-| `channels:read`         | Required                                                  | Required to see public channel details                                                          |
-| `groups:history`        | **Optional** ([details](#optional-scopes-and-trade-offs)) | Read message history in private channels (used as conversational context for **Ask DataHub**)   |
-| `groups:read`           | Required                                                  | Required to see private channel details                                                         |
-| `im:history`            | **Optional** ([details](#optional-scopes-and-trade-offs)) | Read direct message history (used as conversational context for **Ask DataHub**)                |
-| `im:read`               | Required                                                  | Required to see direct message details                                                          |
-| `mpim:history`          | **Optional** ([details](#optional-scopes-and-trade-offs)) | Read group DM history (used as conversational context for **Ask DataHub**)                      |
-| `mpim:read`             | Required                                                  | Required to see group DM details                                                                |
-| `metadata.message:read` | Required                                                  | Required to read message metadata                                                               |
-| `team:read`             | Required                                                  | Required to get workspace ID and create links to user profiles                                  |
-| `channels:join`         | Required                                                  | Allows the bot to join a public channel when someone configures notifications to be sent to one |
-| `links:read`            | Required                                                  | Required to unfurl links                                                                        |
-| `links:write`           | Required                                                  | Required to unfurl links                                                                        |
-| `users:read`            | Required                                                  | Required to resolve user IDs to names/emails                                                    |
-| `users:read.email`      | Required                                                  | Required to enable user lookup by email address                                                 |
-| `reactions:read`        | Required                                                  | Future-proofing                                                                                 |
-| `reactions:write`       | Required                                                  | Future-proofing                                                                                 |
+| Scope                   | Purpose                                                                                         |
+| ----------------------- | ----------------------------------------------------------------------------------------------- |
+| `commands`              | Required for slash commands / shortcuts                                                         |
+| `app_mentions:read`     | Required to get @DataHub messages                                                               |
+| `chat:write`            | Required to send messages as @DataHub                                                           |
+| `chat:write.public`     | Required to post in public channels the bot hasn't joined                                       |
+| `chat:write.customize`  | Allows using a custom icon so messages display the DataHub Cloud logo                           |
+| `channels:history`      | Required to read message history in public channels                                             |
+| `channels:read`         | Required to see public channel details                                                          |
+| `groups:history`        | Required to read message history in private channels                                            |
+| `groups:read`           | Required to see private channel details                                                         |
+| `im:history`            | Required to read direct message history                                                         |
+| `im:read`               | Required to see direct message details                                                          |
+| `mpim:history`          | Required to read group DM history                                                               |
+| `mpim:read`             | Required to see group DM details                                                                |
+| `metadata.message:read` | Required to read message metadata                                                               |
+| `team:read`             | Required to get workspace ID and create links to user profiles                                  |
+| `channels:join`         | Allows the bot to join a public channel when someone configures notifications to be sent to one |
+| `links:read`            | Required to unfurl links                                                                        |
+| `links:write`           | Required to unfurl links                                                                        |
+| `users:read`            | Required to resolve user IDs to names/emails                                                    |
+| `users:read.email`      | Required to enable user lookup by email address                                                 |
+| `reactions:read`        | Future-proofing                                                                                 |
+| `reactions:write`       | Future-proofing                                                                                 |
 
 </details>
 
 ### Optional scopes and trade-offs
 
-DataHub uses Slack's [optional scopes](https://docs.slack.dev/changelog/2026/03/16/optional-scopes/)
-model so that workspaces with stricter security policies can install the DataHub Slack app without
-granting the bot broad message-read access. The following scopes are requested as **optional** by
-default:
+By default, the four message-history scopes (`channels:history`, `groups:history`, `im:history`,
+`mpim:history`) are **required** at install time. The DataHub Slack app supports running these
+scopes as Slack [optional scopes](https://docs.slack.dev/changelog/2026/03/16/optional-scopes/)
+instead — letting your Slack workspace admin decline them — but this is **not the default** and is
+**not something you can toggle yourself in the Slack app settings.**
 
-- `channels:history` — public channel history
-- `groups:history` — private channel history
-- `im:history` — direct message history
-- `mpim:history` — group DM history
+To make the four `*:history` scopes optional for your DataHub Cloud instance, **contact your
+DataHub Cloud representative** to enable it. Once enabled, your workspace admin can decline those
+scopes during install (or remove them later) and the trade-offs below will apply.
 
 These scopes are only used to give **Ask DataHub** access to the surrounding conversation when
 someone @-mentions the bot, so that follow-up questions ("what about the staging table?") can be
 resolved against earlier messages in the thread or channel.
 
-#### What changes if you decline the optional scopes
+#### What changes if the `*:history` scopes are not granted
 
-If your Slack admin declines (or removes) the four `*:history` scopes:
+If optional scopes have been enabled for your instance and your Slack admin declines (or removes)
+the four `*:history` scopes:
 
 - **Notifications, slash commands, subscriptions, and incident management continue to work as
   normal.** None of these features need to read message history.
@@ -123,14 +125,6 @@ If your Slack admin declines (or removes) the four `*:history` scopes:
   question. To make this pattern work without history scopes, the relaying bot must include the
   full original question in the message that @-mentions DataHub, instead of only quoting or
   linking to it.
-
-#### Re-enabling history scopes
-
-If you want **Ask DataHub** to read thread and channel history again, ask your DataHub Cloud
-representative to enable the **"store conversations from Slack"** server-side history feature for
-your instance. When that feature is on, the four `*:history` scopes are requested as **required**
-during install, and you will need to re-authorize the Slack app so the workspace admin can grant
-them.
 
 ### Workspace Admin Approval
 

--- a/docs/managed-datahub/slack/saas-slack-setup.md
+++ b/docs/managed-datahub/slack/saas-slack-setup.md
@@ -57,37 +57,80 @@ Now proceed to [connect your Slack account](#connect-your-slack-account) so you 
 
 ### DataHub Slack Bot Permissions
 
-The DataHub Slack bot requires a certain set of Slack scopes to function properly.
+The DataHub Slack bot requires a certain set of Slack scopes to function properly. Some scopes are
+**optional** — the bot will install successfully without them, but specific features will be
+degraded. See [Optional scopes and trade-offs](#optional-scopes-and-trade-offs) below for what you
+lose if you decline them.
 
 <details>
-<summary>View all required Slack bot scopes</summary>
+<summary>View all Slack bot scopes</summary>
 
-| Scope                   | Purpose                                                                                         |
-| ----------------------- | ----------------------------------------------------------------------------------------------- |
-| `commands`              | Required for slash commands / shortcuts                                                         |
-| `app_mentions:read`     | Required to get @DataHub messages                                                               |
-| `chat:write`            | Required to send messages as @DataHub                                                           |
-| `chat:write.public`     | Required to post in public channels the bot hasn't joined                                       |
-| `chat:write.customize`  | Allows using a custom icon so messages display the DataHub Cloud logo                           |
-| `channels:history`      | Required to read message history in public channels                                             |
-| `channels:read`         | Required to see public channel details                                                          |
-| `groups:history`        | Required to read message history in private channels                                            |
-| `groups:read`           | Required to see private channel details                                                         |
-| `im:history`            | Required to read direct message history                                                         |
-| `im:read`               | Required to see direct message details                                                          |
-| `mpim:history`          | Required to read group DM history                                                               |
-| `mpim:read`             | Required to see group DM details                                                                |
-| `metadata.message:read` | Required to read message metadata                                                               |
-| `team:read`             | Required to get workspace ID and create links to user profiles                                  |
-| `channels:join`         | Allows the bot to join a public channel when someone configures notifications to be sent to one |
-| `links:read`            | Required to unfurl links                                                                        |
-| `links:write`           | Required to unfurl links                                                                        |
-| `users:read`            | Required to resolve user IDs to names/emails                                                    |
-| `users:read.email`      | Required to enable user lookup by email address                                                 |
-| `reactions:read`        | Future-proofing                                                                                 |
-| `reactions:write`       | Future-proofing                                                                                 |
+| Scope                   | Required?                                                 | Purpose                                                                                         |
+| ----------------------- | --------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `commands`              | Required                                                  | Required for slash commands / shortcuts                                                         |
+| `app_mentions:read`     | Required                                                  | Required to get @DataHub messages                                                               |
+| `chat:write`            | Required                                                  | Required to send messages as @DataHub                                                           |
+| `chat:write.public`     | Required                                                  | Required to post in public channels the bot hasn't joined                                       |
+| `chat:write.customize`  | Required                                                  | Allows using a custom icon so messages display the DataHub Cloud logo                           |
+| `channels:history`      | **Optional** ([details](#optional-scopes-and-trade-offs)) | Read message history in public channels (used as conversational context for **Ask DataHub**)    |
+| `channels:read`         | Required                                                  | Required to see public channel details                                                          |
+| `groups:history`        | **Optional** ([details](#optional-scopes-and-trade-offs)) | Read message history in private channels (used as conversational context for **Ask DataHub**)   |
+| `groups:read`           | Required                                                  | Required to see private channel details                                                         |
+| `im:history`            | **Optional** ([details](#optional-scopes-and-trade-offs)) | Read direct message history (used as conversational context for **Ask DataHub**)                |
+| `im:read`               | Required                                                  | Required to see direct message details                                                          |
+| `mpim:history`          | **Optional** ([details](#optional-scopes-and-trade-offs)) | Read group DM history (used as conversational context for **Ask DataHub**)                      |
+| `mpim:read`             | Required                                                  | Required to see group DM details                                                                |
+| `metadata.message:read` | Required                                                  | Required to read message metadata                                                               |
+| `team:read`             | Required                                                  | Required to get workspace ID and create links to user profiles                                  |
+| `channels:join`         | Required                                                  | Allows the bot to join a public channel when someone configures notifications to be sent to one |
+| `links:read`            | Required                                                  | Required to unfurl links                                                                        |
+| `links:write`           | Required                                                  | Required to unfurl links                                                                        |
+| `users:read`            | Required                                                  | Required to resolve user IDs to names/emails                                                    |
+| `users:read.email`      | Required                                                  | Required to enable user lookup by email address                                                 |
+| `reactions:read`        | Required                                                  | Future-proofing                                                                                 |
+| `reactions:write`       | Required                                                  | Future-proofing                                                                                 |
 
 </details>
+
+### Optional scopes and trade-offs
+
+DataHub uses Slack's [optional scopes](https://docs.slack.dev/changelog/2026/03/16/optional-scopes/)
+model so that workspaces with stricter security policies can install the DataHub Slack app without
+granting the bot broad message-read access. The following scopes are requested as **optional** by
+default:
+
+- `channels:history` — public channel history
+- `groups:history` — private channel history
+- `im:history` — direct message history
+- `mpim:history` — group DM history
+
+These scopes are only used to give **Ask DataHub** access to the surrounding conversation when
+someone @-mentions the bot, so that follow-up questions ("what about the staging table?") can be
+resolved against earlier messages in the thread or channel.
+
+#### What changes if you decline the optional scopes
+
+If your Slack admin declines (or removes) the four `*:history` scopes:
+
+- **Notifications, slash commands, subscriptions, and incident management continue to work as
+  normal.** None of these features need to read message history.
+- **Ask DataHub will only see the message that @-mentions the bot.** It cannot read prior messages
+  in the thread or channel, so it cannot use earlier discussion as context. Users should phrase
+  each question to @DataHub as a self-contained message.
+- **Bot-to-bot relays will lose context.** If you have a centralized bot in your workspace that
+  forwards a user's message to @DataHub (for example, an internal "ask" router that re-tags the
+  bot on the user's behalf), DataHub will only see the relay message — not the original user
+  question. To make this pattern work without history scopes, the relaying bot must include the
+  full original question in the message that @-mentions DataHub, instead of only quoting or
+  linking to it.
+
+#### Re-enabling history scopes
+
+If you want **Ask DataHub** to read thread and channel history again, ask your DataHub Cloud
+representative to enable the **"store conversations from Slack"** server-side history feature for
+your instance. When that feature is on, the four `*:history` scopes are requested as **required**
+during install, and you will need to re-authorize the Slack app so the workspace admin can grant
+them.
 
 ### Workspace Admin Approval
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

Documents the new "optional scopes" behavior for the managed DataHub Slack app in the customer-facing setup guide so workspace admins (and CSEs) understand what they get / lose when they decline the optional read scopes during install.

The product change itself (making `channels:history`, `groups:history`, `im:history`, `mpim:history` optional unless the server-side history feature flag is on) was already shipped — see the v0.3.17.4 entry under [`docs/managed-datahub/release-notes/v_0_3_17.md`](https://github.com/datahub-project/datahub/blob/master/docs/managed-datahub/release-notes/v_0_3_17.md). That release note is short and only mentions the change at a high level; this PR adds the supporting "what does this mean for me" content next to where admins actually install the bot.

### What changed in `docs/managed-datahub/slack/saas-slack-setup.md`

- Added a `Required?` column to the bot scopes table and marked the four `*:history` scopes as **Optional**, linking down to a new section.
- New section **"Optional scopes and trade-offs"** that covers:
  - Which scopes are optional and why DataHub uses Slack's [optional scopes model](https://docs.slack.dev/changelog/2026/03/16/optional-scopes/).
  - What still works if you decline them (notifications, slash commands, subscriptions, incidents — all unaffected).
  - What degrades: **Ask DataHub** can only see the single message that @-mentions the bot, not surrounding thread / channel history.
  - **Bot-to-bot relay risk:** if a centralized workspace bot re-tags `@DataHub` on a user's behalf, DataHub will only see the relay message. The relaying bot must include the full original question in its message — quoting / linking is not enough.
  - How to re-enable history scopes by turning on the server-side "store conversations from Slack" feature.

### Why here

Existing scope documentation already lives in `saas-slack-setup.md` as a collapsed table under **DataHub Slack Bot Permissions**. Putting the trade-off explanation next to that table keeps everything an installing admin needs in one place; the release notes entry is left as a high-level pointer.

### PR checklist

- [x] PR conforms to the Contributing Guideline (PR title uses `docs(slack):` scope).
- [x] Docs added (this PR).
- [ ] Tests — N/A (docs-only).
- [ ] Breaking changes entry — N/A (no behavior change; the underlying product change shipped in v0.3.17.4 and is already noted in that release notes file).
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://datahub.slack.com/archives/C09E12NNTMH/p1778197765768769?thread_ts=1778197765.768769&cid=C09E12NNTMH)

<div><a href="https://cursor.com/agents/bc-e743f740-3c19-5c09-9307-8b5b7f5b42ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e743f740-3c19-5c09-9307-8b5b7f5b42ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

