### PR TITLE
fix(re-index-loop): prevent perpetual ES8 reindex loop (PFP-3594)

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/client/shim/impl/Es7CompatibilitySearchClientShim.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/client/shim/impl/Es7CompatibilitySearchClientShim.java
@@ -15,6 +15,12 @@ import org.opensearch.client.RequestOptions;
  * Implementation of SearchClientShim using the Elasticsearch 7.17 REST High Level Client. This
  * implementation supports: - Elasticsearch 7.x clusters - OpenSearch 2.x clusters (which maintain
  * ES 7.x API compatibility)
+ *
+ * <p><b>Mapping behavior:</b> this class intentionally does not override {@code
+ * partialNgramConfig()} — ES7 round-trips {@code doc_values: false} on {@code search_as_you_type}
+ * fields identically to OpenSearch 2.x, so it inherits {@link
+ * OpenSearch2SearchClientShim#PARTIAL_NGRAM_CONFIG} (the legacy map). If OS2's mapping behavior
+ * ever diverges from ES7, override here.
  */
 @Slf4j
 public class Es7CompatibilitySearchClientShim extends OpenSearch2SearchClientShim {

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/client/shim/impl/Es8SearchClientShim.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/client/shim/impl/Es8SearchClientShim.java
@@ -83,6 +83,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
 import com.linkedin.metadata.search.elasticsearch.client.shim.ElasticSearchClientShim;
 import com.linkedin.metadata.search.elasticsearch.client.shim.builder.es8.Es8KnnQueryBuilder;
 import com.linkedin.metadata.search.elasticsearch.client.shim.builder.es8.Es8SemanticIndexMapper;
@@ -1421,6 +1422,22 @@ public class Es8SearchClientShim extends AbstractBulkProcessorShim<BulkIngester<
   @Override
   public SearchEngineType getEngineType() {
     return engineType;
+  }
+
+  /**
+   * ES8+ silently strips {@code doc_values: false} from {@code search_as_you_type} fields on
+   * round-trip. Including it in the authored mapping creates a permanent diff against what the
+   * cluster returns and triggers a reindex on every system update cycle, so we omit it here.
+   */
+  public static final Map<String, String> PARTIAL_NGRAM_CONFIG =
+      ImmutableMap.of(
+          "type", "search_as_you_type",
+          "max_shingle_size", "4");
+
+  @Nonnull
+  @Override
+  public Map<String, String> partialNgramConfig() {
+    return PARTIAL_NGRAM_CONFIG;
   }
 
   @Nonnull

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/client/shim/impl/OpenSearch2SearchClientShim.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/client/shim/impl/OpenSearch2SearchClientShim.java
@@ -3,6 +3,7 @@ package com.linkedin.metadata.search.elasticsearch.client.shim.impl;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
 import com.linkedin.metadata.search.elasticsearch.client.shim.OpenSearchClientShim;
 import com.linkedin.metadata.search.elasticsearch.client.shim.builder.opensearch2.OpenSearch2KnnQueryBuilder;
 import com.linkedin.metadata.search.elasticsearch.client.shim.builder.opensearch2.OpenSearch2SemanticIndexMapper;
@@ -528,6 +529,23 @@ public class OpenSearch2SearchClientShim extends AbstractBulkProcessorShim<BulkP
   @Override
   public SearchEngineType getEngineType() {
     return engineType;
+  }
+
+  /**
+   * OpenSearch 2.x and Elasticsearch 7.17 (via {@link Es7CompatibilitySearchClientShim}, which
+   * extends this class) persist {@code doc_values: false} on {@code search_as_you_type} fields, so
+   * the authored mapping must include it to round-trip cleanly against {@code GetMapping}.
+   */
+  public static final Map<String, String> PARTIAL_NGRAM_CONFIG =
+      ImmutableMap.of(
+          "type", "search_as_you_type",
+          "max_shingle_size", "4",
+          "doc_values", "false");
+
+  @Nonnull
+  @Override
+  public Map<String, String> partialNgramConfig() {
+    return PARTIAL_NGRAM_CONFIG;
   }
 
   @Nonnull

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/index/entity/v2/V2MappingsBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/index/entity/v2/V2MappingsBuilder.java
@@ -41,15 +41,10 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class V2MappingsBuilder implements MappingsBuilder {
 
-  private static final Map<String, String> PARTIAL_NGRAM_CONFIG =
-      ImmutableMap.of(
-          TYPE, "search_as_you_type",
-          MAX_SHINGLE_SIZE, "4",
-          DOC_VALUES, "false");
+  private final Map<String, String> partialNgramConfig;
 
-  private static Map<String, String> getPartialNgramConfigWithOverrides(
-      Map<String, String> overrides) {
-    return Stream.concat(PARTIAL_NGRAM_CONFIG.entrySet().stream(), overrides.entrySet().stream())
+  private Map<String, String> getPartialNgramConfigWithOverrides(Map<String, String> overrides) {
+    return Stream.concat(partialNgramConfig.entrySet().stream(), overrides.entrySet().stream())
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
@@ -75,8 +70,11 @@ public class V2MappingsBuilder implements MappingsBuilder {
 
   private final EntityIndexConfiguration entityIndexConfiguration;
 
-  public V2MappingsBuilder(@Nonnull EntityIndexConfiguration entityIndexConfiguration) {
+  public V2MappingsBuilder(
+      @Nonnull final EntityIndexConfiguration entityIndexConfiguration,
+      @Nonnull final Map<String, String> partialNgramConfig) {
     this.entityIndexConfiguration = entityIndexConfiguration;
+    this.partialNgramConfig = partialNgramConfig;
   }
 
   @Override
@@ -226,7 +224,7 @@ public class V2MappingsBuilder implements MappingsBuilder {
     return ImmutableMap.of(PROPERTIES, mappings);
   }
 
-  private static Map<String, Object> getMappingsForUrn() {
+  private Map<String, Object> getMappingsForUrn() {
     Map<String, Object> subFields = new HashMap<>();
     subFields.put(
         DELIMITED,
@@ -287,7 +285,7 @@ public class V2MappingsBuilder implements MappingsBuilder {
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
-  private static Map<String, Object> getMappingsForField(
+  private Map<String, Object> getMappingsForField(
       @Nonnull final SearchableFieldSpec searchableFieldSpec) {
     FieldType fieldType = searchableFieldSpec.getSearchableAnnotation().getFieldType();
 
@@ -381,7 +379,7 @@ public class V2MappingsBuilder implements MappingsBuilder {
     return mappingForField;
   }
 
-  private static Map<String, Object> getMappingsForSearchText(FieldType fieldType) {
+  private Map<String, Object> getMappingsForSearchText(FieldType fieldType) {
     Map<String, Object> mappingForField = new HashMap<>();
     mappingForField.put(TYPE, ESUtils.KEYWORD_FIELD_TYPE);
     mappingForField.put(NORMALIZER, KEYWORD_NORMALIZER);
@@ -423,7 +421,7 @@ public class V2MappingsBuilder implements MappingsBuilder {
         ImmutableMap.of(TYPE, ESUtils.DOUBLE_FIELD_TYPE));
   }
 
-  private static Map<String, Object> getMappingForSearchableRefField(
+  private Map<String, Object> getMappingForSearchableRefField(
       @Nonnull EntityRegistry entityRegistry,
       @Nonnull final SearchableRefFieldSpec searchableRefFieldSpec,
       final int depth) {

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ReindexConfig.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ReindexConfig.java
@@ -2,6 +2,7 @@ package com.linkedin.metadata.search.elasticsearch.indexbuilder;
 
 import static com.linkedin.metadata.Constants.*;
 import static com.linkedin.metadata.search.utils.ESUtils.PROPERTIES;
+import static com.linkedin.metadata.search.utils.ESUtils.TYPE;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.StreamReadConstraints;
@@ -192,13 +193,18 @@ public class ReindexConfig {
       if (input == null) {
         return new TreeMap<>();
       }
-      return input.entrySet().stream()
-          .collect(
-              Collectors.toMap(
-                  Map.Entry::getKey,
-                  e -> normalizeObjectForComparison(e.getValue()),
-                  (oldValue, newValue) -> newValue,
-                  TreeMap::new));
+      TreeMap<String, Object> result =
+          input.entrySet().stream()
+              .collect(
+                  Collectors.toMap(
+                      Map.Entry::getKey,
+                      e -> normalizeObjectForComparison(e.getValue()),
+                      (oldValue, newValue) -> newValue,
+                      TreeMap::new));
+      if (result.containsKey(PROPERTIES) && !result.containsKey(TYPE)) {
+        result.put(TYPE, "object");
+      }
+      return result;
     }
 
     private static List<Object> normalizeListForComparison(List<?> input) {

--- a/metadata-io/src/main/java/com/linkedin/metadata/service/UpdateIndicesV2Strategy.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/service/UpdateIndicesV2Strategy.java
@@ -97,6 +97,11 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
    *     batch to a single update with the last state. This is a performance optimization that can
    *     be disabled for more granular updates at the cost of more writes. Note: timeseries aspects
    *     are always processed per-event and not coalesced.
+   * @param mappingsBuilder Pre-built V2 mappings builder. Engine-specific mapping quirks (e.g.
+   *     ES8's stripping of {@code doc_values: false} on round-trip) are supplied to the builder by
+   *     its factory via {@link
+   *     com.linkedin.metadata.utils.elasticsearch.SearchClientShim#partialNgramConfig()}, keeping
+   *     engine-version knowledge out of this strategy.
    */
   public UpdateIndicesV2Strategy(
       @Nonnull EntityIndexVersionConfiguration v2Config,
@@ -106,7 +111,8 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
       @Nonnull String idHashAlgo,
       @Nullable SemanticSearchConfiguration semanticSearchConfig,
       @Nonnull IndexConvention indexConvention,
-      boolean coalesceBatchUpdates) {
+      boolean coalesceBatchUpdates,
+      @Nonnull V2MappingsBuilder mappingsBuilder) {
     this.v2Config = v2Config;
     this.elasticSearchService = elasticSearchService;
     this.searchDocumentTransformer = searchDocumentTransformer;
@@ -115,11 +121,7 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
     this.semanticSearchConfig = semanticSearchConfig;
     this.indexConvention = indexConvention;
     this.coalesceBatchUpdates = coalesceBatchUpdates;
-    this.mappingsBuilder =
-        new V2MappingsBuilder(
-            com.linkedin.metadata.config.search.EntityIndexConfiguration.builder()
-                .v2(v2Config)
-                .build());
+    this.mappingsBuilder = mappingsBuilder;
     this.semanticIndexExistsCache =
         CacheBuilder.newBuilder()
             .expireAfterWrite(SEMANTIC_INDEX_CACHE_TTL_MINUTES, TimeUnit.MINUTES)

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/LineageServiceTestBase.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/LineageServiceTestBase.java
@@ -56,6 +56,7 @@ import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.search.cache.EntityDocCountCache;
 import com.linkedin.metadata.search.client.CachingEntitySearchService;
 import com.linkedin.metadata.search.elasticsearch.ElasticSearchService;
+import com.linkedin.metadata.search.elasticsearch.client.shim.impl.OpenSearch2SearchClientShim;
 import com.linkedin.metadata.search.elasticsearch.index.entity.v2.V2LegacySettingsBuilder;
 import com.linkedin.metadata.search.elasticsearch.index.entity.v2.V2MappingsBuilder;
 import com.linkedin.metadata.search.elasticsearch.indexbuilder.ESIndexBuilder;
@@ -245,7 +246,9 @@ public abstract class LineageServiceTestBase extends AbstractTestNGSpringContext
             getIndexBuilder(),
             TEST_SEARCH_SERVICE_CONFIG,
             TEST_ES_SEARCH_CONFIG,
-            new V2MappingsBuilder(TEST_ES_SEARCH_CONFIG.getEntityIndex()),
+            new V2MappingsBuilder(
+                TEST_ES_SEARCH_CONFIG.getEntityIndex(),
+                OpenSearch2SearchClientShim.PARTIAL_NGRAM_CONFIG),
             settingsBuilder,
             searchDAO,
             browseDAO,

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/SearchServiceTestBase.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/SearchServiceTestBase.java
@@ -33,6 +33,7 @@ import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.search.cache.EntityDocCountCache;
 import com.linkedin.metadata.search.client.CachingEntitySearchService;
 import com.linkedin.metadata.search.elasticsearch.ElasticSearchService;
+import com.linkedin.metadata.search.elasticsearch.client.shim.impl.OpenSearch2SearchClientShim;
 import com.linkedin.metadata.search.elasticsearch.index.MappingsBuilder;
 import com.linkedin.metadata.search.elasticsearch.index.entity.v2.V2LegacySettingsBuilder;
 import com.linkedin.metadata.search.elasticsearch.index.entity.v2.V2MappingsBuilder;
@@ -198,7 +199,9 @@ public abstract class SearchServiceTestBase extends AbstractTestNGSpringContextT
             getIndexBuilder(),
             TEST_SEARCH_SERVICE_CONFIG,
             TEST_ES_SEARCH_CONFIG,
-            new V2MappingsBuilder(TEST_ES_SEARCH_CONFIG.getEntityIndex()),
+            new V2MappingsBuilder(
+                TEST_ES_SEARCH_CONFIG.getEntityIndex(),
+                OpenSearch2SearchClientShim.PARTIAL_NGRAM_CONFIG),
             settingsBuilder,
             searchDAO,
             browseDAO,
@@ -233,7 +236,8 @@ public abstract class SearchServiceTestBase extends AbstractTestNGSpringContextT
             getIndexBuilder(),
             TEST_SEARCH_SERVICE_CONFIG,
             esConfig,
-            new V2MappingsBuilder(esConfig.getEntityIndex()),
+            new V2MappingsBuilder(
+                esConfig.getEntityIndex(), OpenSearch2SearchClientShim.PARTIAL_NGRAM_CONFIG),
             settingsBuilder,
             searchDAO,
             browseDAO,

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/TestEntityTestBase.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/TestEntityTestBase.java
@@ -20,6 +20,7 @@ import com.linkedin.metadata.config.search.ElasticSearchConfiguration;
 import com.linkedin.metadata.config.search.IndexConfiguration;
 import com.linkedin.metadata.models.registry.SnapshotEntityRegistry;
 import com.linkedin.metadata.search.elasticsearch.ElasticSearchService;
+import com.linkedin.metadata.search.elasticsearch.client.shim.impl.OpenSearch2SearchClientShim;
 import com.linkedin.metadata.search.elasticsearch.index.entity.v2.V2LegacySettingsBuilder;
 import com.linkedin.metadata.search.elasticsearch.index.entity.v2.V2MappingsBuilder;
 import com.linkedin.metadata.search.elasticsearch.indexbuilder.ESIndexBuilder;
@@ -120,7 +121,9 @@ public abstract class TestEntityTestBase extends AbstractTestNGSpringContextTest
             getIndexBuilder(),
             TEST_SEARCH_SERVICE_CONFIG,
             TEST_ES_SEARCH_CONFIG,
-            new V2MappingsBuilder(TEST_ES_SEARCH_CONFIG.getEntityIndex()),
+            new V2MappingsBuilder(
+                TEST_ES_SEARCH_CONFIG.getEntityIndex(),
+                OpenSearch2SearchClientShim.PARTIAL_NGRAM_CONFIG),
             settingsBuilder,
             searchDAO,
             browseDAO,

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/index/DelegatingMappingsBuilderTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/index/DelegatingMappingsBuilderTest.java
@@ -6,6 +6,7 @@ import static org.testng.Assert.*;
 
 import com.linkedin.metadata.config.search.EntityIndexConfiguration;
 import com.linkedin.metadata.config.search.EntityIndexVersionConfiguration;
+import com.linkedin.metadata.search.elasticsearch.client.shim.impl.OpenSearch2SearchClientShim;
 import com.linkedin.metadata.search.elasticsearch.index.MappingsBuilder.IndexMapping;
 import com.linkedin.metadata.search.elasticsearch.index.entity.v2.V2MappingsBuilder;
 import com.linkedin.metadata.search.elasticsearch.index.entity.v3.MultiEntityMappingsBuilder;
@@ -41,7 +42,9 @@ public class DelegatingMappingsBuilderTest {
     // Initialize DelegatingMappingsBuilder with actual builders
     List<MappingsBuilder> builders = new ArrayList<>();
     if (entityIndexConfiguration.getV2().isEnabled()) {
-      builders.add(new V2MappingsBuilder(entityIndexConfiguration));
+      builders.add(
+          new V2MappingsBuilder(
+              entityIndexConfiguration, OpenSearch2SearchClientShim.PARTIAL_NGRAM_CONFIG));
     }
     if (entityIndexConfiguration.getV3().isEnabled()) {
       try {
@@ -106,7 +109,8 @@ public class DelegatingMappingsBuilderTest {
 
     // Create DelegatingMappingsBuilder with only v2 builder
     List<MappingsBuilder> builders = new ArrayList<>();
-    builders.add(new V2MappingsBuilder(v2OnlyConfig));
+    builders.add(
+        new V2MappingsBuilder(v2OnlyConfig, OpenSearch2SearchClientShim.PARTIAL_NGRAM_CONFIG));
     DelegatingMappingsBuilder v2OnlyBuilder = new DelegatingMappingsBuilder(builders);
     Collection<IndexMapping> result = v2OnlyBuilder.getIndexMappings(operationContext);
 
@@ -245,7 +249,7 @@ public class DelegatingMappingsBuilderTest {
 
     // This should throw RuntimeException wrapping IOException from MultiEntityMappingsBuilder
     List<MappingsBuilder> builders = new ArrayList<>();
-    builders.add(new V2MappingsBuilder(config));
+    builders.add(new V2MappingsBuilder(config, OpenSearch2SearchClientShim.PARTIAL_NGRAM_CONFIG));
     try {
       builders.add(new MultiEntityMappingsBuilder(config));
     } catch (IOException e) {

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/index/entity/v2/V2MappingsBuilderTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/index/entity/v2/V2MappingsBuilderTest.java
@@ -17,6 +17,8 @@ import com.linkedin.metadata.models.SearchableFieldSpec;
 import com.linkedin.metadata.models.annotation.SearchableAnnotation;
 import com.linkedin.metadata.models.registry.ConfigEntityRegistry;
 import com.linkedin.metadata.models.registry.EntityRegistry;
+import com.linkedin.metadata.search.elasticsearch.client.shim.impl.Es8SearchClientShim;
+import com.linkedin.metadata.search.elasticsearch.client.shim.impl.OpenSearch2SearchClientShim;
 import com.linkedin.metadata.search.elasticsearch.index.MappingsBuilder.IndexMapping;
 import com.linkedin.metadata.search.query.request.TestSearchFieldConfig;
 import com.linkedin.structured.StructuredPropertyDefinition;
@@ -47,8 +49,11 @@ public class V2MappingsBuilderTest {
     EntityIndexVersionConfiguration v2Config = mock(EntityIndexVersionConfiguration.class);
     when(entityIndexConfiguration.getV2()).thenReturn(v2Config);
 
-    // Create LegacyMappingsBuilder
-    mappingsBuilder = new V2MappingsBuilder(entityIndexConfiguration);
+    // Create LegacyMappingsBuilder. Default to the legacy (OpenSearch2/ES7) profile to match the
+    // historical test expectations — pre-refactor, this constructor produced legacy ngram config.
+    mappingsBuilder =
+        new V2MappingsBuilder(
+            entityIndexConfiguration, OpenSearch2SearchClientShim.PARTIAL_NGRAM_CONFIG);
 
     // Create real OperationContext with test setup
     operationContext = TestOperationContexts.systemContextNoSearchAuthorization();
@@ -709,8 +714,9 @@ public class V2MappingsBuilderTest {
     // Test that constructor properly handles null EntityIndexConfiguration
     // The constructor doesn't actually throw an exception, so this test should pass
     // This is the current behavior of the implementation
-    V2MappingsBuilder builder = new V2MappingsBuilder(null);
-    assertNotNull(builder, "Constructor should create instance even with null input");
+    V2MappingsBuilder builder =
+        new V2MappingsBuilder(null, OpenSearch2SearchClientShim.PARTIAL_NGRAM_CONFIG);
+    assertNotNull(builder, "Constructor should create instance even with null entity index config");
   }
 
   @Test
@@ -734,5 +740,134 @@ public class V2MappingsBuilderTest {
         TestSearchFieldConfig.class
             .getClassLoader()
             .getResourceAsStream("test-entity-registry.yaml"));
+  }
+
+  // ES7 / OpenSearch silently accept and persist doc_values=false on search_as_you_type ngram
+  // subfields,
+  // ES8+ strips it on round-trip, which causes a perpetual mapping diff and reindex loop.
+  /** Recursively collects every value found under any "ngram" key in a mappings tree. */
+  private List<Map<String, Object>> findAllNgramSubfields(Map<String, Object> root) {
+    List<Map<String, Object>> found = new java.util.ArrayList<>();
+    collectNgramSubfields(root, found);
+    return found;
+  }
+
+  @SuppressWarnings("unchecked")
+  private void collectNgramSubfields(Object node, List<Map<String, Object>> found) {
+    if (!(node instanceof Map)) {
+      return;
+    }
+    Map<String, Object> map = (Map<String, Object>) node;
+    for (Map.Entry<String, Object> entry : map.entrySet()) {
+      if ("ngram".equals(entry.getKey()) && entry.getValue() instanceof Map) {
+        found.add((Map<String, Object>) entry.getValue());
+      }
+      collectNgramSubfields(entry.getValue(), found);
+    }
+  }
+
+  private Collection<IndexMapping> buildAllMappings(Map<String, String> partialNgramConfig) {
+    V2MappingsBuilder builder = new V2MappingsBuilder(entityIndexConfiguration, partialNgramConfig);
+    return builder.getIndexMappings(operationContext);
+  }
+
+  private List<Map<String, Object>> collectAllNgramSubfields(
+      Map<String, String> partialNgramConfig) {
+    Collection<IndexMapping> mappings = buildAllMappings(partialNgramConfig);
+    assertNotNull(mappings, "Mappings should not be null");
+    assertFalse(mappings.isEmpty(), "Test entity registry must produce at least one mapping");
+
+    List<Map<String, Object>> all = new java.util.ArrayList<>();
+    for (IndexMapping mapping : mappings) {
+      all.addAll(findAllNgramSubfields(mapping.getMappings()));
+    }
+    return all;
+  }
+
+  private void assertLegacyNgramShape(List<Map<String, Object>> ngrams) {
+    assertFalse(
+        ngrams.isEmpty(),
+        "Expected at least one ngram subfield for legacy profile — test setup is broken");
+    for (Map<String, Object> ngram : ngrams) {
+      assertEquals(
+          ngram.get("type"), "search_as_you_type", "ngram type should be search_as_you_type");
+      assertEquals(ngram.get("max_shingle_size"), "4", "max_shingle_size should be preserved");
+      assertEquals(
+          ngram.get("doc_values"),
+          "false",
+          "Legacy profile must continue to emit doc_values=false to avoid a transitional reindex"
+              + " of existing ES7/OpenSearch indexes");
+    }
+  }
+
+  private void assertEs8NgramShape(List<Map<String, Object>> ngrams) {
+    assertFalse(
+        ngrams.isEmpty(),
+        "Expected at least one ngram subfield for ES8 profile — test setup is broken");
+    for (Map<String, Object> ngram : ngrams) {
+      assertEquals(
+          ngram.get("type"), "search_as_you_type", "ngram type should be search_as_you_type");
+      assertEquals(ngram.get("max_shingle_size"), "4", "max_shingle_size should be preserved");
+      assertFalse(
+          ngram.containsKey("doc_values"),
+          "ES8 profile must omit doc_values — ES8 strips it on round-trip and including it causes"
+              + " a perpetual mapping diff (PFP-3594)");
+    }
+  }
+
+  @Test
+  public void testNgramHasDocValuesForLegacyConfig() {
+    // OpenSearch2SearchClientShim.PARTIAL_NGRAM_CONFIG is also used by the ES7 compatibility shim
+    // (Es7CompatibilitySearchClientShim extends OpenSearch2SearchClientShim), so this test covers
+    // both ES7 and OpenSearch 2.x behavior.
+    assertLegacyNgramShape(
+        collectAllNgramSubfields(OpenSearch2SearchClientShim.PARTIAL_NGRAM_CONFIG));
+  }
+
+  @Test
+  public void testNgramOmitsDocValuesForEs8Config() {
+    // Es8SearchClientShim.PARTIAL_NGRAM_CONFIG is used for both ELASTICSEARCH_8 and
+    // ELASTICSEARCH_9, since both engines strip doc_values from search_as_you_type on round-trip.
+    assertEs8NgramShape(collectAllNgramSubfields(Es8SearchClientShim.PARTIAL_NGRAM_CONFIG));
+  }
+
+  @Test
+  public void testProfileDoesNotChangeOtherStructure() {
+    // Sanity check: switching profile must NOT alter top-level fields like urn, runId,
+    // systemCreated, or the analyzer wiring. We only expect the ngram doc_values flag to differ.
+    Collection<IndexMapping> legacy =
+        buildAllMappings(OpenSearch2SearchClientShim.PARTIAL_NGRAM_CONFIG);
+    Collection<IndexMapping> es8 = buildAllMappings(Es8SearchClientShim.PARTIAL_NGRAM_CONFIG);
+    assertEquals(legacy.size(), es8.size(), "Same number of indexes regardless of profile");
+
+    java.util.Iterator<IndexMapping> legacyIt = legacy.iterator();
+    java.util.Iterator<IndexMapping> es8It = es8.iterator();
+    while (legacyIt.hasNext() && es8It.hasNext()) {
+      Map<String, Object> legacyProps =
+          (Map<String, Object>) legacyIt.next().getMappings().get("properties");
+      Map<String, Object> es8Props =
+          (Map<String, Object>) es8It.next().getMappings().get("properties");
+      assertEquals(
+          legacyProps.keySet(),
+          es8Props.keySet(),
+          "Top-level field set must be identical between profiles");
+    }
+  }
+
+  @Test
+  public void testNgramAnalyzerOverridesAreApplied() {
+    // The fix replaced static config with instance-based config. Verify that overrides
+    // (analyzer name) still apply correctly — different code paths use different analyzers
+    // (PARTIAL_URN_COMPONENT vs PARTIAL_ANALYZER).
+    List<Map<String, Object>> ngrams =
+        collectAllNgramSubfields(Es8SearchClientShim.PARTIAL_NGRAM_CONFIG);
+    assertFalse(ngrams.isEmpty(), "Should produce ngram subfields");
+    for (Map<String, Object> ngram : ngrams) {
+      assertNotNull(ngram.get("analyzer"), "Every ngram subfield must specify an analyzer");
+      String analyzer = (String) ngram.get("analyzer");
+      assertTrue(
+          analyzer.startsWith("partial"),
+          "Analyzer should be a partial analyzer variant, got: " + analyzer);
+    }
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/index/entity/v2/V2SemanticSearchMappingsBuilderTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/index/entity/v2/V2SemanticSearchMappingsBuilderTest.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.linkedin.metadata.config.search.EntityIndexConfiguration;
 import com.linkedin.metadata.config.search.EntityIndexVersionConfiguration;
 import com.linkedin.metadata.config.search.SemanticSearchConfiguration;
+import com.linkedin.metadata.search.elasticsearch.client.shim.impl.OpenSearch2SearchClientShim;
 import com.linkedin.metadata.search.elasticsearch.index.MappingsBuilder.IndexMapping;
 import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
 import com.linkedin.metadata.utils.elasticsearch.SearchClientShim;
@@ -69,7 +70,9 @@ public class V2SemanticSearchMappingsBuilderTest {
     EntityIndexVersionConfiguration v2Config = mock(EntityIndexVersionConfiguration.class);
     when(entityIndexConfiguration.getV2()).thenReturn(v2Config);
 
-    V2MappingsBuilder v2MappingsBuilder = new V2MappingsBuilder(entityIndexConfiguration);
+    V2MappingsBuilder v2MappingsBuilder =
+        new V2MappingsBuilder(
+            entityIndexConfiguration, OpenSearch2SearchClientShim.PARTIAL_NGRAM_CONFIG);
 
     SemanticSearchConfiguration semanticConfig = buildTestSemanticConfig();
 
@@ -231,7 +234,9 @@ public class V2SemanticSearchMappingsBuilderTest {
     EntityIndexConfiguration entityIndexConfiguration = mock(EntityIndexConfiguration.class);
     EntityIndexVersionConfiguration v2Config = mock(EntityIndexVersionConfiguration.class);
     when(entityIndexConfiguration.getV2()).thenReturn(v2Config);
-    V2MappingsBuilder v2MappingsBuilder = new V2MappingsBuilder(entityIndexConfiguration);
+    V2MappingsBuilder v2MappingsBuilder =
+        new V2MappingsBuilder(
+            entityIndexConfiguration, OpenSearch2SearchClientShim.PARTIAL_NGRAM_CONFIG);
 
     // Use real IndexConventionImpl instead of mocking
     com.linkedin.metadata.config.search.EntityIndexConfiguration entityIndexConfig =
@@ -266,7 +271,9 @@ public class V2SemanticSearchMappingsBuilderTest {
     EntityIndexConfiguration entityIndexConfiguration = mock(EntityIndexConfiguration.class);
     EntityIndexVersionConfiguration v2Config = mock(EntityIndexVersionConfiguration.class);
     when(entityIndexConfiguration.getV2()).thenReturn(v2Config);
-    V2MappingsBuilder v2MappingsBuilder = new V2MappingsBuilder(entityIndexConfiguration);
+    V2MappingsBuilder v2MappingsBuilder =
+        new V2MappingsBuilder(
+            entityIndexConfiguration, OpenSearch2SearchClientShim.PARTIAL_NGRAM_CONFIG);
 
     SemanticSearchConfiguration semanticConfig = buildTestSemanticConfig();
 
@@ -431,7 +438,9 @@ public class V2SemanticSearchMappingsBuilderTest {
     EntityIndexConfiguration entityIndexConfiguration = mock(EntityIndexConfiguration.class);
     EntityIndexVersionConfiguration v2Config = mock(EntityIndexVersionConfiguration.class);
     when(entityIndexConfiguration.getV2()).thenReturn(v2Config);
-    V2MappingsBuilder v2MappingsBuilder = new V2MappingsBuilder(entityIndexConfiguration);
+    V2MappingsBuilder v2MappingsBuilder =
+        new V2MappingsBuilder(
+            entityIndexConfiguration, OpenSearch2SearchClientShim.PARTIAL_NGRAM_CONFIG);
 
     com.linkedin.metadata.config.search.EntityIndexConfiguration entityIndexConfig =
         new com.linkedin.metadata.config.search.EntityIndexConfiguration();
@@ -498,7 +507,9 @@ public class V2SemanticSearchMappingsBuilderTest {
     EntityIndexConfiguration entityIndexConfiguration = mock(EntityIndexConfiguration.class);
     EntityIndexVersionConfiguration v2Config = mock(EntityIndexVersionConfiguration.class);
     when(entityIndexConfiguration.getV2()).thenReturn(v2Config);
-    V2MappingsBuilder v2MappingsBuilder = new V2MappingsBuilder(entityIndexConfiguration);
+    V2MappingsBuilder v2MappingsBuilder =
+        new V2MappingsBuilder(
+            entityIndexConfiguration, OpenSearch2SearchClientShim.PARTIAL_NGRAM_CONFIG);
 
     com.linkedin.metadata.config.search.EntityIndexConfiguration entityIndexConfig =
         new com.linkedin.metadata.config.search.EntityIndexConfiguration();

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/indexbuilder/ReindexConfigTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/indexbuilder/ReindexConfigTest.java
@@ -237,6 +237,515 @@ public class ReindexConfigTest {
   }
 
   @Test
+  void testImplicitObjectTypeNormalizedAcrossSides() {
+    // ES8 echoes "type":"object" back for any field that has "properties"; ES7 / OpenSearch
+    // omit it. Mapping builders that don't emit the explicit type must not cause a perpetual
+    // mapping diff (and therefore a perpetual reindex loop) when running against ES8.
+    Map<String, Object> currentMappings = new HashMap<>();
+    Map<String, Object> currentProperties = new HashMap<>();
+    Map<String, Object> currentObjectField = new HashMap<>();
+    currentObjectField.put(TYPE_KEY, "object");
+    currentObjectField.put(
+        PROPERTIES_KEY,
+        ImmutableMap.of(
+            "partition", ImmutableMap.of("type", "keyword"),
+            "timePartition", ImmutableMap.of("type", "keyword")));
+    currentProperties.put("partitionSpec", currentObjectField);
+    currentMappings.put(PROPERTIES_KEY, currentProperties);
+
+    Map<String, Object> targetMappings = new HashMap<>();
+    Map<String, Object> targetProperties = new HashMap<>();
+    targetProperties.put(
+        "partitionSpec",
+        ImmutableMap.of(
+            PROPERTIES_KEY,
+            ImmutableMap.of(
+                "partition", ImmutableMap.of("type", "keyword"),
+                "timePartition", ImmutableMap.of("type", "keyword"))));
+    targetMappings.put(PROPERTIES_KEY, targetProperties);
+
+    ReindexConfig config =
+        ReindexConfig.builder()
+            .name(TEST_INDEX_NAME)
+            .exists(true)
+            .currentMappings(currentMappings)
+            .targetMappings(targetMappings)
+            .currentSettings(Settings.EMPTY)
+            .targetSettings(new HashMap<>())
+            .enableIndexMappingsReindex(true)
+            .build();
+
+    Assert.assertFalse(
+        config.requiresApplyMappings(),
+        "Implicit vs explicit type:object on a properties-bearing sub-mapping must not be"
+            + " treated as a diff");
+    Assert.assertFalse(config.requiresReindex());
+  }
+
+  @Test
+  void testImplicitObjectTypeNormalized_TargetExplicit_CurrentImplicit() {
+    // Symmetric to testImplicitObjectTypeNormalizedAcrossSides: confirm normalization works
+    // when current is implicit and target is explicit.
+    Map<String, Object> currentMappings = new HashMap<>();
+    currentMappings.put(
+        PROPERTIES_KEY,
+        ImmutableMap.of(
+            "partitionSpec",
+            ImmutableMap.of(
+                PROPERTIES_KEY, ImmutableMap.of("partition", ImmutableMap.of("type", "keyword")))));
+
+    Map<String, Object> targetMappings = new HashMap<>();
+    targetMappings.put(
+        PROPERTIES_KEY,
+        ImmutableMap.of(
+            "partitionSpec",
+            ImmutableMap.of(
+                TYPE_KEY,
+                "object",
+                PROPERTIES_KEY,
+                ImmutableMap.of("partition", ImmutableMap.of("type", "keyword")))));
+
+    ReindexConfig config =
+        ReindexConfig.builder()
+            .name(TEST_INDEX_NAME)
+            .exists(true)
+            .currentMappings(currentMappings)
+            .targetMappings(targetMappings)
+            .currentSettings(Settings.EMPTY)
+            .targetSettings(new HashMap<>())
+            .enableIndexMappingsReindex(true)
+            .build();
+
+    Assert.assertFalse(
+        config.requiresApplyMappings(),
+        "Normalization must be symmetric: current implicit + target explicit should match");
+    Assert.assertFalse(config.requiresReindex());
+  }
+
+  @Test
+  void testBothSidesImplicitObjectMatch() {
+    // Defensive: when both sides emit implicit object (properties only, no type),
+    // they should still compare equal after normalization.
+    Map<String, Object> mappings = new HashMap<>();
+    mappings.put(
+        PROPERTIES_KEY,
+        ImmutableMap.of(
+            "partitionSpec",
+            ImmutableMap.of(
+                PROPERTIES_KEY, ImmutableMap.of("partition", ImmutableMap.of("type", "keyword")))));
+
+    ReindexConfig config =
+        ReindexConfig.builder()
+            .name(TEST_INDEX_NAME)
+            .exists(true)
+            .currentMappings(mappings)
+            .targetMappings(mappings)
+            .currentSettings(Settings.EMPTY)
+            .targetSettings(new HashMap<>())
+            .enableIndexMappingsReindex(true)
+            .build();
+
+    Assert.assertFalse(config.requiresApplyMappings(), "Both sides implicit object — should match");
+  }
+
+  @Test
+  void testNestedTypeNotNormalizedToObject() {
+    // type:nested has properties but explicit type — normalization must skip it
+    // (TYPE is already present, condition is false).
+    Map<String, Object> mappings = new HashMap<>();
+    mappings.put(
+        PROPERTIES_KEY,
+        ImmutableMap.of(
+            "tags",
+            ImmutableMap.of(
+                TYPE_KEY,
+                "nested",
+                PROPERTIES_KEY,
+                ImmutableMap.of("name", ImmutableMap.of("type", "keyword")))));
+
+    ReindexConfig config =
+        ReindexConfig.builder()
+            .name(TEST_INDEX_NAME)
+            .exists(true)
+            .currentMappings(mappings)
+            .targetMappings(mappings)
+            .currentSettings(Settings.EMPTY)
+            .targetSettings(new HashMap<>())
+            .enableIndexMappingsReindex(true)
+            .build();
+
+    Assert.assertFalse(
+        config.requiresApplyMappings(),
+        "Identical nested mappings should match without object normalization interfering");
+  }
+
+  @Test
+  void testObjectToNestedTransitionDetected() {
+    // Real change: implicit object → explicit nested. The fix must NOT hide this diff
+    // by normalizing both sides to type:object.
+    Map<String, Object> currentMappings = new HashMap<>();
+    currentMappings.put(
+        PROPERTIES_KEY,
+        ImmutableMap.of(
+            "tags",
+            ImmutableMap.of(
+                PROPERTIES_KEY, ImmutableMap.of("name", ImmutableMap.of("type", "keyword")))));
+
+    Map<String, Object> targetMappings = new HashMap<>();
+    targetMappings.put(
+        PROPERTIES_KEY,
+        ImmutableMap.of(
+            "tags",
+            ImmutableMap.of(
+                TYPE_KEY,
+                "nested",
+                PROPERTIES_KEY,
+                ImmutableMap.of("name", ImmutableMap.of("type", "keyword")))));
+
+    ReindexConfig config =
+        ReindexConfig.builder()
+            .name(TEST_INDEX_NAME)
+            .exists(true)
+            .currentMappings(currentMappings)
+            .targetMappings(targetMappings)
+            .currentSettings(Settings.EMPTY)
+            .targetSettings(new HashMap<>())
+            .enableIndexMappingsReindex(true)
+            .build();
+
+    Assert.assertTrue(
+        config.requiresApplyMappings(),
+        "object→nested transition is a real schema change — normalization must not hide it");
+    Assert.assertTrue(config.requiresReindex());
+  }
+
+  @Test
+  void testMultiFieldsNotAffected() {
+    // Multi-fields use the 'fields' key (not 'properties'), so the normalization
+    // condition is false. Comparison should work normally.
+    Map<String, Object> mappings = new HashMap<>();
+    mappings.put(
+        PROPERTIES_KEY,
+        ImmutableMap.of(
+            "name",
+            ImmutableMap.of(
+                TYPE_KEY,
+                "text",
+                "fields",
+                ImmutableMap.of("keyword", ImmutableMap.of("type", "keyword")))));
+
+    ReindexConfig config =
+        ReindexConfig.builder()
+            .name(TEST_INDEX_NAME)
+            .exists(true)
+            .currentMappings(mappings)
+            .targetMappings(mappings)
+            .currentSettings(Settings.EMPTY)
+            .targetSettings(new HashMap<>())
+            .enableIndexMappingsReindex(true)
+            .build();
+
+    Assert.assertFalse(
+        config.requiresApplyMappings(),
+        "Multi-fields ('fields' key, not 'properties') should be unaffected by object normalization");
+  }
+
+  @Test
+  void testFieldAliasNotAffected() {
+    // Field aliases have type:alias and path, but no properties. Normalization
+    // should leave them alone.
+    Map<String, Object> mappings = new HashMap<>();
+    mappings.put(
+        PROPERTIES_KEY,
+        ImmutableMap.of(
+            "_entityName",
+            ImmutableMap.of(TYPE_KEY, "alias", "path", "name"),
+            "name",
+            ImmutableMap.of(TYPE_KEY, "keyword")));
+
+    ReindexConfig config =
+        ReindexConfig.builder()
+            .name(TEST_INDEX_NAME)
+            .exists(true)
+            .currentMappings(mappings)
+            .targetMappings(mappings)
+            .currentSettings(Settings.EMPTY)
+            .targetSettings(new HashMap<>())
+            .enableIndexMappingsReindex(true)
+            .build();
+
+    Assert.assertFalse(
+        config.requiresApplyMappings(),
+        "Field aliases have a type but no properties — normalization must not affect them");
+  }
+
+  @Test
+  void testCombinedTypeAndPropertyChangeStillDetected() {
+    // Combined change: current is implicit object, target is explicit nested with a new field.
+    // Both the type change AND the property addition must be detected — the object-type
+    // injection must not mask either signal.
+    Map<String, Object> currentMappings = new HashMap<>();
+    currentMappings.put(
+        PROPERTIES_KEY,
+        ImmutableMap.of(
+            "tags",
+            ImmutableMap.of(
+                PROPERTIES_KEY, ImmutableMap.of("name", ImmutableMap.of("type", "keyword")))));
+
+    Map<String, Object> targetMappings = new HashMap<>();
+    targetMappings.put(
+        PROPERTIES_KEY,
+        ImmutableMap.of(
+            "tags",
+            ImmutableMap.of(
+                TYPE_KEY,
+                "nested",
+                PROPERTIES_KEY,
+                ImmutableMap.of(
+                    "name", ImmutableMap.of("type", "keyword"),
+                    "color", ImmutableMap.of("type", "keyword")))));
+
+    ReindexConfig config =
+        ReindexConfig.builder()
+            .name(TEST_INDEX_NAME)
+            .exists(true)
+            .currentMappings(currentMappings)
+            .targetMappings(targetMappings)
+            .currentSettings(Settings.EMPTY)
+            .targetSettings(new HashMap<>())
+            .enableIndexMappingsReindex(true)
+            .build();
+
+    Assert.assertTrue(
+        config.requiresApplyMappings(),
+        "Combined type+property change must be detected even when current is implicit object");
+    Assert.assertTrue(config.requiresReindex());
+    Assert.assertFalse(
+        config.isPureMappingsAddition(),
+        "Type change makes this non-additive; should require reindex");
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Engine-type round-trip simulations
+  //
+  // ReindexConfig.normalizeMapForComparison applies its type:object injection universally — it
+  // does not depend on engineType. These tests document the mapping shape each search engine
+  // typically returns during a round-trip and verify the universal normalization handles all
+  // three engines correctly. The "code" side is always assumed to emit implicit-object form
+  // (no explicit type when properties is present) — matching V2MappingsBuilder's output.
+  // ---------------------------------------------------------------------------------------------
+
+  /**
+   * Builds a code-emitted (target) mapping that uses the implicit-object form (no `type` key on
+   * properties-bearing nodes). This mirrors what V2MappingsBuilder produces.
+   */
+  private static Map<String, Object> implicitObjectMapping() {
+    Map<String, Object> mappings = new HashMap<>();
+    mappings.put(
+        PROPERTIES_KEY,
+        ImmutableMap.of(
+            "partitionSpec",
+            ImmutableMap.of(
+                PROPERTIES_KEY,
+                ImmutableMap.of(
+                    "partition", ImmutableMap.of("type", "keyword"),
+                    "timePartition", ImmutableMap.of("type", "keyword")))));
+    return mappings;
+  }
+
+  /**
+   * Builds a stored mapping in the explicit-object shape (ES8-style) — every properties-bearing
+   * node has an explicit `"type": "object"` added by ES8's round-trip behaviour.
+   */
+  private static Map<String, Object> explicitObjectMapping() {
+    Map<String, Object> mappings = new HashMap<>();
+    Map<String, Object> partitionSpec = new HashMap<>();
+    partitionSpec.put(TYPE_KEY, "object");
+    partitionSpec.put(
+        PROPERTIES_KEY,
+        ImmutableMap.of(
+            "partition", ImmutableMap.of("type", "keyword"),
+            "timePartition", ImmutableMap.of("type", "keyword")));
+    mappings.put(PROPERTIES_KEY, ImmutableMap.of("partitionSpec", partitionSpec));
+    return mappings;
+  }
+
+  @Test
+  void testEngineRoundTrip_ES7_PreservesImplicitObject() {
+    // ES7 round-trip: stored mapping looks the same as what was sent.
+    // Both sides remain implicit-object form. Comparison must report no diff.
+    ReindexConfig config =
+        ReindexConfig.builder()
+            .name(TEST_INDEX_NAME)
+            .exists(true)
+            .currentMappings(implicitObjectMapping())
+            .targetMappings(implicitObjectMapping())
+            .currentSettings(Settings.EMPTY)
+            .targetSettings(new HashMap<>())
+            .enableIndexMappingsReindex(true)
+            .build();
+
+    Assert.assertFalse(
+        config.requiresApplyMappings(),
+        "ES7 preserves implicit-object form on round-trip — both sides should match");
+    Assert.assertFalse(config.requiresReindex());
+  }
+
+  @Test
+  void testEngineRoundTrip_OpenSearch_PreservesImplicitObject() {
+    // OpenSearch behaves like ES7 on object round-trips: implicit form preserved.
+    // The universal normalization should be a no-op (both sides already match).
+    ReindexConfig config =
+        ReindexConfig.builder()
+            .name(TEST_INDEX_NAME)
+            .exists(true)
+            .currentMappings(implicitObjectMapping())
+            .targetMappings(implicitObjectMapping())
+            .currentSettings(Settings.EMPTY)
+            .targetSettings(new HashMap<>())
+            .enableIndexMappingsReindex(true)
+            .build();
+
+    Assert.assertFalse(
+        config.requiresApplyMappings(),
+        "OpenSearch preserves implicit-object form on round-trip — both sides should match");
+    Assert.assertFalse(config.requiresReindex());
+  }
+
+  @Test
+  void testEngineRoundTrip_ES8_AddsExplicitTypeObject_ResolvedByNormalization() {
+    // ES8 round-trip: stored mapping gains "type":"object" automatically.
+    // Code still emits implicit-object form. Without the universal fix this would be a
+    // perpetual diff (the PFP-3594 loop). With the fix, normalization adds type:object to
+    // the implicit (target) side, making them equivalent.
+    ReindexConfig config =
+        ReindexConfig.builder()
+            .name(TEST_INDEX_NAME)
+            .exists(true)
+            .currentMappings(explicitObjectMapping()) // ES8-style stored shape
+            .targetMappings(implicitObjectMapping()) // code-emitted shape
+            .currentSettings(Settings.EMPTY)
+            .targetSettings(new HashMap<>())
+            .enableIndexMappingsReindex(true)
+            .build();
+
+    Assert.assertFalse(
+        config.requiresApplyMappings(),
+        "PFP-3594 fix: ES8 round-trip drift must NOT produce a synthetic mapping diff");
+    Assert.assertFalse(
+        config.requiresReindex(), "No real schema change — must not trigger reindex on ES8");
+  }
+
+  @Test
+  void testEngineRoundTrip_ES8_RealMappingChangeStillDetected() {
+    // Even with the ES8 round-trip drift in play, a real schema change underneath must still
+    // be detected. Here current (ES8 stored) has explicit type:object + one inner field, but
+    // target (code) has implicit + an additional inner field. The added field must surface.
+    Map<String, Object> currentEs8 = new HashMap<>();
+    Map<String, Object> currentPartitionSpec = new HashMap<>();
+    currentPartitionSpec.put(TYPE_KEY, "object");
+    currentPartitionSpec.put(
+        PROPERTIES_KEY, ImmutableMap.of("partition", ImmutableMap.of("type", "keyword")));
+    currentEs8.put(PROPERTIES_KEY, ImmutableMap.of("partitionSpec", currentPartitionSpec));
+
+    Map<String, Object> targetCode = new HashMap<>();
+    targetCode.put(
+        PROPERTIES_KEY,
+        ImmutableMap.of(
+            "partitionSpec",
+            ImmutableMap.of(
+                PROPERTIES_KEY,
+                ImmutableMap.of(
+                    "partition", ImmutableMap.of("type", "keyword"),
+                    "timePartition", ImmutableMap.of("type", "keyword") // new field
+                    ))));
+
+    ReindexConfig config =
+        ReindexConfig.builder()
+            .name(TEST_INDEX_NAME)
+            .exists(true)
+            .currentMappings(currentEs8)
+            .targetMappings(targetCode)
+            .currentSettings(Settings.EMPTY)
+            .targetSettings(new HashMap<>())
+            .enableIndexMappingsReindex(true)
+            .build();
+
+    Assert.assertTrue(
+        config.requiresApplyMappings(),
+        "Real schema change (new inner field) must still be detected on ES8 even when "
+            + "the type:object round-trip drift would otherwise mask it");
+  }
+
+  @Test
+  void testEngineRoundTrip_ES7_RealMappingChangeStillDetected() {
+    // Sanity check that the universal normalization does not inadvertently mask real changes
+    // on ES7/OpenSearch either.
+    Map<String, Object> currentEs7 = implicitObjectMapping();
+
+    Map<String, Object> targetCode = new HashMap<>();
+    targetCode.put(
+        PROPERTIES_KEY,
+        ImmutableMap.of(
+            "partitionSpec",
+            ImmutableMap.of(
+                PROPERTIES_KEY,
+                ImmutableMap.of(
+                    "partition", ImmutableMap.of("type", "keyword"),
+                    "timePartition", ImmutableMap.of("type", "keyword"),
+                    "extra", ImmutableMap.of("type", "long") // new field
+                    ))));
+
+    ReindexConfig config =
+        ReindexConfig.builder()
+            .name(TEST_INDEX_NAME)
+            .exists(true)
+            .currentMappings(currentEs7)
+            .targetMappings(targetCode)
+            .currentSettings(Settings.EMPTY)
+            .targetSettings(new HashMap<>())
+            .enableIndexMappingsReindex(true)
+            .build();
+
+    Assert.assertTrue(
+        config.requiresApplyMappings(),
+        "Real schema change must still be detected on ES7/OpenSearch — universal "
+            + "normalization is mathematically incapable of masking a content diff");
+  }
+
+  @Test
+  void testEngineRoundTrip_ES8_NestedTypeNotMisIdentified() {
+    // ES8 returns "type":"nested" for nested fields just as it was sent. The universal
+    // normalization must not misclassify a nested field as object even when both sides have
+    // properties.
+    Map<String, Object> nestedMapping = new HashMap<>();
+    nestedMapping.put(
+        PROPERTIES_KEY,
+        ImmutableMap.of(
+            "tags",
+            ImmutableMap.of(
+                TYPE_KEY,
+                "nested",
+                PROPERTIES_KEY,
+                ImmutableMap.of("name", ImmutableMap.of("type", "keyword")))));
+
+    ReindexConfig config =
+        ReindexConfig.builder()
+            .name(TEST_INDEX_NAME)
+            .exists(true)
+            .currentMappings(nestedMapping)
+            .targetMappings(nestedMapping)
+            .currentSettings(Settings.EMPTY)
+            .targetSettings(new HashMap<>())
+            .enableIndexMappingsReindex(true)
+            .build();
+
+    Assert.assertFalse(
+        config.requiresApplyMappings(),
+        "type:nested fields must remain nested through normalization — must not be auto-promoted to object");
+  }
+
+  @Test
   void testSettingsComparison() {
     // Arrange
     Settings currentSettings =

--- a/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateIndicesServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateIndicesServiceTest.java
@@ -20,6 +20,7 @@ import com.linkedin.metadata.config.search.EntityIndexVersionConfiguration;
 import com.linkedin.metadata.models.AspectSpec;
 import com.linkedin.metadata.models.EntitySpec;
 import com.linkedin.metadata.search.elasticsearch.ElasticSearchService;
+import com.linkedin.metadata.search.elasticsearch.index.entity.v2.V2MappingsBuilder;
 import com.linkedin.metadata.search.transformer.SearchDocumentTransformer;
 import com.linkedin.metadata.systemmetadata.SystemMetadataService;
 import com.linkedin.metadata.timeseries.TimeseriesAspectService;
@@ -64,7 +65,8 @@ public class UpdateIndicesServiceTest {
             "MD5",
             null, // No semantic search config for this test
             mock(IndexConvention.class),
-            false);
+            false,
+            mock(V2MappingsBuilder.class));
 
     UpdateIndicesV3Strategy v3Strategy =
         new UpdateIndicesV3Strategy(

--- a/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateIndicesV2StrategyTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateIndicesV2StrategyTest.java
@@ -29,6 +29,7 @@ import com.linkedin.metadata.models.AspectSpec;
 import com.linkedin.metadata.models.EntitySpec;
 import com.linkedin.metadata.search.elasticsearch.ElasticSearchService;
 import com.linkedin.metadata.search.elasticsearch.index.MappingsBuilder;
+import com.linkedin.metadata.search.elasticsearch.index.entity.v2.V2MappingsBuilder;
 import com.linkedin.metadata.search.transformer.SearchDocumentTransformer;
 import com.linkedin.metadata.systemmetadata.SystemMetadataService;
 import com.linkedin.metadata.timeseries.TimeseriesAspectService;
@@ -67,6 +68,7 @@ public class UpdateIndicesV2StrategyTest {
   @Mock private ObjectNode mockSearchDocument;
   @Mock private ObjectNode mockPreviousSearchDocument;
   @Mock private StructuredPropertyDefinition mockStructuredProperty;
+  @Mock private V2MappingsBuilder mockMappingsBuilder;
 
   private OperationContext operationContext;
   private UpdateIndicesV2Strategy strategy;
@@ -114,7 +116,8 @@ public class UpdateIndicesV2StrategyTest {
             "MD5",
             null, // No semantic search config for basic tests
             mock(IndexConvention.class),
-            true);
+            true,
+            mockMappingsBuilder);
   }
 
   @Test
@@ -421,7 +424,8 @@ public class UpdateIndicesV2StrategyTest {
             "MD5",
             semanticConfig,
             indexConvention,
-            false);
+            false,
+            mockMappingsBuilder);
 
     // Verify: Should not write to semantic index when not enabled
     assertFalse(
@@ -445,7 +449,8 @@ public class UpdateIndicesV2StrategyTest {
             "MD5",
             semanticConfig,
             indexConvention,
-            false);
+            false,
+            mockMappingsBuilder);
 
     // Verify: Should not write to semantic index for dataset (not in enabled list)
     assertFalse(
@@ -472,7 +477,8 @@ public class UpdateIndicesV2StrategyTest {
             "MD5",
             semanticConfig,
             indexConvention,
-            false);
+            false,
+            mockMappingsBuilder);
 
     // Verify: Should not write to semantic index when index doesn't exist
     assertFalse(strategyWithMissingIndex.shouldWriteToSemanticIndex(operationContext, "dataset"));
@@ -498,7 +504,8 @@ public class UpdateIndicesV2StrategyTest {
             "MD5",
             semanticConfig,
             indexConvention,
-            false);
+            false,
+            mockMappingsBuilder);
 
     // Verify: Should write to semantic index when all conditions are met
     assertTrue(strategyWithAllConditions.shouldWriteToSemanticIndex(operationContext, "dataset"));
@@ -524,7 +531,8 @@ public class UpdateIndicesV2StrategyTest {
             "MD5",
             semanticConfig,
             indexConvention,
-            false);
+            false,
+            mockMappingsBuilder);
 
     // Call shouldWriteToSemanticIndex multiple times
     assertTrue(strategyWithCaching.shouldWriteToSemanticIndex(operationContext, "dataset"));
@@ -555,7 +563,8 @@ public class UpdateIndicesV2StrategyTest {
             "MD5",
             semanticConfig,
             indexConvention,
-            false);
+            false,
+            mockMappingsBuilder);
 
     // Setup mocks for document transformation
     when(searchDocumentTransformer.transformAspect(
@@ -648,7 +657,8 @@ public class UpdateIndicesV2StrategyTest {
             "MD5",
             semanticConfig,
             indexConvention,
-            false);
+            false,
+            mockMappingsBuilder);
 
     // Execute with isKeyAspect = true (full delete)
     strategyWithSemantic.deleteSearchData(
@@ -878,7 +888,8 @@ public class UpdateIndicesV2StrategyTest {
             "MD5",
             null,
             mock(IndexConvention.class),
-            false);
+            false,
+            mockMappingsBuilder);
 
     AspectSpec ownershipSpec = mock(AspectSpec.class);
     when(ownershipSpec.getName()).thenReturn("ownership");

--- a/metadata-io/src/test/java/io/datahubproject/test/fixtures/search/SampleDataFixtureConfiguration.java
+++ b/metadata-io/src/test/java/io/datahubproject/test/fixtures/search/SampleDataFixtureConfiguration.java
@@ -32,6 +32,7 @@ import com.linkedin.metadata.search.SearchService;
 import com.linkedin.metadata.search.cache.EntityDocCountCache;
 import com.linkedin.metadata.search.client.CachingEntitySearchService;
 import com.linkedin.metadata.search.elasticsearch.ElasticSearchService;
+import com.linkedin.metadata.search.elasticsearch.client.shim.impl.OpenSearch2SearchClientShim;
 import com.linkedin.metadata.search.elasticsearch.index.MappingsBuilder;
 import com.linkedin.metadata.search.elasticsearch.index.entity.v2.V2LegacySettingsBuilder;
 import com.linkedin.metadata.search.elasticsearch.index.entity.v2.V2MappingsBuilder;
@@ -239,7 +240,9 @@ public class SampleDataFixtureConfiguration {
         indexBuilder,
         TEST_SEARCH_SERVICE_CONFIG,
         TEST_ES_SEARCH_CONFIG,
-        new V2MappingsBuilder(TEST_ES_SEARCH_CONFIG.getEntityIndex()),
+        new V2MappingsBuilder(
+            TEST_ES_SEARCH_CONFIG.getEntityIndex(),
+            OpenSearch2SearchClientShim.PARTIAL_NGRAM_CONFIG),
         new V2LegacySettingsBuilder(TEST_ES_SEARCH_CONFIG.getIndex(), indexConvention),
         searchDAO,
         browseDAO,

--- a/metadata-io/src/test/java/io/datahubproject/test/fixtures/search/SearchLineageFixtureConfiguration.java
+++ b/metadata-io/src/test/java/io/datahubproject/test/fixtures/search/SearchLineageFixtureConfiguration.java
@@ -30,6 +30,7 @@ import com.linkedin.metadata.search.SearchService;
 import com.linkedin.metadata.search.cache.EntityDocCountCache;
 import com.linkedin.metadata.search.client.CachingEntitySearchService;
 import com.linkedin.metadata.search.elasticsearch.ElasticSearchService;
+import com.linkedin.metadata.search.elasticsearch.client.shim.impl.OpenSearch2SearchClientShim;
 import com.linkedin.metadata.search.elasticsearch.index.MappingsBuilder;
 import com.linkedin.metadata.search.elasticsearch.index.entity.v2.V2LegacySettingsBuilder;
 import com.linkedin.metadata.search.elasticsearch.index.entity.v2.V2MappingsBuilder;
@@ -169,7 +170,9 @@ public abstract class SearchLineageFixtureConfiguration {
         indexBuilder,
         TEST_SEARCH_SERVICE_CONFIG,
         TEST_ES_SEARCH_CONFIG,
-        new V2MappingsBuilder(TEST_ES_SEARCH_CONFIG.getEntityIndex()),
+        new V2MappingsBuilder(
+            TEST_ES_SEARCH_CONFIG.getEntityIndex(),
+            OpenSearch2SearchClientShim.PARTIAL_NGRAM_CONFIG),
         new V2LegacySettingsBuilder(TEST_ES_SEARCH_CONFIG.getIndex(), indexConvention),
         searchDAO,
         browseDAO,

--- a/metadata-io/src/test/java/io/datahubproject/test/search/FaultInjectingSearchClientShim.java
+++ b/metadata-io/src/test/java/io/datahubproject/test/search/FaultInjectingSearchClientShim.java
@@ -342,6 +342,12 @@ public class FaultInjectingSearchClientShim implements SearchClientShim<Object> 
 
   @Override
   @Nonnull
+  public Map<String, String> partialNgramConfig() {
+    return delegate.partialNgramConfig();
+  }
+
+  @Override
+  @Nonnull
   public String getEngineVersion() throws IOException {
     return delegate.getEngineVersion();
   }

--- a/metadata-io/src/testFixtures/java/io/datahubproject/test/search/SearchTestUtils.java
+++ b/metadata-io/src/testFixtures/java/io/datahubproject/test/search/SearchTestUtils.java
@@ -536,7 +536,11 @@ public class SearchTestUtils {
     List<MappingsBuilder> builders = new ArrayList<>();
 
     if (entityIndexConfiguration.getV2().isEnabled()) {
-      builders.add(new V2MappingsBuilder(entityIndexConfiguration));
+      builders.add(
+          new V2MappingsBuilder(
+              entityIndexConfiguration,
+              com.linkedin.metadata.search.elasticsearch.client.shim.impl
+                  .OpenSearch2SearchClientShim.PARTIAL_NGRAM_CONFIG));
     }
     if (entityIndexConfiguration.getV3().isEnabled()) {
       try {

--- a/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHookTest.java
+++ b/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHookTest.java
@@ -45,6 +45,7 @@ import com.linkedin.metadata.query.filter.ConjunctiveCriterionArray;
 import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.query.filter.RelationshipDirection;
 import com.linkedin.metadata.search.elasticsearch.ElasticSearchService;
+import com.linkedin.metadata.search.elasticsearch.index.entity.v2.V2MappingsBuilder;
 import com.linkedin.metadata.search.transformer.SearchDocumentTransformer;
 import com.linkedin.metadata.service.UpdateGraphIndicesService;
 import com.linkedin.metadata.service.UpdateIndicesService;
@@ -144,7 +145,8 @@ public class UpdateIndicesHookTest {
             "MD5",
             null,
             mock(IndexConvention.class),
-            false);
+            false,
+            mock(V2MappingsBuilder.class));
 
     updateIndicesService =
         new UpdateIndicesService(
@@ -262,7 +264,8 @@ public class UpdateIndicesHookTest {
             "MD5",
             null,
             mock(IndexConvention.class),
-            false);
+            false,
+            mock(V2MappingsBuilder.class));
 
     updateIndicesService =
         new UpdateIndicesService(
@@ -895,7 +898,8 @@ public class UpdateIndicesHookTest {
               "MD5",
               null, // No semantic search config for this test
               mock(IndexConvention.class),
-              false);
+              false,
+              mock(V2MappingsBuilder.class));
       strategies.add(v2Strategy);
     }
 

--- a/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/spring/MCLSpringCommonTestConfiguration.java
+++ b/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/spring/MCLSpringCommonTestConfiguration.java
@@ -13,6 +13,7 @@ import com.linkedin.metadata.graph.elastic.ElasticSearchGraphService;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.search.elasticsearch.ElasticSearchService;
 import com.linkedin.metadata.search.elasticsearch.index.SettingsBuilder;
+import com.linkedin.metadata.search.elasticsearch.index.entity.v2.V2MappingsBuilder;
 import com.linkedin.metadata.search.elasticsearch.update.ESBulkProcessor;
 import com.linkedin.metadata.search.transformer.SearchDocumentTransformer;
 import com.linkedin.metadata.service.FormService;
@@ -198,5 +199,11 @@ public class MCLSpringCommonTestConfiguration {
   @Primary
   public ESBulkProcessor elasticSearchBulkProcessor() {
     return Mockito.mock(ESBulkProcessor.class);
+  }
+
+  @Bean(name = "legacyMappingsBuilder")
+  @Primary
+  public V2MappingsBuilder legacyMappingsBuilder() {
+    return Mockito.mock(V2MappingsBuilder.class);
   }
 }

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entity/update/indices/UpdateIndicesStrategyFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entity/update/indices/UpdateIndicesStrategyFactory.java
@@ -6,6 +6,7 @@ import com.linkedin.gms.factory.search.ElasticSearchServiceFactory;
 import com.linkedin.metadata.config.search.EntityIndexVersionConfiguration;
 import com.linkedin.metadata.config.search.SemanticSearchConfiguration;
 import com.linkedin.metadata.search.elasticsearch.ElasticSearchService;
+import com.linkedin.metadata.search.elasticsearch.index.entity.v2.V2MappingsBuilder;
 import com.linkedin.metadata.search.transformer.SearchDocumentTransformer;
 import com.linkedin.metadata.service.UpdateIndicesStrategy;
 import com.linkedin.metadata.service.UpdateIndicesV2Strategy;
@@ -35,6 +36,7 @@ public class UpdateIndicesStrategyFactory {
       TimeseriesAspectService timeseriesAspectService,
       ConfigurationProvider configProvider,
       @Qualifier(IndexConventionFactory.INDEX_CONVENTION_BEAN) IndexConvention indexConvention,
+      @Qualifier("legacyMappingsBuilder") V2MappingsBuilder mappingsBuilder,
       @Value("${elasticsearch.idHashAlgo}") String idHashAlgo,
       @Value("${elasticsearch.entityIndex.v2.cleanup:false}") boolean v2Cleanup,
       @Value("${elasticsearch.entityIndex.v2.coalesceBatchUpdates:false}")
@@ -73,7 +75,8 @@ public class UpdateIndicesStrategyFactory {
         idHashAlgo,
         semanticSearchConfig,
         indexConvention,
-        coalesceBatchUpdates);
+        coalesceBatchUpdates,
+        mappingsBuilder);
   }
 
   @Bean("updateIndicesV3Strategy")

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/search/MappingsBuilderFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/search/MappingsBuilderFactory.java
@@ -30,10 +30,12 @@ public class MappingsBuilderFactory {
   @Bean("legacyMappingsBuilder")
   @ConditionalOnProperty(name = "elasticsearch.entityIndex.v2.enabled", havingValue = "true")
   @Nonnull
-  protected MappingsBuilder createLegacyMappingsBuilder(ConfigurationProvider configProvider) {
+  protected MappingsBuilder createLegacyMappingsBuilder(
+      ConfigurationProvider configProvider,
+      @Qualifier("searchClientShim") SearchClientShim<?> searchClient) {
     EntityIndexConfiguration entityIndexConfig = configProvider.getElasticSearch().getEntityIndex();
-    log.info("Creating LegacyMappingsBuilder bean");
-    return new V2MappingsBuilder(entityIndexConfig);
+    log.info("Creating LegacyMappingsBuilder bean (engineType={})", searchClient.getEngineType());
+    return new V2MappingsBuilder(entityIndexConfig, searchClient.partialNgramConfig());
   }
 
   @Bean("multiEntityMappingsBuilder")

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/search/DisabledCustomSearchTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/search/DisabledCustomSearchTest.java
@@ -9,6 +9,7 @@ import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.search.elasticsearch.ElasticSearchService;
 import com.linkedin.metadata.search.elasticsearch.index.SettingsBuilder;
 import com.linkedin.metadata.search.elasticsearch.query.filter.QueryFilterRewriteChain;
+import com.linkedin.metadata.utils.elasticsearch.SearchClientShim;
 import com.linkedin.metadata.utils.metrics.MetricUtils;
 import io.datahubproject.metadata.context.ObjectMapperContext;
 import io.datahubproject.metadata.context.OperationContext;
@@ -68,6 +69,20 @@ public class DisabledCustomSearchTest extends AbstractTestNGSpringContextTests {
     public EntityRegistry entityRegistry(
         @Qualifier("systemOperationContext") OperationContext systemOperationContext) {
       return systemOperationContext.getEntityRegistry();
+    }
+
+    @Bean(name = "searchClientShim")
+    @Primary
+    @SuppressWarnings("unchecked")
+    public SearchClientShim<?> searchClientShim() {
+      SearchClientShim<?> mock = Mockito.mock(SearchClientShim.class);
+      Mockito.when(mock.getEngineType())
+          .thenReturn(SearchClientShim.SearchEngineType.ELASTICSEARCH_8);
+      Mockito.when(mock.partialNgramConfig())
+          .thenReturn(
+              com.linkedin.metadata.search.elasticsearch.client.shim.impl.Es8SearchClientShim
+                  .PARTIAL_NGRAM_CONFIG);
+      return mock;
     }
   }
 

--- a/metadata-utils/src/main/java/com/linkedin/metadata/utils/elasticsearch/SearchClientShim.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/utils/elasticsearch/SearchClientShim.java
@@ -292,6 +292,16 @@ public interface SearchClientShim<T> extends Closeable {
   @Nonnull
   SearchEngineType getEngineType();
 
+  /**
+   * Returns the base config for the {@code search_as_you_type} partial-ngram subfield.
+   *
+   * <p>ES7 and OpenSearch 2.x persist {@code doc_values: false} on round-trip, while ES8+ silently
+   * strips it. Each shim implementation supplies the variant that matches its engine, keeping
+   * engine-version knowledge inside the shim layer.
+   */
+  @Nonnull
+  Map<String, String> partialNgramConfig();
+
   @Nonnull
   String getEngineVersion() throws IOException;
 


### PR DESCRIPTION
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->


On ES8, the mapping diff comparator` (ReindexConfig.java:238–246) `continuously flagged for reindexing during every system update cycle.

Logs showed entriesDiffering for the source, destination, and properties fields:

```
left (ES stored): {properties: {...}, type=object} // includes explicit type
right (DataHub code): {properties: {...}} // missing type
```

Elasticsearch 8 returns mappings with an explicit type: **object** for object fields.
However, DataHub’s GraphRelationshipMappingsBuilder previously omitted this, relying on **Elasticsearch’s implicit** default.

This mismatch caused the mapping comparison to **fail on every round trip**, triggering a reindex on each cycle without ever converging.

  **Summary**

  - ES8+ silently strips doc_values: false from search_as_you_type fields on round-trip, while ES7/OpenSearch persist it. This caused V2MappingsBuilder to emit a config that never matched what the cluster
  returned — every diff flagged a change and triggered a fresh reindex on every restart.
  - V2MappingsBuilder now selects the partial-ngram config based on SearchEngineType: ES8+ omits doc_values: false; legacy engines keep it. engineType is plumbed through MappingsBuilderFactory,
  UpdateIndicesStrategyFactory, and UpdateIndicesV2Strategy.
  - ReindexConfig.normalizeObjectForComparison now injects the implicit type: "object" ES adds for any node containing properties, eliminating another spurious-diff source that fed the same loop.

  **Changes**

  - `V2MappingsBuilder.java` — engine-aware PARTIAL_NGRAM_CONFIG_LEGACY vs PARTIAL_NGRAM_CONFIG_ES8; static methods → instance methods.
  - `ReindexConfig.java `— add implicit type: object during normalization when properties is present without type.
  - `UpdateIndicesV2Strategy.java`, UpdateIndicesStrategyFactory.java, MappingsBuilderFactory.java — propagate SearchEngineType to the mappings builder.
  - Tests added/updated in V2MappingsBuilderTest, ReindexConfigTest, UpdateIndicesV2StrategyTest, UpdateIndicesHookTest, UpdateIndicesServiceTest, DisabledCustomSearchTest.