### PR TITLE
docs: replace generic concept mappings with source-specific ones for Snowflake, Databricks, BigQuery, Redshift, and Postgres

### DIFF
--- a/metadata-ingestion/docs/sources/bigquery/README.md
+++ b/metadata-ingestion/docs/sources/bigquery/README.md
@@ -6,12 +6,18 @@ The DataHub integration for BigQuery covers core metadata entities such as datas
 
 ## Concept Mapping
 
-While the specific concept mapping is still pending, this shows the generic concept mapping in DataHub.
-
-| Source Concept                                           | DataHub Concept              | Notes                                                            |
-| -------------------------------------------------------- | ---------------------------- | ---------------------------------------------------------------- |
-| Platform/account/project scope                           | Platform Instance, Container | Organizes assets within the platform context.                    |
-| Core technical asset (for example table/view/topic/file) | Dataset                      | Primary ingested technical asset.                                |
-| Schema fields / columns                                  | SchemaField                  | Included when schema extraction is supported.                    |
-| Ownership and collaboration principals                   | CorpUser, CorpGroup          | Emitted by modules that support ownership and identity metadata. |
-| Dependencies and processing relationships                | Lineage edges                | Available when lineage extraction is supported and enabled.      |
+| BigQuery Concept           | DataHub Entity (Subtype)               | Notes                                                                                                                        |
+| -------------------------- | -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| GCP Project                | Platform Instance, Container (PROJECT) | Project ID is used as both the platform instance and the top-level container.                                                |
+| Dataset                    | Container (DATASET)                    | Nested under its Project container. Includes location and labels.                                                            |
+| Table                      | Dataset (TABLE)                        | Regular and partitioned tables. Schema, descriptions, PKs/FKs, partition keys, clustering columns, and labels are extracted. |
+| Sharded Table              | Dataset (SHARDED TABLE)                | Tables with a `_yyyymmdd` suffix pattern; grouped under a shared URN prefix.                                                 |
+| External Table             | Dataset (EXTERNAL TABLE)               | Includes source format, URIs, and compression properties.                                                                    |
+| Table Snapshot             | Dataset (BIGQUERY TABLE SNAPSHOT)      | Identified by name pattern `{table}@{timestamp_ms}`.                                                                         |
+| View                       | Dataset (VIEW)                         | SQL definition captured in ViewProperties. `materialized=false`.                                                             |
+| Materialized View          | Dataset (VIEW)                         | SQL definition captured. `materialized=true` in ViewProperties.                                                              |
+| Column / field             | SchemaField                            | Includes partition key, clustering key, PKs, FKs, and policy tags where available.                                           |
+| Label                      | Tag                                    | Table, view, and dataset labels captured as tags when `capture_*_label_as_tag` is enabled.                                   |
+| Policy tag (Data Catalog)  | Tag                                    | Column-level policy tags extracted when `extract_policy_tags_from_catalog` is enabled.                                       |
+| Table / column lineage     | Lineage edges                          | From view definitions and audit log query history.                                                                           |
+| Query operations and usage | DatasetUsageStatistics, Operation      | Per-dataset and per-column access counts extracted from audit logs.                                                          |

--- a/metadata-ingestion/docs/sources/databricks/README.md
+++ b/metadata-ingestion/docs/sources/databricks/README.md
@@ -30,12 +30,20 @@ For a deeper look at how to think about DataHub within and across your Databrick
 
 ## Concept Mapping
 
