### PR TITLE
fix(precommit): propagate schemaVersion bump through PDL field-type deps

### DIFF
--- a/.github/scripts/bump_schema_versions.md
+++ b/.github/scripts/bump_schema_versions.md
@@ -1,13 +1,16 @@
 # bump_schema_versions.py
 
-A pre-commit CLI tool that automatically bumps `schemaVersion` annotations on PDL aspect files whenever their content — or the content of any record they include — changes relative to the base branch.
+A pre-commit CLI tool that automatically bumps `schemaVersion` annotations on PDL aspect files whenever their content — or the content of any record/enum/typeref they depend on (via `includes` **or** as a field type) — changes relative to the base branch.
 
 ## Why this exists
 
 DataHub's metadata model is defined in PDL files under `metadata-models/src/main/pegasus/`. Each **aspect** file carries a `schemaVersion` field inside its `@Aspect` annotation. This version must be incremented whenever the aspect's schema changes so that downstream consumers (schema registries, compatibility checks, migration tooling) can detect and react to the change. The `schemaVersion` is optional and when
 missing, defaults to 1.
 
-Without automation this is easy to forget, especially for **implicit** changes — where a shared base record (e.g. `TimeseriesAspectBase`) is modified and every aspect that includes it is silently affected.
+Without automation this is easy to forget, especially for **implicit** changes — where a shared record, enum, or typeref is modified and every aspect that depends on it is silently affected. Two flavors of dependency are tracked:
+
+- `record X includes Y` — the historical case (shared base records like `TimeseriesAspectBase`).
+- Field-type references — e.g. `record X { schedule: optional Y }`. If `Y` is modified, `X` must be bumped even though no `includes` relationship exists. This catches cases like `DataHubIngestionSourceInfo` referencing `DataHubIngestionSourceSchedule`, where both live in the same namespace and no import is needed.
 
 ## Usage
 
@@ -84,11 +87,13 @@ git diff --name-only --diff-filter=ACM <base-branch> -- *.pdl
 
 This captures added, copied, and modified PDL files relative to the base branch, including uncommitted staged and unstaged changes. **Untracked files** (not yet `git add`ed) are not detected.
 
-### Step 2 — Build the include graph
+### Step 2 — Build the dependency graph
 
-All PDL files under `metadata-models/src/main/pegasus/` are scanned once to build a **reverse include map**: for every record, which files include it?
+All PDL files under `metadata-models/src/main/pegasus/` are scanned once to build a **reverse dependency map**: for every record/enum/typeref, which files depend on it?
 
-PDL `includes` resolution follows the language rules:
+Two kinds of edges are recorded:
+
+**1. `includes` clauses.**
 
 ```pdl
 namespace com.linkedin.dataset
@@ -97,11 +102,21 @@ import com.linkedin.timeseries.TimeseriesAspectBase
 record DatasetUsageStatistics includes TimeseriesAspectBase { ... }
 ```
 
-`TimeseriesAspectBase` is resolved to `com.linkedin.timeseries.TimeseriesAspectBase` via the `import` statement (namespace is used as a fallback for unimported names).
+**2. Field-type references** — direct, optional, generic, union members, and types inside inline records.
+
+```pdl
+namespace com.linkedin.ingestion
+
+record DataHubIngestionSourceInfo {
+  schedule: optional DataHubIngestionSourceSchedule   // same-namespace ref
+}
+```
+
+Short names are resolved to FQNs via the file's `import` statements, with the file's own `namespace` as fallback (this is how same-namespace refs like the example above are resolved without needing an explicit import). Identifiers inside strings, comments, `@Annotation = {...}` values, and `import` lines are excluded from the scan.
 
 ### Step 3 — Transitive propagation (BFS)
 
