### PR TITLE
fix(ownership): always materialize ownerTypes from owners list

### DIFF
--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/hooks/OwnershipOwnerTypes.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/hooks/OwnershipOwnerTypes.java
@@ -6,6 +6,7 @@ import static com.linkedin.metadata.Constants.OWNERSHIP_ASPECT_NAME;
 import com.linkedin.common.*;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.DataMap;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.aspect.RetrieverContext;
 import com.linkedin.metadata.aspect.batch.ChangeMCP;
@@ -36,39 +37,34 @@ public class OwnershipOwnerTypes extends MutationHook {
     List<Pair<ChangeMCP, Boolean>> results = new LinkedList<>();
 
     for (ChangeMCP item : changeMCPS) {
-      if (OWNERSHIP_ASPECT_NAME.equals(item.getAspectName()) && item.getRecordTemplate() != null) {
-        final Map<Urn, Set<Owner>> oldTypeOwner =
-            groupByOwnerType(item.getPreviousRecordTemplate());
-        final Map<Urn, Set<Owner>> newTypeOwner = groupByOwnerType(item.getRecordTemplate());
-
-        Set<Urn> removedTypes =
-            oldTypeOwner.keySet().stream()
-                .filter(typeUrn -> !newTypeOwner.containsKey(typeUrn))
-                .collect(Collectors.toSet());
-
-        // Only update if there are actual changes
-        if (!removedTypes.isEmpty() || !oldTypeOwner.equals(newTypeOwner)) {
-          // Build complete typeOwners map with ALL types
-          Map<String, UrnArray> typeOwners =
-              newTypeOwner.entrySet().stream()
-                  .collect(
-                      Collectors.toMap(
-                          e -> encodeFieldName(e.getKey().toString()),
-                          e ->
-                              new UrnArray(
-                                  e.getValue().stream()
-                                      .map(Owner::getOwner)
-                                      .collect(Collectors.toSet()))));
-
-          item.getAspect(Ownership.class).setOwnerTypes(new UrnArrayMap(typeOwners));
-          results.add(Pair.of(item, true));
-        } else {
-          // No changes detected
-          results.add(Pair.of(item, false));
-        }
-      } else {
-        // Not an ownership aspect
+      if (!OWNERSHIP_ASPECT_NAME.equals(item.getAspectName()) || item.getRecordTemplate() == null) {
         results.add(Pair.of(item, false));
+        continue;
+      }
+
+      // ownerTypes is a server-managed denormalization of owners used for search indexing.
+      // Always (re)materialize it from the proposal's owners list so an ingestion payload that
+      // omits ownerTypes (typical for dbt and other connectors) cannot overwrite the stored map.
+      Map<String, UrnArray> typeOwners =
+          groupByOwnerType(item.getRecordTemplate()).entrySet().stream()
+              .collect(
+                  Collectors.toMap(
+                      e -> encodeFieldName(e.getKey().toString()),
+                      e ->
+                          new UrnArray(
+                              e.getValue().stream()
+                                  .map(Owner::getOwner)
+                                  .collect(Collectors.toSet()))));
+
+      UrnArrayMap materialized = new UrnArrayMap(typeOwners);
+      Ownership ownership = item.getAspect(Ownership.class);
+      UrnArrayMap existing = ownership.getOwnerTypes();
+      DataMap existingData = existing != null ? existing.data() : new DataMap();
+      if (existingData.equals(materialized.data())) {
+        results.add(Pair.of(item, false));
+      } else {
+        ownership.setOwnerTypes(materialized);
+        results.add(Pair.of(item, true));
       }
     }
 

--- a/entity-registry/src/test/java/com/linkedin/metadata/aspect/hooks/OwnershipOwnerTypeTest.java
+++ b/entity-registry/src/test/java/com/linkedin/metadata/aspect/hooks/OwnershipOwnerTypeTest.java
@@ -113,6 +113,30 @@ public class OwnershipOwnerTypeTest {
     assertEquals(resulted.getSecond(), false);
   }
 
+  /**
+   * Regression: ingestion sources commonly emit Ownership with owners populated and ownerTypes
+   * omitted. When the owner list is unchanged from the stored aspect, the hook must still
+   * re-materialize ownerTypes on the proposal so the empty map cannot wipe the persisted one.
+   */
+  @Test
+  public void testRepeatIngestPreservesOwnerTypesWhenProposalOmitsThem() throws URISyntaxException {
+    Ownership stored = getOwnership(true, true, false);
+    Ownership proposal = getOwnership(true, false, false);
+    TestMCP mcp = withPrevious(getTestMcpBuilder().recordTemplate(proposal), stored).build();
+
+    List<Pair<ChangeMCP, Boolean>> result =
+        test.writeMutation(Set.of(mcp), retrieverContext).toList();
+
+    assertEquals(result.size(), 1);
+    assertTrue(
+        result.get(0).getSecond(),
+        "Hook must mutate the proposal so the omitted ownerTypes does not overwrite storage.");
+    assertEquals(
+        proposal.getOwnerTypes(),
+        stored.getOwnerTypes(),
+        "Re-materialized ownerTypes should match the previously stored map.");
+  }
+
   @Test
   public void testChangeAddBusinessOwnerType() throws URISyntaxException {
     Ownership ownership = getOwnership(true, false, false);

--- a/smoke-test/tests/openapi/v3/ownership_owner_types.json
+++ b/smoke-test/tests/openapi/v3/ownership_owner_types.json
@@ -1,0 +1,74 @@
+[
+  {
+    "request": {
+      "description": "Clean slate",
+      "method": "delete",
+      "url": "/openapi/v3/entity/dataset/urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Atest%2CownerTypesIdempotencyV3%2CPROD%29"
+    },
+    "response": {
+      "status_codes": [200, 204, 404]
+    }
+  },
+  {
+    "request": {
+      "description": "Write #1: owners populated, ownerTypes omitted (typical ingestion payload)",
+      "url": "/openapi/v3/entity/dataset/urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Atest%2CownerTypesIdempotencyV3%2CPROD%29/ownership",
+      "params": {
+        "createIfNotExists": "false",
+        "createEntityIfNotExists": "true",
+        "async": "false"
+      },
+      "json": {
+        "value": {
+          "owners": [
+            {"owner": "urn:li:corpuser:datahub", "type": "TECHNICAL_OWNER"}
+          ],
+          "lastModified": {"time": 0, "actor": "urn:li:corpuser:datahub"}
+        }
+      }
+    }
+  },
+  {
+    "request": {
+      "description": "Write #2 (regression): identical owners, ownerTypes again omitted. Before the OwnershipOwnerTypes hook fix the grouped owner map matched the previous state, the hook short-circuited setOwnerTypes, and the empty map on the proposal overwrote the stored materialization.",
+      "url": "/openapi/v3/entity/dataset/urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Atest%2CownerTypesIdempotencyV3%2CPROD%29/ownership",
+      "params": {
+        "createIfNotExists": "false",
+        "async": "false"
+      },
+      "json": {
+        "value": {
+          "owners": [
+            {"owner": "urn:li:corpuser:datahub", "type": "TECHNICAL_OWNER"}
+          ],
+          "lastModified": {"time": 0, "actor": "urn:li:corpuser:datahub"}
+        }
+      }
+    }
+  },
+  {
+    "request": {
+      "description": "Regression assertion: ownerTypes must survive the repeat ingest",
+      "method": "get",
+      "url": "/openapi/v3/entity/dataset/urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Atest%2CownerTypesIdempotencyV3%2CPROD%29/ownership",
+      "params": {"systemMetadata": "false"}
+    },
+    "response": {
+      "exclude_regex_paths": [
+        "root\\['value'\\]\\['lastModified'\\]"
+      ],
+      "json": {
+        "value": {
+          "owners": [
+            {"owner": "urn:li:corpuser:datahub", "type": "TECHNICAL_OWNER"}
+          ],
+          "ownerTypes": {
+            "urn:li:ownershipType:__system__technical_owner": [
+              "urn:li:corpuser:datahub"
+            ]
+          }
+        }
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Summary

The `OwnershipOwnerTypes` mutation hook short-circuited `setOwnerTypes` whenever the grouped-by-type owner map on the incoming proposal equaled the previous aspect's grouped map. Ingestion connectors (dbt and others) routinely emit `Ownership` with `owners` populated and `ownerTypes` omitted; on repeat ingestion the grouped map matched, the hook never set `ownerTypes`, and the empty map on the proposal overwrote the persisted materialization. Because `ownerTypes` is the field Elasticsearch indexes for ownership-type search facets and Metadata Tests, ownership-type filters silently stopped returning the entity even though its `Owner` list was intact.

The hook now always (re)materializes `ownerTypes` from `owners` on the incoming proposal, and only flags a mutation when the newly materialized map differs from the one already on the proposal. This preserves idempotency for no-op writes (no spurious MCL emission) while guaranteeing the denormalization is never lost.

## Root cause

Old logic compared the grouped map of the proposal against the grouped map of the **previous** aspect and used inequality as the gate for re-materialization. Same `owners` → same grouped map → skip → `ownerTypes` left empty on the proposal → empty map persisted. The invariant the hook is supposed to enforce — *`ownerTypes` is a server-managed denormalization of `owners`* — only held on the first write of a given owner set.

## Changes

| File | What |
| --- | --- |
| `entity-registry/.../OwnershipOwnerTypes.java` | Always materialize `ownerTypes` from `owners`; compare against the proposal's existing `ownerTypes` (not the previous aspect's) to decide whether the proposal mutated. |
| `entity-registry/.../OwnershipOwnerTypeTest.java` | New unit test `testRepeatIngestPreservesOwnerTypesWhenProposalOmitsThem` covering the exact regression: stored aspect has populated `ownerTypes`, proposal omits them, same `owners`. |
| `smoke-test/tests/openapi/v3/ownership_owner_types.json` | New declarative fixture driven by the existing `test_openapi` harness. Double-ingests via OpenAPI v3 and asserts `ownerTypes` survives the repeat write. |

## Verification

- `./gradlew :entity-registry:check` — passes; all 11 `OwnershipOwnerTypeTest` cases green.
- **Unit-test bisect**: stashed the source fix and re-ran the new test against the unfixed source. The test fails on the assertion that `ownerTypes` is re-materialized (proves coverage, not vacuous).
- **Smoke-test bisect**: ran the new fixture against a GMS built with the unfixed source. Step 3 fails with `{'dictionary_item_added': ["root['value']['ownerTypes']"]}` — the buggy server returns no `ownerTypes` key after the second write. Re-running against the fixed server passes.
- Live triple-ingest of a dbt-style payload (owners populated, `ownerTypes` omitted) through the REST emitter: `ownerTypes` has the expected 2 entries after every write.