-While the specific concept mapping is still pending, this shows the generic concept mapping in DataHub.
-
-| Source Concept                                           | DataHub Concept              | Notes                                                            |
-| -------------------------------------------------------- | ---------------------------- | ---------------------------------------------------------------- |
-| Platform/account/project scope                           | Platform Instance, Container | Organizes assets within the platform context.                    |
-| Core technical asset (for example table/view/topic/file) | Dataset                      | Primary ingested technical asset.                                |
-| Schema fields / columns                                  | SchemaField                  | Included when schema extraction is supported.                    |
-| Ownership and collaboration principals                   | CorpUser, CorpGroup          | Emitted by modules that support ownership and identity metadata. |
-| Dependencies and processing relationships                | Lineage edges                | Available when lineage extraction is supported and enabled.      |
+| Databricks Concept                        | DataHub Entity (Subtype)          | Notes                                                                                              |
+| ----------------------------------------- | --------------------------------- | -------------------------------------------------------------------------------------------------- |
+| Workspace / Account                       | Platform Instance                 | Top-level scope; all URNs include the configured platform instance.                                |
+| Metastore                                 | Container (METASTORE)             | Top-level Unity Catalog container.                                                                 |
+| Catalog                                   | Container (CATALOG)               | Namespace within a metastore. Hive Metastore is ingested as a special catalog type.                |
+| Schema                                    | Container (SCHEMA)                | Nested under its Catalog container.                                                                |
+| Table (managed, external, Delta, Iceberg) | Dataset (TABLE)                   | All non-view table types including streaming tables. Schema, descriptions, and tags are extracted. |
+| View / Materialized View                  | Dataset (VIEW)                    | View definition is captured.                                                                       |
+| Notebook                                  | Dataset (NOTEBOOK)                | Ingested when `include_notebooks` is enabled. Lineage to and from tables is extracted.             |
+| ML Model Group                            | MLModelGroup                      | Represents an MLflow Registered Model.                                                             |
+| ML Model Version                          | MLModel                           | Each registered version with run metrics, parameters, tags, and aliases.                           |
+| Column / field                            | SchemaField                       | Column type, nullability, and descriptions are extracted.                                          |
+| User / Service Principal                  | CorpUser                          | Ownership; service principals mapped via display name to user URN.                                 |
+| Group                                     | CorpGroup                         | Ownership mapped as `urn:li:corpGroup:{group_name}`.                                               |
+| Unity Catalog Tag                         | Tag                               | Extracted at catalog, schema, table, and column levels.                                            |
+| Table / column lineage                    | Lineage edges                     | From view definitions and SQL query history. Notebook-to-table lineage also extracted.             |
+| Query operations and usage                | DatasetUsageStatistics, Operation | Per-dataset query counts and DML operation metrics.                                                |

--- a/metadata-ingestion/docs/sources/postgres/README.md
+++ b/metadata-ingestion/docs/sources/postgres/README.md
@@ -6,12 +6,14 @@ The DataHub integration for Postgres covers core metadata entities such as datas
 
 ## Concept Mapping
 
-While the specific concept mapping is still pending, this shows the generic concept mapping in DataHub.
-
-| Source Concept                                           | DataHub Concept              | Notes                                                            |
-| -------------------------------------------------------- | ---------------------------- | ---------------------------------------------------------------- |
-| Platform/account/project scope                           | Platform Instance, Container | Organizes assets within the platform context.                    |
-| Core technical asset (for example table/view/topic/file) | Dataset                      | Primary ingested technical asset.                                |
-| Schema fields / columns                                  | SchemaField                  | Included when schema extraction is supported.                    |
-| Ownership and collaboration principals                   | CorpUser, CorpGroup          | Emitted by modules that support ownership and identity metadata. |
-| Dependencies and processing relationships                | Lineage edges                | Available when lineage extraction is supported and enabled.      |
+| PostgreSQL Concept                  | DataHub Entity (Subtype)          | Notes                                                                                                                                    |
+| ----------------------------------- | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| Database                            | Container (DATABASE)              | Top-level namespace. Multiple databases can be ingested in one run.                                                                      |
+| Schema                              | Container (SCHEMA)                | Nested under its Database container.                                                                                                     |
+| Table                               | Dataset (TABLE)                   | Includes regular, foreign, temporary, and unlogged tables.                                                                               |
+| View / Materialized View            | Dataset (VIEW)                    | View definition is captured. No subtype distinction between standard and materialized views.                                             |
+| Stored Procedure                    | DataJob (STORED PROCEDURE)        | Grouped into a DataFlow (PROCEDURES CONTAINER) per schema. Extracted via `pg_proc`.                                                      |
+| Column / field                      | SchemaField                       | Column type, nullability, and comments (as descriptions) are extracted.                                                                  |
+| Query executor (pg_stat_statements) | CorpUser                          | User attribution for lineage and usage statistics. Requires `pg_stat_statements` extension.                                              |
+| View / query lineage                | Lineage edges                     | View-based lineage via `pg_depend`; query-based lineage via `pg_stat_statements` (requires PostgreSQL 13+ and `pg_read_all_stats` role). |
+| Query operations and usage          | DatasetUsageStatistics, Operation | From `pg_stat_statements`. Requires `include_query_lineage` and `include_usage_statistics` to be enabled.                                |

--- a/metadata-ingestion/docs/sources/redshift/README.md
+++ b/metadata-ingestion/docs/sources/redshift/README.md
@@ -6,12 +6,17 @@ The DataHub integration for Redshift covers core metadata entities such as datas
 
 ## Concept Mapping
 
