### PR TITLE
fix(ingest/teradata): make tables-cache lookups case-insensitive on database name

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/teradata.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/teradata.py
@@ -277,7 +277,7 @@ def optimized_get_columns(
     # Incremental extraction: skip column fetch for tables unchanged since the watermark
     if (
         tables_needing_extraction is not None
-        and (schema, table_name) not in tables_needing_extraction
+        and (schema.lower(), table_name) not in tables_needing_extraction
     ):
         logger.debug(
             f"Skipping column extraction for {schema}.{table_name} (unchanged since watermark)"
@@ -290,7 +290,7 @@ def optimized_get_columns(
 
     td_table: Optional[TeradataTable] = None
     # Check if the object is a view
-    for t in tables_cache[schema]:
+    for t in tables_cache.get(schema.lower(), []):
         if t.name == table_name:
             td_table = t
             break
@@ -473,10 +473,11 @@ def optimized_get_view_definition(
     if schema is None:
         schema = self.default_schema_name
 
-    if schema not in tables_cache:
+    schema_key = schema.lower()
+    if schema_key not in tables_cache:
         return None
 
-    for table in tables_cache[schema]:
+    for table in tables_cache[schema_key]:
         if table.name == view_name:
             return self.normalize_name(table.request_text)
 
@@ -865,8 +866,11 @@ ORDER by DataBaseName, TableName;
         if self.config.databases:
             # Teradata identifiers cannot contain single quotes; strip defensively.
             safe_names = [db.replace("'", "") for db in self.config.databases]
-            db_allowlist = "\nAND DataBaseName IN ({})".format(
-                ",".join(f"'{db}'" for db in safe_names)
+            # (NOT CASESPECIFIC) on both sides so the filter works even if the
+            # session collation is set to CASESPECIFIC (rare but seen in compliance-
+            # configured installations); the audit-log query below uses the same idiom.
+            db_allowlist = "\nAND DataBaseName (NOT CASESPECIFIC) IN ({})".format(
+                ",".join(f"'{db}' (NOT CASESPECIFIC)" for db in safe_names)
             )
 
         return self._TABLES_AND_VIEWS_QUERY_TEMPLATE.format(
@@ -1119,7 +1123,7 @@ ORDER by DataBaseName, TableName;
                 i.name
                 for i in filter(
                     lambda t: t.object_type != "View",
-                    self._tables_cache.get(schema, []),
+                    self._tables_cache.get(schema.lower(), []),
                 )
             ],
         )
@@ -1135,7 +1139,7 @@ ORDER by DataBaseName, TableName;
         # this method and provide a location.
         location: Optional[str] = None
 
-        cache_entries = self._tables_cache.get(schema, [])
+        cache_entries = self._tables_cache.get(schema.lower(), [])
         for entry in cache_entries:
             if entry.name == table:
                 description = entry.description
@@ -1147,7 +1151,7 @@ ORDER by DataBaseName, TableName;
     def _get_creator_for_entity(self, schema: str, entity_name: str) -> Optional[str]:
         """Get creator name for a table or view."""
         with self._tables_cache_lock:
-            return self._table_creator_cache.get((schema, entity_name))
+            return self._table_creator_cache.get((schema.lower(), entity_name))
 
     def _emit_ownership_if_available(
         self,
@@ -1215,7 +1219,8 @@ ORDER by DataBaseName, TableName;
         view_names = [
             i.name
             for i in filter(
-                lambda t: t.object_type == "View", self._tables_cache.get(schema, [])
+                lambda t: t.object_type == "View",
+                self._tables_cache.get(schema.lower(), []),
             )
         ]
         actual_view_count = len(view_names)
@@ -1600,12 +1605,15 @@ ORDER by DataBaseName, TableName;
                         database_counts[table.database]["tables"] += 1
 
                     with self._tables_cache_lock:
-                        self._tables_cache[table.database].append(table)
+                        # Cache key is lowercased so lookups by schema name from
+                        # config.databases (case as the user typed it) match entries
+                        # populated from dbc.TablesV (returned in Teradata's stored case).
+                        self._tables_cache[table.database.lower()].append(table)
                         creator_name = (entry.CreatorName or "").strip()
                         if creator_name:
-                            self._table_creator_cache[(table.database, table.name)] = (
-                                creator_name
-                            )
+                            self._table_creator_cache[
+                                (table.database.lower(), table.name)
+                            ] = creator_name
 
                     # Track which tables need column extraction under incremental mode
                     if (
@@ -1616,7 +1624,7 @@ ORDER by DataBaseName, TableName;
                         # Include when timestamp is missing (conservative) or at/after watermark
                         if last_alter is None or last_alter >= watermark:
                             self._tables_needing_column_extraction.add(
-                                (table.database, table.name)
+                                (table.database.lower(), table.name)
                             )
 
                 if self._tables_needing_column_extraction is not None:

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/teradata.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/teradata.py
@@ -1091,13 +1091,48 @@ ORDER by DataBaseName, TableName;
             else:
                 databases = inspector.get_schema_names()
 
+        # When the user supplied an explicit database list, validate each entry
+        # against dbc.TablesV (populated into _tables_cache during discovery).
+        # Without this, a typo in `databases` silently emits a container URN for
+        # a database that does not exist on the source. Only applies when
+        # discovery actually ran (include_tables or include_views).
+        user_supplied_databases = bool(
+            (self.config.database and self.config.database != "")
+            or self.config.databases
+        )
+        # Only validate when discovery actually produced an inventory we can
+        # check against. An empty cache means either discovery was disabled
+        # (include_tables/include_views both False) or it ran and genuinely
+        # found nothing — in both cases there is no oracle to validate against
+        # and we fall back to trusting the user's list.
+        have_db_inventory = (
+            self.config.include_tables or self.config.include_views
+        ) and bool(self._tables_cache)
+
         # Create separate connections for each database to avoid connection lifecycle issues
         for db in databases:
-            if self.config.database_pattern.allowed(db):
-                with engine.connect() as conn:
-                    db_inspector = inspect(conn)
-                    db_inspector._datahub_database = db
-                    yield db_inspector
+            if not self.config.database_pattern.allowed(db):
+                continue
+            if (
+                user_supplied_databases
+                and have_db_inventory
+                and db.lower() not in self._tables_cache
+            ):
+                self.report.warning(
+                    title="Configured database not found on source",
+                    message=(
+                        f"Database {db!r} is listed in the connector config but no "
+                        "tables or views were found for it in dbc.TablesV. Skipping "
+                        "to avoid emitting a container URN for a database that does "
+                        "not exist (or that exists but is empty). Check for typos or "
+                        "remove the entry."
+                    ),
+                )
+                continue
+            with engine.connect() as conn:
+                db_inspector = inspect(conn)
+                db_inspector._datahub_database = db
+                yield db_inspector
 
     def get_db_name(self, inspector: Inspector) -> str:
         if hasattr(inspector, "_datahub_database"):

--- a/metadata-ingestion/tests/unit/test_teradata_integration.py
+++ b/metadata-ingestion/tests/unit/test_teradata_integration.py
@@ -5,6 +5,7 @@ These tests focus on end-to-end workflows, complex interactions,
 and integration between different components.
 """
 
+from collections import defaultdict
 from datetime import datetime
 from typing import Any, Dict
 from unittest.mock import MagicMock, patch
@@ -18,6 +19,17 @@ from datahub.ingestion.source.sql.teradata import (
     TeradataTable,
 )
 from datahub.metadata.urns import CorpUserUrn
+
+
+@pytest.fixture(autouse=True)
+def isolate_teradata_caches(monkeypatch):
+    """Reset TeradataSource class-level caches before each test.
+
+    The caches are class attributes, so without isolation tests that populate
+    them via `source._tables_cache["schema"] = …` leak state into later tests.
+    """
+    monkeypatch.setattr(TeradataSource, "_tables_cache", defaultdict(list))
+    monkeypatch.setattr(TeradataSource, "_table_creator_cache", {})
 
 
 def _base_config() -> Dict[str, Any]:

--- a/metadata-ingestion/tests/unit/test_teradata_performance.py
+++ b/metadata-ingestion/tests/unit/test_teradata_performance.py
@@ -5,8 +5,11 @@ These tests focus on performance optimizations, memory management,
 and efficiency improvements in the Teradata source.
 """
 
+from collections import defaultdict
 from datetime import datetime
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.source.sql.teradata import (
@@ -17,6 +20,14 @@ from datahub.ingestion.source.sql.teradata import (
     get_schema_foreign_keys,
     get_schema_pk_constraints,
 )
+
+
+@pytest.fixture(autouse=True)
+def isolate_teradata_caches(monkeypatch):
+    """Reset TeradataSource class-level caches before each test to prevent
+    cross-test state leakage."""
+    monkeypatch.setattr(TeradataSource, "_tables_cache", defaultdict(list))
+    monkeypatch.setattr(TeradataSource, "_table_creator_cache", {})
 
 
 def _base_config():

--- a/metadata-ingestion/tests/unit/test_teradata_performance.py
+++ b/metadata-ingestion/tests/unit/test_teradata_performance.py
@@ -557,7 +557,14 @@ class TestQueryOptimizations:
 
         query = source._build_tables_and_views_query()
 
-        assert "AND DataBaseName IN ('DB_A','DB_B','DB_C')" in query
+        # (NOT CASESPECIFIC) on both sides keeps the IN-list matching even on
+        # installations whose session default is CASESPECIFIC.
+        assert (
+            "AND DataBaseName (NOT CASESPECIFIC) IN ("
+            "'DB_A' (NOT CASESPECIFIC),"
+            "'DB_B' (NOT CASESPECIFIC),"
+            "'DB_C' (NOT CASESPECIFIC))"
+        ) in query
         # System database exclusion still present
         assert "NOT IN" in query
 

--- a/metadata-ingestion/tests/unit/test_teradata_source.py
+++ b/metadata-ingestion/tests/unit/test_teradata_source.py
@@ -2674,3 +2674,107 @@ class TestCacheCaseInsensitivity:
         query = source._build_tables_and_views_query()
         assert "DataBaseName (NOT CASESPECIFIC) IN" in query
         assert "'my_db' (NOT CASESPECIFIC)" in query
+
+
+class TestConfiguredDatabasesValidation:
+    """When the user supplies an explicit `databases` list, entries that don't
+    exist on the source must not produce a container URN. Pre-fix, every name
+    in the list was yielded by get_inspectors() and the base SQL source emitted
+    a container for it — so a typo polluted the platform with phantom entities.
+    """
+
+    @patch("datahub.ingestion.source.sql.teradata.create_engine")
+    def test_nonexistent_database_skipped_with_warning(
+        self, mock_create_engine: MagicMock
+    ) -> None:
+        source = _create_source_patched({"databases": ["real_db", "typo_db"]})
+        # Discovery populates the cache for "real_db" only (uppercase from
+        # Teradata → lowercased by the cache fix).
+        source._tables_cache["real_db"] = [
+            TeradataTable(
+                database="REAL_DB",
+                name="T",
+                description=None,
+                object_type="Table",
+                create_timestamp=datetime(2024, 1, 1),
+                last_alter_name=None,
+                last_alter_timestamp=None,
+                request_text=None,
+            )
+        ]
+
+        mock_engine = MagicMock()
+        mock_engine.connect.return_value.__enter__.return_value = MagicMock()
+        mock_create_engine.return_value = mock_engine
+
+        with patch("datahub.ingestion.source.sql.teradata.inspect") as mock_inspect:
+            mock_inspect.return_value = MagicMock()
+            inspectors = list(source.get_inspectors())
+
+        # Only the database that actually has entries in the cache gets an
+        # inspector yielded; the typo is dropped before a container is emitted.
+        yielded = [i._datahub_database for i in inspectors]
+        assert yielded == ["real_db"]
+
+        warning_titles = [w.title for w in source.report.warnings]
+        assert "Configured database not found on source" in warning_titles
+
+    @patch("datahub.ingestion.source.sql.teradata.create_engine")
+    def test_no_validation_when_discovery_disabled(
+        self, mock_create_engine: MagicMock
+    ) -> None:
+        """include_tables=False and include_views=False means the cache was
+        never populated, so we have no oracle to validate against. Fall back
+        to trusting the user's list.
+        """
+        source = _create_source_patched(
+            {
+                "databases": ["any_db"],
+                "include_tables": False,
+                "include_views": False,
+            }
+        )
+        # _tables_cache is empty in this scenario.
+
+        mock_engine = MagicMock()
+        mock_engine.connect.return_value.__enter__.return_value = MagicMock()
+        mock_create_engine.return_value = mock_engine
+
+        with patch("datahub.ingestion.source.sql.teradata.inspect") as mock_inspect:
+            mock_inspect.return_value = MagicMock()
+            inspectors = list(source.get_inspectors())
+
+        yielded = [i._datahub_database for i in inspectors]
+        assert yielded == ["any_db"]
+        assert source.report.warnings == []
+
+    @patch("datahub.ingestion.source.sql.teradata.create_engine")
+    def test_no_validation_when_databases_not_user_supplied(
+        self, mock_create_engine: MagicMock
+    ) -> None:
+        """When the user did not supply config.database(s), the database list
+        comes from inspector.get_schema_names() which is already authoritative.
+        Validation against the cache would be redundant (and would wrongly
+        suppress empty-but-real databases).
+        """
+        source = _create_source_patched()  # no `databases` set
+
+        mock_inspector = MagicMock()
+        mock_inspector.get_schema_names.return_value = ["from_inspector"]
+        # _tables_cache is empty (no discovery in this minimal test setup),
+        # but we still expect "from_inspector" to be yielded because it came
+        # from the authoritative source.
+
+        mock_engine = MagicMock()
+        mock_engine.connect.return_value.__enter__.return_value = MagicMock()
+        mock_create_engine.return_value = mock_engine
+
+        with patch(
+            "datahub.ingestion.source.sql.teradata.inspect",
+            return_value=mock_inspector,
+        ):
+            inspectors = list(source.get_inspectors())
+
+        yielded = [i._datahub_database for i in inspectors]
+        assert yielded == ["from_inspector"]
+        assert source.report.warnings == []

--- a/metadata-ingestion/tests/unit/test_teradata_source.py
+++ b/metadata-ingestion/tests/unit/test_teradata_source.py
@@ -18,6 +18,7 @@ from datahub.ingestion.source.sql.teradata import (
     get_schema_foreign_keys,
     get_schema_pk_constraints,
     optimized_get_columns,
+    optimized_get_view_definition,
 )
 from datahub.metadata.urns import CorpUserUrn
 from datahub.sql_parsing.sql_parsing_aggregator import ObservedQuery
@@ -2484,3 +2485,192 @@ class TestConfigurableTimeouts:
         )
         assert connect_args["request_timeout"] == "300000"
         assert connect_args["connect_timeout"] == "60000"
+
+
+class TestCacheCaseInsensitivity:
+    """Cache must hit regardless of whether config and Teradata report the database
+    name in the same case. dbc.TablesV returns Teradata's stored case (typically
+    uppercase) while users commonly write `databases: [my_db]` in lowercase — the
+    pre-fix lookup missed and the run silently produced zero datasets.
+    """
+
+    def _make_table(
+        self, database: str, name: str, object_type: str = "Table"
+    ) -> TeradataTable:
+        return TeradataTable(
+            database=database,
+            name=name,
+            description=None,
+            object_type=object_type,
+            create_timestamp=datetime(2024, 1, 1),
+            last_alter_name=None,
+            last_alter_timestamp=None,
+            request_text="SELECT 1" if object_type == "View" else None,
+        )
+
+    def test_cache_write_lowercases_database_key(self) -> None:
+        """Teradata returns uppercase DataBaseName; the cache stores it lowercased."""
+        source = _create_source_patched()
+        mock_engine = MagicMock()
+        mock_engine.execute.return_value = [
+            _create_mock_table_entry("MY_DB", "MY_TABLE")
+        ]
+        with patch.object(source, "get_metadata_engine", return_value=mock_engine):
+            source.cache_tables_and_views()
+
+        assert "my_db" in source._tables_cache
+        assert "MY_DB" not in source._tables_cache
+
+    def test_cached_loop_tables_finds_uppercase_entries_with_lowercase_schema(
+        self,
+    ) -> None:
+        """Lookup with a lowercase schema must hit cache entries written in
+        Teradata's stored (typically uppercase) case."""
+        source = _create_source_patched()
+        source._tables_cache["my_db"] = [self._make_table("MY_DB", "MY_TABLE")]
+
+        with patch(
+            "datahub.ingestion.source.sql.two_tier_sql_source.TwoTierSQLAlchemySource.loop_tables"
+        ) as mock_super:
+            mock_super.return_value = []
+            list(source.cached_loop_tables(MagicMock(), "my_db", MagicMock()))
+
+        # super().loop_tables sees the patched get_table_names — invoke it and check
+        # that the schema lookup hits the cache despite case mismatch.
+        inspector = mock_super.call_args.args[0]
+        assert inspector.get_table_names("my_db") == ["MY_TABLE"]
+
+    def test_cached_loop_views_finds_uppercase_entries_with_lowercase_schema(
+        self,
+    ) -> None:
+        source = _create_source_patched()
+        source._tables_cache["my_db"] = [
+            self._make_table("MY_DB", "MY_VIEW", object_type="View")
+        ]
+
+        with patch.object(
+            source, "_loop_views_with_connection_pool", return_value=iter([])
+        ) as mock_pool:
+            list(source.cached_loop_views(MagicMock(), "my_db", MagicMock()))
+
+        # Pre-fix the view list would be empty and the pool never invoked.
+        mock_pool.assert_called_once()
+        view_names = mock_pool.call_args.args[0]
+        assert view_names == ["MY_VIEW"]
+
+    def test_cached_get_table_properties_finds_entry_with_lowercase_schema(
+        self,
+    ) -> None:
+        source = _create_source_patched()
+        entry = self._make_table("MY_DB", "MY_TABLE", object_type="View")
+        entry.description = "promo mart"
+        source._tables_cache["my_db"] = [entry]
+
+        description, properties, _ = source.cached_get_table_properties(
+            MagicMock(), "my_db", "MY_TABLE"
+        )
+
+        assert description == "promo mart"
+        assert properties["view_definition"] == "SELECT 1"
+
+    def test_optimized_get_columns_lowercases_schema_lookup(self) -> None:
+        mock_dialect = MagicMock()
+        mock_dialect.default_schema_name = "MY_DB"
+        mock_dialect.get_schema_columns.return_value = {"MY_TABLE": []}
+
+        tables_cache: Dict[str, List[TeradataTable]] = {
+            "my_db": [self._make_table("MY_DB", "MY_TABLE")]
+        }
+
+        optimized_get_columns(
+            mock_dialect,
+            MagicMock(),
+            "MY_TABLE",
+            "MY_DB",
+            tables_cache=tables_cache,
+        )
+
+        # Reaches column extraction only if the cache lookup hits.
+        mock_dialect.get_schema_columns.assert_called_once()
+
+    def test_optimized_get_view_definition_lowercases_schema_lookup(self) -> None:
+        mock_dialect = MagicMock()
+        mock_dialect.default_schema_name = "MY_DB"
+        mock_dialect.normalize_name = lambda s: s
+
+        tables_cache: Dict[str, List[TeradataTable]] = {
+            "my_db": [self._make_table("MY_DB", "MY_VIEW", object_type="View")]
+        }
+
+        view_def = optimized_get_view_definition(
+            mock_dialect,
+            MagicMock(),
+            "MY_VIEW",
+            "MY_DB",
+            tables_cache=tables_cache,
+        )
+
+        assert view_def == "SELECT 1"
+
+    def test_creator_cache_lookup_is_case_insensitive_on_database(self) -> None:
+        """extract_ownership: True + lowercase databases must still find creators."""
+        source = _create_source_patched()
+        mock_engine = MagicMock()
+        mock_engine.execute.return_value = [
+            _create_mock_table_entry("MY_DB", "MY_TABLE", creator_name="creator_user")
+        ]
+        with patch.object(source, "get_metadata_engine", return_value=mock_engine):
+            source.cache_tables_and_views()
+
+        assert source._get_creator_for_entity("my_db", "MY_TABLE") == "creator_user"
+
+    def test_column_extraction_set_lookup_is_case_insensitive_on_database(
+        self,
+    ) -> None:
+        """Incremental column extraction must hit the set when the watermark-populated
+        rows are uppercase but the SQLAlchemy reflection passes the user's lowercase
+        schema. Pre-fix this skipped every table with a "unchanged since watermark"
+        debug log.
+        """
+        watermark = datetime(2024, 6, 1)
+        source = _create_source_patched(
+            {"column_extraction_watermark": watermark.isoformat()}
+        )
+        mock_engine = MagicMock()
+        mock_engine.execute.return_value = [
+            _create_mock_table_entry(
+                "MY_DB",
+                "MY_TABLE",
+                alter_time=datetime(2024, 6, 2),
+            )
+        ]
+        with patch.object(source, "get_metadata_engine", return_value=mock_engine):
+            source.cache_tables_and_views()
+
+        assert source._tables_needing_column_extraction == {("my_db", "MY_TABLE")}
+
+        mock_dialect = MagicMock()
+        mock_dialect.default_schema_name = "MY_DB"
+        mock_dialect.get_schema_columns.return_value = {"MY_TABLE": []}
+
+        optimized_get_columns(
+            mock_dialect,
+            MagicMock(),
+            "MY_TABLE",
+            "MY_DB",
+            tables_cache=dict(source._tables_cache),
+            tables_needing_extraction=source._tables_needing_column_extraction,
+        )
+
+        # Reaches column extraction only if the (schema, table) tuple matched the set.
+        mock_dialect.get_schema_columns.assert_called_once()
+
+    def test_tables_query_uses_not_casespecific_on_database_filter(self) -> None:
+        """Guards against installations whose default session collation is
+        CASESPECIFIC — without (NOT CASESPECIFIC) the IN-list would not match the
+        uppercase DataBaseName rows in dbc.TablesV.
+        """
+        source = _create_source_patched({"databases": ["my_db"]})
+        query = source._build_tables_and_views_query()
+        assert "DataBaseName (NOT CASESPECIFIC) IN" in query
+        assert "'my_db' (NOT CASESPECIFIC)" in query


### PR DESCRIPTION
## Summary

Two related bugs in the Teradata source where `config.databases` was handled incorrectly. Both surface as silent failures (no error, no warning, no incorrect data — just outcomes the user did not intend).

### 1. Case-insensitive cache lookups on the database name

`dbc.TablesV` returns `DataBaseName` in Teradata's stored case (typically uppercase). The in-memory caches that hold metadata after discovery were keyed by whatever case the user wrote in `config.databases`, so lookups with a different case silently missed and the run produced zero datasets.

The same pattern bit three caches independently:

- `_tables_cache` — table/view discovery; lookups in `cached_loop_tables`, `cached_loop_views`, `cached_get_table_properties`, `optimized_get_columns`, `optimized_get_view_definition`. Effect when missed: zero datasets ingested for the configured databases.
- `_table_creator_cache` — ownership lookup in `_get_creator_for_entity`. Effect when missed: `extract_ownership: true` recipes silently emit no ownership.
- `_tables_needing_column_extraction` — incremental column extraction in `optimized_get_columns`. Effect when missed: `column_extraction_watermark` / `column_extraction_days_back` recipes skip column extraction for every table.

**Fix**: lowercase the database key on insert and on every read site. The cached `TeradataTable` value still holds the original case (used by URN minting, the `DATABASE \"…\"` session statement, and the audit-log SQL), so emitted URNs and downstream SQL are unchanged.

Also added `(NOT CASESPECIFIC)` to both sides of the `DataBaseName IN (...)` filter in `_build_tables_and_views_query`. The query previously relied on Teradata's default session collation being `NOT CASESPECIFIC`; installations that set a `CASESPECIFIC` session default (rare but seen in compliance-configured environments) would hit the same zero-datasets symptom. The audit-log query already uses this idiom — this brings the discovery query in line.

Fixed a latent defaultdict-subscript footgun in `optimized_get_columns` while I was there (was creating empty list entries on miss).

### 2. Phantom container URNs for databases that don't exist on the source

When `config.databases` (or `config.database`) listed a name that did not exist on the source, `get_inspectors()` still yielded an inspector for it. The base SQL source then emitted a database container URN for that name. A typo in the recipe produced a phantom container with no children and no warning.

**Fix**: filter user-supplied database names against `_tables_cache` (populated from `dbc.TablesV` during discovery). Names not in the cache are skipped and surfaced as a `report.warning` so the user can correct the recipe. Falls back to trusting the user list when discovery cannot validate (both `include_tables` and `include_views` false, or discovery produced an empty inventory).

## Test plan

- [x] New `TestCacheCaseInsensitivity` unit-test class (9 tests) — exercises every cache lookup site with a lowercase schema against an uppercase cache, plus asserts the `(NOT CASESPECIFIC)` form of the generated SQL.
- [x] New `TestConfiguredDatabasesValidation` unit-test class (3 tests) — verifies the existence check, the discovery-disabled fallback, and that the inspector-derived path is unaffected.
- [x] Updated `test_tables_query_database_filter` in `test_teradata_performance.py` to expect the new `(NOT CASESPECIFIC)` IN-list.
- [x] Added the `_tables_cache` isolation autouse fixture to `test_teradata_integration.py` and `test_teradata_performance.py` (already present in `test_teradata_source.py`) so the class-level cache is reset between tests under `--random-order`.
- [x] Full Teradata unit suite (135 tests) — passes in declared order and across 5 consecutive `--random-order` runs.
- [x] `testPerformance` (`tests/performance -m 'perf'`) — 5 passed, 1 skipped.
- [x] `./gradlew :metadata-ingestion:lintFix` clean; `ruff check`, `ruff format --check`, `mypy` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)