### PR TITLE
fix(ingest/sigma): chart and cross-DM resolver edge cases + multi-ref formula emission

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
@@ -198,6 +198,11 @@ class SigmaSourceReport(StaleEntityRemovalSourceReport):
     chart_input_fields_skipped_parameter: int = 0
     # Column whose formula refs are exclusively bare sibling refs (e.g. [col]).
     chart_input_fields_skipped_sibling: int = 0
+    # Extra InputFields emitted for columns whose formula resolves to more than
+    # one distinct (upstream_urn, upstream_field) pair. The first resolved pair
+    # is counted in chart_input_fields_resolved; each additional pair increments
+    # this counter. Non-zero means some chart columns have multi-upstream lineage.
+    chart_input_fields_multi_ref_extra: int = 0
     # Sub-bucket of self_ref_fallback: source name that is a case-only mismatch
     # against a workbook element name (warehouse fallback intentionally skipped).
     chart_input_fields_case_mismatch: int = 0
@@ -329,7 +334,8 @@ class SigmaSourceReport(StaleEntityRemovalSourceReport):
     # the warehouse table name rather than the element name.
     data_model_element_fgl_warehouse_resolved: int = 0
     # Refs whose source element is in this DM but not listed as an upstream by
-    # /lineage; dropped to avoid orphan FGL the UI silently rejects.
+    # /lineage, and whose cross-DM rescue (_try_emit_self_named_cross_dm_fgl)
+    # also found no match; dropped to avoid orphan FGL the UI silently rejects.
     data_model_element_fgl_dropped_orphan_upstream: int = 0
     # Refs whose column name has no matching fieldPath in the upstream element's
     # schema; dropped to avoid a dangling schemaField URN.

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -2042,6 +2042,45 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             confidenceScore=1.0,
         )
 
+    def _try_emit_self_named_cross_dm_fgl(
+        self,
+        *,
+        ref: "BracketRef",
+        element: SigmaDataModelElement,
+        element_dataset_urn: str,
+        entity_level_upstream_urns: Set[str],
+        downstream_field: str,
+        emitted_pairs: Set[Tuple[str, str]],
+        cross_dm_fgls: List[FineGrainedLineageClass],
+    ) -> bool:
+        """Try cross-DM FGL for a ref whose source name matches the element itself.
+
+        Called when all intra-DM candidates were self-references (element named
+        after a cross-DM source element rather than its warehouse table). Returns
+        True when a cross-DM FGL is resolved and appended; False otherwise.
+
+        The element.source_ids guard prevents false-positive data_model_element_fgl_cross_dm_deferred
+        increments for warehouse-only elements whose source_ids list is always empty.
+        """
+        if not element.source_ids:
+            return False
+        cross_dm_fgl = self._resolve_cross_dm_fgl(
+            ref=ref,
+            element=element,
+            element_dataset_urn=element_dataset_urn,
+            entity_level_upstream_urns=entity_level_upstream_urns,
+            downstream_field=downstream_field,
+        )
+        if cross_dm_fgl is None:
+            return False
+        assert cross_dm_fgl.upstreams
+        pair = (downstream_field, cross_dm_fgl.upstreams[0])
+        if pair not in emitted_pairs:
+            emitted_pairs.add(pair)
+            cross_dm_fgls.append(cross_dm_fgl)
+            self.reporter.data_model_element_fgl_cross_dm_resolved += 1
+        return True
+
     def _resolve_cross_dm_fgl(
         self,
         *,
@@ -2280,8 +2319,21 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
 
                 if not candidate_eids_after_self_strip:
                     if candidate_eids:
-                        # All candidates were self-references; actual upstream is the
-                        # warehouse table — use the pre-computed warehouse FGL.
+                        # All intra-DM candidates were self-references. Two scenarios:
+                        # (a) element named after its warehouse source → warehouse FGL
+                        # (b) element named after a cross-DM source element → cross-DM FGL
+                        # Try cross-DM first; returns True if a cross-DM FGL was emitted.
+                        if self._try_emit_self_named_cross_dm_fgl(
+                            ref=ref,
+                            element=element,
+                            element_dataset_urn=element_dataset_urn,
+                            entity_level_upstream_urns=entity_level_upstream_urns,
+                            downstream_field=downstream_field,
+                            emitted_pairs=emitted_pairs,
+                            cross_dm_fgls=cross_dm_fgls,
+                        ):
+                            continue
+                        # No cross-DM match; element is named after its warehouse source.
                         if not warehouse_consumed:
                             warehouse_consumed = True
                             if warehouse_fgl is None:

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -3267,22 +3267,34 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             if dm_urn:
                 return (dm_urn, ref.column)
 
+            # If the element IS a registered upstream (sheet_matches==1) but was
+            # filtered from chart emission and has no DM match, stop here — do not
+            # fall through to warehouse because the formula ref explicitly targets
+            # a known (filtered) element, not a warehouse table.
+            if sheet_matches:
+                return None
+
+            # sheet_matches is empty: the workbook element is not a registered
+            # lineage upstream. The element may share its name with a warehouse table
+            # in the chart's data path (e.g. a sibling element whose SQL selects
+            # from the same table). Fall through to Step 4 so the ref can still
+            # resolve to the warehouse table URN.
             logger.debug(
                 "Formula ref source %r matched workbook element names but none were "
-                "lineage upstreams for chart element %s; treating as unresolved.",
+                "lineage upstreams for chart element %s; falling through to "
+                "warehouse-table resolution.",
                 ref.source,
                 chart_element_id,
             )
-            return None
-
-        # Step 3c: No workbook page element is named ref.source (candidates was
-        # empty above), but the formula ref may still point to a DM element that
-        # is an upstream of this chart without being exposed as a page element.
-        # Check dm_upstream_urn_by_element_name directly before falling through
-        # to the warehouse-table short-name index.
-        dm_urn = dm_upstream_urn_by_element_name.get(ref.source)
-        if dm_urn:
-            return (dm_urn, ref.column)
+        else:
+            # Step 3c: No workbook page element is named ref.source (candidates was
+            # empty above), but the formula ref may still point to a DM element that
+            # is an upstream of this chart without being exposed as a page element.
+            # Check dm_upstream_urn_by_element_name directly before falling through
+            # to the warehouse-table short-name index.
+            dm_urn = dm_upstream_urn_by_element_name.get(ref.source)
+            if dm_urn:
+                return (dm_urn, ref.column)
 
         # Step 4: warehouse-table short-name fallback.
         wh_candidates = element_warehouse_table_index.get(ref.source.upper(), [])

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -2161,15 +2161,17 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         urn_to_cols: Dict[str, Dict[str, str]],
         downstream_field: str,
         element: SigmaDataModelElement,
+        element_dataset_urn: str,
         data_model: SigmaDataModel,
         fgls: List[FineGrainedLineageClass],
+        cross_dm_fgls: List[FineGrainedLineageClass],
         emitted_pairs: Set[Tuple[str, str]],
     ) -> None:
         """Resolve a formula ref against intra-DM sibling elements.
 
-        Appends to fgls and emitted_pairs on success; bumps the appropriate
-        counter on any resolution failure.  Counter bookkeeping and dedup are
-        handled here so the caller needs no conditional on the result.
+        Appends to fgls / cross_dm_fgls and emitted_pairs on success; bumps
+        the appropriate counter on any resolution failure.  Counter bookkeeping
+        and dedup are handled here so the caller needs no conditional on the result.
         """
         assert (
             ref.column is not None
@@ -2184,9 +2186,23 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         )
 
         if not surviving_urns:
-            # Intra-DM candidate(s) exist but none appear in /lineage.
-            # Rare on tenants where /lineage correctly reports intra-DM edges;
-            # keep counter for observability on future tenants.
+            # Intra-DM candidate(s) exist but none appear in /lineage upstreams.
+            # Two distinct causes:
+            #   (a) name collision: a sibling shares the name but the actual
+            #       upstream is cross-DM (e.g. two "Custom SQL" elements in one
+            #       DM where the consumer pulls from a cross-DM "Custom SQL")
+            #   (b) genuine orphan: Sigma /lineage reporting gap
+            # Try cross-DM first; falls through to orphan-drop for case (b).
+            if self._try_emit_self_named_cross_dm_fgl(
+                ref=ref,
+                element=element,
+                element_dataset_urn=element_dataset_urn,
+                entity_level_upstream_urns=entity_level_upstream_urns,
+                downstream_field=downstream_field,
+                emitted_pairs=emitted_pairs,
+                cross_dm_fgls=cross_dm_fgls,
+            ):
+                return
             self.reporter.data_model_element_fgl_dropped_orphan_upstream += 1
             return
 
@@ -2393,8 +2409,10 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                     urn_to_cols=urn_to_cols,
                     downstream_field=downstream_field,
                     element=element,
+                    element_dataset_urn=element_dataset_urn,
                     data_model=data_model,
                     fgls=fgls,
+                    cross_dm_fgls=cross_dm_fgls,
                     emitted_pairs=emitted_pairs,
                 )
         # fgl_emitted is the umbrella count for intra-DM AND warehouse-passthrough

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -268,6 +268,15 @@ class _WorkbookWarehouseIndex:
 
 
 @dataclass
+class _ResolvedRef:
+    """A single formula ref resolved to an upstream dataset field."""
+
+    upstream_urn: str
+    upstream_field: str
+    ref: BracketRef
+
+
+@dataclass
 class _CustomSqlRegistration:
     """Carries the per-kind variant parameters for _register_customsql_with_aggregator."""
 
@@ -2074,18 +2083,34 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         if not any(
             "/" in sid and not sid.startswith("inode-") for sid in element.source_ids
         ):
+            logger.debug(
+                "element %s: no cross-DM source_ids — skipping self-named cross-DM FGL",
+                element.elementId,
+            )
             return False
