### PR TITLE
fix(ingest/trino): lowercase data_type before TRINO_SQL_TYPES_MAP lookup

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/sql_types.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/sql_types.py
@@ -243,6 +243,10 @@ def resolve_postgres_modified_type(type_string: str) -> Any:
 
 
 def resolve_trino_modified_type(type_string: str) -> Any:
+    # Trino is case-insensitive for type names, and TRINO_SQL_TYPES_MAP keys are
+    # all lowercase. dbt manifest `data_type` strings frequently arrive uppercase
+    # (e.g. "VARCHAR(10)", "TIMESTAMP(6) WITH TIME ZONE"). See issue #17078.
+    type_string = type_string.lower()
     # for cases like timestamp(3), decimal(10,0), row(...)
     match = re.match(r"([a-zA-Z]+)\(.+\)", type_string)
     if match:

--- a/metadata-ingestion/tests/unit/test_sql_types.py
+++ b/metadata-ingestion/tests/unit/test_sql_types.py
@@ -56,6 +56,26 @@ def test_resolve_trino_modified_type(data_type, expected_data_type):
 @pytest.mark.parametrize(
     "data_type, expected_data_type",
     [
+        # Trino is case-insensitive for type names; dbt manifest `data_type` strings
+        # can arrive uppercase or mixed-case. See issue #17078.
+        ("VARCHAR(10)", "varchar"),
+        ("DECIMAL(10,2)", "decimal"),
+        ("TIMESTAMP(6) WITH TIME ZONE", "timestamp"),
+        ("TIMESTAMP", "timestamp"),
+        ("BIGINT", "bigint"),
+        ("Varchar(20)", "varchar"),
+    ],
+)
+def test_resolve_trino_modified_type_case_insensitive(data_type, expected_data_type):
+    assert (
+        resolve_trino_modified_type(data_type)
+        == TRINO_SQL_TYPES_MAP[expected_data_type]
+    )
+
+
+@pytest.mark.parametrize(
+    "data_type, expected_data_type",
+    [
         ("boolean", "boolean"),
         ("tinyint", "tinyint"),
         ("smallint", "smallint"),


### PR DESCRIPTION
### Description

`resolve_trino_modified_type` in `metadata-ingestion/src/datahub/ingestion/source/sql/sql_types.py` does a case-sensitive dict lookup against `TRINO_SQL_TYPES_MAP`, whose keys are all lowercase. dbt manifest `data_type` strings on the Trino path frequently arrive uppercase (e.g. `VARCHAR(10)`, `TIMESTAMP(6) WITH TIME ZONE`, the same case convention as Trino DDL), so a single such column aborts the entire ingestion pipeline with `KeyError`. This only surfaces on the manifest-fallback path (node missing from `catalog.json`), which is why catalogued projects do not hit it.

Trino itself is case-insensitive for type names. Lowercasing the input before the regex/dict lookup mirrors the existing `column_type.upper()` treatment for the Snowflake branch in `resolve_sql_type`.

### Related Issue

Closes #17078

### How was this tested?

Added a parametrized unit test `test_resolve_trino_modified_type_case_insensitive` in `tests/unit/test_sql_types.py` covering simple (`VARCHAR(10)`, `DECIMAL(10,2)`), bare (`TIMESTAMP`, `BIGINT`), mixed-case (`Varchar(20)`), and the exact failing input from the issue (`TIMESTAMP(6) WITH TIME ZONE`). All six cases raise `KeyError` on master and pass with the fix; the existing `test_resolve_trino_modified_type` parametrized cases continue to pass unchanged.