-While the specific concept mapping is still pending, this shows the generic concept mapping in DataHub.
-
-| Source Concept                                           | DataHub Concept              | Notes                                                            |
-| -------------------------------------------------------- | ---------------------------- | ---------------------------------------------------------------- |
-| Platform/account/project scope                           | Platform Instance, Container | Organizes assets within the platform context.                    |
-| Core technical asset (for example table/view/topic/file) | Dataset                      | Primary ingested technical asset.                                |
-| Schema fields / columns                                  | SchemaField                  | Included when schema extraction is supported.                    |
-| Ownership and collaboration principals                   | CorpUser, CorpGroup          | Emitted by modules that support ownership and identity metadata. |
-| Dependencies and processing relationships                | Lineage edges                | Available when lineage extraction is supported and enabled.      |
+| Redshift Concept            | DataHub Entity (Subtype)          | Notes                                                                                                               |
+| --------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Cluster / Account           | Platform Instance                 | Top-level scope; all URNs include the configured platform instance.                                                 |
+| Database                    | Container (DATABASE)              | Top-level namespace. Shared databases (datashares) are also ingested.                                               |
+| Schema                      | Container (SCHEMA)                | Nested under its Database container. External schemas (Glue, Hive, PostgreSQL) include external platform metadata.  |
+| Table                       | Dataset (TABLE)                   | Regular, foreign, and external tables (Redshift Spectrum). Custom properties include `dist_style` and `table_type`. |
+| View                        | Dataset (VIEW)                    | View definition is captured.                                                                                        |
+| Materialized View           | Dataset (VIEW)                    | `materialized=true` in ViewProperties.                                                                              |
+| Late Binding View           | Dataset (VIEW)                    | Columns extracted from `pg_get_late_binding_view_cols()`.                                                           |
+| External Table (Spectrum)   | Dataset (TABLE)                   | Includes location, input/output format, and SerDe parameters.                                                       |
+| Column / field              | SchemaField                       | `dist_key` and `sort_key` columns are tagged accordingly.                                                           |
+| User (schema / table owner) | CorpUser                          | Extracted when `extract_ownership` is enabled.                                                                      |
+| Table / column lineage      | Lineage edges                     | From STL_SCAN, view dependencies, COPY/UNLOAD commands, ALTER TABLE RENAME, and datashare references.               |
+| Query operations and usage  | DatasetUsageStatistics, Operation | From STL_SCAN (provisioned) or SYS_QUERY_DETAIL (serverless).                                                       |

--- a/metadata-ingestion/docs/sources/snowflake/README.md
+++ b/metadata-ingestion/docs/sources/snowflake/README.md
@@ -30,7 +30,7 @@ Read on if you are interested in ingesting Snowflake metadata using the **datahu
 
 ## Concept Mapping
 
-| Snowflake Concept               | DataHub Concept                                              | Notes                                                                                                                               |
+| Snowflake Concept               | DataHub Entity (Subtype)                                     | Notes                                                                                                                               |
 | ------------------------------- | ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
 | Account                         | Platform Instance                                            | Top-level scope; all URNs include the configured platform instance.                                                                 |
 | Database                        | Container (DATABASE)                                         | Top-level namespace. Ingested with description, tags, and Snowsight URL.                                                            |

--- a/metadata-ingestion/docs/sources/snowflake/README.md
+++ b/metadata-ingestion/docs/sources/snowflake/README.md
@@ -30,12 +30,24 @@ Read on if you are interested in ingesting Snowflake metadata using the **datahu
 
 ## Concept Mapping
 
