### PR TITLE
fix(ingest/snowflake): test snowflake unit tests

### DIFF
--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_source.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_source.py
@@ -584,6 +584,10 @@ def test_test_connection_capability_all_success(mock_connect):
             SourceCapability.DATA_PROFILING,
             SourceCapability.DESCRIPTIONS,
             SourceCapability.LINEAGE_COARSE,
+            SourceCapability.LINEAGE_FINE,
+            SourceCapability.USAGE_STATS,
+            SourceCapability.OPERATION_CAPTURE,
+            SourceCapability.TAGS,
         ],
     )
 


### PR DESCRIPTION
# Summary
  
  test_test_connection_capability_all_success was only asserting a subset of the capabilities that should succeed when a role has full access to
  SNOWFLAKE.ACCOUNT_USAGE views. After #17366 added OPERATION_CAPTURE to SnowflakeV2Source's declared capabilities, the new capability was emitted by test_connection
  but not covered by the test — making the test blind to regressions in that code path.

  This PR adds the four missing capabilities (LINEAGE_FINE, USAGE_STATS, OPERATION_CAPTURE, TAGS) to the success assertions. The mock already grants access to the
  SNOWFLAKE.ACCOUNT_USAGE.* views that trigger all four, so no mock changes are needed.
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)