### PR TITLE
docs(executor): add ingestion executor security and hardening guide

### DIFF
--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -1372,6 +1372,7 @@ module.exports = {
         // "smoke-test/test_resources/analytics_backfill/README",
         "docker/datahub-upgrade/README",
         "docs/docker/bundled-ingestion-venvs",
+        "docs/docker/ingestion-executor-security",
         "metadata-ingestion/adding-source",
         "docs/how/add-custom-ingestion-source",
         "docs/how/add-custom-data-platform",

--- a/docs/actions/actions/executor.md
+++ b/docs/actions/actions/executor.md
@@ -28,6 +28,10 @@ Specifically, changes to the `dataHubExecutionRequestInput` and `dataHubExecutio
 
 The executor runs ingestion in pre-built virtual environments under `DATAHUB_BUNDLED_VENV_PATH` (default `/opt/datahub/venvs`) **when the execution uses the bundled CLI version**—the same `acryl-datahub` version baked into the image at build time (`BUNDLED_CLI_VERSION`). To ship additional connectors or group installs, configure those environments **when building** the container image (for example `BUNDLED_VENV_PLUGINS` and `BUNDLED_CLI_VERSION`). See [Bundled ingestion virtual environments](/docs/docker/bundled-ingestion-venvs.md).
 
+## Security
+
+Anyone who can configure UI-driven ingestion sources influences recipe content executed by this Action. For production, combine least-privilege platform privileges with operational controls such as **locked** `datahub-actions` images, a **private Python package mirror**, and restricted outbound egress as described in [Ingestion executor security and hardening](/docs/docker/ingestion-executor-security.md).
+
 ## Action Quickstart
 
 ### Prerequisites

--- a/docs/docker/bundled-ingestion-venvs.md
+++ b/docs/docker/bundled-ingestion-venvs.md
@@ -53,6 +53,8 @@ Docker substitutes **`${BUNDLED_VENV_PLUGINS}`** from the parent image so you ne
 
 **Locked** (**`*-locked`**) images remove **`uv`**/**`pip`**—do not use them as the base for this flow.
 
+**Security hardening:** Trust boundaries for executor workloads, why locked images remove runtime package managers, and how to steer installs through an internal PyPI mirror are covered in [Ingestion executor security and hardening](/docs/docker/ingestion-executor-security.md).
+
 ### Remote Executor (`datahub-executor`)
 
 Same **`ENV`** + **`RUN`** pattern if your image includes **`/opt/datahub/bundled-venv-build/`**. Otherwise see below or ask DataHub Cloud for a custom image. Deploy help: [Configuring Remote Executor](/docs/managed-datahub/operator-guide/setting-up-remote-ingestion-executor.md).
@@ -79,5 +81,6 @@ Maintainers: **`docker/datahub-actions/Dockerfile`** + **`--build-arg`** (see Do
 
 ## Related documentation
 
+- [Ingestion executor security and hardening](/docs/docker/ingestion-executor-security.md)
 - [Ingestion Executor](/docs/actions/actions/executor.md)
 - [Docker development](/docs/docker/development.md)

--- a/docs/docker/ingestion-executor-security.md
+++ b/docs/docker/ingestion-executor-security.md
@@ -1,0 +1,32 @@
+---
+title: Ingestion executor security and hardening
+description: Trust boundaries for UI-driven ingestion, locked datahub-actions images, and controlling Python package indexes for the ingestion executor.
+---
+
+# Ingestion executor security and hardening
+
+The **ingestion executor** runs recipes submitted from DataHub (for example via managed ingestion sources). Treat it as infrastructure that executes **user-influenced configuration**: anyone who can **create or edit** those sources controls recipe fields the executor processes. Combine that with **least privilege** for platform privileges (for example **Manage Metadata Ingestion**, secrets access, and executor-related tokens) so only trusted operators can define scheduled or ad hoc runs.
+
+The executor Action itself requires a privileged token for secret resolution; see [Ingestion Executor](/docs/actions/actions/executor.md) for prerequisites.
+
+## Locked (`*-locked`) images
+
+**Locked** variants of **`datahub-actions`** (tags such as **`*-locked`**) are intended for deployments that rely on **pre-built bundled virtual environments** under **`DATAHUB_BUNDLED_VENV_PATH`** (default **`/opt/datahub/venvs`**) instead of installing connectors at container runtime. In those images, **`pip`** and **`uv`** are removed from the runtime image, and default package index URLs are set to unusable localhost endpoints as defense in depth—see the **`final-locked`** stage in **`docker/datahub-actions/Dockerfile`** in the repository.
+
+**Tradeoff:** You cannot extend a locked image at runtime with arbitrary **`pip install`**. Add connectors by **rebuilding** the image with the bundled venv builder and variables such as **`BUNDLED_VENV_PLUGINS`** and **`BUNDLED_CLI_VERSION`**. Do not use locked images as the base for “append plugins via Dockerfile **RUN** pip” flows that expect a package manager in the final layer; see [Bundled ingestion virtual environments](/docs/docker/bundled-ingestion-venvs.md).
+
+Remote Executor (**`datahub-executor`**) images follow the same bundled-venv contract where applicable; deployment details: [Configuring Remote Executor](/docs/managed-datahub/operator-guide/setting-up-remote-ingestion-executor.md).
+
+## Package index control (private mirror / PyPI proxy)
+
+Even when connectors are resolved from PyPI, **controlling which indexes the environment can use** reduces supply-chain risk: route installs through an **internal mirror** (for example Artifactory, Nexus, or DevPI), allow only approved packages, and restrict **outbound egress** so executors cannot reach arbitrary third-party index URLs.
+
+When **building** custom images from the DataHub Dockerfiles, you can steer installs at build time using mirror-related build arguments and environment variables set on the Python base image (for example **`PIP_MIRROR_URL`**, **`PIP_EXTRA_INDEX_URL`**, and **`UV_INDEX_URL`** in **`docker/datahub-actions/Dockerfile`**). Align runtime or orchestration-level networking with the same policy so executor workloads cannot bypass your mirror.
+
+Non-locked images may still expose package managers at runtime; **locked** images aim to avoid relying on runtime installers altogether. Operational controls (mirror, egress, RBAC) remain **defense in depth** and should not replace reviewing trust boundaries above.
+
+## Related documentation
+
+- [Bundled ingestion virtual environments](/docs/docker/bundled-ingestion-venvs.md)
+- [Ingestion Executor](/docs/actions/actions/executor.md)
+- [Configuring Remote Executor](/docs/managed-datahub/operator-guide/setting-up-remote-ingestion-executor.md)

--- a/docs/managed-datahub/operator-guide/setting-up-remote-ingestion-executor.md
+++ b/docs/managed-datahub/operator-guide/setting-up-remote-ingestion-executor.md
@@ -50,7 +50,7 @@ Before deploying a Remote Executor, ensure you have the following:
 
    - `https://<your-company>.acryl.io/*` — DataHub GMS API
    - `https://sqs.*.amazonaws.com/*` — AWS SQS, used for remote execution task dispatch
-   - A Python package index (e.g., `https://pypi.org`) or an alternate internal mirror, to download pip packages required by ingestion sources
+   - A Python package index—for production, prefer an **internal mirror** (with egress or firewall rules that enforce your supply-chain policy rather than open access to arbitrary public indexes). Details: [Ingestion executor security and hardening](/docs/docker/ingestion-executor-security.md).
    - A container registry hosting the DataHub Remote Executor image (e.g., AWS ECR or `docker.datahub.com`)
 
 4. **Registry Access**


### PR DESCRIPTION
Document trust boundaries, locked datahub-actions images, and PyPI mirror controls. Link from executor, bundled venvs, remote executor, and sidebars.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
