### PR TITLE
fix: mask invite token in ViewInviteTokenModal for security

### DIFF
--- a/datahub-web-react/src/app/identity/user/ViewInviteTokenModal.tsx
+++ b/datahub-web-react/src/app/identity/user/ViewInviteTokenModal.tsx
@@ -164,7 +164,7 @@ export default function ViewInviteTokenModal({ open, onClose }: Props) {
                             {roleSelectOptions()}
                         </RoleSelect>
                         <CopyText>
-                            <pre data-meticulous-mask>{inviteLink}</pre>
+                            <pre className="meticulous-ignore">{inviteLink}</pre>
                         </CopyText>
                     </InfoContainer>
                     <ActionsContainer>

--- a/datahub-web-react/src/app/identity/user/ViewInviteTokenModal.tsx
+++ b/datahub-web-react/src/app/identity/user/ViewInviteTokenModal.tsx
@@ -164,7 +164,7 @@ export default function ViewInviteTokenModal({ open, onClose }: Props) {
                             {roleSelectOptions()}
                         </RoleSelect>
                         <CopyText>
-                            <pre>{inviteLink}</pre>
+                            <pre data-meticulous-mask>{inviteLink}</pre>
                         </CopyText>
                     </InfoContainer>
                     <ActionsContainer>


### PR DESCRIPTION
## Description
Added `data-meticulous-mask` attribute to the invite link display element in `ViewInviteTokenModal` to prevent meticulous from flagging changes to the URL (which changes on every vercel deployment)