### PR TITLE
fix(search): skip search hits with missing/invalid URN instead of crashing

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/SearchRequestHandler.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/SearchRequestHandler.java
@@ -457,8 +457,18 @@ public class SearchRequestHandler extends BaseRequestHandler {
 
     List<SearchEntity> results = new ArrayList<>(searchHits.length);
     for (SearchHit hit : searchHits) {
-      // Build base SearchEntity
-      SearchEntity entity = getResult(hit);
+      // Build base SearchEntity — skip hits with missing/invalid URN rather than crashing
+      SearchEntity entity;
+      try {
+        entity = getResult(hit);
+      } catch (Exception e) {
+        log.warn(
+            "Skipping scroll hit with invalid or missing URN. Index: {}, ID: {}. Error: {}",
+            hit.getIndex(),
+            hit.getId(),
+            e.getMessage());
+        continue;
+      }
       // Compute per-hit scrollId using this hit's sort values
       Object[] sort = hit.getSortValues();
       String perHitScrollId =
@@ -607,7 +617,9 @@ public class SearchRequestHandler extends BaseRequestHandler {
   }
 
   /**
-   * Gets list of entities returned in the search response
+   * Gets list of entities returned in the search response, skipping any hits with missing or
+   * invalid URN fields (e.g. documents created by older bootstrap code) instead of crashing the
+   * entire search operation.
    *
    * @param searchResponse the raw search response from search engine
    * @return List of search entities
@@ -615,11 +627,23 @@ public class SearchRequestHandler extends BaseRequestHandler {
   @Nonnull
   private Collection<SearchEntity> getRestrictedResults(
       @Nonnull OperationContext opContext, @Nonnull SearchResponse searchResponse) {
-    return ESAccessControlUtil.restrictSearchResult(
-        opContext,
+    List<SearchEntity> results =
         Arrays.stream(searchResponse.getHits().getHits())
-            .map(this::getResult)
-            .collect(Collectors.toList()));
+            .flatMap(
+                hit -> {
+                  try {
+                    return Stream.of(getResult(hit));
+                  } catch (Exception e) {
+                    log.warn(
+                        "Skipping search hit with invalid or missing URN. Index: {}, ID: {}. Error: {}",
+                        hit.getIndex(),
+                        hit.getId(),
+                        e.getMessage());
+                    return Stream.empty();
+                  }
+                })
+            .collect(Collectors.toList());
+    return ESAccessControlUtil.restrictSearchResult(opContext, results);
   }
 
   @Nonnull


### PR DESCRIPTION
## Summary

Fixes #13181

When a document in Elasticsearch is missing the `urn` field — such as the `datahub-gc` bootstrap ingestion source document that was persisted in v1.0.0 — the call to `getResult(hit)` throws an exception. This exception propagates up and crashes the **entire** search/scroll operation, making the Ingestion Sources page completely fail to load for affected deployments.

### Root cause

`UrnExtractionUtils.extractUrnFromSearchHit()` throws when the `urn` field is absent or null. This exception was not caught in either:
- `getRestrictedResults()` — used by the standard search path
- `extractScrollResult()` — used by the scroll/pagination path

### Fix

Wrap the `getResult(hit)` call in a per-hit try-catch in both methods:
- `getRestrictedResults()`: switch from `.map(this::getResult)` to `.flatMap(...)` with try-catch, emitting an empty stream for bad hits
- `extractScrollResult()`: wrap in try-catch with `continue` to skip bad hits

Bad hits are skipped with a `warn`-level log including the index and document ID so operators can identify and clean up the offending documents.

### Impact

- **No regression**: valid documents are returned normally
- **Affected deployments**: Ingestion Sources page becomes functional again without requiring manual index cleanup
- **Operator visibility**: warning log identifies the bad document for optional cleanup

## Test plan

- [ ] Deploy against an Elasticsearch index containing a document missing the `urn` field
- [ ] Verify the Ingestion Sources page loads successfully and lists valid sources
- [ ] Verify a `WARN` log is emitted identifying the skipped document
- [ ] Verify existing unit tests for `SearchRequestHandler` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)