-Starting from the directly changed files, the tool does a breadth-first search through the reverse include graph to find every file that (directly or transitively) depends on any changed record. From that reachable set, only files with an `@Aspect` annotation are eligible for a version bump.
+Starting from the directly changed files, the tool does a breadth-first search through the reverse dependency graph to find every file that (directly or transitively) depends on any changed record. From that reachable set, only files with an `@Aspect` annotation are eligible for a version bump.
 
 ```
 TimeseriesAspectBase.pdl  ← changed
@@ -109,6 +124,9 @@ TimeseriesAspectBase.pdl  ← changed
   └─ included by DatasetProfile.pdl          (aspect → bumped)
   └─ included by ChartUsageStatistics.pdl    (aspect → bumped)
   └─ ...
+
+DataHubIngestionSourceSchedule.pdl  ← changed (non-aspect)
+  └─ used as field type in DataHubIngestionSourceInfo.pdl  (aspect → bumped)
 ```
 
 ### Step 4 — Bump the version
@@ -163,7 +181,7 @@ SKIP  <path>  (reason)          ← only with --verbose
 Reason labels:
 
 - `[direct change]` — the aspect file itself was modified
-- `[implicit (includes changed record)]` — a record this aspect includes was modified
+- `[implicit (depends on changed record)]` — a record/enum/typeref this aspect depends on (via `includes` or as a field type) was modified
 
 ### Example output
 
@@ -172,11 +190,11 @@ Comparing against branch: master
 Found 1 directly changed PDL file(s):
   metadata-models/src/main/pegasus/com/linkedin/timeseries/TimeseriesAspectBase.pdl
 
-BUMP  metadata-models/.../chart/ChartUsageStatistics.pdl         v1 → v2  [implicit (includes changed record)]
-BUMP  metadata-models/.../common/Operation.pdl                    v1 → v2  [implicit (includes changed record)]
-BUMP  metadata-models/.../dashboard/DashboardUsageStatistics.pdl  v1 → v2  [implicit (includes changed record)]
-BUMP  metadata-models/.../dataset/DatasetProfile.pdl              v1 → v2  [implicit (includes changed record)]
-BUMP  metadata-models/.../dataset/DatasetUsageStatistics.pdl      v1 → v2  [implicit (includes changed record)]
+BUMP  metadata-models/.../chart/ChartUsageStatistics.pdl         v1 → v2  [implicit (depends on changed record)]
+BUMP  metadata-models/.../common/Operation.pdl                    v1 → v2  [implicit (depends on changed record)]
+BUMP  metadata-models/.../dashboard/DashboardUsageStatistics.pdl  v1 → v2  [implicit (depends on changed record)]
+BUMP  metadata-models/.../dataset/DatasetProfile.pdl              v1 → v2  [implicit (depends on changed record)]
+BUMP  metadata-models/.../dataset/DatasetUsageStatistics.pdl      v1 → v2  [implicit (depends on changed record)]
 ...
 
 Summary: 9 bumped, 0 skipped, 0 errors

--- a/.github/scripts/bump_schema_versions.py
+++ b/.github/scripts/bump_schema_versions.py
@@ -4,14 +4,16 @@ CLI tool to bump schemaVersion annotations on changed PDL aspect files.
 
 Compares PDL files against a base branch and increments the schemaVersion
 annotation on any aspect that has changed — including aspects that transitively
-include a changed record via PDL `includes`.
+depend on a changed record via PDL `includes` or field-type references.
 
 Rules:
   - Only aspects (files with @Aspect annotation) are versioned
   - Default version if not specified is 1
   - Any change bumps to base_branch_version + 1
   - New files (not on base branch) already default to version 1; no write needed
-  - If record A is included by aspect B and A changes, B is also bumped
+  - If a non-aspect record A is included by aspect B and A changes, B is bumped
+  - If a non-aspect record A is referenced as a field type in aspect B
+    (e.g. `schedule: optional A`) and A changes, B is bumped
 
 Environment variables:
   PDL_ROOTS    Colon-separated list of PDL source roots to scan.
@@ -180,6 +182,156 @@ def resolve_includes(content: str) -> list[str]:
     return fqns
 
 