-While the specific concept mapping is still pending, this shows the generic concept mapping in DataHub.
-
-| Source Concept                                           | DataHub Concept              | Notes                                                            |
-| -------------------------------------------------------- | ---------------------------- | ---------------------------------------------------------------- |
-| Platform/account/project scope                           | Platform Instance, Container | Organizes assets within the platform context.                    |
-| Core technical asset (for example table/view/topic/file) | Dataset                      | Primary ingested technical asset.                                |
-| Schema fields / columns                                  | SchemaField                  | Included when schema extraction is supported.                    |
-| Ownership and collaboration principals                   | CorpUser, CorpGroup          | Emitted by modules that support ownership and identity metadata. |
-| Dependencies and processing relationships                | Lineage edges                | Available when lineage extraction is supported and enabled.      |
+| Snowflake Concept               | DataHub Concept                                              | Notes                                                                                                                               |
+| ------------------------------- | ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Account                         | Platform Instance                                            | Top-level scope; all URNs include the configured platform instance.                                                                 |
+| Database                        | Container (DATABASE)                                         | Top-level namespace. Ingested with description, tags, and Snowsight URL.                                                            |
+| Schema                          | Container (SCHEMA)                                           | Nested under its Database container.                                                                                                |
+| Table                           | Dataset (TABLE)                                              | Includes regular, Iceberg, and hybrid tables. Schema, PKs/FKs, tags, and descriptions are extracted.                                |
+| Dynamic Table                   | Dataset (DYNAMIC TABLE)                                      | Includes target lag, SQL definition, and lineage to source tables.                                                                  |
+| View                            | Dataset (VIEW)                                               | Standard, materialized, and secure views. View definition is captured.                                                              |
+| Semantic View                   | Dataset (SEMANTIC VIEW)                                      | Columns classified as DIMENSION, FACT, or METRIC. Column-level lineage to physical tables is extracted.                             |
+| Stream                          | Dataset (SNOWFLAKE STREAM)                                   | Change-data-capture stream. Adds `METADATA$ACTION`, `METADATA$ISUPDATE`, `METADATA$ROW_ID` columns and lineage to the source table. |
+| External Table                  | Dataset (TABLE)                                              | Lineage to the backing cloud storage location is emitted when available.                                                            |
+| Internal Stage                  | Container (SNOWFLAKE STAGE) + Dataset (SNOWFLAKE STAGE DATA) | Emits both a Container (organizational) and a Dataset (for the resident data).                                                      |
+| External Stage                  | Container (SNOWFLAKE STAGE)                                  | Container only; the backing cloud storage asset (S3/GCS/Azure) is referenced via lineage.                                           |
+| Task                            | DataFlow (SNOWFLAKE TASK GROUP) + DataJob (SNOWFLAKE TASK)   | One DataFlow per schema; each task is a DataJob. Predecessor relationships appear as DataJob inputs.                                |
+| Pipe                            | DataFlow (SNOWFLAKE PIPE GROUP) + DataJob (SNOWFLAKE PIPE)   | One DataFlow per schema; each pipe is a DataJob linking a stage to a target table via lineage.                                      |
+| Streamlit App                   | Dashboard (STREAMLIT)                                        | App name, owner, and Snowsight URL captured as custom properties.                                                                   |
+| Column / field                  | SchemaField                                                  | Column type, nullability, descriptions, and tags are extracted where available.                                                     |
+| Role                            | CorpGroup                                                    | Ownership roles are mapped to `urn:li:corpGroup:{role_name}`.                                                                       |
+| Tag                             | Tag or Structured Property                                   | Controlled by `extract_tags` config. Tags support database/schema/table/column inheritance.                                         |
+| Table- and column-level lineage | Lineage edges                                                | Extracted from view definitions, dynamic table definitions, and SQL query history.                                                  |
+| Query operations and usage      | DatasetUsageStatistics, Operation                            | Per-dataset query counts, user access patterns, and DML operation metrics.                                                          |


### PR DESCRIPTION
## Summary

Five connector READMEs previously contained an identical placeholder concept mapping table with a note saying "the specific concept mapping is still pending." This PR replaces all five with accurate, source-specific tables derived from the actual ingestion source code.

- **Snowflake**: account/database/schema containers, table/dynamic-table/view/semantic-view/stream/external-table datasets, internal and external stage containers, task and pipe DataFlow/DataJob pairs, Streamlit dashboards, role→CorpGroup ownership, tag inheritance, lineage, usage
- **Databricks**: workspace→Platform Instance, metastore/catalog/schema containers, table/view/notebook datasets, MLModelGroup and MLModel entities, CorpUser/CorpGroup ownership, Unity Catalog tag levels, notebook lineage, usage
- **BigQuery**: GCP project as both Platform Instance and container, dataset containers, table/sharded-table/external-table/snapshot/view datasets, label and Data Catalog policy tag handling, audit-log lineage and usage
- **Redshift**: database/schema containers (shared databases and external schemas included), table/view/materialized-view/late-binding-view/external-table datasets, `dist_key`/`sort_key` column tags, owner→CorpUser, lineage sources (STL_SCAN, COPY/UNLOAD, datashares), serverless vs provisioned usage
- **Postgres**: database/schema containers, table/view datasets, stored procedures as DataJob in a PROCEDURES CONTAINER DataFlow, `pg_stat_statements`-based lineage and usage with version/role requirements noted

## Test plan

- [x] Docs render correctly — run `./gradlew :docs-website:yarnStart` and navigate to each connector page
- [x] Markdown formatting passes — `./gradlew :datahub-web-react:mdPrettierCheck`
- [x] Manual validation on vercel docs deployment

https://claude.ai/code/session_01PpsWMRGA9qXJMWsof1acYZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpsWMRGA9qXJMWsof1acYZ)_