### PR TITLE
feat: Add PdlEnumMapper for safe PDL-to-GraphQL enum conversion

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mappers/PdlEnumMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mappers/PdlEnumMapper.java
@@ -1,0 +1,53 @@
+package com.linkedin.datahub.graphql.types.mappers;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Safe mapping from PDL enum values to GraphQL-generated Java enums.
+ *
+ * <p>PDL enums use {@code $UNKNOWN} as a sentinel for forwards compatibility: when an older schema
+ * reads an enum value added in a newer version, Pegasus deserializes it as {@code $UNKNOWN}. The
+ * GraphQL-generated Java enums do not include {@code $UNKNOWN}, so a raw {@link Enum#valueOf} call
+ * will throw {@link IllegalArgumentException}. Always use this mapper instead.
+ */
+@Slf4j
+public final class PdlEnumMapper {
+
+  private PdlEnumMapper() {}
+
+  /**
+   * Maps a PDL enum value to the corresponding GraphQL enum constant, falling back to {@code
+   * defaultValue} for any unrecognized value (including {@code $UNKNOWN}).
+   */
+  @Nonnull
+  public static <T extends Enum<T>> T map(
+      @Nonnull Class<T> graphqlEnum, @Nonnull Enum<?> pdlValue, @Nonnull T defaultValue) {
+    try {
+      return Enum.valueOf(graphqlEnum, pdlValue.toString());
+    } catch (IllegalArgumentException e) {
+      log.warn(
+          "Unmapped PDL enum value '{}' for {}; falling back to {}",
+          pdlValue,
+          graphqlEnum.getSimpleName(),
+          defaultValue);
+      return defaultValue;
+    }
+  }
+
+  /** Maps a PDL enum value to the corresponding GraphQL enum constant, falling back to null. */
+  @Nullable
+  public static <T extends Enum<T>> T mapDefaultNull(
+      @Nonnull Class<T> graphqlEnum, @Nonnull Enum<?> pdlValue) {
+    try {
+      return Enum.valueOf(graphqlEnum, pdlValue.toString());
+    } catch (IllegalArgumentException e) {
+      log.warn(
+          "Unmapped PDL enum value '{}' for {}; falling back to null",
+          pdlValue,
+          graphqlEnum.getSimpleName());
+      return null;
+    }
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mappers/PdlEnumMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mappers/PdlEnumMapper.java
@@ -25,7 +25,7 @@ public final class PdlEnumMapper {
   public static <T extends Enum<T>> T map(
       @Nonnull Class<T> graphqlEnum, @Nonnull Enum<?> pdlValue, @Nonnull T defaultValue) {
     try {
-      return Enum.valueOf(graphqlEnum, pdlValue.toString());
+      return Enum.valueOf(graphqlEnum, pdlValue.name());
     } catch (IllegalArgumentException e) {
       log.warn(
           "Unmapped PDL enum value '{}' for {}; falling back to {}",
@@ -41,7 +41,7 @@ public final class PdlEnumMapper {
   public static <T extends Enum<T>> T mapDefaultNull(
       @Nonnull Class<T> graphqlEnum, @Nonnull Enum<?> pdlValue) {
     try {
-      return Enum.valueOf(graphqlEnum, pdlValue.toString());
+      return Enum.valueOf(graphqlEnum, pdlValue.name());
     } catch (IllegalArgumentException e) {
       log.warn(
           "Unmapped PDL enum value '{}' for {}; falling back to null",

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/mappers/PdlEnumMapperTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/mappers/PdlEnumMapperTest.java
@@ -16,7 +16,13 @@ public class PdlEnumMapperTest {
 
   private enum FakePdlEnum {
     KNOWN_VALUE,
-    $UNKNOWN
+    UNKNOWN_WITH_CUSTOM_TO_STRING,
+    $UNKNOWN;
+
+    @Override
+    public String toString() {
+      return this == UNKNOWN_WITH_CUSTOM_TO_STRING ? "UNKNOWN" : name();
+    }
   }
 
   @Test
@@ -31,6 +37,14 @@ public class PdlEnumMapperTest {
     OriginType result =
         PdlEnumMapper.map(OriginType.class, FakePdlEnum.KNOWN_VALUE, OriginType.UNKNOWN);
     assertEquals(result, OriginType.UNKNOWN);
+  }
+
+  @Test
+  public void testMapUsesEnumNameNotToString() {
+    OriginType result =
+        PdlEnumMapper.map(
+            OriginType.class, FakePdlEnum.UNKNOWN_WITH_CUSTOM_TO_STRING, OriginType.NATIVE);
+    assertEquals(result, OriginType.NATIVE);
   }
 
   @Test

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/mappers/PdlEnumMapperTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/mappers/PdlEnumMapperTest.java
@@ -1,0 +1,47 @@
+package com.linkedin.datahub.graphql.types.mappers;
+
+import static org.testng.Assert.*;
+
+import com.linkedin.datahub.graphql.generated.OriginType;
+import org.testng.annotations.Test;
+
+public class PdlEnumMapperTest {
+
+  @Test
+  public void testMapKnownValue() {
+    assertEquals(
+        PdlEnumMapper.map(OriginType.class, OriginType.UNKNOWN, OriginType.UNKNOWN),
+        OriginType.UNKNOWN);
+  }
+
+  private enum FakePdlEnum {
+    KNOWN_VALUE,
+    $UNKNOWN
+  }
+
+  @Test
+  public void testMapDollarUnknownFallsBack() {
+    OriginType result =
+        PdlEnumMapper.map(OriginType.class, FakePdlEnum.$UNKNOWN, OriginType.UNKNOWN);
+    assertEquals(result, OriginType.UNKNOWN);
+  }
+
+  @Test
+  public void testMapUnrecognizedValueFallsBack() {
+    OriginType result =
+        PdlEnumMapper.map(OriginType.class, FakePdlEnum.KNOWN_VALUE, OriginType.UNKNOWN);
+    assertEquals(result, OriginType.UNKNOWN);
+  }
+
+  @Test
+  public void testMapDefaultNullMatch() {
+    OriginType result = PdlEnumMapper.mapDefaultNull(OriginType.class, OriginType.UNKNOWN);
+    assertEquals(result, OriginType.UNKNOWN);
+  }
+
+  @Test
+  public void testMapDefaultNullNoMatch() {
+    OriginType result = PdlEnumMapper.mapDefaultNull(OriginType.class, FakePdlEnum.KNOWN_VALUE);
+    assertNull(result);
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/mappers/UnsafeEnumValueOfLintTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/mappers/UnsafeEnumValueOfLintTest.java
@@ -1,0 +1,285 @@
+package com.linkedin.datahub.graphql.types.mappers;
+
+import static org.testng.Assert.fail;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.testng.annotations.Test;
+
+/**
+ * Lint-style test that detects unsafe {@code SomeEnum.valueOf(pdlValue.toString())} and {@code
+ * SomeEnum.valueOf(pdlValue.name())} calls in mapper code that reads PDL data into GraphQL types.
+ *
+ * <p>PDL enums use {@code $UNKNOWN} as a sentinel for forwards compatibility: when an older schema
+ * reads an enum value added in a newer version, Pegasus deserializes it as {@code $UNKNOWN}. The
+ * GraphQL-generated Java enums do not include {@code $UNKNOWN}, so a raw {@link Enum#valueOf} call
+ * will throw {@link IllegalArgumentException}. Use {@link PdlEnumMapper#map} instead.
+ *
+ * <p>This test scans mapper files (files whose names end with {@code Mapper.java}) under {@code
+ * datahub-graphql-core/src/main/java}. A GraphQL-generated enum is identified either by its import
+ * ({@code import com.linkedin.datahub.graphql.generated.Foo}) or by a fully-qualified reference
+ * ({@code com.linkedin.datahub.graphql.generated.Foo.valueOf(...)}) in the source code.
+ *
+ * <p>The file is read as a single string so that multi-line {@code valueOf()} calls (where the
+ * arguments are wrapped to the next line) are detected. The regex uses {@code [^;]*?} (not {@code
+ * .*?}) to constrain matches to a single statement, preventing false positives across semicolons.
+ */
+public class UnsafeEnumValueOfLintTest {
+
+  private static final String GENERATED_PKG = "com.linkedin.datahub.graphql.generated.";
+
+  /**
+   * Matches {@code SomeEnum.valueOf(<expr>.toString())} or {@code .name())} within a single
+   * statement. Uses {@code [^;]*?} instead of {@code .*?} so the match cannot cross a semicolon
+   * boundary, preventing false positives when two unrelated calls appear in the same file. Group 1
+   * captures the simple enum name (e.g. {@code MonitorState}).
+   */
+  private static final Pattern SIMPLE_VALUEOF_PATTERN =
+      Pattern.compile("(\\w+)\\.valueOf\\([^;]*?\\.(?:toString|name)\\(\\)\\)", Pattern.DOTALL);
+
+  /**
+   * Matches the fully-qualified form {@code com.linkedin.datahub.graphql.generated.Foo.valueOf(
+   * <expr>.toString())} or {@code .name())}. Group 1 captures the simple enum name. This catches
+   * calls that bypass imports and would otherwise be invisible to the import-based check.
+   */
+  private static final Pattern QUALIFIED_VALUEOF_PATTERN =
+      Pattern.compile(
+          "com\\.linkedin\\.datahub\\.graphql\\.generated\\.(\\w+)"
+              + "\\.valueOf\\([^;]*?\\.(?:toString|name)\\(\\)\\)",
+          Pattern.DOTALL);
+
+  /**
+   * Pre-existing violations that should be migrated to PdlEnumMapper.map(). Do not add new entries
+   * -- fix the code instead. Each entry here is a ticking time bomb that will crash if the
+   * corresponding PDL enum gets a new value on a newer writer.
+   */
+  private static final Set<String> PREEXISTING_VIOLATIONS =
+      Set.of(
+          "java/com/linkedin/datahub/graphql/resolvers/connection/ConnectionMapper.java",
+          "java/com/linkedin/datahub/graphql/resolvers/policy/mappers/PolicyInfoPolicyMapper.java",
+          "java/com/linkedin/datahub/graphql/resolvers/settings/SettingsMapper.java",
+          "java/com/linkedin/datahub/graphql/resolvers/test/BatchTestRunEventMapper.java",
+          "java/com/linkedin/datahub/graphql/types/ai/mappers/DataHubAiConversationMapper.java",
+          "java/com/linkedin/datahub/graphql/types/assertion/AssertionAssignmentRuleMapper.java",
+          "java/com/linkedin/datahub/graphql/types/assertion/AssertionMapper.java",
+          "java/com/linkedin/datahub/graphql/types/assertion/FieldAssertionMapper.java",
+          "java/com/linkedin/datahub/graphql/types/assertion/FreshnessAssertionMapper.java",
+          "java/com/linkedin/datahub/graphql/types/assertion/SqlAssertionMapper.java",
+          "java/com/linkedin/datahub/graphql/types/assertion/VolumeAssertionMapper.java",
+          "java/com/linkedin/datahub/graphql/types/auth/mappers/OAuthAuthorizationServerMapper.java",
+          "java/com/linkedin/datahub/graphql/types/chart/mappers/ChartMapper.java",
+          "java/com/linkedin/datahub/graphql/types/common/mappers/CostMapper.java",
+          "java/com/linkedin/datahub/graphql/types/common/mappers/DataTransformLogicMapper.java",
+          "java/com/linkedin/datahub/graphql/types/common/mappers/DisplayPropertiesMapper.java",
+          "java/com/linkedin/datahub/graphql/types/common/mappers/OperationMapper.java",
+          "java/com/linkedin/datahub/graphql/types/common/mappers/OriginMapper.java",
+          "java/com/linkedin/datahub/graphql/types/common/mappers/OwnerMapper.java",
+          "java/com/linkedin/datahub/graphql/types/common/mappers/ShareMapper.java",
+          "java/com/linkedin/datahub/graphql/types/corpgroup/mappers/CorpGroupMapper.java",
+          "java/com/linkedin/datahub/graphql/types/corpuser/mappers/CorpUserInvitationStatusMapper.java",
+          "java/com/linkedin/datahub/graphql/types/corpuser/mappers/CorpUserMapper.java",
+          "java/com/linkedin/datahub/graphql/types/dashboard/mappers/DashboardMapper.java",
+          "java/com/linkedin/datahub/graphql/types/datacontract/DataContractMapper.java",
+          "java/com/linkedin/datahub/graphql/types/dataplatform/mappers/DataPlatformInfoMapper.java",
+          "java/com/linkedin/datahub/graphql/types/dataplatform/mappers/DataPlatformPropertiesMapper.java",
+          "java/com/linkedin/datahub/graphql/types/dataprocessinst/mappers/DataProcessInstanceRunEventMapper.java",
+          "java/com/linkedin/datahub/graphql/types/dataprocessinst/mappers/DataProcessInstanceRunResultMapper.java",
+          "java/com/linkedin/datahub/graphql/types/dataset/mappers/AssertionRunEventMapper.java",
+          "java/com/linkedin/datahub/graphql/types/dataset/mappers/DatasetFilterMapper.java",
+          "java/com/linkedin/datahub/graphql/types/dataset/mappers/DatasetMapper.java",
+          "java/com/linkedin/datahub/graphql/types/dataset/mappers/DatasetProfileMapper.java",
+          "java/com/linkedin/datahub/graphql/types/dataset/mappers/VersionedDatasetMapper.java",
+          "java/com/linkedin/datahub/graphql/types/ermodelrelationship/mappers/ERModelRelationMapper.java",
+          "java/com/linkedin/datahub/graphql/types/file/DataHubFileMapper.java",
+          "java/com/linkedin/datahub/graphql/types/form/FormMapper.java",
+          "java/com/linkedin/datahub/graphql/types/incident/IncidentMapper.java",
+          "java/com/linkedin/datahub/graphql/types/ingestion/IngestionSourceMapper.java",
+          "java/com/linkedin/datahub/graphql/types/knowledge/DocumentMapper.java",
+          "java/com/linkedin/datahub/graphql/types/mappers/UrnSearchAcrossLineageResultsMapper.java",
+          "java/com/linkedin/datahub/graphql/types/mlmodel/mappers/IntendedUseMapper.java",
+          "java/com/linkedin/datahub/graphql/types/mlmodel/mappers/MLFeatureMapper.java",
+          "java/com/linkedin/datahub/graphql/types/mlmodel/mappers/MLFeaturePropertiesMapper.java",
+          "java/com/linkedin/datahub/graphql/types/mlmodel/mappers/MLModelGroupMapper.java",
+          "java/com/linkedin/datahub/graphql/types/mlmodel/mappers/MLModelMapper.java",
+          "java/com/linkedin/datahub/graphql/types/mlmodel/mappers/MLPrimaryKeyMapper.java",
+          "java/com/linkedin/datahub/graphql/types/mlmodel/mappers/MLPrimaryKeyPropertiesMapper.java",
+          "java/com/linkedin/datahub/graphql/types/mlmodel/mappers/SourceCodeUrlMapper.java",
+          "java/com/linkedin/datahub/graphql/types/module/PageModuleTypeMapper.java",
+          "java/com/linkedin/datahub/graphql/types/module/PageModuleVisibilityMapper.java",
+          "java/com/linkedin/datahub/graphql/types/monitor/MonitorMapper.java",
+          "java/com/linkedin/datahub/graphql/types/notebook/mappers/NotebookMapper.java",
+          "java/com/linkedin/datahub/graphql/types/notification/mappers/NotificationSettingMapMapper.java",
+          "java/com/linkedin/datahub/graphql/types/notification/mappers/NotificationSettingsMapper.java",
+          "java/com/linkedin/datahub/graphql/types/operations/OperationsAggregationMapper.java",
+          "java/com/linkedin/datahub/graphql/types/policy/DataHubPolicyMapper.java",
+          "java/com/linkedin/datahub/graphql/types/post/PostMapper.java",
+          "java/com/linkedin/datahub/graphql/types/remoteexecutor/RemoteExecutorPoolMapper.java",
+          "java/com/linkedin/datahub/graphql/types/service/mappers/ServiceMapper.java",
+          "java/com/linkedin/datahub/graphql/types/structuredproperty/StructuredPropertyMapper.java",
+          "java/com/linkedin/datahub/graphql/types/subscription/mappers/DataHubSubscriptionMapper.java",
+          "java/com/linkedin/datahub/graphql/types/template/PageTemplateMapper.java",
+          "java/com/linkedin/datahub/graphql/types/template/PageTemplateSurfaceMapper.java",
+          "java/com/linkedin/datahub/graphql/types/template/PageTemplateVisibilityMapper.java",
+          "java/com/linkedin/datahub/graphql/types/test/TestMapper.java",
+          "java/com/linkedin/datahub/graphql/types/timeline/mappers/ChangeEventMapper.java",
+          "java/com/linkedin/datahub/graphql/types/usage/UsageAggregationMapper.java",
+          "java/com/linkedin/datahub/graphql/types/view/DataHubViewMapper.java");
+
+  /**
+   * Scans all *Mapper.java files for unsafe valueOf(toString()/name()) calls on GraphQL-generated
+   * enums.
+   *
+   * <p>How the scan works, step by step:
+   *
+   * <ol>
+   *   <li><b>Walk the source tree</b> — recursively visit every file under {@code
+   *       datahub-graphql-core/src/main/java}.
+   *   <li><b>Filter to mapper files only</b> — only files ending in {@code Mapper.java} are
+   *       checked. Resolvers are skipped because they typically map in the safe direction (GraphQL
+   *       input → PDL), not the dangerous direction (PDL → GraphQL output).
+   *   <li><b>Skip pre-existing violations</b> — files listed in {@link #PREEXISTING_VIOLATIONS} are
+   *       excluded so the test passes today; those files are tech debt to migrate later.
+   *   <li><b>Read the whole file as a string</b> — so that multi-line {@code valueOf()} calls
+   *       (where arguments wrap to the next line) are visible to the regex.
+   *   <li><b>Collect GraphQL enum imports</b> — scan import statements for anything from {@code
+   *       com.linkedin.datahub.graphql.generated.*}. These simple names are used to identify the
+   *       import-based pattern.
+   *   <li><b>Regex-match — import-based pattern</b> — find {@code <EnumName>.valueOf([^;]*?
+   *       .toString()) } or {@code .name())} where {@code <EnumName>} matches a collected import.
+   *       Uses {@code [^;]*?} to stay within a single statement. Uses {@link Pattern#DOTALL} so the
+   *       match can cross newlines.
+   *   <li><b>Regex-match — fully-qualified pattern</b> — independently find {@code
+   *       com.linkedin.datahub.graphql.generated.<Enum>.valueOf(...)} calls. These don't need an
+   *       import to be dangerous — the package prefix is proof enough.
+   *   <li><b>Fail with actionable output</b> — if any violations are found, the test fails with the
+   *       exact file, line number, and enum name, plus instructions to use {@link PdlEnumMapper}.
+   * </ol>
+   */
+  @Test
+  public void noUnsafeEnumValueOfCallsInMappers() throws IOException {
+    Path srcRoot = findSourceRoot();
+    if (srcRoot == null || !Files.isDirectory(srcRoot)) {
+      return;
+    }
+
+    List<String> violations = new ArrayList<>();
+
+    // Step 1: Walk the source tree
+    Files.walkFileTree(
+        srcRoot,
+        new SimpleFileVisitor<Path>() {
+          @Override
+          public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+              throws IOException {
+            // Step 2: Only inspect *Mapper.java files (the PDL → GraphQL read path)
+            String fileName = file.getFileName().toString();
+            if (!fileName.endsWith("Mapper.java")) {
+              return FileVisitResult.CONTINUE;
+            }
+
+            // Step 3: Skip files with known pre-existing violations (tech debt)
+            String relativePath = srcRoot.getParent().relativize(file).toString();
+            if (PREEXISTING_VIOLATIONS.contains(relativePath)) {
+              return FileVisitResult.CONTINUE;
+            }
+
+            // Step 4: Read the entire file as one string so multi-line valueOf()
+            // calls (where arguments wrap to the next line) are visible to the regex.
+            String content = Files.readString(file);
+
+            // Step 5: Collect the simple names of all GraphQL-generated enum imports.
+            // These are the types that DON'T have a $UNKNOWN constant and will crash
+            // if valueOf() receives one.
+            Set<String> generatedEnumImports = new HashSet<>();
+            for (String line : content.split("\n")) {
+              if (line.startsWith("import " + GENERATED_PKG) && !line.contains("*")) {
+                String imported = line.replace("import ", "").replace(";", "").trim();
+                String simpleName = imported.substring(imported.lastIndexOf('.') + 1);
+                generatedEnumImports.add(simpleName);
+              }
+            }
+
+            // Track violations by character offset to deduplicate across the two patterns.
+            Set<Integer> reportedOffsets = new HashSet<>();
+
+            // Step 6: Match the import-based pattern — SomeEnum.valueOf(<expr>.toString()/name())
+            // where SomeEnum is one of the GraphQL-generated imports.
+            if (!generatedEnumImports.isEmpty()) {
+              Matcher m = SIMPLE_VALUEOF_PATTERN.matcher(content);
+              while (m.find()) {
+                String enumName = m.group(1);
+                if (generatedEnumImports.contains(enumName)) {
+                  reportedOffsets.add(m.start());
+                  violations.add(formatViolation(content, m.start(), relativePath, enumName));
+                }
+              }
+            }
+
+            // Step 7: Match the fully-qualified pattern —
+            // com.linkedin.datahub.graphql.generated.Foo.valueOf(<expr>.toString()/name()).
+            // These don't need an import to be dangerous.
+            Matcher qm = QUALIFIED_VALUEOF_PATTERN.matcher(content);
+            while (qm.find()) {
+              if (!reportedOffsets.contains(qm.start())) {
+                violations.add(formatViolation(content, qm.start(), relativePath, qm.group(1)));
+              }
+            }
+
+            return FileVisitResult.CONTINUE;
+          }
+        });
+
+    // Step 8: Fail with actionable output listing every violation
+    if (!violations.isEmpty()) {
+      fail(
+          "Found unsafe Enum.valueOf(pdlValue.toString()/name()) calls in mapper code.\n"
+              + "PDL may deserialize unknown enum values as $UNKNOWN, which crashes valueOf().\n"
+              + "Use PdlEnumMapper.map(EnumClass.class, pdlValue, defaultValue) instead.\n\n"
+              + String.join("\n", violations)
+              + "\n\n"
+              + "Do NOT add new entries to PREEXISTING_VIOLATIONS — fix the code instead.\n");
+    }
+  }
+
+  /** Convert a character offset in {@code content} to a 1-based line number. */
+  private static int lineNumberAt(String content, int offset) {
+    int line = 1;
+    for (int i = 0; i < offset && i < content.length(); i++) {
+      if (content.charAt(i) == '\n') {
+        line++;
+      }
+    }
+    return line;
+  }
+
+  private static String formatViolation(
+      String content, int matchStart, String relativePath, String enumName) {
+    return String.format(
+        "  %s:%d — %s.valueOf(...toString()/name()) is unsafe for PDL enums. "
+            + "Use PdlEnumMapper.map() instead.",
+        relativePath, lineNumberAt(content, matchStart), enumName);
+  }
+
+  private static Path findSourceRoot() {
+    Path candidate = Paths.get("datahub-graphql-core/src/main/java");
+    if (Files.isDirectory(candidate)) {
+      return candidate;
+    }
+    candidate = Paths.get("src/main/java");
+    if (Files.isDirectory(candidate)) {
+      return candidate;
+    }
+    return null;
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/mappers/UnsafeEnumValueOfLintTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/mappers/UnsafeEnumValueOfLintTest.java
@@ -10,162 +10,584 @@ import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.testng.annotations.Test;
 
 /**
- * Lint-style test that detects unsafe {@code SomeEnum.valueOf(pdlValue.toString())} and {@code
- * SomeEnum.valueOf(pdlValue.name())} calls in mapper code that reads PDL data into GraphQL types.
+ * Detects unsafe GraphQL enum {@code valueOf(pdlValue.name()/toString())} calls in mapper code.
  *
- * <p>PDL enums use {@code $UNKNOWN} as a sentinel for forwards compatibility: when an older schema
- * reads an enum value added in a newer version, Pegasus deserializes it as {@code $UNKNOWN}. The
- * GraphQL-generated Java enums do not include {@code $UNKNOWN}, so a raw {@link Enum#valueOf} call
- * will throw {@link IllegalArgumentException}. Use {@link PdlEnumMapper#map} instead.
- *
- * <p>This test scans mapper files (files whose names end with {@code Mapper.java}) under {@code
- * datahub-graphql-core/src/main/java}. A GraphQL-generated enum is identified either by its import
- * ({@code import com.linkedin.datahub.graphql.generated.Foo}) or by a fully-qualified reference
- * ({@code com.linkedin.datahub.graphql.generated.Foo.valueOf(...)}) in the source code.
- *
- * <p>The file is read as a single string so that multi-line {@code valueOf()} calls (where the
- * arguments are wrapped to the next line) are detected. The regex uses {@code [^;]*?} (not {@code
- * .*?}) to constrain matches to a single statement, preventing false positives across semicolons.
+ * <p>PDL enums can deserialize newer values as {@code $UNKNOWN}, but GraphQL-generated Java enums
+ * do not include that sentinel. New mapper code should use {@link PdlEnumMapper#map} instead.
  */
 public class UnsafeEnumValueOfLintTest {
 
   private static final String GENERATED_PKG = "com.linkedin.datahub.graphql.generated.";
 
-  /**
-   * Matches {@code SomeEnum.valueOf(<expr>.toString())} or {@code .name())} within a single
-   * statement. Uses {@code [^;]*?} instead of {@code .*?} so the match cannot cross a semicolon
-   * boundary, preventing false positives when two unrelated calls appear in the same file. Group 1
-   * captures the simple enum name (e.g. {@code MonitorState}).
-   */
   private static final Pattern SIMPLE_VALUEOF_PATTERN =
       Pattern.compile("(\\w+)\\.valueOf\\([^;]*?\\.(?:toString|name)\\(\\)\\)", Pattern.DOTALL);
 
-  /**
-   * Matches the fully-qualified form {@code com.linkedin.datahub.graphql.generated.Foo.valueOf(
-   * <expr>.toString())} or {@code .name())}. Group 1 captures the simple enum name. This catches
-   * calls that bypass imports and would otherwise be invisible to the import-based check.
-   */
   private static final Pattern QUALIFIED_VALUEOF_PATTERN =
       Pattern.compile(
           "com\\.linkedin\\.datahub\\.graphql\\.generated\\.(\\w+)"
               + "\\.valueOf\\([^;]*?\\.(?:toString|name)\\(\\)\\)",
           Pattern.DOTALL);
 
-  /**
-   * Pre-existing violations that should be migrated to PdlEnumMapper.map(). Do not add new entries
-   * -- fix the code instead. Each entry here is a ticking time bomb that will crash if the
-   * corresponding PDL enum gets a new value on a newer writer.
-   */
-  private static final Set<String> PREEXISTING_VIOLATIONS =
-      Set.of(
-          "java/com/linkedin/datahub/graphql/resolvers/connection/ConnectionMapper.java",
-          "java/com/linkedin/datahub/graphql/resolvers/policy/mappers/PolicyInfoPolicyMapper.java",
-          "java/com/linkedin/datahub/graphql/resolvers/settings/SettingsMapper.java",
-          "java/com/linkedin/datahub/graphql/resolvers/test/BatchTestRunEventMapper.java",
-          "java/com/linkedin/datahub/graphql/types/ai/mappers/DataHubAiConversationMapper.java",
-          "java/com/linkedin/datahub/graphql/types/assertion/AssertionAssignmentRuleMapper.java",
-          "java/com/linkedin/datahub/graphql/types/assertion/AssertionMapper.java",
-          "java/com/linkedin/datahub/graphql/types/assertion/FieldAssertionMapper.java",
-          "java/com/linkedin/datahub/graphql/types/assertion/FreshnessAssertionMapper.java",
-          "java/com/linkedin/datahub/graphql/types/assertion/SqlAssertionMapper.java",
-          "java/com/linkedin/datahub/graphql/types/assertion/VolumeAssertionMapper.java",
-          "java/com/linkedin/datahub/graphql/types/auth/mappers/OAuthAuthorizationServerMapper.java",
-          "java/com/linkedin/datahub/graphql/types/chart/mappers/ChartMapper.java",
-          "java/com/linkedin/datahub/graphql/types/common/mappers/CostMapper.java",
-          "java/com/linkedin/datahub/graphql/types/common/mappers/DataTransformLogicMapper.java",
-          "java/com/linkedin/datahub/graphql/types/common/mappers/DisplayPropertiesMapper.java",
-          "java/com/linkedin/datahub/graphql/types/common/mappers/OperationMapper.java",
-          "java/com/linkedin/datahub/graphql/types/common/mappers/OriginMapper.java",
-          "java/com/linkedin/datahub/graphql/types/common/mappers/OwnerMapper.java",
-          "java/com/linkedin/datahub/graphql/types/common/mappers/ShareMapper.java",
-          "java/com/linkedin/datahub/graphql/types/corpgroup/mappers/CorpGroupMapper.java",
-          "java/com/linkedin/datahub/graphql/types/corpuser/mappers/CorpUserInvitationStatusMapper.java",
-          "java/com/linkedin/datahub/graphql/types/corpuser/mappers/CorpUserMapper.java",
-          "java/com/linkedin/datahub/graphql/types/dashboard/mappers/DashboardMapper.java",
-          "java/com/linkedin/datahub/graphql/types/datacontract/DataContractMapper.java",
-          "java/com/linkedin/datahub/graphql/types/dataplatform/mappers/DataPlatformInfoMapper.java",
-          "java/com/linkedin/datahub/graphql/types/dataplatform/mappers/DataPlatformPropertiesMapper.java",
-          "java/com/linkedin/datahub/graphql/types/dataprocessinst/mappers/DataProcessInstanceRunEventMapper.java",
-          "java/com/linkedin/datahub/graphql/types/dataprocessinst/mappers/DataProcessInstanceRunResultMapper.java",
-          "java/com/linkedin/datahub/graphql/types/dataset/mappers/AssertionRunEventMapper.java",
-          "java/com/linkedin/datahub/graphql/types/dataset/mappers/DatasetFilterMapper.java",
-          "java/com/linkedin/datahub/graphql/types/dataset/mappers/DatasetMapper.java",
-          "java/com/linkedin/datahub/graphql/types/dataset/mappers/DatasetProfileMapper.java",
-          "java/com/linkedin/datahub/graphql/types/dataset/mappers/VersionedDatasetMapper.java",
-          "java/com/linkedin/datahub/graphql/types/ermodelrelationship/mappers/ERModelRelationMapper.java",
-          "java/com/linkedin/datahub/graphql/types/file/DataHubFileMapper.java",
-          "java/com/linkedin/datahub/graphql/types/form/FormMapper.java",
-          "java/com/linkedin/datahub/graphql/types/incident/IncidentMapper.java",
-          "java/com/linkedin/datahub/graphql/types/ingestion/IngestionSourceMapper.java",
-          "java/com/linkedin/datahub/graphql/types/knowledge/DocumentMapper.java",
-          "java/com/linkedin/datahub/graphql/types/mappers/UrnSearchAcrossLineageResultsMapper.java",
-          "java/com/linkedin/datahub/graphql/types/mlmodel/mappers/IntendedUseMapper.java",
-          "java/com/linkedin/datahub/graphql/types/mlmodel/mappers/MLFeatureMapper.java",
-          "java/com/linkedin/datahub/graphql/types/mlmodel/mappers/MLFeaturePropertiesMapper.java",
-          "java/com/linkedin/datahub/graphql/types/mlmodel/mappers/MLModelGroupMapper.java",
-          "java/com/linkedin/datahub/graphql/types/mlmodel/mappers/MLModelMapper.java",
-          "java/com/linkedin/datahub/graphql/types/mlmodel/mappers/MLPrimaryKeyMapper.java",
-          "java/com/linkedin/datahub/graphql/types/mlmodel/mappers/MLPrimaryKeyPropertiesMapper.java",
-          "java/com/linkedin/datahub/graphql/types/mlmodel/mappers/SourceCodeUrlMapper.java",
-          "java/com/linkedin/datahub/graphql/types/module/PageModuleTypeMapper.java",
-          "java/com/linkedin/datahub/graphql/types/module/PageModuleVisibilityMapper.java",
-          "java/com/linkedin/datahub/graphql/types/monitor/MonitorMapper.java",
-          "java/com/linkedin/datahub/graphql/types/notebook/mappers/NotebookMapper.java",
-          "java/com/linkedin/datahub/graphql/types/notification/mappers/NotificationSettingMapMapper.java",
-          "java/com/linkedin/datahub/graphql/types/notification/mappers/NotificationSettingsMapper.java",
-          "java/com/linkedin/datahub/graphql/types/operations/OperationsAggregationMapper.java",
-          "java/com/linkedin/datahub/graphql/types/policy/DataHubPolicyMapper.java",
-          "java/com/linkedin/datahub/graphql/types/post/PostMapper.java",
-          "java/com/linkedin/datahub/graphql/types/remoteexecutor/RemoteExecutorPoolMapper.java",
-          "java/com/linkedin/datahub/graphql/types/service/mappers/ServiceMapper.java",
-          "java/com/linkedin/datahub/graphql/types/structuredproperty/StructuredPropertyMapper.java",
-          "java/com/linkedin/datahub/graphql/types/subscription/mappers/DataHubSubscriptionMapper.java",
-          "java/com/linkedin/datahub/graphql/types/template/PageTemplateMapper.java",
-          "java/com/linkedin/datahub/graphql/types/template/PageTemplateSurfaceMapper.java",
-          "java/com/linkedin/datahub/graphql/types/template/PageTemplateVisibilityMapper.java",
-          "java/com/linkedin/datahub/graphql/types/test/TestMapper.java",
-          "java/com/linkedin/datahub/graphql/types/timeline/mappers/ChangeEventMapper.java",
-          "java/com/linkedin/datahub/graphql/types/usage/UsageAggregationMapper.java",
-          "java/com/linkedin/datahub/graphql/types/view/DataHubViewMapper.java");
+  private static final Pattern WHITESPACE_PATTERN = Pattern.compile("\\s+");
 
   /**
-   * Scans all *Mapper.java files for unsafe valueOf(toString()/name()) calls on GraphQL-generated
-   * enums.
-   *
-   * <p>How the scan works, step by step:
-   *
-   * <ol>
-   *   <li><b>Walk the source tree</b> — recursively visit every file under {@code
-   *       datahub-graphql-core/src/main/java}.
-   *   <li><b>Filter to mapper files only</b> — only files ending in {@code Mapper.java} are
-   *       checked. Resolvers are skipped because they typically map in the safe direction (GraphQL
-   *       input → PDL), not the dangerous direction (PDL → GraphQL output).
-   *   <li><b>Skip pre-existing violations</b> — files listed in {@link #PREEXISTING_VIOLATIONS} are
-   *       excluded so the test passes today; those files are tech debt to migrate later.
-   *   <li><b>Read the whole file as a string</b> — so that multi-line {@code valueOf()} calls
-   *       (where arguments wrap to the next line) are visible to the regex.
-   *   <li><b>Collect GraphQL enum imports</b> — scan import statements for anything from {@code
-   *       com.linkedin.datahub.graphql.generated.*}. These simple names are used to identify the
-   *       import-based pattern.
-   *   <li><b>Regex-match — import-based pattern</b> — find {@code <EnumName>.valueOf([^;]*?
-   *       .toString()) } or {@code .name())} where {@code <EnumName>} matches a collected import.
-   *       Uses {@code [^;]*?} to stay within a single statement. Uses {@link Pattern#DOTALL} so the
-   *       match can cross newlines.
-   *   <li><b>Regex-match — fully-qualified pattern</b> — independently find {@code
-   *       com.linkedin.datahub.graphql.generated.<Enum>.valueOf(...)} calls. These don't need an
-   *       import to be dangerous — the package prefix is proof enough.
-   *   <li><b>Fail with actionable output</b> — if any violations are found, the test fails with the
-   *       exact file, line number, and enum name, plus instructions to use {@link PdlEnumMapper}.
-   * </ol>
+   * Exact legacy unsafe call shapes allowed for now. The integer is the number of identical
+   * occurrences currently present. This is deliberately narrower than file-level allowlisting so
+   * new unsafe conversions added to files with existing debt still fail this test.
    */
+  private static final Map<String, Integer> PREEXISTING_VIOLATIONS =
+      Map.ofEntries(
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/resolvers/connection/ConnectionMapper.java",
+                  "DataHubConnectionDetailsType",
+                  "com.linkedin.datahub.graphql.generated.DataHubConnectionDetailsType.valueOf( gmsDetails.getType().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/resolvers/policy/mappers/PolicyInfoPolicyMapper.java",
+                  "PolicyMatchCondition",
+                  "PolicyMatchCondition.valueOf(criterion.getCondition().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/assertion/AssertionMapper.java",
+                  "AssertionActionType",
+                  "AssertionActionType.valueOf(gmsAssertionAction.getType().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/assertion/AssertionMapper.java",
+                  "AssertionSourceType",
+                  "AssertionSourceType.valueOf(gmsSource.getType().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/assertion/AssertionMapper.java",
+                  "AssertionStdAggregation",
+                  "AssertionStdAggregation.valueOf(gmsDatasetAssertion.getAggregation().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/assertion/AssertionMapper.java",
+                  "AssertionStdOperator",
+                  "AssertionStdOperator.valueOf(gmsDatasetAssertion.getOperator().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/assertion/AssertionMapper.java",
+                  "AssertionStdParameterType",
+                  "AssertionStdParameterType.valueOf(param.getType().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/assertion/AssertionMapper.java",
+                  "AssertionType",
+                  "AssertionType.valueOf(gmsAssertionInfo.getType().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/assertion/AssertionMapper.java",
+                  "DatasetAssertionScope",
+                  "DatasetAssertionScope.valueOf(gmsDatasetAssertion.getScope().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/assertion/AssertionMapper.java",
+                  "DateInterval",
+                  "DateInterval.valueOf(gmsFixedIntervalSchedule.getUnit().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/assertion/AssertionMapper.java",
+                  "SchemaAssertionCompatibility",
+                  "SchemaAssertionCompatibility.valueOf(gmsSchemaAssertionInfo.getCompatibility().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/assertion/FieldAssertionMapper.java",
+                  "AssertionStdOperator",
+                  "AssertionStdOperator.valueOf(gmsFieldMetricAssertion.getOperator().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/assertion/FieldAssertionMapper.java",
+                  "AssertionStdOperator",
+                  "AssertionStdOperator.valueOf(gmsFieldValuesAssertion.getOperator().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/assertion/FieldAssertionMapper.java",
+                  "FieldAssertionType",
+                  "FieldAssertionType.valueOf(gmsFieldAssertionInfo.getType().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/assertion/FieldAssertionMapper.java",
+                  "FieldMetricType",
+                  "FieldMetricType.valueOf(gmsFieldMetricAssertion.getMetric().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/assertion/FieldAssertionMapper.java",
+                  "FieldTransformType",
+                  "FieldTransformType.valueOf(gmsFieldTransform.getType().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/assertion/FieldAssertionMapper.java",
+                  "FieldValuesFailThresholdType",
+                  "FieldValuesFailThresholdType.valueOf(gmsFieldValuesFailThreshold.getType().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/assertion/FreshnessAssertionMapper.java",
+                  "FreshnessAssertionScheduleType",
+                  "FreshnessAssertionScheduleType.valueOf(gmsFreshnessAssertionSchedule.getType().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/assertion/FreshnessAssertionMapper.java",
+                  "FreshnessAssertionType",
+                  "FreshnessAssertionType.valueOf(gmsFreshnessAssertionInfo.getType().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/assertion/SqlAssertionMapper.java",
+                  "AssertionStdOperator",
+                  "AssertionStdOperator.valueOf(gmsSqlAssertionInfo.getOperator().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/assertion/SqlAssertionMapper.java",
+                  "AssertionValueChangeType",
+                  "AssertionValueChangeType.valueOf(gmsSqlAssertionInfo.getChangeType().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/assertion/SqlAssertionMapper.java",
+                  "SqlAssertionType",
+                  "SqlAssertionType.valueOf(gmsSqlAssertionInfo.getType().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/assertion/VolumeAssertionMapper.java",
+                  "AssertionStdOperator",
+                  "AssertionStdOperator.valueOf(gmsIncrementingSegmentRowCountChange.getOperator().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/assertion/VolumeAssertionMapper.java",
+                  "AssertionStdOperator",
+                  "AssertionStdOperator.valueOf(gmsIncrementingSegmentRowCountTotal.getOperator().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/assertion/VolumeAssertionMapper.java",
+                  "AssertionStdOperator",
+                  "AssertionStdOperator.valueOf(gmsRowCountChange.getOperator().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/assertion/VolumeAssertionMapper.java",
+                  "AssertionStdOperator",
+                  "AssertionStdOperator.valueOf(gmsRowCountTotal.getOperator().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/assertion/VolumeAssertionMapper.java",
+                  "AssertionValueChangeType",
+                  "AssertionValueChangeType.valueOf(gmsIncrementingSegmentRowCountChange.getType().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/assertion/VolumeAssertionMapper.java",
+                  "AssertionValueChangeType",
+                  "AssertionValueChangeType.valueOf(gmsRowCountChange.getType().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/assertion/VolumeAssertionMapper.java",
+                  "IncrementingSegmentFieldTransformerType",
+                  "IncrementingSegmentFieldTransformerType.valueOf(gmsTransformer.getType().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/assertion/VolumeAssertionMapper.java",
+                  "VolumeAssertionType",
+                  "VolumeAssertionType.valueOf(gmsVolumeAssertionInfo.getType().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/chart/mappers/ChartMapper.java",
+                  "AccessLevel",
+                  "AccessLevel.valueOf(info.getAccess().toString())"),
+              2),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/chart/mappers/ChartMapper.java",
+                  "ChartQueryType",
+                  "ChartQueryType.valueOf(query.getType().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/chart/mappers/ChartMapper.java",
+                  "ChartType",
+                  "ChartType.valueOf(info.getType().toString())"),
+              2),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/common/mappers/CostMapper.java",
+                  "CostType",
+                  "CostType.valueOf(cost.getCostType().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/common/mappers/DataTransformLogicMapper.java",
+                  "QueryLanguage",
+                  "QueryLanguage.valueOf(input.getQueryStatement().getLanguage().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/common/mappers/DisplayPropertiesMapper.java",
+                  "IconLibrary",
+                  "IconLibrary.valueOf(iconPropertiesInput.getIconLibrary().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/common/mappers/OperationMapper.java",
+                  "OperationSourceType",
+                  "OperationSourceType.valueOf(gmsProfile.getSourceType().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/common/mappers/OperationMapper.java",
+                  "OperationType",
+                  "OperationType.valueOf(OperationType.class, gmsProfile.getOperationType().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/common/mappers/OwnerMapper.java",
+                  "OwnershipType",
+                  "OwnershipType.valueOf(owner.getType().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/corpgroup/mappers/CorpGroupMapper.java",
+                  "OriginType",
+                  "com.linkedin.datahub.graphql.generated.OriginType.valueOf( groupOrigin.getType().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/dashboard/mappers/DashboardMapper.java",
+                  "AccessLevel",
+                  "AccessLevel.valueOf(info.getAccess().toString())"),
+              2),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/datacontract/DataContractMapper.java",
+                  "DataContractState",
+                  "DataContractState.valueOf(status.getState().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/dataplatform/mappers/DataPlatformInfoMapper.java",
+                  "PlatformType",
+                  "PlatformType.valueOf(input.getType().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/dataplatform/mappers/DataPlatformPropertiesMapper.java",
+                  "PlatformType",
+                  "PlatformType.valueOf(input.getType().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/dataprocessinst/mappers/DataProcessInstanceRunEventMapper.java",
+                  "DataProcessRunStatus",
+                  "com.linkedin.datahub.graphql.generated.DataProcessRunStatus.valueOf( runEvent.getStatus().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/dataprocessinst/mappers/DataProcessInstanceRunResultMapper.java",
+                  "DataProcessInstanceRunResultType",
+                  "DataProcessInstanceRunResultType.valueOf(input.getType().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/dataset/mappers/AssertionRunEventMapper.java",
+                  "AssertionResultSeverity",
+                  "AssertionResultSeverity.valueOf(gmsResult.getSeverity().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/dataset/mappers/AssertionRunEventMapper.java",
+                  "AssertionResultType",
+                  "AssertionResultType.valueOf(gmsResult.getType().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/dataset/mappers/AssertionRunEventMapper.java",
+                  "AssertionRunStatus",
+                  "AssertionRunStatus.valueOf(gmsAssertionRunEvent.getStatus().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/dataset/mappers/AssertionRunEventMapper.java",
+                  "PartitionType",
+                  "PartitionType.valueOf(gmsPartitionSpec.getType().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/dataset/mappers/DatasetFilterMapper.java",
+                  "DatasetFilterType",
+                  "DatasetFilterType.valueOf(input.getType().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/dataset/mappers/DatasetMapper.java",
+                  "FabricType",
+                  "FabricType.valueOf(gmsKey.getOrigin().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/dataset/mappers/VersionedDatasetMapper.java",
+                  "FabricType",
+                  "FabricType.valueOf(gmsKey.getOrigin().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/ermodelrelationship/mappers/ERModelRelationMapper.java",
+                  "ERModelRelationshipCardinality",
+                  "ERModelRelationshipCardinality.valueOf( ermodelrelationProperties.getCardinality().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/file/DataHubFileMapper.java",
+                  "UploadDownloadScenario",
+                  "com.linkedin.datahub.graphql.generated.UploadDownloadScenario.valueOf( gmsFileInfo.getScenario().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/form/FormMapper.java",
+                  "FormPromptType",
+                  "FormPromptType.valueOf(gmsFormPrompt.getType().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/form/FormMapper.java",
+                  "FormType",
+                  "FormType.valueOf(gmsFormInfo.getType().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/incident/IncidentMapper.java",
+                  "IncidentSourceType",
+                  "IncidentSourceType.valueOf(incidentSource.getType().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/incident/IncidentMapper.java",
+                  "IncidentStage",
+                  "IncidentStage.valueOf(incidentStatus.getStage().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/incident/IncidentMapper.java",
+                  "IncidentState",
+                  "IncidentState.valueOf(incidentStatus.getState().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/incident/IncidentMapper.java",
+                  "IncidentType",
+                  "IncidentType.valueOf(info.getType().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/ingestion/IngestionSourceMapper.java",
+                  "IngestionSourceSourceType",
+                  "IngestionSourceSourceType.valueOf(source.getType().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/knowledge/DocumentMapper.java",
+                  "DocumentSourceType",
+                  "com.linkedin.datahub.graphql.generated.DocumentSourceType.valueOf( source.getSourceType().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/knowledge/DocumentMapper.java",
+                  "DocumentState",
+                  "com.linkedin.datahub.graphql.generated.DocumentState.valueOf(status.getState().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/mappers/UrnSearchAcrossLineageResultsMapper.java",
+                  "LineageSearchPath",
+                  "LineageSearchPath.valueOf(input.getLineageSearchPath().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/mlmodel/mappers/IntendedUseMapper.java",
+                  "IntendedUserType",
+                  "IntendedUserType.valueOf(v.toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/mlmodel/mappers/MLFeatureMapper.java",
+                  "MLFeatureDataType",
+                  "MLFeatureDataType.valueOf(featureProperties.getDataType().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/mlmodel/mappers/MLFeaturePropertiesMapper.java",
+                  "MLFeatureDataType",
+                  "MLFeatureDataType.valueOf(mlFeatureProperties.getDataType().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/mlmodel/mappers/MLModelGroupMapper.java",
+                  "FabricType",
+                  "FabricType.valueOf(mlModelGroupKey.getOrigin().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/mlmodel/mappers/MLModelMapper.java",
+                  "FabricType",
+                  "FabricType.valueOf(mlModelKey.getOrigin().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/mlmodel/mappers/MLPrimaryKeyMapper.java",
+                  "MLFeatureDataType",
+                  "MLFeatureDataType.valueOf(primaryKeyProperties.getDataType().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/mlmodel/mappers/MLPrimaryKeyPropertiesMapper.java",
+                  "MLFeatureDataType",
+                  "MLFeatureDataType.valueOf(mlPrimaryKeyProperties.getDataType().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/mlmodel/mappers/SourceCodeUrlMapper.java",
+                  "SourceCodeUrlType",
+                  "SourceCodeUrlType.valueOf(input.getType().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/module/PageModuleTypeMapper.java",
+                  "DataHubPageModuleType",
+                  "com.linkedin.datahub.graphql.generated.DataHubPageModuleType.valueOf(type.toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/module/PageModuleVisibilityMapper.java",
+                  "PageModuleScope",
+                  "PageModuleScope.valueOf(visibility.getScope().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/notebook/mappers/NotebookMapper.java",
+                  "NotebookCellType",
+                  "NotebookCellType.valueOf(pegasusCell.getType().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/operations/OperationsAggregationMapper.java",
+                  "WindowDuration",
+                  "WindowDuration.valueOf(pdlUsageAggregation.getDuration().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/policy/DataHubPolicyMapper.java",
+                  "PolicyMatchCondition",
+                  "PolicyMatchCondition.valueOf(criterion.getCondition().name())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/post/PostMapper.java",
+                  "MediaType",
+                  "MediaType.valueOf(postMedia.getType().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/post/PostMapper.java",
+                  "PostContentType",
+                  "PostContentType.valueOf(postContent.getType().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/post/PostMapper.java",
+                  "PostType",
+                  "PostType.valueOf(postInfo.getType().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/structuredproperty/StructuredPropertyMapper.java",
+                  "PropertyCardinality",
+                  "PropertyCardinality.valueOf(gmsDefinition.getCardinality().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/template/PageTemplateMapper.java",
+                  "SummaryElementType",
+                  "SummaryElementType.valueOf(el.getElementType().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/template/PageTemplateSurfaceMapper.java",
+                  "PageTemplateSurfaceType",
+                  "PageTemplateSurfaceType.valueOf(surface.getSurfaceType().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/template/PageTemplateVisibilityMapper.java",
+                  "PageTemplateScope",
+                  "PageTemplateScope.valueOf(visibility.getScope().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/timeline/mappers/ChangeEventMapper.java",
+                  "ChangeCategoryType",
+                  "ChangeCategoryType.valueOf(incomingChangeEvent.getCategory().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/timeline/mappers/ChangeEventMapper.java",
+                  "ChangeOperationType",
+                  "ChangeOperationType.valueOf(incomingChangeEvent.getOperation().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/usage/UsageAggregationMapper.java",
+                  "WindowDuration",
+                  "WindowDuration.valueOf(pdlUsageAggregation.getDuration().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/view/DataHubViewMapper.java",
+                  "DataHubViewType",
+                  "DataHubViewType.valueOf(viewInfo.getType().toString())"),
+              1),
+          Map.entry(
+              violation(
+                  "java/com/linkedin/datahub/graphql/types/view/DataHubViewMapper.java",
+                  "FilterOperator",
+                  "FilterOperator.valueOf(andFilter.getCondition().toString())"),
+              1));
+
   @Test
   public void noUnsafeEnumValueOfCallsInMappers() throws IOException {
     Path srcRoot = findSourceRoot();
@@ -174,65 +596,53 @@ public class UnsafeEnumValueOfLintTest {
     }
 
     List<String> violations = new ArrayList<>();
+    Map<String, Integer> observedCounts = new HashMap<>();
 
-    // Step 1: Walk the source tree
     Files.walkFileTree(
         srcRoot,
         new SimpleFileVisitor<Path>() {
           @Override
           public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
               throws IOException {
-            // Step 2: Only inspect *Mapper.java files (the PDL → GraphQL read path)
-            String fileName = file.getFileName().toString();
-            if (!fileName.endsWith("Mapper.java")) {
+            if (!file.getFileName().toString().endsWith("Mapper.java")) {
               return FileVisitResult.CONTINUE;
             }
 
-            // Step 3: Skip files with known pre-existing violations (tech debt)
             String relativePath = srcRoot.getParent().relativize(file).toString();
-            if (PREEXISTING_VIOLATIONS.contains(relativePath)) {
-              return FileVisitResult.CONTINUE;
-            }
-
-            // Step 4: Read the entire file as one string so multi-line valueOf()
-            // calls (where arguments wrap to the next line) are visible to the regex.
             String content = Files.readString(file);
+            Set<String> generatedEnumImports = getGeneratedEnumImports(content);
+            Set<Integer> reportedSimpleNameOffsets = new HashSet<>();
 
-            // Step 5: Collect the simple names of all GraphQL-generated enum imports.
-            // These are the types that DON'T have a $UNKNOWN constant and will crash
-            // if valueOf() receives one.
-            Set<String> generatedEnumImports = new HashSet<>();
-            for (String line : content.split("\n")) {
-              if (line.startsWith("import " + GENERATED_PKG) && !line.contains("*")) {
-                String imported = line.replace("import ", "").replace(";", "").trim();
-                String simpleName = imported.substring(imported.lastIndexOf('.') + 1);
-                generatedEnumImports.add(simpleName);
-              }
-            }
-
-            // Track violations by character offset to deduplicate across the two patterns.
-            Set<Integer> reportedOffsets = new HashSet<>();
-
-            // Step 6: Match the import-based pattern — SomeEnum.valueOf(<expr>.toString()/name())
-            // where SomeEnum is one of the GraphQL-generated imports.
             if (!generatedEnumImports.isEmpty()) {
-              Matcher m = SIMPLE_VALUEOF_PATTERN.matcher(content);
-              while (m.find()) {
-                String enumName = m.group(1);
+              Matcher matcher = SIMPLE_VALUEOF_PATTERN.matcher(content);
+              while (matcher.find()) {
+                String enumName = matcher.group(1);
                 if (generatedEnumImports.contains(enumName)) {
-                  reportedOffsets.add(m.start());
-                  violations.add(formatViolation(content, m.start(), relativePath, enumName));
+                  reportedSimpleNameOffsets.add(matcher.start());
+                  addViolation(
+                      violations,
+                      observedCounts,
+                      content,
+                      matcher.start(),
+                      relativePath,
+                      enumName,
+                      matcher.group(0));
                 }
               }
             }
 
-            // Step 7: Match the fully-qualified pattern —
-            // com.linkedin.datahub.graphql.generated.Foo.valueOf(<expr>.toString()/name()).
-            // These don't need an import to be dangerous.
-            Matcher qm = QUALIFIED_VALUEOF_PATTERN.matcher(content);
-            while (qm.find()) {
-              if (!reportedOffsets.contains(qm.start())) {
-                violations.add(formatViolation(content, qm.start(), relativePath, qm.group(1)));
+            Matcher qualifiedMatcher = QUALIFIED_VALUEOF_PATTERN.matcher(content);
+            while (qualifiedMatcher.find()) {
+              int simpleNameOffset = qualifiedMatcher.start() + GENERATED_PKG.length();
+              if (!reportedSimpleNameOffsets.contains(simpleNameOffset)) {
+                addViolation(
+                    violations,
+                    observedCounts,
+                    content,
+                    qualifiedMatcher.start(),
+                    relativePath,
+                    qualifiedMatcher.group(1),
+                    qualifiedMatcher.group(0));
               }
             }
 
@@ -240,7 +650,6 @@ public class UnsafeEnumValueOfLintTest {
           }
         });
 
-    // Step 8: Fail with actionable output listing every violation
     if (!violations.isEmpty()) {
       fail(
           "Found unsafe Enum.valueOf(pdlValue.toString()/name()) calls in mapper code.\n"
@@ -248,11 +657,45 @@ public class UnsafeEnumValueOfLintTest {
               + "Use PdlEnumMapper.map(EnumClass.class, pdlValue, defaultValue) instead.\n\n"
               + String.join("\n", violations)
               + "\n\n"
-              + "Do NOT add new entries to PREEXISTING_VIOLATIONS — fix the code instead.\n");
+              + "Do not add entries to PREEXISTING_VIOLATIONS; migrate new code to PdlEnumMapper.\n");
     }
   }
 
-  /** Convert a character offset in {@code content} to a 1-based line number. */
+  private static Set<String> getGeneratedEnumImports(String content) {
+    Set<String> generatedEnumImports = new HashSet<>();
+    for (String line : content.split("\n")) {
+      if (line.startsWith("import " + GENERATED_PKG) && !line.contains("*")) {
+        String imported = line.replace("import ", "").replace(";", "").trim();
+        generatedEnumImports.add(imported.substring(imported.lastIndexOf('.') + 1));
+      }
+    }
+    return generatedEnumImports;
+  }
+
+  private static void addViolation(
+      List<String> violations,
+      Map<String, Integer> observedCounts,
+      String content,
+      int matchStart,
+      String relativePath,
+      String enumName,
+      String rawCall) {
+    String call = violation(relativePath, enumName, normalizeCall(rawCall));
+    int observedCount = observedCounts.merge(call, 1, Integer::sum);
+    int allowedCount = PREEXISTING_VIOLATIONS.getOrDefault(call, 0);
+    if (observedCount > allowedCount) {
+      violations.add(formatViolation(content, matchStart, relativePath, enumName));
+    }
+  }
+
+  private static String violation(String relativePath, String enumName, String normalizedCall) {
+    return relativePath + "\t" + enumName + "\t" + normalizedCall;
+  }
+
+  private static String normalizeCall(String call) {
+    return WHITESPACE_PATTERN.matcher(call).replaceAll(" ").trim();
+  }
+
   private static int lineNumberAt(String content, int offset) {
     int line = 1;
     for (int i = 0; i < offset && i < content.length(); i++) {
@@ -266,7 +709,7 @@ public class UnsafeEnumValueOfLintTest {
   private static String formatViolation(
       String content, int matchStart, String relativePath, String enumName) {
     return String.format(
-        "  %s:%d — %s.valueOf(...toString()/name()) is unsafe for PDL enums. "
+        "  %s:%d - %s.valueOf(...toString()/name()) is unsafe for PDL enums. "
             + "Use PdlEnumMapper.map() instead.",
         relativePath, lineNumberAt(content, matchStart), enumName);
   }


### PR DESCRIPTION
## Overview
Introduces a safe enum mapping utility and lint test to prevent crashes when converting PDL enum values to GraphQL-generated Java enums.

## Problem
PDL enums use `$UNKNOWN` as a sentinel for forwards compatibility—when an older schema reads an enum value added in a newer version, Pegasus deserializes it as `$UNKNOWN`. However, GraphQL-generated Java enums do not include `$UNKNOWN`, so raw `Enum.valueOf()` calls will throw `IllegalArgumentException` when encountering this value.

## Solution
- **PdlEnumMapper**: New utility class providing two safe mapping methods:
  - `map(Class<T>, Enum<?>, T defaultValue)` — maps PDL enum to GraphQL enum, falling back to a provided default for unrecognized values
  - `mapDefaultNull(Class<T>, Enum<?> pdlValue)` — same behavior but returns null as fallback
  - Both methods log warnings when falling back, aiding in debugging

- **UnsafeEnumValueOfLintTest**: New lint-style test that scans all `*Mapper.java` files for unsafe `SomeEnum.valueOf(pdlValue.toString()/name())` patterns:
  - Detects both import-based patterns (`EnumName.valueOf(...)`) and fully-qualified patterns (`com.linkedin.datahub.graphql.generated.Foo.valueOf(...)`)
  - Uses regex with `[^;]*?` to stay within single statements and handle multi-line calls
  - Includes a `PREEXISTING_VIOLATIONS` allowlist for existing code that needs migration (tech debt)
  - Provides actionable error messages with file paths, line numbers, and enum names

## Testing
- Added `PdlEnumMapperTest` with unit tests covering:
  - Known value mapping
  - `$UNKNOWN` fallback behavior
  - Unrecognized value fallback
  - Both `map()` and `mapDefaultNull()` variants
- Lint test validates no new unsafe patterns are introduced while allowing pre-existing violations to be tracked for future migration

## Migration Path
Existing code with unsafe `valueOf()` calls is tracked in `PREEXISTING_VIOLATIONS`. These should be migrated to use `PdlEnumMapper` over time. New code must use the mapper to pass the lint test.

https://claude.ai/code/session_01WxD9GYuQP69mC8qrZ5oWTo