### PR TITLE
fix(search): compute SP diffs independently of mappingsDiff [PFP-3594]

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ReindexConfig.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ReindexConfig.java
@@ -244,35 +244,38 @@ public class ReindexConfig {
         super.requiresApplyMappings =
             !mappingsDiff.entriesDiffering().isEmpty()
                 || !mappingsDiff.entriesOnlyOnRight().isEmpty();
-        super.isPureStructuredPropertyAddition =
-            mappingsDiff
-                    .entriesDiffering()
-                    .keySet()
-                    .equals(Set.of(STRUCTURED_PROPERTY_MAPPING_FIELD))
-                || mappingsDiff
-                    .entriesOnlyOnRight()
-                    .keySet()
-                    .equals(Set.of(STRUCTURED_PROPERTY_MAPPING_FIELD));
         super.isPureMappingsAddition =
             super.requiresApplyMappings
                 && mappingsDiff.entriesDiffering().isEmpty()
                 && !mappingsDiff.entriesOnlyOnRight().isEmpty();
-        super.hasNewStructuredProperty =
-            (mappingsDiff.entriesDiffering().containsKey(STRUCTURED_PROPERTY_MAPPING_FIELD)
+        // Compute SP diffs independently of mappingsDiff because calculateMapDifference
+        // strips dynamic fields (including structuredProperties) from the comparison.
+        Pair<Long, Long> spDiffCount =
+            structuredPropertiesDiffCount(super.currentMappings, super.targetMappings);
+        super.hasNewStructuredProperty = spDiffCount.getSecond() > 0;
+        super.hasRemovedStructuredProperty = spDiffCount.getFirst() > 0;
+        // True when the only mapping change is adding structured properties.
+        // Covers both cases: SP visible in mappingsDiff (no dynamic flag) and
+        // SP stripped from mappingsDiff (dynamic=true, the common production case).
+        boolean onlySPInDiff =
+            (mappingsDiff.entriesDiffering().isEmpty()
+                    || mappingsDiff
+                        .entriesDiffering()
+                        .keySet()
+                        .equals(Set.of(STRUCTURED_PROPERTY_MAPPING_FIELD)))
+                && (mappingsDiff.entriesOnlyOnRight().isEmpty()
                     || mappingsDiff
                         .entriesOnlyOnRight()
-                        .containsKey(STRUCTURED_PROPERTY_MAPPING_FIELD))
-                && structuredPropertiesDiffCount(super.currentMappings, super.targetMappings)
-                        .getSecond()
-                    > 0;
-        super.hasRemovedStructuredProperty =
-            (mappingsDiff.entriesDiffering().containsKey(STRUCTURED_PROPERTY_MAPPING_FIELD)
+                        .keySet()
+                        .equals(Set.of(STRUCTURED_PROPERTY_MAPPING_FIELD)))
+                && (mappingsDiff.entriesDiffering().containsKey(STRUCTURED_PROPERTY_MAPPING_FIELD)
                     || mappingsDiff
-                        .entriesOnlyOnLeft()
-                        .containsKey(STRUCTURED_PROPERTY_MAPPING_FIELD))
-                && structuredPropertiesDiffCount(super.currentMappings, super.targetMappings)
-                        .getFirst()
-                    > 0;
+                        .entriesOnlyOnRight()
+                        .containsKey(STRUCTURED_PROPERTY_MAPPING_FIELD));
+        super.isPureStructuredPropertyAddition =
+            (onlySPInDiff || !super.requiresApplyMappings)
+                && super.hasNewStructuredProperty
+                && !super.hasRemovedStructuredProperty;
 
         // Detect new or modified non-structured-property fields that require DB backfill.
         // New fields: _reindex won't populate them (they didn't exist in the source index).

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/indexbuilder/ReindexConfigTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/indexbuilder/ReindexConfigTest.java
@@ -367,6 +367,62 @@ public class ReindexConfigTest {
   }
 
   @Test
+  void testStructuredPropertyAdditionWithDynamicTrue() {
+    // Verify new SP detection works when structuredProperties has dynamic=true,
+    // matching real V2MappingsBuilder output. This was a bug where calculateMapDifference
+    // stripped structuredProperties from the diff because it was dynamic.
+    Map<String, Object> currentMappings =
+        createMappingsWithDynamicStructuredProperties(
+            ImmutableMap.of("prop1", ImmutableMap.of("type", "text")));
+    Map<String, Object> targetMappings =
+        createMappingsWithDynamicStructuredProperties(
+            ImmutableMap.of(
+                "prop1", ImmutableMap.of("type", "text"),
+                "prop2", ImmutableMap.of("type", "keyword")));
+
+    ReindexConfig config =
+        ReindexConfig.builder()
+            .name(TEST_INDEX_NAME)
+            .exists(true)
+            .currentMappings(currentMappings)
+            .targetMappings(targetMappings)
+            .currentSettings(Settings.EMPTY)
+            .targetSettings(new HashMap<>())
+            .enableStructuredPropertiesReindex(true)
+            .build();
+
+    Assert.assertTrue(config.hasNewStructuredProperty());
+    Assert.assertTrue(config.isPureStructuredPropertyAddition());
+    Assert.assertFalse(config.hasRemovedStructuredProperty());
+  }
+
+  @Test
+  void testStructuredPropertyRemovalWithDynamicTrue() {
+    Map<String, Object> currentMappings =
+        createMappingsWithDynamicStructuredProperties(
+            ImmutableMap.of(
+                "prop1", ImmutableMap.of("type", "text"),
+                "prop2", ImmutableMap.of("type", "keyword")));
+    Map<String, Object> targetMappings =
+        createMappingsWithDynamicStructuredProperties(
+            ImmutableMap.of("prop1", ImmutableMap.of("type", "text")));
+
+    ReindexConfig config =
+        ReindexConfig.builder()
+            .name(TEST_INDEX_NAME)
+            .exists(true)
+            .currentMappings(currentMappings)
+            .targetMappings(targetMappings)
+            .currentSettings(Settings.EMPTY)
+            .targetSettings(new HashMap<>())
+            .enableStructuredPropertiesReindex(true)
+            .build();
+
+    Assert.assertFalse(config.hasNewStructuredProperty());
+    Assert.assertTrue(config.hasRemovedStructuredProperty());
+  }
+
+  @Test
   void testStructuredPropertyRemoval() {
     // Arrange
     Map<String, Object> currentMappings =
@@ -725,6 +781,22 @@ public class ReindexConfigTest {
     Map<String, Object> properties = new HashMap<>();
 
     Map<String, Object> structuredPropertyMapping = new HashMap<>();
+    structuredPropertyMapping.put(PROPERTIES_KEY, structuredProps);
+
+    properties.put(STRUCTURED_PROPERTY_MAPPING_FIELD, structuredPropertyMapping);
+    mappings.put(PROPERTIES_KEY, properties);
+
+    return mappings;
+  }
+
+  private Map<String, Object> createMappingsWithDynamicStructuredProperties(
+      Map<String, Object> structuredProps) {
+    Map<String, Object> mappings = new HashMap<>();
+    Map<String, Object> properties = new HashMap<>();
+
+    Map<String, Object> structuredPropertyMapping = new HashMap<>();
+    structuredPropertyMapping.put("type", "object");
+    structuredPropertyMapping.put("dynamic", true);
     structuredPropertyMapping.put(PROPERTIES_KEY, structuredProps);
 
     properties.put(STRUCTURED_PROPERTY_MAPPING_FIELD, structuredPropertyMapping);


### PR DESCRIPTION
## Summary

- Fixes perpetual reindexing when structured properties use `dynamic=true` (the common production case)
- `calculateMapDifference` strips dynamic fields from the comparison, making SP additions/removals invisible to `mappingsDiff`
- The fix computes `hasNewStructuredProperty` and `hasRemovedStructuredProperty` directly from `structuredPropertiesDiffCount()` instead of gating on `mappingsDiff` containment
- Derives `isPureStructuredPropertyAddition` from the independent SP diff plus a check that no non-SP mapping changes exist

Cherry-picked from acryldata/datahub-fork#8877.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://datahubproject.io/docs/contributing).
- [x] Links to the related issue: [PFP-3594](https://linear.app/acryl-data/issue/PFP-3594/perpetual-reindex-es8)
- [x] Tests added for dynamic=true structured property scenarios