+# ---------------------------------------------------------------------------
+# Field-type reference parsing
+#
+# `includes` alone is not enough: a non-aspect record referenced as a *field
+# type* (e.g. `schedule: optional DataHubIngestionSourceSchedule`) creates a
+# real schema dependency. When the referenced record changes, every aspect
+# that uses it must be bumped, even though no `includes` relationship exists.
+# ---------------------------------------------------------------------------
+
+_STRING_LITERAL_RE = re.compile(r'"(?:[^"\\]|\\.)*"')
+_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+_LINE_COMMENT_RE = re.compile(r"//[^\n]*")
+_IMPORT_LINE_RE = re.compile(r"^\s*import\s+[\w.]+\s*$", re.MULTILINE)
+_ANNOTATION_PREFIX_RE = re.compile(r"@\w+\s*=\s*\{")
+# `pkg.subpkg.PascalName` — lowercase package parts joined by dots, ending in a PascalCase type
+_FQN_REF_RE = re.compile(r"\b(?:[a-z][\w]*\.)+[A-Z]\w*\b")
+_PASCAL_CASE_RE = re.compile(r"\b[A-Z]\w*\b")
+
+_PDL_KEYWORDS = frozenset(
+    {
+        "namespace",
+        "import",
+        "package",
+        "record",
+        "enum",
+        "union",
+        "array",
+        "map",
+        "typeref",
+        "fixed",
+        "optional",
+        "includes",
+    }
+)
+
+
+def _strip_strings_and_comments(content: str) -> str:
+    # Strings first — guards against comment markers (`/*`, `*/`, `//`) embedded
+    # inside string literals being mis-recognized as real comments.
+    content = _STRING_LITERAL_RE.sub('""', content)
+    content = _BLOCK_COMMENT_RE.sub(" ", content)
+    content = _LINE_COMMENT_RE.sub(" ", content)
+    return content
+
+
+def _strip_annotation_blocks(content: str) -> str:
+    """
+    Remove `@Foo = { ... }` annotation values.
+
+    Annotation values are JSON-like, not PDL — identifiers inside are never type
+    references. Brace-balanced so nested objects are handled correctly.
+    """
+    out: list[str] = []
+    i = 0
+    while True:
+        m = _ANNOTATION_PREFIX_RE.search(content, i)
+        if m is None:
+            out.append(content[i:])
+            return "".join(out)
+        out.append(content[i : m.start()])
+        depth = 0
+        j = m.end() - 1  # position of the opening '{'
+        while j < len(content):
+            ch = content[j]
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    j += 1
+                    break
+            j += 1
+        i = j
+
+
+def parse_field_types(content: str) -> list[str]:
+    """
+    Return tokens used as field types in this PDL file. Each token is either:
+      - a fully-qualified name (`com.linkedin.common.AuditStamp`), already
+        resolved; or
+      - a PascalCase short name (`AuditStamp`), to be resolved later via the
+        file's imports or namespace.
+
+    The scan masks strings, comments, import lines, and `@Annotation = {...}`
+    blocks first, so only real field-type references remain. It catches:
+
+      - direct references:   `field: Foo`
+      - optional fields:     `field: optional Foo`
+      - generic params:      `field: array[Foo]`, `field: map[string, Foo]`
+      - union members:       `field: union[Foo, Bar]`
+      - nested fields inside inline `record { ... }` definitions
+      - inline FQN refs:     `field: com.linkedin.common.Foo`
+
+    Unresolved short names (no matching import, no matching namespace record)
+    are dropped by `resolve_dependencies`, so any false positives are harmless.
+    """
+    cleaned = _strip_strings_and_comments(content)
+    cleaned = _IMPORT_LINE_RE.sub(" ", cleaned)
+    cleaned = _strip_annotation_blocks(cleaned)
+
+    out: list[str] = []
+    seen: set[str] = set()
+
+    for m in _FQN_REF_RE.finditer(cleaned):
+        ref = m.group(0)
+        if ref not in seen:
+            seen.add(ref)
+            out.append(ref)
+
+    # Mask the FQN matches so their trailing PascalCase tokens aren't counted twice
+    cleaned_no_fqn = _FQN_REF_RE.sub(" ", cleaned)
+
+    for token in _PASCAL_CASE_RE.findall(cleaned_no_fqn):
+        if token in _PDL_KEYWORDS or token in seen:
+            continue
+        seen.add(token)
+        out.append(token)
+
+    return out
+
+
+def resolve_dependencies(content: str) -> list[str]:
+    """
+    Return FQNs for every record / enum / typeref this PDL file depends on,
+    via either `includes` clauses or field-type references.
+
+    Short names are resolved via import statements, with namespace as fallback.
+    Tokens already containing dots are treated as fully-qualified.
+    Unresolvable names (no namespace, not imported) are silently dropped.
+    """
+    namespace, imports = parse_pdl_header(content)
+
+    tokens: list[str] = []
+    seen: set[str] = set()
+    for name in parse_includes(content) + parse_field_types(content):
+        if name not in seen:
+            seen.add(name)
+            tokens.append(name)
+
+    fqns: list[str] = []
+    for name in tokens:
+        if "." in name:
+            fqns.append(name)
+        elif name in imports:
+            fqns.append(imports[name])
+        elif namespace:
+            fqns.append(f"{namespace}.{name}")
+    return fqns
+
+
 def find_aspect_annotation_bounds(content: str) -> tuple[int, int] | None:
     """Locate the @Aspect annotation object. Returns (start, end) or None."""
     match = re.search(r"@Aspect\s*=\s*(\{)", content)
