### PR TITLE
feat(smoke-test): add degree and skip_cache params to search_across_lineage

### DIFF
--- a/smoke-test/tests/utilities/metadata_operations.py
+++ b/smoke-test/tests/utilities/metadata_operations.py
@@ -298,6 +298,8 @@ def search_across_lineage(
     direction: str = "UPSTREAM",
     query: str = "*",
     count: int = 10,
+    degree: Optional[int] = None,
+    skip_cache: bool = False,
 ) -> Dict[str, Any]:
     """Search across lineage from a given entity."""
     graphql_query = """
@@ -328,6 +330,21 @@ def search_across_lineage(
             "count": count,
         }
     }
+    if degree is not None:
+        variables["input"]["orFilters"] = [
+            {
+                "and": [
+                    {
+                        "field": "degree",
+                        "condition": "EQUAL",
+                        "values": [str(degree)],
+                        "negated": False,
+                    }
+                ]
+            }
+        ]
+    if skip_cache:
+        variables["input"]["searchFlags"] = {"skipCache": True}
 
     res_data = execute_graphql(auth_session, graphql_query, variables)
     return res_data["data"]["searchAcrossLineage"]


### PR DESCRIPTION
## Summary

Extends the `search_across_lineage` smoke-test helper in `tests/utilities/metadata_operations.py` with two optional parameters:

- `degree: Optional[int] = None` — when set, restricts results to entities exactly this many hops away (applied as a `degree` orFilter on the GraphQL input).
- `skip_cache: bool = False` — when True, sets `searchFlags.skipCache` so results reflect the underlying graph state rather than the lineage cache.

Defaults preserve existing behavior; all current callers (e.g. `tests/read_only/test_lineage_apis.py`) continue to work unchanged.

## Why upstream this now

A lineage-correctness test in our managed deployment (Acryl Cloud) uses both new params for strict edge-correctness assertions. Keeping the shared `metadata_operations.py` helper in sync between fork and OSS prevents merge conflicts during the daily fork-sync, even though no OSS test consumes the new params today. The functionality itself (`degree` filtering, `skipCache` flag) is already supported by GMS's `searchAcrossLineage` GraphQL endpoint in OSS.

## Test plan

- [x] `ruff check tests/utilities/metadata_operations.py` clean
- [x] `ruff format` clean
- [x] No change to default-parameter call sites — backward compatible