### PR TITLE
fix(ingest/snowflake): add sweden-central azure region mapping

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/constants.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/constants.py
@@ -33,6 +33,7 @@ SNOWFLAKE_REGION_CLOUD_REGION_MAPPING = {
     "azure_northeurope": (SnowflakeCloudProvider.AZURE, "north-europe"),
     "azure_westeurope": (SnowflakeCloudProvider.AZURE, "west-europe"),
     "azure_switzerlandnorth": (SnowflakeCloudProvider.AZURE, "switzerland-north"),
+    "azure_swedencentral": (SnowflakeCloudProvider.AZURE, "sweden-central"),
     "azure_uaenorth": (SnowflakeCloudProvider.AZURE, "uae-north"),
     "azure_centralindia": (SnowflakeCloudProvider.AZURE, "central-india"),
     "azure_japaneast": (SnowflakeCloudProvider.AZURE, "japan-east"),


### PR DESCRIPTION
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [x ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ x] Links to related issues (if applicable)
- [ x] Tests for the changes have been added/updated (if applicable)
- [x ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
The Snowsight URL builder constructs broken external URLs for Snowflake
accounts hosted in Azure Sweden Central. The `SNOWFLAKE_REGION_CLOUD_REGION_MAPPING`
dict in `constants.py` is missing an entry for `azure_swedencentral`, so the
fallback in `SnowsightUrlBuilder.get_cloud_region_from_snowflake_region_id`
produces `swedencentral` instead of the hyphenated `sweden-central` that
Snowsight expects in the URL path.

This results in URLs like:
  https://app.snowflake.com/swedencentral.azure/<locator>/    (broken)

instead of:
  https://app.snowflake.com/sweden-central.azure/<locator>/   (correct)

Adds the missing mapping entry, matching the pattern in #8376 for the other Azure regions.