-        cross_dm_fgl = self._resolve_cross_dm_fgl(
-            ref=ref,
-            element=element,
-            element_dataset_urn=element_dataset_urn,
-            entity_level_upstream_urns=entity_level_upstream_urns,
-            downstream_field=downstream_field,
-        )
+        try:
+            cross_dm_fgl = self._resolve_cross_dm_fgl(
+                ref=ref,
+                element=element,
+                element_dataset_urn=element_dataset_urn,
+                entity_level_upstream_urns=entity_level_upstream_urns,
+                downstream_field=downstream_field,
+            )
+        except Exception as e:
+            self.reporter.warning(
+                title="Cross-DM FGL resolution failed",
+                message=(
+                    f"Unexpected error resolving cross-DM FGL for element "
+                    f"{element.elementId} ref {ref.raw!r}: {e}"
+                ),
+                context=f"ref={ref.raw!r}, element={element.elementId}",
+            )
+            return False
         if cross_dm_fgl is None:
             return False
         # _resolve_cross_dm_fgl always returns a single-upstream FGL or None.
-        pair = (downstream_field, cross_dm_fgl.upstreams[0])  # type: ignore[index]
+        assert cross_dm_fgl.upstreams
+        pair = (downstream_field, cross_dm_fgl.upstreams[0])
         if pair not in emitted_pairs:
             emitted_pairs.add(pair)
             cross_dm_fgls.append(cross_dm_fgl)
@@ -3601,8 +3626,8 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         fields: List[InputFieldClass] = []
         for column in element.columns:
             formula = element.column_formulas.get(column)
-            resolved: Optional[Tuple[str, str]] = None
-            resolving_ref = None
+            resolved_refs: List[_ResolvedRef] = []
+            seen: Set[Tuple[str, str]] = set()
             all_param = False
             all_sibling = False
 
@@ -3618,7 +3643,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                         if ref.column is None:
                             sibling_count += 1
                             continue
