### PR TITLE
fix(datahub-web-react): Member Group UI fixes

### DIFF
--- a/datahub-web-react/src/app/entityV2/group/GroupInfoHeaderSection.tsx
+++ b/datahub-web-react/src/app/entityV2/group/GroupInfoHeaderSection.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { MemberCount } from '@app/entityV2/group/GroupSidebar';
+import { getExternalGroupMembershipTooltip } from '@app/entityV2/group/utils';
 
 import { EntityRelationshipsResult } from '@types';
 
@@ -13,9 +14,18 @@ const GroupHeader = styled.div`
     z-index: 2;
 `;
 
+const NameRow = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+`;
+
 const GroupName = styled(Typography.Title)`
     word-wrap: break-word;
     text-align: left;
+    flex: 1;
+    min-width: 0;
     &&& {
         margin-bottom: 0;
         word-break: break-all;
@@ -31,8 +41,15 @@ const GroupName = styled(Typography.Title)`
     }
 `;
 
+const ExternalGroupLock = styled(LockOutlined)`
+    flex-shrink: 0;
+    color: ${(props) => props.theme.colors.bg};
+    font-size: 11px;
+    opacity: 0.85;
+`;
+
 type Props = {
-    groupMemberRelationships: EntityRelationshipsResult;
+    groupMemberRelationships?: EntityRelationshipsResult;
     isExternalGroup: boolean;
     externalGroupType: string | undefined;
     groupName: string | undefined;
@@ -47,17 +64,17 @@ export const GroupInfoHeaderSection = ({
     const groupMemberRelationshipsTotal = groupMemberRelationships?.total || 0;
     return (
         <GroupHeader>
-            <Tooltip title={groupName}>
-                <GroupName level={3}>{groupName}</GroupName>
-            </Tooltip>
-            {groupMemberRelationshipsTotal > 0 && <MemberCount>{groupMemberRelationshipsTotal} members</MemberCount>}
-            {isExternalGroup && (
-                <Tooltip
-                    title={`Membership for this group cannot be edited in DataHub as it originates from ${externalGroupType}.`}
-                >
-                    <LockOutlined />
+            <NameRow>
+                <Tooltip title={groupName}>
+                    <GroupName level={3}>{groupName}</GroupName>
                 </Tooltip>
-            )}
+                {isExternalGroup && (
+                    <Tooltip title={getExternalGroupMembershipTooltip(externalGroupType)}>
+                        <ExternalGroupLock />
+                    </Tooltip>
+                )}
+            </NameRow>
+            {groupMemberRelationshipsTotal > 0 && <MemberCount>{groupMemberRelationshipsTotal} members</MemberCount>}
         </GroupHeader>
     );
 };

--- a/datahub-web-react/src/app/entityV2/group/GroupMembers.tsx
+++ b/datahub-web-react/src/app/entityV2/group/GroupMembers.tsx
@@ -1,5 +1,5 @@
 import { MoreOutlined, UserAddOutlined, UserDeleteOutlined } from '@ant-design/icons';
-import { Avatar } from '@components';
+import { Avatar, Tooltip } from '@components';
 import { Button, Col, Dropdown, Empty, MenuProps, Pagination, Row, Typography, message } from 'antd';
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
@@ -8,6 +8,7 @@ import styled from 'styled-components';
 import { AvatarType } from '@components/components/AvatarStack/types';
 
 import { AddGroupMembersModal } from '@app/entityV2/group/AddGroupMembersModal';
+import { getExternalGroupMembershipTooltip } from '@app/entityV2/group/utils';
 import { scrollToTop } from '@app/shared/searchUtils';
 import { ConfirmationModal } from '@app/sharedV2/modals/ConfirmationModal';
 import { useEntityRegistry } from '@app/useEntityRegistry';
@@ -88,10 +89,11 @@ type Props = {
     urn: string;
     pageSize: number;
     isExternalGroup: boolean;
+    externalGroupType?: string;
     onChangeMembers?: () => void;
 };
 
-export default function GroupMembers({ urn, pageSize, isExternalGroup, onChangeMembers }: Props) {
+export default function GroupMembers({ urn, pageSize, isExternalGroup, externalGroupType, onChangeMembers }: Props) {
     const entityRegistry = useEntityRegistry();
 
     const [page, setPage] = useState(1);
@@ -176,15 +178,27 @@ export default function GroupMembers({ urn, pageSize, isExternalGroup, onChangeM
     return (
         <>
             <Row style={ADD_MEMBER_STYLE}>
-                <AddMember
-                    type="text"
-                    disabled={isExternalGroup}
-                    onClick={onClickEditMembers}
-                    data-testid="add-group-member-button"
+                <Tooltip
+                    showArrow={false}
+                    title={isExternalGroup ? getExternalGroupMembershipTooltip(externalGroupType) : null}
                 >
-                    <UserAddOutlined />
-                    <AddMemberText>Add Member</AddMemberText>
-                </AddMember>
+                    {/*
+                     * Wrapper needed so the Tooltip has a hover target: antd's `disabled`
+                     * Buttons get `pointer-events: none`, which swallows mouse events and
+                     * prevents the Tooltip from firing when disabled.
+                     */}
+                    <div style={{ display: 'inline-block', cursor: isExternalGroup ? 'not-allowed' : 'auto' }}>
+                        <AddMember
+                            type="text"
+                            disabled={isExternalGroup}
+                            onClick={onClickEditMembers}
+                            data-testid="add-group-member-button"
+                        >
+                            <UserAddOutlined />
+                            <AddMemberText>Add Member</AddMemberText>
+                        </AddMember>
+                    </div>
+                </Tooltip>
             </Row>
             <GroupMemberWrapper>
                 {groupMembers.length === 0 && <NoGroupMembers description="No members in this group yet." />}

--- a/datahub-web-react/src/app/entityV2/group/GroupMembersSidebarSectionContent.tsx
+++ b/datahub-web-react/src/app/entityV2/group/GroupMembersSidebarSectionContent.tsx
@@ -13,7 +13,7 @@ import { useEntityRegistry } from '@app/useEntityRegistry';
 import { CorpUser, EntityRelationshipsResult } from '@types';
 
 type Props = {
-    groupMemberRelationships: EntityRelationshipsResult;
+    groupMemberRelationships?: EntityRelationshipsResult;
     showAddMemberModal: boolean;
     setShowAddMemberModal: (show: boolean) => void;
     urn: string;

--- a/datahub-web-react/src/app/entityV2/group/GroupProfile.tsx
+++ b/datahub-web-react/src/app/entityV2/group/GroupProfile.tsx
@@ -121,6 +121,7 @@ export default function GroupProfile({ urn }: Props) {
                         urn={urn}
                         pageSize={MEMBER_PAGE_SIZE}
                         isExternalGroup={isExternalGroup}
+                        externalGroupType={externalGroupType}
                         onChangeMembers={() => {
                             setTimeout(() => refetch(), 3000);
                         }}

--- a/datahub-web-react/src/app/entityV2/group/GroupSidebar.tsx
+++ b/datahub-web-react/src/app/entityV2/group/GroupSidebar.tsx
@@ -26,7 +26,14 @@ export const MemberCount = styled.div`
  * Responsible for reading & writing users.
  */
 export default function GroupSidebar({ sidebarData, refetch }: Props) {
-    const { aboutText, groupMemberRelationships, urn, groupOwnership: ownership } = sidebarData;
+    const {
+        aboutText,
+        groupMemberRelationships,
+        urn,
+        groupOwnership: ownership,
+        isExternalGroup,
+        externalGroupType,
+    } = sidebarData;
     const [updateCorpGroupPropertiesMutation] = useUpdateCorpGroupPropertiesMutation();
 
     // About Text save
@@ -62,6 +69,8 @@ export default function GroupSidebar({ sidebarData, refetch }: Props) {
                     groupMemberRelationships={groupMemberRelationships}
                     urn={urn}
                     refetch={refetch}
+                    isExternalGroup={isExternalGroup}
+                    externalGroupType={externalGroupType}
                 />
             </Content>
         </SideBar>

--- a/datahub-web-react/src/app/entityV2/group/GroupSidebarMembersSection.tsx
+++ b/datahub-web-react/src/app/entityV2/group/GroupSidebarMembersSection.tsx
@@ -1,20 +1,30 @@
-import { PlusOutlined } from '@ant-design/icons';
+import { Plus } from '@phosphor-icons/react/dist/csr/Plus';
 import React, { useState } from 'react';
 
 import GroupMembersSideBarSectionContent from '@app/entityV2/group/GroupMembersSidebarSectionContent';
+import { getExternalGroupMembershipTooltip } from '@app/entityV2/group/utils';
 import SectionActionButton from '@app/entityV2/shared/containers/profile/sidebar/SectionActionButton';
 import { SidebarSection } from '@app/entityV2/shared/containers/profile/sidebar/SidebarSection';
 
 import { EntityRelationshipsResult } from '@types';
 
 type Props = {
-    groupMemberRelationships: EntityRelationshipsResult;
+    groupMemberRelationships?: EntityRelationshipsResult;
     urn: string;
     refetch: () => void;
+    isExternalGroup?: boolean;
+    externalGroupType?: string;
 };
 
-export const GroupSidebarMembersSection = ({ groupMemberRelationships, urn, refetch }: Props) => {
+export const GroupSidebarMembersSection = ({
+    groupMemberRelationships,
+    urn,
+    refetch,
+    isExternalGroup = false,
+    externalGroupType,
+}: Props) => {
     const [showAddMemberModal, setShowAddMemberModal] = useState(false);
+    const externalGroupTip = isExternalGroup ? getExternalGroupMembershipTooltip(externalGroupType) : undefined;
     return (
         <SidebarSection
             title="Members"
@@ -31,11 +41,15 @@ export const GroupSidebarMembersSection = ({ groupMemberRelationships, urn, refe
             }
             extra={
                 <SectionActionButton
-                    button={<PlusOutlined />}
+                    icon={Plus}
                     onClick={(event) => {
-                        setShowAddMemberModal(true);
                         event.stopPropagation();
+                        if (isExternalGroup) return;
+                        setShowAddMemberModal(true);
                     }}
+                    actionPrivilege={!isExternalGroup}
+                    tip={externalGroupTip}
+                    dataTestId="add-group-members-sidebar-button"
                 />
             }
         />

--- a/datahub-web-react/src/app/entityV2/group/GroupSidebarOwnersSection.tsx
+++ b/datahub-web-react/src/app/entityV2/group/GroupSidebarOwnersSection.tsx
@@ -1,4 +1,4 @@
-import { PlusOutlined } from '@ant-design/icons';
+import { Plus } from '@phosphor-icons/react/dist/csr/Plus';
 import React, { useState } from 'react';
 
 import GroupOwnerSidebarSectionContent from '@app/entityV2/group/GroupOwnerSidebarSectionContent';
@@ -31,11 +31,12 @@ export const GroupSidebarOwnersSection = ({ ownership, refetch, urn }: Props) =>
             }
             extra={
                 <SectionActionButton
-                    button={<PlusOutlined data-testid="add-owners-sidebar-button" />}
+                    icon={Plus}
                     onClick={(event) => {
                         setShowAddOwnerModal(true);
                         event.stopPropagation();
                     }}
+                    dataTestId="add-owners-sidebar-button"
                 />
             }
         />

--- a/datahub-web-react/src/app/entityV2/group/utils.ts
+++ b/datahub-web-react/src/app/entityV2/group/utils.ts
@@ -6,3 +6,15 @@ import { CorpGroup, Entity, EntityType } from '@src/types.generated';
 export function isCorpGroup(entity?: Entity | null | undefined): entity is CorpGroup {
     return !!entity && entity.type === EntityType.CorpGroup;
 }
+
+/**
+ * Tooltip copy shown whenever we disable a membership-editing because
+ * the group is sourced from an external identity provider (SSO/SCIM/etc.). Kept
+ * here so every surface — main pane, sidebar `+`, header lock icon — stays in
+ * sync.
+ */
+export function getExternalGroupMembershipTooltip(externalGroupType: string | undefined): string {
+    return `Membership for this group cannot be edited in DataHub as it originates from ${
+        externalGroupType || 'outside DataHub'
+    }.`;
+}

--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/SectionActionButton.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/SectionActionButton.tsx
@@ -38,14 +38,22 @@ type Props = {
 };
 
 const SectionActionButton = ({ tip, icon, button, onClick, actionPrivilege = true, dataTestId }: Props) => {
+    const tooltipTitle = tip ?? (!actionPrivilege ? 'You do not have permission to change this.' : undefined);
+    // Wrapper needed so the Tooltip has a hover target: the disabled inner control gets
+    // `pointer-events: none`, which swallows mouse events and prevents the Tooltip from
+    // firing when disabled.
+    const wrapperStyle: React.CSSProperties = {
+        display: 'inline-block',
+        cursor: !actionPrivilege ? 'not-allowed' : undefined,
+    };
+    // When disabled, stop click propagation at the wrapper so a click on the action doesn't
+    // bubble up and trigger the parent SidebarSection's collapse/expand handler.
+    const wrapperOnClick = !actionPrivilege ? (e: React.MouseEvent) => e.stopPropagation() : undefined;
     return (
-        <Tooltip
-            placement="top"
-            title={!actionPrivilege ? 'You do not have permission to change this.' : tip}
-            showArrow={false}
-        >
+        <Tooltip placement="top" title={tooltipTitle} showArrow={false}>
             {icon ? (
-                <span>
+                // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
+                <span style={wrapperStyle} onClick={wrapperOnClick}>
                     <Button
                         variant="text"
                         color="violet"
@@ -57,9 +65,12 @@ const SectionActionButton = ({ tip, icon, button, onClick, actionPrivilege = tru
                     />
                 </span>
             ) : (
-                <ActionButton onClick={onClick} privilege={actionPrivilege} data-testid={dataTestId}>
-                    {button}
-                </ActionButton>
+                // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
+                <span style={wrapperStyle} onClick={wrapperOnClick}>
+                    <ActionButton onClick={onClick} privilege={actionPrivilege} data-testid={dataTestId}>
+                        {button}
+                    </ActionButton>
+                </span>
             )}
         </Tooltip>
     );


### PR DESCRIPTION
**Summary**
For groups synced from an external IdP (Okta, Azure AD, etc.), DataHub blocks membership edits because they're owned by the source system. The UX around this was inconsistent and confusing:

When the "Add Member" button is disabled because SSO integration is active, there is no explanation provided to the user as to why the button is not clickable. This creates confusion — users don't know if it's a bug, a permissions issue, or an intentional restriction.
The "Add Member" action is inconsistently handled between the main pane and the side pane in the RBAC / Members settings:
Main pane: The "Add Member" button is blocked (disabled), but no tooltip explains why — leaving users confused. See related issue [UX-84](https://linear.app/acryl-data/issue/UX-84/add-member-button-disabled-due-to-sso-integration-needs-a-tooltip) for the tooltip work.
Side pane: The "Add Member" action is allowed, but leads to an error — creating a worse experience than simply being blocked.
This inconsistency means users may encounter a confusing error in the side pane even though the same action is intentionally restricted in the main pane.

After Changes:
<img width="876" height="670" alt="Screenshot 2026-05-12 at 3 51 56 PM" src="https://github.com/user-attachments/assets/351957c5-8ff4-41ef-8b1a-e4b7bc769b8e" />
<img width="1012" height="588" alt="Screenshot 2026-05-12 at 3 52 19 PM" src="https://github.com/user-attachments/assets/0f26a61d-c057-47c5-a96e-2884b1679713" />


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