@@ -272,9 +424,13 @@ def build_reverse_include_graph(
     all_pdl_files: list[Path],
 ) -> dict[str, set[str]]:
     """
-    Build a reverse map: fqn → set of repo-relative file paths that include it.
+    Build a reverse map: fqn → set of file paths that depend on it.
 
-    Given that A.pdl `includes` B and C, the graph will have:
+    A "depends on" edge is recorded both for `record X includes Y` clauses and
+    for field-type references like `field: Y` or `field: optional Y`.
+
+    Given that A.pdl includes B and references C as a field type, the graph
+    will have:
       fqn(B) → { path(A.pdl) }
       fqn(C) → { path(A.pdl) }
     """
@@ -291,8 +447,14 @@ def build_reverse_include_graph(
         if rel is None:
             continue
 
-        for included_fqn in resolve_includes(content):
-            reverse[included_fqn].add(str(pdl_path))
+        # The PascalCase field-type scan will pick up the record's own name
+        # (`record Foo { ... }` → `Foo`). Drop that self-reference here.
+        own_fqn = ".".join(rel.with_suffix("").parts)
+
+        for dep_fqn in resolve_dependencies(content):
+            if dep_fqn == own_fqn:
+                continue
+            reverse[dep_fqn].add(str(pdl_path))
 
     return reverse
 
@@ -303,11 +465,13 @@ def find_transitively_affected_aspects(
     all_pdl_files: list[Path],
 ) -> set[str]:
     """
-    BFS from the set of directly changed files through the reverse include graph.
-    Returns all *aspect* files (including the originals) that need a version bump.
+    BFS from the set of directly changed files through the reverse dependency
+    graph. Returns all *aspect* files (including the originals) that need a
+    version bump.
 
     'directly changed' files don't need to be aspects themselves — a changed
-    non-aspect record can trigger bumps in aspects that include it.
+    non-aspect record (whether referenced via `includes` or as a field type)
+    can trigger bumps in aspects that depend on it.
     """
     # Build fqn → path index for fast lookup
     roots = get_pdl_roots()
@@ -427,7 +591,7 @@ def main() -> int:
                 reason = (
                     "direct change"
                     if filepath in directly_changed_set
-                    else "implicit (includes changed record)"
+                    else "implicit (depends on changed record)"
                 )
                 print(
                     f"SKIP  {filepath}  "
@@ -439,7 +603,7 @@ def main() -> int:
         reason = (
             "direct change"
             if filepath in directly_changed_set
-            else "implicit (includes changed record)"
+            else "implicit (depends on changed record)"
         )
 
         try:

--- a/.github/scripts/test/test_bump_schema_versions.py
+++ b/.github/scripts/test/test_bump_schema_versions.py
@@ -370,6 +370,265 @@ def test_changed_file_with_no_dependents_not_in_result_if_not_aspect(tmp_path, m
 
 
 # ---------------------------------------------------------------------------
+# parse_field_types  /  resolve_dependencies
+# ---------------------------------------------------------------------------
+
+
+def test_parse_field_types_picks_up_short_name():
+    content = (
+        "namespace com.linkedin.ingestion\n"
+        "record Foo { schedule: optional Bar }"
+    )
+    # Both the record's own name and the referenced type are PascalCase tokens
+    assert "Bar" in bsv.parse_field_types(content)
+
+
+def test_parse_field_types_handles_generic_params():
+    content = (
+        "namespace com.linkedin.x\n"
+        "record Foo {\n"
+        "  arr: array[Bar]\n"
+        "  m: map[string, Baz]\n"
+        "  u: union[Qux, Quux]\n"
+        "}"
+    )
+    tokens = bsv.parse_field_types(content)
+    for name in ("Bar", "Baz", "Qux", "Quux"):
+        assert name in tokens
+
+
+def test_parse_field_types_strips_annotation_blocks():
+    # Field type `realRef` should be picked up, but identifier `Searchable`
+    # inside `@Searchable = { ... }` must not.
+    content = (
+        "namespace com.linkedin.x\n"
+        "record Foo {\n"
+        '  @Searchable = { "fieldType": "TEXT" }\n'
+        "  realRef: SomeRecord\n"
+        "}"
+    )
+    tokens = bsv.parse_field_types(content)
+    assert "SomeRecord" in tokens
+    assert "Searchable" not in tokens
+
+
+def test_parse_field_types_strips_doc_comments():
+    content = (
+        "namespace com.linkedin.x\n"
+        "/** This refers to BogusType in prose */\n"
+        "record Foo { field: RealType }"
+    )
+    tokens = bsv.parse_field_types(content)
+    assert "RealType" in tokens
+    assert "BogusType" not in tokens
+
+
+def test_parse_field_types_strips_import_lines():
+    # Identifiers from `import` lines should not be treated as field references
+    content = (
+        "namespace com.linkedin.x\n"
+        "import com.linkedin.common.OnlyImported\n"
+        "record Foo { used: ActuallyUsed }"
+    )
+    tokens = bsv.parse_field_types(content)
+    assert "ActuallyUsed" in tokens
+    assert "OnlyImported" not in tokens
+    assert "com.linkedin.common.OnlyImported" not in tokens
+
+
+def test_parse_field_types_captures_inline_fqn_ref():
+    content = (
+        "namespace com.linkedin.x\n"
+        "record Foo { field: com.linkedin.common.Bar }"
+    )
+    tokens = bsv.parse_field_types(content)
+    assert "com.linkedin.common.Bar" in tokens
+
+
+def test_resolve_dependencies_same_namespace_field_ref():
+    # The original bug: schedule field uses a record in the SAME namespace,
+    # with no import. Must still resolve to the right FQN via namespace fallback.
+    content = (
+        "namespace com.linkedin.ingestion\n"
+        "import com.linkedin.common.Urn\n"
+        "@Aspect = { \"name\": \"info\" }\n"
+        "record DataHubIngestionSourceInfo {\n"
+        "  platform: optional Urn\n"
+        "  schedule: optional DataHubIngestionSourceSchedule\n"
+        "}"
+    )
+    deps = bsv.resolve_dependencies(content)
+    assert "com.linkedin.ingestion.DataHubIngestionSourceSchedule" in deps
+    assert "com.linkedin.common.Urn" in deps
+
+
+def test_resolve_dependencies_inline_fqn_is_passed_through():
+    content = (
+        "namespace com.linkedin.x\n"
+        "record Foo { field: com.linkedin.common.Bar }"
+    )
+    assert "com.linkedin.common.Bar" in bsv.resolve_dependencies(content)
+
+
+def test_resolve_dependencies_unresolved_short_name_dropped():
+    # No namespace, no imports — bare PascalCase token can't be resolved
+    content = "record Foo { field: Unknown }"
+    assert bsv.resolve_dependencies(content) == []
+
+
+# ---------------------------------------------------------------------------
+# field-type propagation end-to-end (the user's reported bug)
+# ---------------------------------------------------------------------------
+
+
+def test_changed_non_aspect_field_type_bumps_using_aspect(tmp_path, monkeypatch):
+    """
+    Replicates the DataHubIngestionSourceInfo / DataHubIngestionSourceSchedule case:
+    a non-aspect record is referenced as a field type (not via `includes`) inside
+    an aspect, and lives in the SAME namespace (no import).
+    """
+    monkeypatch.setenv("PDL_ROOTS", str(tmp_path))
+
+    schedule = write_pdl(
+        tmp_path,
+        "com/linkedin/ingestion/DataHubIngestionSourceSchedule.pdl",
+        record_pdl("com.linkedin.ingestion", "DataHubIngestionSourceSchedule"),
+    )
+    info = write_pdl(
+        tmp_path,
+        "com/linkedin/ingestion/DataHubIngestionSourceInfo.pdl",
+        "namespace com.linkedin.ingestion\n"
+        '@Aspect = { "name": "dataHubIngestionSourceInfo" }\n'
+        "record DataHubIngestionSourceInfo {\n"
+        "  schedule: optional DataHubIngestionSourceSchedule\n"
+        "}",
+    )
+
+    graph = bsv.build_reverse_include_graph([schedule, info])
+    assert str(info) in graph["com.linkedin.ingestion.DataHubIngestionSourceSchedule"]
+
+    result = bsv.find_transitively_affected_aspects(
+        [str(schedule)], graph, [schedule, info]
+    )
+    assert str(info) in result          # aspect that uses it gets bumped
+    assert str(schedule) not in result  # non-aspect itself is never bumped
+
+
+def test_changed_enum_field_type_bumps_using_aspect(tmp_path, monkeypatch):
+    """
+    Mirrors the AssertionAssignmentRuleInfo case where the field type is an
+    enum in the same namespace (e.g. `mode: AssertionAssignmentRuleMode`).
+    """
+    monkeypatch.setenv("PDL_ROOTS", str(tmp_path))
+
+    mode = write_pdl(
+        tmp_path,
+        "com/linkedin/a/Mode.pdl",
+        "namespace com.linkedin.a\nenum Mode { ENABLED, DISABLED }",
+    )
+    aspect = write_pdl(
+        tmp_path,
+        "com/linkedin/a/RuleInfo.pdl",
+        "namespace com.linkedin.a\n"
+        '@Aspect = { "name": "ruleInfo" }\n'
+        'record RuleInfo { mode: Mode = "ENABLED" }',
+    )
+
+    graph = bsv.build_reverse_include_graph([mode, aspect])
+    result = bsv.find_transitively_affected_aspects(
+        [str(mode)], graph, [mode, aspect]
+    )
+    assert str(aspect) in result
+
+
+def test_field_type_propagates_through_non_aspect_chain(tmp_path, monkeypatch):
+    """
+    Multi-hop chain via field types only (no `includes` at any step):
+       leaf (non-aspect)  ←  middle (non-aspect)  ←  aspect
+    Changing the leaf must bump the aspect.
+    """
+    monkeypatch.setenv("PDL_ROOTS", str(tmp_path))
+
+    leaf = write_pdl(
+        tmp_path,
+        "com/linkedin/x/Leaf.pdl",
+        record_pdl("com.linkedin.x", "Leaf"),
+    )
+    middle = write_pdl(
+        tmp_path,
+        "com/linkedin/x/Middle.pdl",
+        "namespace com.linkedin.x\nrecord Middle { l: Leaf }",
+    )
+    top = write_pdl(
+        tmp_path,
+        "com/linkedin/x/Top.pdl",
+        "namespace com.linkedin.x\n"
+        '@Aspect = { "name": "top" }\n'
+        "record Top { m: Middle }",
+    )
+
+    graph = bsv.build_reverse_include_graph([leaf, middle, top])
+    result = bsv.find_transitively_affected_aspects(
+        [str(leaf)], graph, [leaf, middle, top]
+    )
+    assert str(top) in result
+    assert str(middle) not in result  # not an aspect
+    assert str(leaf) not in result    # not an aspect
+
+
+def test_field_type_imported_cross_namespace(tmp_path, monkeypatch):
+    """A changed record referenced via `import` from another namespace must
+    bump the using aspect."""
+    monkeypatch.setenv("PDL_ROOTS", str(tmp_path))
+
+    audit = write_pdl(
+        tmp_path,
+        "com/linkedin/common/AuditStamp.pdl",
+        record_pdl("com.linkedin.common", "AuditStamp"),
+    )
+    aspect = write_pdl(
+        tmp_path,
+        "com/linkedin/x/Info.pdl",
+        "namespace com.linkedin.x\n"
+        "import com.linkedin.common.AuditStamp\n"
+        '@Aspect = { "name": "info" }\n'
+        "record Info { created: optional AuditStamp }",
+    )
+
+    graph = bsv.build_reverse_include_graph([audit, aspect])
+    result = bsv.find_transitively_affected_aspects(
+        [str(audit)], graph, [audit, aspect]
+    )
+    assert str(aspect) in result
+
+
+def test_unrelated_same_namespace_record_is_not_a_dependency(tmp_path, monkeypatch):
+    """Two records in the same namespace that don't reference each other must
+    NOT trigger a bump — this is what makes the field-type scan worth doing
+    over the simpler 'any same-namespace file is a dep' heuristic."""
+    monkeypatch.setenv("PDL_ROOTS", str(tmp_path))
+
+    unrelated = write_pdl(
+        tmp_path,
+        "com/linkedin/x/Unrelated.pdl",
+        record_pdl("com.linkedin.x", "Unrelated"),
+    )
+    aspect = write_pdl(
+        tmp_path,
+        "com/linkedin/x/Other.pdl",
+        "namespace com.linkedin.x\n"
+        '@Aspect = { "name": "other" }\n'
+        "record Other { field: string }",
+    )
+
+    graph = bsv.build_reverse_include_graph([unrelated, aspect])
+    result = bsv.find_transitively_affected_aspects(
+        [str(unrelated)], graph, [unrelated, aspect]
+    )
+    assert str(aspect) not in result
+
+
+# ---------------------------------------------------------------------------
 # detect_default_branch
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
bump_schema_versions.py previously walked only `record X includes Y` relationships, missing the common case where an aspect references another record or enum as a field type (e.g. `schedule: DataHubIngestionSourceSchedule`). A change to the referenced record left the using aspect unbumped.

resolve_dependencies now unions includes + field-type references, resolving short names via the file's imports with namespace fallback (which is how same-namespace refs resolve — no import is required). The PascalCase scan strips strings, comments, import lines, and `@Annotation = {...}` values so only real field-type references are picked up; inline FQN refs are captured directly.

Verified on real PDL: DataHubIngestionSourceInfo now lists DataHubIngestionSourceSchedule as a dependency; AssertionAssignmentRuleInfo picks up its same-namespace enum/record refs and the imported AuditStamp.

56 tests pass (42 existing + 14 new covering same-namespace refs, imported refs, generic params, inline FQNs, multi-hop non-aspect chains, and a negative case ensuring unrelated same-namespace records do not trigger bumps).

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