-                        resolved = self._resolve_chart_formula_upstream(
+                        result = self._resolve_chart_formula_upstream(
                             ref,
                             chart_element_id=element.elementId,
                             chart_upstream_element_ids=chart_upstream_eids,
@@ -3627,58 +3652,73 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                             element_warehouse_table_index=element_warehouse_table_index,
                             elementId_to_chart_urn=elementId_to_chart_urn,
                         )
-                        if resolved is not None:
-                            resolving_ref = ref
-                            break
-                    if resolved is None and refs:
+                        if result is not None:
+                            upstream_urn, upstream_field = result
+                            key = (upstream_urn, upstream_field)
+                            if key not in seen:
+                                seen.add(key)
+                                resolved_refs.append(
+                                    _ResolvedRef(
+                                        upstream_urn=upstream_urn,
+                                        upstream_field=upstream_field,
+                                        ref=ref,
+                                    )
+                                )
+                    if not resolved_refs and refs:
                         total = len(refs)
                         if param_count == total:
                             all_param = True
                         elif sibling_count == total:
                             all_sibling = True
 
-            if resolved is not None:
-                upstream_urn, upstream_field = resolved
-                bridged_field = self._bridge_warehouse_column_name(
-                    upstream_urn=upstream_urn,
-                    sigma_display_name=upstream_field,
-                    column_native_names=element.column_native_names,
-                    element_id=element.elementId,
-                )
-                schema_field_urn = builder.make_schema_field_urn(
-                    upstream_urn, bridged_field
-                )
+            if resolved_refs:
                 self.reporter.chart_input_fields_resolved += 1
-                # Sub-category: resolved via warehouse-table short-name index (Step 4).
-                # The resolver (Step 4) returns None for ambiguous (>1 candidate) keys,
-                # so upstream_urn in wh_candidates implies a single-candidate match in
-                # practice, but the membership check is the semantically correct predicate.
-                # resolving_ref is always set when resolved is set (see loop above),
-                # but guard explicitly so -O optimisation doesn't hide the invariant.
-                if resolving_ref is not None:
-                    wh_candidates = element_warehouse_table_index.get(
-                        resolving_ref.source.upper(), []
-                    )
-                    if upstream_urn in wh_candidates:
-                        self.reporter.chart_input_fields_warehouse_qualified += 1
-                        if resolving_ref.source.upper() in wb_only_warehouse_keys:
-                            self.reporter.chart_input_fields_warehouse_qualified_via_workbook_index += 1
-            elif all_param:
-                schema_field_urn = builder.make_schema_field_urn(chart_urn, column)
-                self.reporter.chart_input_fields_skipped_parameter += 1
-            elif all_sibling:
-                schema_field_urn = builder.make_schema_field_urn(chart_urn, column)
-                self.reporter.chart_input_fields_skipped_sibling += 1
-            else:
-                schema_field_urn = builder.make_schema_field_urn(chart_urn, column)
-                self.reporter.chart_input_fields_self_ref_fallback += 1
-
-            fields.append(
-                InputFieldClass(
-                    schemaFieldUrn=schema_field_urn,
-                    schemaField=self._make_string_schema_field(column),
+                self.reporter.chart_input_fields_multi_ref_extra += (
+                    len(resolved_refs) - 1
                 )
-            )
+                for rr in resolved_refs:
+                    bridged_field = self._bridge_warehouse_column_name(
+                        upstream_urn=rr.upstream_urn,
+                        sigma_display_name=rr.upstream_field,
+                        column_native_names=element.column_native_names,
+                        element_id=element.elementId,
+                    )
+                    schema_field_urn = builder.make_schema_field_urn(
+                        rr.upstream_urn, bridged_field
+                    )
+                    # Sub-category: resolved via warehouse-table short-name index (Step 4).
+                    # The resolver (Step 4) returns None for ambiguous (>1 candidate) keys,
+                    # so upstream_urn in wh_candidates implies a single-candidate match in
+                    # practice, but the membership check is the semantically correct predicate.
+                    wh_candidates = element_warehouse_table_index.get(
+                        rr.ref.source.upper(), []
+                    )
+                    if rr.upstream_urn in wh_candidates:
+                        self.reporter.chart_input_fields_warehouse_qualified += 1
+                        if rr.ref.source.upper() in wb_only_warehouse_keys:
+                            self.reporter.chart_input_fields_warehouse_qualified_via_workbook_index += 1
+                    fields.append(
+                        InputFieldClass(
+                            schemaFieldUrn=schema_field_urn,
+                            schemaField=self._make_string_schema_field(column),
+                        )
+                    )
+            else:
+                if all_param:
+                    schema_field_urn = builder.make_schema_field_urn(chart_urn, column)
+                    self.reporter.chart_input_fields_skipped_parameter += 1
+                elif all_sibling:
+                    schema_field_urn = builder.make_schema_field_urn(chart_urn, column)
+                    self.reporter.chart_input_fields_skipped_sibling += 1
+                else:
+                    schema_field_urn = builder.make_schema_field_urn(chart_urn, column)
+                    self.reporter.chart_input_fields_self_ref_fallback += 1
+                fields.append(
+                    InputFieldClass(
+                        schemaFieldUrn=schema_field_urn,
+                        schemaField=self._make_string_schema_field(column),
+                    )
+                )
         return fields
 
     def _gen_elements_workunit(

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -2059,10 +2059,21 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         after a cross-DM source element rather than its warehouse table). Returns
         True when a cross-DM FGL is resolved and appended; False otherwise.
 
-        The element.source_ids guard prevents false-positive data_model_element_fgl_cross_dm_deferred
-        increments for warehouse-only elements whose source_ids list is always empty.
+        The source_ids guard short-circuits for elements that have no cross-DM
+        source entries (format <dm-url-id>/<suffix>). This prevents a false
+        data_model_element_fgl_cross_dm_deferred increment when source_ids
+        contains only bare intra-DM element IDs or is empty entirely.
+
+        Note: when this returns False because _resolve_cross_dm_fgl deferred,
+        both data_model_element_fgl_cross_dm_deferred (from the callee) and
+        data_model_element_fgl_warehouse_passthrough_deferred (from the caller's
+        fall-through) are incremented for the same ref. This is intentional —
+        the two counters measure independent dimensions (cross-DM attempt outcome
+        vs. warehouse-passthrough gate), and operators should not sum them.
         """
-        if not element.source_ids:
+        if not any(
+            "/" in sid and not sid.startswith("inode-") for sid in element.source_ids
+        ):
             return False
         cross_dm_fgl = self._resolve_cross_dm_fgl(
             ref=ref,
@@ -2073,8 +2084,8 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         )
         if cross_dm_fgl is None:
             return False
-        assert cross_dm_fgl.upstreams
-        pair = (downstream_field, cross_dm_fgl.upstreams[0])
+        # _resolve_cross_dm_fgl always returns a single-upstream FGL or None.
+        pair = (downstream_field, cross_dm_fgl.upstreams[0])  # type: ignore[index]
         if pair not in emitted_pairs:
             emitted_pairs.add(pair)
             cross_dm_fgls.append(cross_dm_fgl)

--- a/metadata-ingestion/tests/unit/sigma/test_chart_input_fields_resolver.py
+++ b/metadata-ingestion/tests/unit/sigma/test_chart_input_fields_resolver.py
@@ -80,6 +80,9 @@ def _make_source(config_overrides: Optional[dict] = None) -> SigmaSource:
     source.reporter.chart_input_fields_case_mismatch = 0
     source.reporter.chart_input_fields_warehouse_column_bridged = 0
     source.reporter.chart_input_fields_warehouse_column_bridge_unresolved = 0
+    source.reporter.chart_input_fields_multi_ref_extra = 0
+    source.reporter.chart_input_fields_warehouse_qualified = 0
+    source.reporter.chart_input_fields_warehouse_qualified_via_workbook_index = 0
     # T4.C: sigma_api is needed by _gen_pages_workunit →
     # _build_workbook_warehouse_table_index → get_workbook_lineage.
     source.sigma_api = MagicMock()
@@ -616,6 +619,86 @@ class TestGenElementsWorkunitInputFields:
         assert len(input_fields_aspects) == 1
         assert len(input_fields_aspects[0].fields) == 1
         assert len(all_input_fields) == 1
+        assert src.reporter.chart_input_fields_multi_ref_extra == 0
+
+    def test_multi_ref_distinct_upstreams_emit_two_input_fields(self) -> None:
+        """[ORDERS/col] + [CUSTOMERS/id]: two distinct refs → 2 fields, multi_ref_extra=1."""
+        src = _make_source()
+        src.dataset_upstream_urn_mapping = {}
+        orders_urn = (
+            "urn:li:dataset:(urn:li:dataPlatform:snowflake,DB.SCHEMA.ORDERS,PROD)"
+        )
+        customers_urn = (
+            "urn:li:dataset:(urn:li:dataPlatform:snowflake,DB.SCHEMA.CUSTOMERS,PROD)"
+        )
+        chart = _make_element_with_formula(
+            "chart-1",
+            "Multi Chart",
+            {"Calc": "[ORDERS/col] + [CUSTOMERS/id]"},
+        )
+        src._get_element_input_details = MagicMock(  # type: ignore[method-assign]
+            return_value=({orders_urn: [], customers_urn: []}, [])
+        )
+
+        workunits = list(
+            src._gen_elements_workunit(
+                elements=[chart],
+                workbook=_make_workbook_with_elements([]),
+                all_input_fields=[],
+                paths=[],
+                elementId_to_chart_urn={},
+                wb_element_index={},
+                wb_warehouse_table_index=None,
+            )
+        )
+
+        input_fields_aspects = [
+            aspect
+            for wu in workunits
+            if (aspect := wu.get_aspect_of_type(InputFieldsClass)) is not None
+        ]
+        assert len(input_fields_aspects) == 1
+        assert len(input_fields_aspects[0].fields) == 2
+        assert src.reporter.chart_input_fields_resolved == 1
+        assert src.reporter.chart_input_fields_multi_ref_extra == 1
+
+    def test_multi_ref_duplicate_upstream_emits_one_input_field(self) -> None:
+        """[ORDERS/col] + [ORDERS/col]: same ref twice → 1 field, multi_ref_extra=0."""
+        src = _make_source()
+        src.dataset_upstream_urn_mapping = {}
+        orders_urn = (
+            "urn:li:dataset:(urn:li:dataPlatform:snowflake,DB.SCHEMA.ORDERS,PROD)"
+        )
+        chart = _make_element_with_formula(
+            "chart-1",
+            "Dup Ref Chart",
+            {"Calc": "[ORDERS/col] + [ORDERS/col]"},
+        )
+        src._get_element_input_details = MagicMock(  # type: ignore[method-assign]
+            return_value=({orders_urn: []}, [])
+        )
+
+        workunits = list(
+            src._gen_elements_workunit(
+                elements=[chart],
+                workbook=_make_workbook_with_elements([]),
+                all_input_fields=[],
+                paths=[],
+                elementId_to_chart_urn={},
+                wb_element_index={},
+                wb_warehouse_table_index=None,
+            )
+        )
+
+        input_fields_aspects = [
+            aspect
+            for wu in workunits
+            if (aspect := wu.get_aspect_of_type(InputFieldsClass)) is not None
+        ]
+        assert len(input_fields_aspects) == 1
+        assert len(input_fields_aspects[0].fields) == 1
+        assert src.reporter.chart_input_fields_resolved == 1
+        assert src.reporter.chart_input_fields_multi_ref_extra == 0
 
     def test_dashboard_input_fields_dedup_across_charts(self) -> None:
         src = _make_source()

--- a/metadata-ingestion/tests/unit/sigma/test_chart_input_fields_resolver.py
+++ b/metadata-ingestion/tests/unit/sigma/test_chart_input_fields_resolver.py
@@ -328,10 +328,13 @@ class TestResolveChartFormulaUpstream:
         assert result is None
         assert self.src.reporter.chart_input_fields_case_mismatch == 1
 
-    def test_exact_workbook_name_without_lineage_match_does_not_fallback_to_warehouse(
+    def test_exact_workbook_name_without_lineage_match_falls_through_to_warehouse(
         self,
     ) -> None:
-        """An exact workbook name match must satisfy the lineage filter."""
+        """When a workbook element name matches but none satisfy the lineage filter,
+        fall through to warehouse-table resolution so the formula ref can still
+        resolve (e.g. a sibling element that shares its name with the warehouse
+        table it wraps)."""
         upstream_elem = _make_element("sourceElem", "Orders")
         wh_urn = "urn:li:dataset:(urn:li:dataPlatform:snowflake,DB.SCHEMA.ORDERS,PROD)"
         ref = _make_ref("Orders", "id")
@@ -346,7 +349,7 @@ class TestResolveChartFormulaUpstream:
             elementId_to_chart_urn={"sourceElem": "urn:source"},
         )
 
-        assert result is None
+        assert result == (wh_urn, "id")
 
     def test_self_reference_is_excluded_from_workbook_element_matches(self) -> None:
         """A self-loop in Sigma lineage must not resolve to the chart itself."""

--- a/metadata-ingestion/tests/unit/sigma/test_dm_element_fgl.py
+++ b/metadata-ingestion/tests/unit/sigma/test_dm_element_fgl.py
@@ -772,3 +772,94 @@ def test_self_named_warehouse_element_unaffected_without_cross_dm_sources() -> N
     assert source.reporter.data_model_element_fgl_warehouse_passthrough_deferred == 1
     assert source.reporter.data_model_element_fgl_cross_dm_deferred == 0
     assert source.reporter.data_model_element_fgl_cross_dm_resolved == 0
+
+
+def test_orphan_branch_rescued_by_cross_dm_on_name_collision() -> None:
+    """When a sibling shares the consumer's formula-ref name but isn't in /lineage
+    upstreams, the orphan branch tries cross-DM before dropping.
+
+    Mirrors dev-tenant: DM 'Test Data Model' has TWO elements named 'Custom SQL'
+    (sibling XpQ7V2hYt6 and consumer YqPcfY1MZm). YqPcfY1MZm's formula
+    [Custom SQL/<col>] finds XpQ7V2hYt6 as intra-DM candidate (after self-strip),
+    but XpQ7V2hYt6 is NOT in entity_level_upstream_urns. Old code: orphan drop.
+    New code: cross-DM rescue succeeds via source_ids → DM B's 'Custom SQL'.
+    """
+    source = _source()
+    dm_b_url_id = "dm-b"
+    producer_urn = _urn("producer-custom-sql")
+    sibling_urn = _urn("sibling-custom-sql")
+    consumer_urn = _urn("consumer-custom-sql")
+
+    consumer = _element(
+        "consumer-eid",
+        "Custom SQL",
+        [_column("c1", "Visit Id", "[Custom SQL/Visit Id]")],
+        source_ids=[f"{dm_b_url_id}/s1qt_Ccng5"],
+    )
+    sibling = _upstream_element("sibling-eid", "Custom SQL", ["Visit Id"])
+
+    source.dm_element_urn_by_name = {dm_b_url_id: {"custom sql": [producer_urn]}}
+    source.dm_element_urn_to_cols = {producer_urn: {"visit id": "Visit Id"}}
+
+    lineages = _build(
+        source,
+        consumer,
+        element_dataset_urn=consumer_urn,
+        # Both sibling and consumer share the name "Custom SQL" in this DM.
+        element_name_to_eids={"custom sql": ["sibling-eid", "consumer-eid"]},
+        elementId_to_dataset_urn={
+            "sibling-eid": sibling_urn,
+            "consumer-eid": consumer_urn,
+        },
+        # Entity-level upstream is cross-DM producer, NOT sibling.
+        entity_level_upstream_urns={producer_urn},
+        upstream_elements=[sibling],
+    )
+
+    assert len(lineages) == 1
+    assert lineages[0].upstreams == [
+        builder.make_schema_field_urn(producer_urn, "Visit Id")
+    ]
+    assert lineages[0].downstreams == [
+        builder.make_schema_field_urn(consumer_urn, "Visit Id")
+    ]
+    assert source.reporter.data_model_element_fgl_cross_dm_resolved == 1
+    assert source.reporter.data_model_element_fgl_dropped_orphan_upstream == 0
+    assert source.reporter.data_model_element_fgl_cross_dm_deferred == 0
+
+
+def test_orphan_branch_not_rescued_without_cross_dm_sources() -> None:
+    """Regression: name collision with no cross-DM source_ids still hits orphan drop.
+    The rescue guard (element.source_ids) prevents false-positive cross_dm_deferred
+    for genuine orphans.
+    """
+    source = _source()
+    sibling_urn = _urn("sibling")
+    consumer_urn = _urn("consumer")
+
+    consumer = _element(
+        "consumer-eid",
+        "Shared",
+        [_column("c1", "x", "[Shared/x]")],
+        # source_ids=[] — no cross-DM refs
+    )
+    sibling = _upstream_element("sibling-eid", "Shared", ["x"])
+
+    lineages = _build(
+        source,
+        consumer,
+        element_dataset_urn=consumer_urn,
+        element_name_to_eids={"shared": ["sibling-eid", "consumer-eid"]},
+        elementId_to_dataset_urn={
+            "sibling-eid": sibling_urn,
+            "consumer-eid": consumer_urn,
+        },
+        # sibling not in entity_level_upstream_urns → genuine orphan
+        entity_level_upstream_urns=set(),
+        upstream_elements=[sibling],
+    )
+
+    assert lineages == []
+    assert source.reporter.data_model_element_fgl_dropped_orphan_upstream == 1
+    assert source.reporter.data_model_element_fgl_cross_dm_deferred == 0
+    assert source.reporter.data_model_element_fgl_cross_dm_resolved == 0

--- a/metadata-ingestion/tests/unit/sigma/test_dm_element_fgl.py
+++ b/metadata-ingestion/tests/unit/sigma/test_dm_element_fgl.py
@@ -863,3 +863,43 @@ def test_orphan_branch_not_rescued_without_cross_dm_sources() -> None:
     assert source.reporter.data_model_element_fgl_dropped_orphan_upstream == 1
     assert source.reporter.data_model_element_fgl_cross_dm_deferred == 0
     assert source.reporter.data_model_element_fgl_cross_dm_resolved == 0
+
+
+def test_intra_dm_only_source_ids_not_treated_as_cross_dm() -> None:
+    """Regression: source_ids containing only bare intra-DM element IDs (no '/')
+    must not trigger a cross-DM probe and must not inflate cross_dm_deferred.
+
+    Covers both Case A (orphan-drop branch) and Case B (self-named strip branch):
+    here a sibling shares the name but isn't a lineage upstream, exercising the
+    orphan-drop path where the guard matters most.
+    """
+    source = _source()
+    sibling_urn = _urn("sibling")
+    consumer_urn = _urn("consumer")
+
+    consumer = _element(
+        "consumer-eid",
+        "Shared",
+        [_column("c1", "x", "[Shared/x]")],
+        # Intra-DM source IDs only — no "/" separator, not cross-DM shaped.
+        source_ids=["some-intra-dm-eid"],
+    )
+    sibling = _upstream_element("sibling-eid", "Shared", ["x"])
+
+    lineages = _build(
+        source,
+        consumer,
+        element_dataset_urn=consumer_urn,
+        element_name_to_eids={"shared": ["sibling-eid", "consumer-eid"]},
+        elementId_to_dataset_urn={
+            "sibling-eid": sibling_urn,
+            "consumer-eid": consumer_urn,
+        },
+        entity_level_upstream_urns=set(),
+        upstream_elements=[sibling],
+    )
+
+    assert lineages == []
+    assert source.reporter.data_model_element_fgl_dropped_orphan_upstream == 1
+    assert source.reporter.data_model_element_fgl_cross_dm_deferred == 0
+    assert source.reporter.data_model_element_fgl_cross_dm_resolved == 0

--- a/metadata-ingestion/tests/unit/sigma/test_dm_element_fgl.py
+++ b/metadata-ingestion/tests/unit/sigma/test_dm_element_fgl.py
@@ -869,9 +869,10 @@ def test_intra_dm_only_source_ids_not_treated_as_cross_dm() -> None:
     """Regression: source_ids containing only bare intra-DM element IDs (no '/')
     must not trigger a cross-DM probe and must not inflate cross_dm_deferred.
 
-    Covers both Case A (orphan-drop branch) and Case B (self-named strip branch):
-    here a sibling shares the name but isn't a lineage upstream, exercising the
-    orphan-drop path where the guard matters most.
+    Covers Case A (orphan-drop branch): a sibling shares the name but isn't a
+    lineage upstream, so surviving_urns is empty and the orphan-drop path fires.
+    Case B (self-named strip branch) is covered in
+    test_self_named_intra_dm_source_ids_not_treated_as_cross_dm below.
     """
     source = _source()
     sibling_urn = _urn("sibling")
@@ -899,6 +900,79 @@ def test_intra_dm_only_source_ids_not_treated_as_cross_dm() -> None:
         upstream_elements=[sibling],
     )
 
+    assert lineages == []
+    assert source.reporter.data_model_element_fgl_dropped_orphan_upstream == 1
+    assert source.reporter.data_model_element_fgl_cross_dm_deferred == 0
+    assert source.reporter.data_model_element_fgl_cross_dm_resolved == 0
+
+
+def test_self_named_intra_dm_source_ids_not_treated_as_cross_dm() -> None:
+    """Case B: element is the sole intra-DM candidate for its own name (self-named
+    strip branch). After stripping itself, candidate_eids_after_self_strip is empty
+    and _try_emit_self_named_cross_dm_fgl is called. When source_ids contains only
+    bare intra-DM IDs, the guard must short-circuit without a cross-DM probe.
+    Falls through to warehouse passthrough (deferred here — no warehouse FGL).
+    """
+    source = _source()
+    consumer_urn = _urn("consumer")
+
+    consumer = _element(
+        "consumer-eid",
+        "Orders",
+        [_column("c1", "x", "[Orders/x]")],
+        source_ids=["some-intra-dm-eid"],  # bare ID, no "/" — not cross-DM shaped
+    )
+
+    lineages = _build(
+        source,
+        consumer,
+        element_dataset_urn=consumer_urn,
+        # Only the element itself under "orders"; after self-strip the list is empty.
+        element_name_to_eids={"orders": ["consumer-eid"]},
+        elementId_to_dataset_urn={"consumer-eid": consumer_urn},
+        entity_level_upstream_urns=set(),
+    )
+
+    assert lineages == []
+    assert source.reporter.data_model_element_fgl_dropped_orphan_upstream == 0
+    assert source.reporter.data_model_element_fgl_cross_dm_deferred == 0
+    assert source.reporter.data_model_element_fgl_cross_dm_resolved == 0
+    assert source.reporter.data_model_element_fgl_warehouse_passthrough_deferred == 1
+
+
+def test_inode_source_ids_excluded_from_cross_dm_guard() -> None:
+    """inode-<urlId>/<suffix> shaped source_ids must not pass the cross-DM guard
+    even though they contain '/'. Only <dm-url-id>/<suffix> entries (without the
+    'inode-' prefix) qualify as cross-DM sources.
+    """
+    source = _source()
+    consumer_urn = _urn("consumer")
+    sibling_urn = _urn("sibling")
+
+    consumer = _element(
+        "consumer-eid",
+        "Shared",
+        [_column("c1", "x", "[Shared/x]")],
+        # inode-shaped entry has '/' but is NOT a cross-DM source ID.
+        source_ids=["inode-abc123/some-suffix"],
+    )
+    sibling = _upstream_element("sibling-eid", "Shared", ["x"])
+
+    lineages = _build(
+        source,
+        consumer,
+        element_dataset_urn=consumer_urn,
+        element_name_to_eids={"shared": ["sibling-eid", "consumer-eid"]},
+        elementId_to_dataset_urn={
+            "sibling-eid": sibling_urn,
+            "consumer-eid": consumer_urn,
+        },
+        entity_level_upstream_urns=set(),
+        upstream_elements=[sibling],
+    )
+
+    # Sibling is not a lineage upstream and inode source_ids are not cross-DM;
+    # orphan-drop fires without touching cross-DM counters.
     assert lineages == []
     assert source.reporter.data_model_element_fgl_dropped_orphan_upstream == 1
     assert source.reporter.data_model_element_fgl_cross_dm_deferred == 0

--- a/metadata-ingestion/tests/unit/sigma/test_dm_element_fgl.py
+++ b/metadata-ingestion/tests/unit/sigma/test_dm_element_fgl.py
@@ -699,3 +699,76 @@ def test_cross_dm_unknown_upstream_column_is_dropped() -> None:
     )
     assert source.reporter.data_model_element_fgl_cross_dm_resolved == 0
     assert source.reporter.data_model_element_fgl_cross_dm_deferred == 0
+
+
+def test_self_named_cross_dm_element_resolves_fgl() -> None:
+    """Element named 'Custom SQL' in DM A with formula [Custom SQL/col] and
+    source_ids pointing to DM B resolves FGL against DM B's 'Custom SQL' element.
+
+    Without the fix the self-name-only branch goes straight to warehouse passthrough
+    and emits 0 FGLs. With the fix, cross-DM is tried first and succeeds because
+    DM B has a matching element name and column. Mirrors dev-tenant element YqPcfY1MZm.
+    """
+    source = _source()
+    dm_b_url_id = "dm-b"
+    producer_urn = _urn("producer-custom-sql")
+    consumer_urn = _urn("consumer-custom-sql")
+
+    consumer = _element(
+        "consumer-eid",
+        "Custom SQL",
+        [_column("c1", "Visit Id", "[Custom SQL/Visit Id]")],
+        source_ids=[f"{dm_b_url_id}/s1qt_Ccng5"],
+    )
+
+    source.dm_element_urn_by_name = {dm_b_url_id: {"custom sql": [producer_urn]}}
+    source.dm_element_urn_to_cols = {producer_urn: {"visit id": "Visit Id"}}
+
+    lineages = _build(
+        source,
+        consumer,
+        element_dataset_urn=consumer_urn,
+        element_name_to_eids={"custom sql": ["consumer-eid"]},
+        elementId_to_dataset_urn={"consumer-eid": consumer_urn},
+        entity_level_upstream_urns={producer_urn},
+    )
+
+    assert len(lineages) == 1
+    assert lineages[0].upstreams == [
+        builder.make_schema_field_urn(producer_urn, "Visit Id")
+    ]
+    assert lineages[0].downstreams == [
+        builder.make_schema_field_urn(consumer_urn, "Visit Id")
+    ]
+    assert source.reporter.data_model_element_fgl_cross_dm_resolved == 1
+    assert source.reporter.data_model_element_fgl_warehouse_passthrough_deferred == 0
+    assert source.reporter.data_model_element_fgl_cross_dm_deferred == 0
+
+
+def test_self_named_warehouse_element_unaffected_without_cross_dm_sources() -> None:
+    """Regression: self-named element with no cross-DM source_ids still defers
+    to warehouse passthrough. The cross-DM probe is guarded by source_ids so
+    warehouse-only elements are unaffected and cross_dm_deferred is not inflated.
+    """
+    source = _source()
+    self_urn = _urn("customers")
+    element = _element(
+        "elem-customers",
+        "CUSTOMERS",
+        [_column("c1", "id", "[CUSTOMERS/id]")],
+        # source_ids=[] — no cross-DM refs, warehouse-only element
+    )
+
+    lineages = _build(
+        source,
+        element,
+        element_dataset_urn=self_urn,
+        element_name_to_eids={"customers": ["elem-customers"]},
+        elementId_to_dataset_urn={"elem-customers": self_urn},
+        entity_level_upstream_urns=set(),
+    )
+
+    assert lineages == []
+    assert source.reporter.data_model_element_fgl_warehouse_passthrough_deferred == 1
+    assert source.reporter.data_model_element_fgl_cross_dm_deferred == 0
+    assert source.reporter.data_model_element_fgl_cross_dm_resolved == 0


### PR DESCRIPTION
- Restore DM resolution when self-exclusion empties candidates; try cross-DM FGL before  warehouse passthrough on self-named elements; try cross-DM FGL before orphan-drop; emit one InputField per unique resolved formula ref (with dedup for identical refs)
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
