### PR TITLE
fix(kafka): correct MCL batch listener registration and enable batchi…

### DIFF
--- a/docker/profiles/docker-compose.gms.yml
+++ b/docker/profiles/docker-compose.gms.yml
@@ -147,6 +147,8 @@ x-datahub-gms-service: &datahub-gms-service
     POLICY_CACHE_REFRESH_INTERVAL_SECONDS: ${POLICY_CACHE_REFRESH_INTERVAL_SECONDS:-120}
     SHOW_INGESTION_PAGE_REDESIGN: ${SHOW_INGESTION_PAGE_REDESIGN:-true}
     SHOW_HOME_PAGE_REDESIGN: ${SHOW_HOME_PAGE_REDESIGN:-true}
+    MCL_CONSUMER_BATCH_ENABLED: ${MCL_CONSUMER_BATCH_ENABLED:-true}
+    MCP_CONSUMER_BATCH_ENABLED: ${MCP_CONSUMER_BATCH_ENABLED:-true}
   healthcheck:
     test: curl -sS --fail http://datahub-gms:${DATAHUB_GMS_PORT:-8080}/health
     start_period: 90s
@@ -217,6 +219,7 @@ x-datahub-mae-consumer-service: &datahub-mae-consumer-service
   environment: &datahub-mae-consumer-env
     <<: [*primary-datastore-mysql-env, *graph-datastore-search-env, *search-datastore-env, *kafka-env, *datahub-common-env]
     ENTITY_VERSIONING_ENABLED: ${ENTITY_VERSIONING_ENABLED:-true}
+    MCL_CONSUMER_BATCH_ENABLED: ${MCL_CONSUMER_BATCH_ENABLED:-true}
 
 x-datahub-mae-consumer-service-dev: &datahub-mae-consumer-service-dev
   <<: *datahub-mae-consumer-service
@@ -249,6 +252,7 @@ x-datahub-mce-consumer-service: &datahub-mce-consumer-service
     ALTERNATE_MCP_VALIDATION: ${ALTERNATE_MCP_VALIDATION:-true}
     STRICT_URN_VALIDATION_ENABLED: ${STRICT_URN_VALIDATION_ENABLED:-true}
     ENTITY_VERSIONING_ENABLED: ${ENTITY_VERSIONING_ENABLED:-true}
+    MCP_CONSUMER_BATCH_ENABLED: ${MCP_CONSUMER_BATCH_ENABLED:-true}
 
 x-datahub-mce-consumer-service-dev: &datahub-mce-consumer-service-dev
   <<: *datahub-mce-consumer-service

--- a/docker/quickstart/docker-compose.quickstart-profile.yml
+++ b/docker/quickstart/docker-compose.quickstart-profile.yml
@@ -91,6 +91,8 @@ services:
       KAFKA_SCHEMAREGISTRY_URL: http://datahub-gms:8080/schema-registry/api/
       MAE_CONSUMER_ENABLED: 'true'
       MCE_CONSUMER_ENABLED: 'true'
+      MCL_CONSUMER_BATCH_ENABLED: 'true'
+      MCP_CONSUMER_BATCH_ENABLED: 'true'
       METADATA_SERVICE_AUTH_ENABLED: 'false'
       NEO4J_HOST: http://neo4j:7474
       NEO4J_PASSWORD: datahub

--- a/metadata-jobs/common/src/main/java/com/linkedin/metadata/kafka/listener/BatchKafkaListenerEndpoint.java
+++ b/metadata-jobs/common/src/main/java/com/linkedin/metadata/kafka/listener/BatchKafkaListenerEndpoint.java
@@ -1,0 +1,112 @@
+package com.linkedin.metadata.kafka.listener;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Properties;
+import java.util.regex.Pattern;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.springframework.kafka.config.ContainerPostProcessor;
+import org.springframework.kafka.config.KafkaListenerEndpoint;
+import org.springframework.kafka.listener.BatchMessageListener;
+import org.springframework.kafka.listener.MessageListenerContainer;
+import org.springframework.kafka.support.TopicPartitionOffset;
+import org.springframework.kafka.support.converter.MessageConverter;
+
+/**
+ * A {@link KafkaListenerEndpoint} that directly sets a {@link BatchMessageListener} on the
+ * container, bypassing Spring's {@code BatchMessagingMessageListenerAdapter}. This avoids the
+ * parameter-resolution issues that occur when {@code MethodKafkaListenerEndpoint} tries to invoke a
+ * method accepting {@code List<ConsumerRecord>} in batch mode — the adapter strips {@code
+ * ConsumerRecord} wrappers before method invocation, causing a {@code
+ * MethodArgumentResolutionException}.
+ */
+public class BatchKafkaListenerEndpoint<K, V> implements KafkaListenerEndpoint {
+
+  private final String id;
+  private final String groupId;
+  private final List<String> topics;
+  private final BatchMessageListener<K, V> messageListener;
+
+  public BatchKafkaListenerEndpoint(
+      @Nonnull String id,
+      @Nonnull String groupId,
+      @Nonnull List<String> topics,
+      @Nonnull BatchMessageListener<K, V> messageListener) {
+    this.id = id;
+    this.groupId = groupId;
+    this.topics = topics;
+    this.messageListener = messageListener;
+  }
+
+  @Override
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public String getGroupId() {
+    return groupId;
+  }
+
+  @Override
+  public String getGroup() {
+    return null;
+  }
+
+  @Override
+  public Collection<String> getTopics() {
+    return topics;
+  }
+
+  @Override
+  public TopicPartitionOffset[] getTopicPartitionsToAssign() {
+    return null;
+  }
+
+  @Override
+  public Pattern getTopicPattern() {
+    return null;
+  }
+
+  @Override
+  public String getClientIdPrefix() {
+    return null;
+  }
+
+  @Override
+  public Integer getConcurrency() {
+    return null;
+  }
+
+  @Override
+  public Boolean getAutoStartup() {
+    return false;
+  }
+
+  @Override
+  public void setupListenerContainer(
+      MessageListenerContainer listenerContainer, @Nullable MessageConverter messageConverter) {
+    listenerContainer.setupMessageListener(messageListener);
+  }
+
+  @Override
+  public boolean isSplitIterables() {
+    return false;
+  }
+
+  @Override
+  public Properties getConsumerProperties() {
+    return new Properties();
+  }
+
+  @Override
+  public Boolean getBatchListener() {
+    return true;
+  }
+
+  @Override
+  public ContainerPostProcessor<?, ?, ?> getContainerPostProcessor() {
+    return null;
+  }
+}

--- a/metadata-jobs/common/src/main/java/com/linkedin/metadata/kafka/listener/GenericKafkaListener.java
+++ b/metadata-jobs/common/src/main/java/com/linkedin/metadata/kafka/listener/GenericKafkaListener.java
@@ -2,6 +2,7 @@ package com.linkedin.metadata.kafka.listener;
 
 import io.datahubproject.metadata.context.OperationContext;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -35,11 +36,22 @@ public interface GenericKafkaListener<E, H extends EventHook<E>, R> {
       @Nonnull Map<String, Set<String>> aspectsToDrop);
 
   /**
-   * Process a Kafka consumer record.
+   * Process a batch of Kafka consumer records. This is the primary entry point for record
+   * processing. All listeners must implement this method.
+   *
+   * @param consumerRecords The batch of consumer records to process
+   */
+  void consumeBatch(@Nonnull List<ConsumerRecord<String, R>> consumerRecords);
+
+  /**
+   * Process a single Kafka consumer record. Default implementation wraps the record in a singleton
+   * list and delegates to {@link #consumeBatch(List)}.
    *
    * @param consumerRecord The Kafka consumer record to process
    */
-  void consume(@Nonnull ConsumerRecord<String, R> consumerRecord);
+  default void consume(@Nonnull ConsumerRecord<String, R> consumerRecord) {
+    consumeBatch(Collections.singletonList(consumerRecord));
+  }
 
   /**
    * Converts a generic record to the specific event type.

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/listener/mcl/MCLBatchKafkaListener.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/listener/mcl/MCLBatchKafkaListener.java
@@ -133,10 +133,7 @@ public class MCLBatchKafkaListener
             });
   }
 
-  /**
-   * Process a batch of Kafka consumer records for better performance. This method overrides the
-   * individual processing to handle batches.
-   */
+  @Override
   public void consumeBatch(
       @Nonnull final List<ConsumerRecord<String, GenericRecord>> consumerRecords) {
     List<MetadataChangeLog> allMCLs = new ArrayList<>(consumerRecords.size());

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/listener/mcl/MCLKafkaListener.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/listener/mcl/MCLKafkaListener.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.slf4j.MDC;
 
 @Slf4j
@@ -30,6 +31,13 @@ public class MCLKafkaListener
     extends AbstractKafkaListener<MetadataChangeLog, MetadataChangeLogHook, GenericRecord> {
 
   private static final String WILDCARD = "*";
+
+  @Override
+  public void consumeBatch(@Nonnull List<ConsumerRecord<String, GenericRecord>> consumerRecords) {
+    for (ConsumerRecord<String, GenericRecord> record : consumerRecords) {
+      consume(record);
+    }
+  }
 
   @Override
   @Nonnull

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/listener/mcl/MCLKafkaListenerRegistrar.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/listener/mcl/MCLKafkaListenerRegistrar.java
@@ -1,5 +1,6 @@
 package com.linkedin.metadata.kafka.listener.mcl;
 
+import static com.linkedin.metadata.config.kafka.KafkaConfiguration.MCL_BATCH_EVENT_CONSUMER_NAME;
 import static com.linkedin.metadata.config.kafka.KafkaConfiguration.MCL_EVENT_CONSUMER_NAME;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -11,18 +12,21 @@ import com.linkedin.metadata.kafka.listener.GenericKafkaListener;
 import com.linkedin.mxe.MetadataChangeLog;
 import com.linkedin.mxe.Topics;
 import io.datahubproject.metadata.context.OperationContext;
+import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.generic.GenericRecord;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.kafka.config.KafkaListenerContainerFactory;
+import org.springframework.kafka.config.KafkaListenerEndpoint;
 import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
+import org.springframework.kafka.config.MethodKafkaListenerEndpoint;
+import org.springframework.messaging.handler.annotation.support.DefaultMessageHandlerMethodFactory;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -33,13 +37,7 @@ public class MCLKafkaListenerRegistrar
         MetadataChangeLog, MetadataChangeLogHook, GenericRecord> {
   private final OperationContext systemOperationContext;
   private final ConfigurationProvider configurationProvider;
-
-  @Autowired
-  @Qualifier(MCL_EVENT_CONSUMER_NAME)
-  private KafkaListenerContainerFactory<?> kafkaListenerContainerFactory;
-
-  @Value("${METADATA_CHANGE_LOG_KAFKA_CONSUMER_GROUP_ID:generic-mae-consumer-job-client}")
-  private String consumerGroupBase;
+  private final KafkaListenerContainerFactory<?> batchKafkaListenerContainerFactory;
 
   @Value("${METADATA_CHANGE_LOG_VERSIONED_TOPIC_NAME:" + Topics.METADATA_CHANGE_LOG_VERSIONED + "}")
   private String mclVersionedTopicName;
@@ -52,6 +50,8 @@ public class MCLKafkaListenerRegistrar
       KafkaListenerEndpointRegistry kafkaListenerEndpointRegistry,
       @Qualifier(MCL_EVENT_CONSUMER_NAME)
           KafkaListenerContainerFactory<?> kafkaListenerContainerFactory,
+      @Qualifier(MCL_BATCH_EVENT_CONSUMER_NAME)
+          KafkaListenerContainerFactory<?> batchKafkaListenerContainerFactory,
       @Value("${METADATA_CHANGE_LOG_KAFKA_CONSUMER_GROUP_ID:generic-mae-consumer-job-client}")
           String consumerGroupBase,
       List<MetadataChangeLogHook> hooks,
@@ -64,27 +64,28 @@ public class MCLKafkaListenerRegistrar
         consumerGroupBase,
         hooks,
         objectMapper);
+    this.batchKafkaListenerContainerFactory = batchKafkaListenerContainerFactory;
     this.systemOperationContext = systemOperationContext;
     this.configurationProvider = configurationProvider;
   }
 
-  @Override
-  protected String getProcessorType() {
-    // Check if batch processing is enabled
-    boolean batchEnabled = false;
+  boolean isBatchEnabled() {
     try {
       if (configurationProvider.getMetadataChangeLog() != null
           && configurationProvider.getMetadataChangeLog().getConsumer() != null
           && configurationProvider.getMetadataChangeLog().getConsumer().getBatch() != null) {
-        batchEnabled =
-            configurationProvider.getMetadataChangeLog().getConsumer().getBatch().isEnabled();
+        return configurationProvider.getMetadataChangeLog().getConsumer().getBatch().isEnabled();
       }
     } catch (Exception e) {
       log.debug(
           "Error checking batch processing configuration, defaulting to individual processing", e);
     }
+    return false;
+  }
 
-    return batchEnabled ? "BatchMetadataChangeLogProcessor" : "MetadataChangeLogProcessor";
+  @Override
+  protected String getProcessorType() {
+    return isBatchEnabled() ? "BatchMetadataChangeLogProcessor" : "MetadataChangeLogProcessor";
   }
 
   @Override
@@ -103,6 +104,51 @@ public class MCLKafkaListenerRegistrar
   }
 
   @Override
+  public void registerKafkaListener(
+      @Nonnull KafkaListenerEndpoint kafkaListenerEndpoint, boolean startImmediately) {
+    KafkaListenerContainerFactory<?> factory =
+        isBatchEnabled() ? batchKafkaListenerContainerFactory : kafkaListenerContainerFactory;
+    kafkaListenerEndpointRegistry.registerListenerContainer(
+        kafkaListenerEndpoint, factory, startImmediately);
+  }
+
+  @Override
+  @Nonnull
+  public KafkaListenerEndpoint createListenerEndpoint(
+      @Nonnull String consumerGroupId,
+      @Nonnull List<String> topics,
+      @Nonnull List<MetadataChangeLogHook> groupHooks) {
+
+    if (!isBatchEnabled()) {
+      return super.createListenerEndpoint(consumerGroupId, topics, groupHooks);
+    }
+
+    MethodKafkaListenerEndpoint<String, GenericRecord> kafkaListenerEndpoint =
+        new MethodKafkaListenerEndpoint<>();
+    kafkaListenerEndpoint.setId(consumerGroupId);
+    kafkaListenerEndpoint.setGroupId(consumerGroupId);
+    kafkaListenerEndpoint.setAutoStartup(false);
+    kafkaListenerEndpoint.setTopics(topics.toArray(new String[0]));
+    kafkaListenerEndpoint.setMessageHandlerMethodFactory(new DefaultMessageHandlerMethodFactory());
+
+    Map<String, Set<String>> aspectsToDrop = parseAspectsToDrop();
+
+    GenericKafkaListener<MetadataChangeLog, MetadataChangeLogHook, GenericRecord> listener =
+        createListener(consumerGroupId, groupHooks, isFineGrainedLoggingEnabled(), aspectsToDrop);
+
+    kafkaListenerEndpoint.setBean(listener);
+
+    try {
+      Method batchConsumeMethod = MCLBatchKafkaListener.class.getMethod("consumeBatch", List.class);
+      kafkaListenerEndpoint.setMethod(batchConsumeMethod);
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    }
+
+    return kafkaListenerEndpoint;
+  }
+
+  @Override
   @Nonnull
   public GenericKafkaListener<MetadataChangeLog, MetadataChangeLogHook, GenericRecord>
       createListener(
@@ -111,21 +157,7 @@ public class MCLKafkaListenerRegistrar
           boolean fineGrainedLoggingEnabled,
           @Nonnull Map<String, Set<String>> aspectsToDrop) {
 
-    // Check if batch processing is enabled
-    boolean batchEnabled = false;
-    try {
-      if (configurationProvider.getMetadataChangeLog() != null
-          && configurationProvider.getMetadataChangeLog().getConsumer() != null
-          && configurationProvider.getMetadataChangeLog().getConsumer().getBatch() != null) {
-        batchEnabled =
-            configurationProvider.getMetadataChangeLog().getConsumer().getBatch().isEnabled();
-      }
-    } catch (Exception e) {
-      log.debug(
-          "Error checking batch processing configuration, defaulting to individual processing", e);
-    }
-
-    if (batchEnabled) {
+    if (isBatchEnabled()) {
       MCLBatchKafkaListener listener = new MCLBatchKafkaListener();
       return listener.init(
           systemOperationContext, consumerGroupId, hooks, fineGrainedLoggingEnabled, aspectsToDrop);

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/listener/mcl/MCLKafkaListenerRegistrar.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/listener/mcl/MCLKafkaListenerRegistrar.java
@@ -8,11 +8,11 @@ import com.linkedin.gms.factory.config.ConfigurationProvider;
 import com.linkedin.metadata.kafka.config.MetadataChangeLogProcessorCondition;
 import com.linkedin.metadata.kafka.hook.MetadataChangeLogHook;
 import com.linkedin.metadata.kafka.listener.AbstractKafkaListenerRegistrar;
+import com.linkedin.metadata.kafka.listener.BatchKafkaListenerEndpoint;
 import com.linkedin.metadata.kafka.listener.GenericKafkaListener;
 import com.linkedin.mxe.MetadataChangeLog;
 import com.linkedin.mxe.Topics;
 import io.datahubproject.metadata.context.OperationContext;
-import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -25,8 +25,6 @@ import org.springframework.context.annotation.Conditional;
 import org.springframework.kafka.config.KafkaListenerContainerFactory;
 import org.springframework.kafka.config.KafkaListenerEndpoint;
 import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
-import org.springframework.kafka.config.MethodKafkaListenerEndpoint;
-import org.springframework.messaging.handler.annotation.support.DefaultMessageHandlerMethodFactory;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -123,29 +121,13 @@ public class MCLKafkaListenerRegistrar
       return super.createListenerEndpoint(consumerGroupId, topics, groupHooks);
     }
 
-    MethodKafkaListenerEndpoint<String, GenericRecord> kafkaListenerEndpoint =
-        new MethodKafkaListenerEndpoint<>();
-    kafkaListenerEndpoint.setId(consumerGroupId);
-    kafkaListenerEndpoint.setGroupId(consumerGroupId);
-    kafkaListenerEndpoint.setAutoStartup(false);
-    kafkaListenerEndpoint.setTopics(topics.toArray(new String[0]));
-    kafkaListenerEndpoint.setMessageHandlerMethodFactory(new DefaultMessageHandlerMethodFactory());
-
     Map<String, Set<String>> aspectsToDrop = parseAspectsToDrop();
 
     GenericKafkaListener<MetadataChangeLog, MetadataChangeLogHook, GenericRecord> listener =
         createListener(consumerGroupId, groupHooks, isFineGrainedLoggingEnabled(), aspectsToDrop);
 
-    kafkaListenerEndpoint.setBean(listener);
-
-    try {
-      Method batchConsumeMethod = MCLBatchKafkaListener.class.getMethod("consumeBatch", List.class);
-      kafkaListenerEndpoint.setMethod(batchConsumeMethod);
-    } catch (NoSuchMethodException e) {
-      throw new RuntimeException(e);
-    }
-
-    return kafkaListenerEndpoint;
+    return new BatchKafkaListenerEndpoint<>(
+        consumerGroupId, consumerGroupId, topics, listener::consumeBatch);
   }
 
   @Override

--- a/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/listener/BatchKafkaListenerEndpointTest.java
+++ b/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/listener/BatchKafkaListenerEndpointTest.java
@@ -1,0 +1,98 @@
+package com.linkedin.metadata.kafka.listener;
+
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.kafka.listener.BatchMessageListener;
+import org.springframework.kafka.listener.MessageListenerContainer;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class BatchKafkaListenerEndpointTest {
+
+  @Mock private MessageListenerContainer mockContainer;
+
+  @BeforeMethod
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  public void testSetupListenerContainerSetsMessageListenerDirectly() {
+    List<ConsumerRecord<String, GenericRecord>> received = new ArrayList<>();
+    BatchMessageListener<String, GenericRecord> listener = received::addAll;
+
+    BatchKafkaListenerEndpoint<String, GenericRecord> endpoint =
+        new BatchKafkaListenerEndpoint<>("test-id", "test-group", List.of("topic1"), listener);
+
+    endpoint.setupListenerContainer(mockContainer, null);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<BatchMessageListener<String, GenericRecord>> captor =
+        ArgumentCaptor.forClass(BatchMessageListener.class);
+    verify(mockContainer).setupMessageListener(captor.capture());
+    assertSame(captor.getValue(), listener);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testSetupListenerContainerPreservesConsumerRecordWrappers() {
+    List<ConsumerRecord<String, GenericRecord>> received = new ArrayList<>();
+    BatchMessageListener<String, GenericRecord> listener = received::addAll;
+
+    BatchKafkaListenerEndpoint<String, GenericRecord> endpoint =
+        new BatchKafkaListenerEndpoint<>("test-id", "test-group", List.of("topic1"), listener);
+
+    endpoint.setupListenerContainer(mockContainer, null);
+
+    ArgumentCaptor<BatchMessageListener<String, GenericRecord>> captor =
+        ArgumentCaptor.forClass(BatchMessageListener.class);
+    verify(mockContainer).setupMessageListener(captor.capture());
+
+    ConsumerRecord<String, GenericRecord> record1 = mock(ConsumerRecord.class);
+    ConsumerRecord<String, GenericRecord> record2 = mock(ConsumerRecord.class);
+    when(record1.topic()).thenReturn("topic1");
+    when(record1.timestamp()).thenReturn(1000L);
+    when(record2.topic()).thenReturn("topic1");
+    when(record2.timestamp()).thenReturn(2000L);
+
+    captor.getValue().onMessage(List.of(record1, record2));
+
+    assertEquals(received.size(), 2);
+    assertSame(received.get(0), record1);
+    assertSame(received.get(1), record2);
+    assertEquals(received.get(0).timestamp(), 1000L);
+    assertEquals(received.get(1).timestamp(), 2000L);
+  }
+
+  @Test
+  public void testEndpointProperties() {
+    BatchMessageListener<String, GenericRecord> listener = records -> {};
+
+    BatchKafkaListenerEndpoint<String, GenericRecord> endpoint =
+        new BatchKafkaListenerEndpoint<>(
+            "my-id", "my-group", List.of("topic-a", "topic-b"), listener);
+
+    assertEquals(endpoint.getId(), "my-id");
+    assertEquals(endpoint.getGroupId(), "my-group");
+    assertTrue(endpoint.getTopics().containsAll(List.of("topic-a", "topic-b")));
+    assertTrue(endpoint.getBatchListener());
+    assertFalse(endpoint.getAutoStartup());
+    assertFalse(endpoint.isSplitIterables());
+    assertNull(endpoint.getGroup());
+    assertNull(endpoint.getTopicPartitionsToAssign());
+    assertNull(endpoint.getTopicPattern());
+    assertNull(endpoint.getClientIdPrefix());
+    assertNull(endpoint.getConcurrency());
+    assertNull(endpoint.getContainerPostProcessor());
+    assertNotNull(endpoint.getConsumerProperties());
+    assertTrue(endpoint.getConsumerProperties().isEmpty());
+  }
+}

--- a/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/listener/mcl/MCLBatchKafkaListenerTest.java
+++ b/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/listener/mcl/MCLBatchKafkaListenerTest.java
@@ -1,0 +1,274 @@
+package com.linkedin.metadata.kafka.listener.mcl;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.events.metadata.ChangeType;
+import com.linkedin.metadata.EventUtils;
+import com.linkedin.metadata.kafka.hook.MetadataChangeLogHook;
+import com.linkedin.metadata.utils.SystemMetadataUtils;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
+import com.linkedin.mxe.MetadataChangeLog;
+import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.metadata.context.SystemTelemetryContext;
+import io.datahubproject.test.metadata.context.TestOperationContexts;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.*;
+import javax.annotation.Nonnull;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class MCLBatchKafkaListenerTest {
+
+  private static final String TEST_ENTITY_URN =
+      "urn:li:dataset:(urn:li:dataPlatform:hive,test.dataset,PROD)";
+  private static final String TEST_ASPECT_NAME = "datasetProperties";
+  private static final String TEST_ENTITY_TYPE = "dataset";
+  private static final String TEST_TOPIC = "MetadataChangeLog_v1";
+  private static final String TEST_CONSUMER_GROUP = "mcl-batch-consumer-group";
+
+  @Mock private MetricUtils metricUtils;
+
+  private MCLBatchKafkaListener listener;
+  private MetadataChangeLogHook mockHook1;
+  private MetadataChangeLogHook mockHook2;
+  private OperationContext systemOperationContext;
+
+  @BeforeMethod
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+
+    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    when(metricUtils.getRegistry()).thenReturn(meterRegistry);
+
+    systemOperationContext =
+        TestOperationContexts.Builder.builder()
+            .systemTelemetryContextSupplier(
+                () ->
+                    SystemTelemetryContext.builder()
+                        .tracer(SystemTelemetryContext.TEST.getTracer())
+                        .metricUtils(metricUtils)
+                        .build())
+            .buildSystemContext();
+
+    listener = new MCLBatchKafkaListener();
+
+    mockHook1 = spy(new TestBatchHook("hook1"));
+    mockHook2 = spy(new TestBatchHook("hook2"));
+
+    Map<String, Set<String>> aspectsToDrop = new HashMap<>();
+    aspectsToDrop.put("dataset", new HashSet<>(Arrays.asList("deprecation")));
+    aspectsToDrop.put("*", new HashSet<>(Arrays.asList("status")));
+
+    listener.init(
+        systemOperationContext,
+        TEST_CONSUMER_GROUP,
+        Arrays.asList(mockHook1, mockHook2),
+        false,
+        aspectsToDrop);
+  }
+
+  @Test
+  public void testConsumeBatchInvokesHooksWithAllEvents() throws Exception {
+    MetadataChangeLog mcl1 = createTestMCL("datasetProperties", ChangeType.UPSERT);
+    MetadataChangeLog mcl2 = createTestMCL("ownership", ChangeType.UPSERT);
+
+    List<ConsumerRecord<String, GenericRecord>> records =
+        List.of(createMockConsumerRecord(0), createMockConsumerRecord(1));
+
+    try (MockedStatic<EventUtils> eventUtils = mockStatic(EventUtils.class)) {
+      eventUtils.when(() -> EventUtils.avroToPegasusMCL(any())).thenReturn(mcl1).thenReturn(mcl2);
+
+      listener.consumeBatch(records);
+
+      verify(mockHook1).invokeBatch(argThat(events -> events.size() == 2));
+      verify(mockHook2).invokeBatch(argThat(events -> events.size() == 2));
+    }
+  }
+
+  @Test
+  public void testConsumeBatchFiltersDroppedAspects() throws Exception {
+    MetadataChangeLog kept = createTestMCL("datasetProperties", ChangeType.UPSERT);
+    MetadataChangeLog dropped = createTestMCL("deprecation", ChangeType.UPSERT);
+
+    List<ConsumerRecord<String, GenericRecord>> records =
+        List.of(createMockConsumerRecord(0), createMockConsumerRecord(1));
+
+    try (MockedStatic<EventUtils> eventUtils = mockStatic(EventUtils.class)) {
+      eventUtils
+          .when(() -> EventUtils.avroToPegasusMCL(any()))
+          .thenReturn(kept)
+          .thenReturn(dropped);
+
+      listener.consumeBatch(records);
+
+      verify(mockHook1)
+          .invokeBatch(
+              argThat(
+                  events -> {
+                    List<MetadataChangeLog> list = new ArrayList<>(events);
+                    return list.size() == 1
+                        && "datasetProperties".equals(list.get(0).getAspectName());
+                  }));
+    }
+  }
+
+  @Test
+  public void testConsumeBatchFiltersWildcardDroppedAspects() throws Exception {
+    MetadataChangeLog kept = createTestMCL("datasetProperties", ChangeType.UPSERT);
+    MetadataChangeLog dropped = createTestMCL("status", ChangeType.UPSERT);
+    dropped.setEntityType("chart");
+
+    List<ConsumerRecord<String, GenericRecord>> records =
+        List.of(createMockConsumerRecord(0), createMockConsumerRecord(1));
+
+    try (MockedStatic<EventUtils> eventUtils = mockStatic(EventUtils.class)) {
+      eventUtils
+          .when(() -> EventUtils.avroToPegasusMCL(any()))
+          .thenReturn(kept)
+          .thenReturn(dropped);
+
+      listener.consumeBatch(records);
+
+      verify(mockHook1).invokeBatch(argThat(events -> events.size() == 1));
+    }
+  }
+
+  @Test
+  public void testConsumeBatchHandlesDeserializationError() throws Exception {
+    MetadataChangeLog validMcl = createTestMCL("datasetProperties", ChangeType.UPSERT);
+
+    List<ConsumerRecord<String, GenericRecord>> records =
+        List.of(createMockConsumerRecord(0), createMockConsumerRecord(1));
+
+    try (MockedStatic<EventUtils> eventUtils = mockStatic(EventUtils.class)) {
+      eventUtils
+          .when(() -> EventUtils.avroToPegasusMCL(any()))
+          .thenThrow(new IOException("bad record"))
+          .thenReturn(validMcl);
+
+      listener.consumeBatch(records);
+
+      verify(mockHook1).invokeBatch(argThat(events -> events.size() == 1));
+    }
+  }
+
+  @Test
+  public void testConsumeBatchAllDeserializationErrorsSkipsHooks() throws Exception {
+    List<ConsumerRecord<String, GenericRecord>> records =
+        List.of(createMockConsumerRecord(0), createMockConsumerRecord(1));
+
+    try (MockedStatic<EventUtils> eventUtils = mockStatic(EventUtils.class)) {
+      eventUtils
+          .when(() -> EventUtils.avroToPegasusMCL(any()))
+          .thenThrow(new IOException("bad record"));
+
+      listener.consumeBatch(records);
+
+      verify(mockHook1, never()).invokeBatch(any());
+      verify(mockHook2, never()).invokeBatch(any());
+    }
+  }
+
+  @Test
+  public void testConsumeBatchEmptyListSkipsHooks() throws Exception {
+    listener.consumeBatch(Collections.emptyList());
+
+    verify(mockHook1, never()).invokeBatch(any());
+    verify(mockHook2, never()).invokeBatch(any());
+  }
+
+  @Test
+  public void testConsumeBatchHookFailureContinuesToNextHook() throws Exception {
+    MetadataChangeLog mcl = createTestMCL("datasetProperties", ChangeType.UPSERT);
+
+    List<ConsumerRecord<String, GenericRecord>> records = List.of(createMockConsumerRecord(0));
+
+    doThrow(new RuntimeException("hook1 failed")).when(mockHook1).invokeBatch(any());
+
+    try (MockedStatic<EventUtils> eventUtils = mockStatic(EventUtils.class)) {
+      eventUtils.when(() -> EventUtils.avroToPegasusMCL(any())).thenReturn(mcl);
+
+      listener.consumeBatch(records);
+
+      verify(mockHook1).invokeBatch(any());
+      verify(mockHook2).invokeBatch(any());
+    }
+  }
+
+  @Test
+  public void testConsumeBatchAllEventsDroppedSkipsHooks() throws Exception {
+    MetadataChangeLog dropped1 = createTestMCL("deprecation", ChangeType.UPSERT);
+    MetadataChangeLog dropped2 = createTestMCL("status", ChangeType.UPSERT);
+
+    List<ConsumerRecord<String, GenericRecord>> records =
+        List.of(createMockConsumerRecord(0), createMockConsumerRecord(1));
+
+    try (MockedStatic<EventUtils> eventUtils = mockStatic(EventUtils.class)) {
+      eventUtils
+          .when(() -> EventUtils.avroToPegasusMCL(any()))
+          .thenReturn(dropped1)
+          .thenReturn(dropped2);
+
+      listener.consumeBatch(records);
+
+      verify(mockHook1, never()).invokeBatch(any());
+      verify(mockHook2, never()).invokeBatch(any());
+    }
+  }
+
+  private MetadataChangeLog createTestMCL(String aspectName, ChangeType changeType)
+      throws URISyntaxException {
+    MetadataChangeLog mcl = new MetadataChangeLog();
+    mcl.setEntityUrn(Urn.createFromString(TEST_ENTITY_URN));
+    mcl.setAspectName(aspectName);
+    mcl.setEntityType(TEST_ENTITY_TYPE);
+    mcl.setChangeType(changeType);
+    mcl.setSystemMetadata(SystemMetadataUtils.createDefaultSystemMetadata());
+    return mcl;
+  }
+
+  private ConsumerRecord<String, GenericRecord> createMockConsumerRecord(int offset) {
+    @SuppressWarnings("unchecked")
+    ConsumerRecord<String, GenericRecord> record = mock(ConsumerRecord.class);
+    when(record.topic()).thenReturn(TEST_TOPIC);
+    when(record.partition()).thenReturn(0);
+    when(record.offset()).thenReturn((long) offset);
+    when(record.timestamp()).thenReturn(System.currentTimeMillis() - 1000);
+    when(record.key()).thenReturn("key-" + offset);
+    when(record.serializedValueSize()).thenReturn(512);
+    when(record.value()).thenReturn(mock(GenericRecord.class));
+    return record;
+  }
+
+  static class TestBatchHook implements MetadataChangeLogHook {
+    private final String name;
+
+    TestBatchHook(String name) {
+      this.name = name;
+    }
+
+    @Nonnull
+    @Override
+    public String getConsumerGroupSuffix() {
+      return "";
+    }
+
+    @Override
+    public boolean isEnabled() {
+      return true;
+    }
+
+    @Override
+    public void invoke(@Nonnull MetadataChangeLog event) {}
+  }
+}

--- a/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/listener/mcl/MCLKafkaListenerRegistrarTest.java
+++ b/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/listener/mcl/MCLKafkaListenerRegistrarTest.java
@@ -1,13 +1,19 @@
 package com.linkedin.metadata.kafka.listener.mcl;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.gms.factory.config.ConfigurationProvider;
 import com.linkedin.metadata.config.MetadataChangeLogConfig;
+import com.linkedin.metadata.config.kafka.ConsumerConfiguration;
+import com.linkedin.metadata.config.kafka.KafkaConfiguration;
 import com.linkedin.metadata.kafka.hook.MetadataChangeLogHook;
 import com.linkedin.metadata.kafka.listener.GenericKafkaListener;
 import io.datahubproject.metadata.context.OperationContext;
@@ -18,7 +24,9 @@ import java.util.Set;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.kafka.config.KafkaListenerContainerFactory;
+import org.springframework.kafka.config.KafkaListenerEndpoint;
 import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
+import org.springframework.kafka.config.MethodKafkaListenerEndpoint;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -26,6 +34,7 @@ public class MCLKafkaListenerRegistrarTest {
 
   @Mock private KafkaListenerEndpointRegistry mockKafkaListenerEndpointRegistry;
   @Mock private KafkaListenerContainerFactory<?> mockKafkaListenerContainerFactory;
+  @Mock private KafkaListenerContainerFactory<?> mockBatchKafkaListenerContainerFactory;
   private String mockConsumerGroupBase = "test-consumer-group";
   @Mock private ObjectMapper mockObjectMapper;
   @Mock private OperationContext mockOperationContext;
@@ -33,6 +42,9 @@ public class MCLKafkaListenerRegistrarTest {
   @Mock private MetadataChangeLogConfig mockMetadataChangeLogConfig;
   @Mock private MetadataChangeLogConfig.ConsumerBatchConfig mockConsumerBatchConfig;
   @Mock private MetadataChangeLogConfig.BatchConfig mockBatchConfig;
+  @Mock private KafkaConfiguration mockKafkaConfiguration;
+  @Mock private ConsumerConfiguration mockConsumerConfiguration;
+  @Mock private ConsumerConfiguration.ConsumerOptions mockMclConsumerOptions;
 
   private MCLKafkaListenerRegistrar registrar;
   private List<MetadataChangeLogHook> hooks;
@@ -48,21 +60,26 @@ public class MCLKafkaListenerRegistrarTest {
         new MCLKafkaListenerRegistrar(
             mockKafkaListenerEndpointRegistry,
             mockKafkaListenerContainerFactory,
+            mockBatchKafkaListenerContainerFactory,
             mockConsumerGroupBase,
             hooks,
             mockObjectMapper,
             mockOperationContext,
             mockConfigurationProvider);
 
-    // Setup configuration mocks
     when(mockConfigurationProvider.getMetadataChangeLog()).thenReturn(mockMetadataChangeLogConfig);
     when(mockMetadataChangeLogConfig.getConsumer()).thenReturn(mockConsumerBatchConfig);
     when(mockConsumerBatchConfig.getBatch()).thenReturn(mockBatchConfig);
+
+    when(mockConfigurationProvider.getKafka()).thenReturn(mockKafkaConfiguration);
+    when(mockKafkaConfiguration.getConsumer()).thenReturn(mockConsumerConfiguration);
+    when(mockConsumerConfiguration.getMcl()).thenReturn(mockMclConsumerOptions);
+    when(mockMclConsumerOptions.isFineGrainedLoggingEnabled()).thenReturn(false);
+    when(mockMclConsumerOptions.getAspectsToDrop()).thenReturn(null);
   }
 
   @Test
   public void testCreateListenerWithBatchEnabled() {
-    // Configure batch processing to be enabled
     when(mockBatchConfig.isEnabled()).thenReturn(true);
 
     GenericKafkaListener<
@@ -72,13 +89,11 @@ public class MCLKafkaListenerRegistrarTest {
         listener = registrar.createListener("test-consumer-group", hooks, true, aspectsToDrop);
 
     assertNotNull(listener);
-    // Should create MCLBatchKafkaListener when batch is enabled
     assertTrue(listener instanceof MCLBatchKafkaListener);
   }
 
   @Test
   public void testCreateListenerWithBatchDisabled() {
-    // Configure batch processing to be disabled
     when(mockBatchConfig.isEnabled()).thenReturn(false);
 
     GenericKafkaListener<
@@ -88,31 +103,23 @@ public class MCLKafkaListenerRegistrarTest {
         listener = registrar.createListener("test-consumer-group", hooks, true, aspectsToDrop);
 
     assertNotNull(listener);
-    // Should create MCLKafkaListener when batch is disabled
     assertTrue(listener instanceof MCLKafkaListener);
   }
 
   @Test
   public void testGetProcessorTypeWithBatchEnabled() {
     when(mockBatchConfig.isEnabled()).thenReturn(true);
-
-    String processorType = registrar.getProcessorType();
-
-    assertEquals(processorType, "BatchMetadataChangeLogProcessor");
+    assertEquals(registrar.getProcessorType(), "BatchMetadataChangeLogProcessor");
   }
 
   @Test
   public void testGetProcessorTypeWithBatchDisabled() {
     when(mockBatchConfig.isEnabled()).thenReturn(false);
-
-    String processorType = registrar.getProcessorType();
-
-    assertEquals(processorType, "MetadataChangeLogProcessor");
+    assertEquals(registrar.getProcessorType(), "MetadataChangeLogProcessor");
   }
 
   @Test
   public void testCreateListenerWithNullConfiguration() {
-    // Test behavior when configuration is null
     when(mockConfigurationProvider.getMetadataChangeLog()).thenReturn(null);
 
     GenericKafkaListener<
@@ -122,13 +129,11 @@ public class MCLKafkaListenerRegistrarTest {
         listener = registrar.createListener("test-consumer-group", hooks, true, aspectsToDrop);
 
     assertNotNull(listener);
-    // Should default to MCLKafkaListener when configuration is null
     assertTrue(listener instanceof MCLKafkaListener);
   }
 
   @Test
   public void testCreateListenerWithNullBatchConfig() {
-    // Test behavior when batch config is null
     when(mockConsumerBatchConfig.getBatch()).thenReturn(null);
 
     GenericKafkaListener<
@@ -138,82 +143,108 @@ public class MCLKafkaListenerRegistrarTest {
         listener = registrar.createListener("test-consumer-group", hooks, true, aspectsToDrop);
 
     assertNotNull(listener);
-    // Should default to MCLKafkaListener when batch config is null
     assertTrue(listener instanceof MCLKafkaListener);
   }
 
   @Test
-  public void testCreateListenerWithDifferentConsumerGroupIds() {
-    when(mockBatchConfig.isEnabled()).thenReturn(true);
+  public void testCreateEndpointRegistersConsumeMethodWhenBatchDisabled() {
+    when(mockBatchConfig.isEnabled()).thenReturn(false);
 
-    // Test with different consumer group IDs
-    GenericKafkaListener<
-            com.linkedin.mxe.MetadataChangeLog,
-            MetadataChangeLogHook,
-            org.apache.avro.generic.GenericRecord>
-        listener1 = registrar.createListener("consumer-group-1", hooks, true, aspectsToDrop);
+    KafkaListenerEndpoint endpoint =
+        registrar.createListenerEndpoint("test-consumer-group", List.of("topic1"), hooks);
 
-    GenericKafkaListener<
-            com.linkedin.mxe.MetadataChangeLog,
-            MetadataChangeLogHook,
-            org.apache.avro.generic.GenericRecord>
-        listener2 = registrar.createListener("consumer-group-2", hooks, true, aspectsToDrop);
-
-    assertNotNull(listener1);
-    assertNotNull(listener2);
-    assertTrue(listener1 instanceof MCLBatchKafkaListener);
-    assertTrue(listener2 instanceof MCLBatchKafkaListener);
+    assertNotNull(endpoint);
+    assertTrue(endpoint instanceof MethodKafkaListenerEndpoint);
+    MethodKafkaListenerEndpoint<?, ?> methodEndpoint = (MethodKafkaListenerEndpoint<?, ?>) endpoint;
+    assertEquals(methodEndpoint.getMethod().getName(), "consume");
   }
 
   @Test
-  public void testCreateListenerWithDifferentFineGrainedLoggingSettings() {
+  public void testCreateEndpointRegistersConsumeBatchMethodWhenBatchEnabled() {
     when(mockBatchConfig.isEnabled()).thenReturn(true);
 
-    // Test with fine-grained logging enabled
-    GenericKafkaListener<
-            com.linkedin.mxe.MetadataChangeLog,
-            MetadataChangeLogHook,
-            org.apache.avro.generic.GenericRecord>
-        listener1 = registrar.createListener("test-consumer-group", hooks, true, aspectsToDrop);
+    KafkaListenerEndpoint endpoint =
+        registrar.createListenerEndpoint("test-consumer-group", List.of("topic1"), hooks);
 
-    // Test with fine-grained logging disabled
-    GenericKafkaListener<
-            com.linkedin.mxe.MetadataChangeLog,
-            MetadataChangeLogHook,
-            org.apache.avro.generic.GenericRecord>
-        listener2 = registrar.createListener("test-consumer-group", hooks, false, aspectsToDrop);
-
-    assertNotNull(listener1);
-    assertNotNull(listener2);
-    assertTrue(listener1 instanceof MCLBatchKafkaListener);
-    assertTrue(listener2 instanceof MCLBatchKafkaListener);
+    assertNotNull(endpoint);
+    assertTrue(endpoint instanceof MethodKafkaListenerEndpoint);
+    MethodKafkaListenerEndpoint<?, ?> methodEndpoint = (MethodKafkaListenerEndpoint<?, ?>) endpoint;
+    assertEquals(methodEndpoint.getMethod().getName(), "consumeBatch");
   }
 
   @Test
-  public void testCreateListenerWithDifferentAspectsToDrop() {
+  public void testRegisterKafkaListenerUsesBatchFactoryWhenBatchEnabled() {
     when(mockBatchConfig.isEnabled()).thenReturn(true);
 
-    Map<String, Set<String>> emptyAspectsToDrop = Collections.emptyMap();
-    Map<String, Set<String>> nonEmptyAspectsToDrop =
-        Map.of("dataset", Set.of("aspect1", "aspect2"));
+    KafkaListenerEndpoint endpoint =
+        registrar.createListenerEndpoint("test-consumer-group", List.of("topic1"), hooks);
+    registrar.registerKafkaListener(endpoint, false);
 
-    GenericKafkaListener<
-            com.linkedin.mxe.MetadataChangeLog,
-            MetadataChangeLogHook,
-            org.apache.avro.generic.GenericRecord>
-        listener1 =
-            registrar.createListener("test-consumer-group", hooks, true, emptyAspectsToDrop);
+    verify(mockKafkaListenerEndpointRegistry)
+        .registerListenerContainer(
+            any(KafkaListenerEndpoint.class),
+            eq(mockBatchKafkaListenerContainerFactory),
+            eq(false));
+  }
 
-    GenericKafkaListener<
-            com.linkedin.mxe.MetadataChangeLog,
-            MetadataChangeLogHook,
-            org.apache.avro.generic.GenericRecord>
-        listener2 =
-            registrar.createListener("test-consumer-group", hooks, true, nonEmptyAspectsToDrop);
+  @Test
+  public void testRegisterKafkaListenerUsesStandardFactoryWhenBatchDisabled() {
+    when(mockBatchConfig.isEnabled()).thenReturn(false);
 
-    assertNotNull(listener1);
-    assertNotNull(listener2);
-    assertTrue(listener1 instanceof MCLBatchKafkaListener);
-    assertTrue(listener2 instanceof MCLBatchKafkaListener);
+    KafkaListenerEndpoint endpoint =
+        registrar.createListenerEndpoint("test-consumer-group", List.of("topic1"), hooks);
+    registrar.registerKafkaListener(endpoint, false);
+
+    verify(mockKafkaListenerEndpointRegistry)
+        .registerListenerContainer(
+            any(KafkaListenerEndpoint.class), eq(mockKafkaListenerContainerFactory), eq(false));
+  }
+
+  @Test
+  public void testCreateEndpointBeanIsBatchListenerWhenBatchEnabled() {
+    when(mockBatchConfig.isEnabled()).thenReturn(true);
+
+    KafkaListenerEndpoint endpoint =
+        registrar.createListenerEndpoint("test-consumer-group", List.of("topic1"), hooks);
+
+    MethodKafkaListenerEndpoint<?, ?> methodEndpoint = (MethodKafkaListenerEndpoint<?, ?>) endpoint;
+    assertTrue(methodEndpoint.getBean() instanceof MCLBatchKafkaListener);
+  }
+
+  @Test
+  public void testCreateEndpointBeanIsStandardListenerWhenBatchDisabled() {
+    when(mockBatchConfig.isEnabled()).thenReturn(false);
+
+    KafkaListenerEndpoint endpoint =
+        registrar.createListenerEndpoint("test-consumer-group", List.of("topic1"), hooks);
+
+    MethodKafkaListenerEndpoint<?, ?> methodEndpoint = (MethodKafkaListenerEndpoint<?, ?>) endpoint;
+    assertTrue(methodEndpoint.getBean() instanceof MCLKafkaListener);
+  }
+
+  @Test
+  public void testIsBatchEnabledReturnsFalseWhenConsumerConfigIsNull() {
+    when(mockMetadataChangeLogConfig.getConsumer()).thenReturn(null);
+
+    assertFalse(registrar.isBatchEnabled());
+  }
+
+  @Test
+  public void testIsBatchEnabledReturnsFalseOnException() {
+    when(mockConfigurationProvider.getMetadataChangeLog()).thenThrow(new RuntimeException("boom"));
+
+    assertFalse(registrar.isBatchEnabled());
+  }
+
+  @Test
+  public void testBatchEndpointSetsConsumerGroupAndTopics() {
+    when(mockBatchConfig.isEnabled()).thenReturn(true);
+
+    KafkaListenerEndpoint endpoint =
+        registrar.createListenerEndpoint("my-batch-group", List.of("topic-a", "topic-b"), hooks);
+
+    MethodKafkaListenerEndpoint<?, ?> methodEndpoint = (MethodKafkaListenerEndpoint<?, ?>) endpoint;
+    assertEquals(methodEndpoint.getId(), "my-batch-group");
+    assertEquals(methodEndpoint.getGroupId(), "my-batch-group");
   }
 }

--- a/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/listener/mcl/MCLKafkaListenerRegistrarTest.java
+++ b/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/listener/mcl/MCLKafkaListenerRegistrarTest.java
@@ -15,6 +15,7 @@ import com.linkedin.metadata.config.MetadataChangeLogConfig;
 import com.linkedin.metadata.config.kafka.ConsumerConfiguration;
 import com.linkedin.metadata.config.kafka.KafkaConfiguration;
 import com.linkedin.metadata.kafka.hook.MetadataChangeLogHook;
+import com.linkedin.metadata.kafka.listener.BatchKafkaListenerEndpoint;
 import com.linkedin.metadata.kafka.listener.GenericKafkaListener;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.Collections;
@@ -160,16 +161,15 @@ public class MCLKafkaListenerRegistrarTest {
   }
 
   @Test
-  public void testCreateEndpointRegistersConsumeBatchMethodWhenBatchEnabled() {
+  public void testCreateEndpointReturnsBatchEndpointWhenBatchEnabled() {
     when(mockBatchConfig.isEnabled()).thenReturn(true);
 
     KafkaListenerEndpoint endpoint =
         registrar.createListenerEndpoint("test-consumer-group", List.of("topic1"), hooks);
 
     assertNotNull(endpoint);
-    assertTrue(endpoint instanceof MethodKafkaListenerEndpoint);
-    MethodKafkaListenerEndpoint<?, ?> methodEndpoint = (MethodKafkaListenerEndpoint<?, ?>) endpoint;
-    assertEquals(methodEndpoint.getMethod().getName(), "consumeBatch");
+    assertTrue(endpoint instanceof BatchKafkaListenerEndpoint);
+    assertTrue(endpoint.getBatchListener());
   }
 
   @Test
@@ -201,14 +201,15 @@ public class MCLKafkaListenerRegistrarTest {
   }
 
   @Test
-  public void testCreateEndpointBeanIsBatchListenerWhenBatchEnabled() {
+  public void testCreateEndpointIsBatchEndpointWhenBatchEnabled() {
     when(mockBatchConfig.isEnabled()).thenReturn(true);
 
     KafkaListenerEndpoint endpoint =
         registrar.createListenerEndpoint("test-consumer-group", List.of("topic1"), hooks);
 
-    MethodKafkaListenerEndpoint<?, ?> methodEndpoint = (MethodKafkaListenerEndpoint<?, ?>) endpoint;
-    assertTrue(methodEndpoint.getBean() instanceof MCLBatchKafkaListener);
+    assertTrue(endpoint instanceof BatchKafkaListenerEndpoint);
+    assertEquals(endpoint.getId(), "test-consumer-group");
+    assertEquals(endpoint.getGroupId(), "test-consumer-group");
   }
 
   @Test
@@ -243,8 +244,10 @@ public class MCLKafkaListenerRegistrarTest {
     KafkaListenerEndpoint endpoint =
         registrar.createListenerEndpoint("my-batch-group", List.of("topic-a", "topic-b"), hooks);
 
-    MethodKafkaListenerEndpoint<?, ?> methodEndpoint = (MethodKafkaListenerEndpoint<?, ?>) endpoint;
-    assertEquals(methodEndpoint.getId(), "my-batch-group");
-    assertEquals(methodEndpoint.getGroupId(), "my-batch-group");
+    assertTrue(endpoint instanceof BatchKafkaListenerEndpoint);
+    assertEquals(endpoint.getId(), "my-batch-group");
+    assertEquals(endpoint.getGroupId(), "my-batch-group");
+    assertTrue(endpoint.getTopics().contains("topic-a"));
+    assertTrue(endpoint.getTopics().contains("topic-b"));
   }
 }

--- a/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/listener/mcl/MCLKafkaListenerTest.java
+++ b/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/listener/mcl/MCLKafkaListenerTest.java
@@ -617,6 +617,52 @@ public class MCLKafkaListenerTest {
     }
   }
 
+  @Test
+  public void testConsumeBatchDelegatesToConsumeForEachRecord() throws Exception {
+    MetadataChangeLog mcl1 = createTestMCL(ChangeType.UPSERT);
+    MetadataChangeLog mcl2 = createTestMCL(ChangeType.CREATE);
+
+    ConsumerRecord<String, GenericRecord> record1 = mock(ConsumerRecord.class);
+    ConsumerRecord<String, GenericRecord> record2 = mock(ConsumerRecord.class);
+    GenericRecord genericRecord1 = mock(GenericRecord.class);
+    GenericRecord genericRecord2 = mock(GenericRecord.class);
+
+    when(record1.topic()).thenReturn(TEST_TOPIC);
+    when(record1.partition()).thenReturn(0);
+    when(record1.offset()).thenReturn(100L);
+    when(record1.timestamp()).thenReturn(TEST_TIMESTAMP - 1000);
+    when(record1.key()).thenReturn("key-1");
+    when(record1.serializedValueSize()).thenReturn(512);
+    when(record1.value()).thenReturn(genericRecord1);
+
+    when(record2.topic()).thenReturn(TEST_TOPIC);
+    when(record2.partition()).thenReturn(0);
+    when(record2.offset()).thenReturn(101L);
+    when(record2.timestamp()).thenReturn(TEST_TIMESTAMP - 2000);
+    when(record2.key()).thenReturn("key-2");
+    when(record2.serializedValueSize()).thenReturn(256);
+    when(record2.value()).thenReturn(genericRecord2);
+
+    try (MockedStatic<EventUtils> eventUtils = mockStatic(EventUtils.class)) {
+      eventUtils.when(() -> EventUtils.avroToPegasusMCL(genericRecord1)).thenReturn(mcl1);
+      eventUtils.when(() -> EventUtils.avroToPegasusMCL(genericRecord2)).thenReturn(mcl2);
+
+      listener.consumeBatch(List.of(record1, record2));
+
+      verify(mockHook1).invoke(mcl1);
+      verify(mockHook1).invoke(mcl2);
+      verify(mockHook2).invoke(mcl1);
+      verify(mockHook2).invoke(mcl2);
+    }
+  }
+
+  @Test
+  public void testConsumeBatchWithEmptyList() throws Exception {
+    listener.consumeBatch(Collections.emptyList());
+    verify(mockHook1, never()).invoke(any(MetadataChangeLog.class));
+    verify(mockHook2, never()).invoke(any(MetadataChangeLog.class));
+  }
+
   // Helper method to create test MCL
   private MetadataChangeLog createTestMCL(ChangeType changeType) throws URISyntaxException {
     MetadataChangeLog mcl = new MetadataChangeLog();

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/kafka/KafkaConfiguration.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/kafka/KafkaConfiguration.java
@@ -25,6 +25,7 @@ public class KafkaConfiguration {
       "spring.deserializer.value.delegate.class";
   public static final String MCP_EVENT_CONSUMER_NAME = "mcpEventConsumer";
   public static final String MCL_EVENT_CONSUMER_NAME = "mclEventConsumer";
+  public static final String MCL_BATCH_EVENT_CONSUMER_NAME = "mclBatchEventConsumer";
   public static final String PE_EVENT_CONSUMER_NAME = "platformEventConsumer";
   public static final String SIMPLE_EVENT_CONSUMER_NAME = "simpleKafkaConsumer";
   public static final String CDC_EVENT_CONSUMER_NAME = "cdcKafkaConsumer";

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/KafkaEventConsumerFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/KafkaEventConsumerFactory.java
@@ -1,6 +1,7 @@
 package com.linkedin.gms.factory.kafka;
 
 import static com.linkedin.metadata.config.kafka.KafkaConfiguration.DEFAULT_EVENT_CONSUMER_NAME;
+import static com.linkedin.metadata.config.kafka.KafkaConfiguration.MCL_BATCH_EVENT_CONSUMER_NAME;
 import static com.linkedin.metadata.config.kafka.KafkaConfiguration.MCL_EVENT_CONSUMER_NAME;
 import static com.linkedin.metadata.config.kafka.KafkaConfiguration.MCP_EVENT_CONSUMER_NAME;
 import static com.linkedin.metadata.config.kafka.KafkaConfiguration.PE_EVENT_CONSUMER_NAME;
@@ -206,6 +207,20 @@ public class KafkaEventConsumerFactory {
         configurationProvider.getKafka().getConsumer().getMcl());
   }
 
+  @Bean(name = MCL_BATCH_EVENT_CONSUMER_NAME)
+  protected KafkaListenerContainerFactory<?> mclBatchEventConsumer(
+      @Qualifier("kafkaConsumerFactory")
+          DefaultKafkaConsumerFactory<String, GenericRecord> kafkaConsumerFactory,
+      @Qualifier("configurationProvider") ConfigurationProvider configurationProvider) {
+
+    return buildDefaultKafkaListenerContainerFactory(
+        MCL_BATCH_EVENT_CONSUMER_NAME,
+        kafkaConsumerFactory,
+        configurationProvider.getKafka().getConsumer().isStopOnDeserializationError(),
+        configurationProvider.getKafka().getConsumer().getMcl(),
+        true);
+  }
+
   @Bean(name = DEFAULT_EVENT_CONSUMER_NAME)
   protected KafkaListenerContainerFactory<?> kafkaEventConsumer(
       @Qualifier("kafkaConsumerFactory")
@@ -224,12 +239,24 @@ public class KafkaEventConsumerFactory {
       DefaultKafkaConsumerFactory<String, GenericRecord> kafkaConsumerFactory,
       boolean isStopOnDeserializationError,
       @Nullable ConsumerConfiguration.ConsumerOptions consumerOptions) {
+    return buildDefaultKafkaListenerContainerFactory(
+        consumerFactoryName,
+        kafkaConsumerFactory,
+        isStopOnDeserializationError,
+        consumerOptions,
+        false);
+  }
+
+  private KafkaListenerContainerFactory<?> buildDefaultKafkaListenerContainerFactory(
+      String consumerFactoryName,
+      DefaultKafkaConsumerFactory<String, GenericRecord> kafkaConsumerFactory,
+      boolean isStopOnDeserializationError,
+      @Nullable ConsumerConfiguration.ConsumerOptions consumerOptions,
+      boolean batchListener) {
 
     final DefaultKafkaConsumerFactory<String, GenericRecord> factoryWithOverrides;
     if (consumerOptions != null) {
-      // Copy the base config
       Map<String, Object> props = new HashMap<>(kafkaConsumerFactory.getConfigurationProperties());
-      // Override just the auto.offset.reset
       props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, consumerOptions.getAutoOffsetReset());
       factoryWithOverrides =
           new DefaultKafkaConsumerFactory<>(
@@ -246,6 +273,9 @@ public class KafkaEventConsumerFactory {
     factory.setContainerCustomizer(new ThreadPoolContainerCustomizer());
     factory.setConcurrency(kafkaEventConsumerConcurrency);
     factory.setAutoStartup(false);
+    if (batchListener) {
+      factory.setBatchListener(true);
+    }
 
     // Allow consumer containers to survive transient authentication failures (e.g.,
     // MSK IAM credential rotation with EKS Pod Identity) instead of stopping fatally.
@@ -257,14 +287,6 @@ public class KafkaEventConsumerFactory {
           .setAuthExceptionRetryInterval(Duration.ofSeconds(authExceptionRetryIntervalSeconds));
     }
 
-    /*
-     * Sets up a delegating error handler for Deserialization errors, if disabled
-     * will
-     * use DefaultErrorHandler (does back-off retry and then logs) rather than
-     * stopping the container. Stopping the container
-     * prevents lost messages until the error can be examined, disabling this will
-     * allow progress, but may lose data
-     */
     if (isStopOnDeserializationError) {
       CommonDelegatingErrorHandler delegatingErrorHandler =
           new CommonDelegatingErrorHandler(new DefaultErrorHandler());
@@ -273,8 +295,9 @@ public class KafkaEventConsumerFactory {
       factory.setCommonErrorHandler(delegatingErrorHandler);
     }
     log.info(
-        "Event-based {} KafkaListenerContainerFactory built successfully. Consumer concurrency = {}",
+        "Event-based {}{} KafkaListenerContainerFactory built successfully. Consumer concurrency = {}",
         consumerFactoryName,
+        batchListener ? " (batch)" : "",
         kafkaEventConsumerConcurrency);
 
     return factory;

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/kafka/KafkaEventConsumerFactoryTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/kafka/KafkaEventConsumerFactoryTest.java
@@ -3,6 +3,7 @@ package com.linkedin.gms.factory.kafka;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import com.linkedin.gms.factory.config.ConfigurationProvider;
 import com.linkedin.metadata.config.kafka.ConsumerConfiguration;
@@ -12,6 +13,7 @@ import java.lang.reflect.Field;
 import java.time.Duration;
 import java.util.Map;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.common.serialization.Deserializer;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.testng.annotations.BeforeMethod;
@@ -34,9 +36,15 @@ public class KafkaEventConsumerFactoryTest {
     ConsumerConfiguration consumerConfig = new ConsumerConfiguration();
     consumerConfig.setAuthExceptionRetryIntervalSeconds(10);
     consumerConfig.setMaxAuthExceptionRetries(3);
-    consumerConfig.setPe(new ConsumerConfiguration.ConsumerOptions());
-    consumerConfig.setMcp(new ConsumerConfiguration.ConsumerOptions());
-    consumerConfig.setMcl(new ConsumerConfiguration.ConsumerOptions());
+    ConsumerConfiguration.ConsumerOptions peOptions = new ConsumerConfiguration.ConsumerOptions();
+    peOptions.setAutoOffsetReset("earliest");
+    consumerConfig.setPe(peOptions);
+    ConsumerConfiguration.ConsumerOptions mcpOptions = new ConsumerConfiguration.ConsumerOptions();
+    mcpOptions.setAutoOffsetReset("earliest");
+    consumerConfig.setMcp(mcpOptions);
+    ConsumerConfiguration.ConsumerOptions mclOptions = new ConsumerConfiguration.ConsumerOptions();
+    mclOptions.setAutoOffsetReset("earliest");
+    consumerConfig.setMcl(mclOptions);
     kafkaConfig.setConsumer(consumerConfig);
 
     ListenerConfiguration listenerConfig = new ListenerConfiguration();
@@ -45,10 +53,13 @@ public class KafkaEventConsumerFactoryTest {
 
     when(configProvider.getKafka()).thenReturn(kafkaConfig);
 
-    // Create a consumer factory directly — we only need it as input to the listener
-    // factory beans, not to test consumer properties themselves.
+    @SuppressWarnings("unchecked")
+    Deserializer<GenericRecord> valueDeserializer = mock(Deserializer.class);
     kafkaConsumerFactory =
-        new DefaultKafkaConsumerFactory<>(Map.of("bootstrap.servers", "localhost:9092"));
+        new DefaultKafkaConsumerFactory<>(
+            Map.of("bootstrap.servers", "localhost:9092"),
+            new org.apache.kafka.common.serialization.StringDeserializer(),
+            valueDeserializer);
 
     // Initialize the config-driven instance fields that are normally set by createConsumerFactory.
     // We skip createConsumerFactory because it requires full serde setup.
@@ -74,6 +85,33 @@ public class KafkaEventConsumerFactoryTest {
         listenerFactory.getContainerProperties().getAuthExceptionRetryInterval(),
         Duration.ofSeconds(10),
         "Event consumers should retry on auth exceptions to survive MSK IAM credential rotation");
+  }
+
+  @Test
+  void testMclBatchEventConsumerEnablesBatchListener() {
+    var listenerFactory =
+        (ConcurrentKafkaListenerContainerFactory<?, ?>)
+            factory.mclBatchEventConsumer(kafkaConsumerFactory, configProvider);
+
+    assertEquals(
+        listenerFactory.isBatchListener(),
+        Boolean.TRUE,
+        "MCL batch event consumer must have batch listener enabled");
+    assertEquals(
+        listenerFactory.getContainerProperties().getAuthExceptionRetryInterval(),
+        Duration.ofSeconds(10));
+  }
+
+  @Test
+  void testMclEventConsumerDoesNotEnableBatchListener() {
+    var listenerFactory =
+        (ConcurrentKafkaListenerContainerFactory<?, ?>)
+            factory.mclEventConsumer(kafkaConsumerFactory, configProvider);
+
+    // When batchListener is not set, isBatchListener() returns null (not false)
+    assertTrue(
+        listenerFactory.isBatchListener() == null || !listenerFactory.isBatchListener(),
+        "Standard MCL event consumer must not have batch listener enabled");
   }
 
   @Test


### PR DESCRIPTION
…ng by default

The MCL batch listener was not being registered correctly — the endpoint always pointed at the single-record `consume` method and the container factory was never configured for batch mode. This fixes three root causes:

1. Make `consumeBatch` the primary contract on `GenericKafkaListener`, with `consume` as a convenience default that delegates via singleton list.
2. Add a batch-enabled `KafkaListenerContainerFactory` bean (`mclBatchEventConsumer`) and select it when batching is enabled.
3. Override `createListenerEndpoint` in `MCLKafkaListenerRegistrar` to register the `consumeBatch(List)` method when batch mode is active.

Additionally, enable MCL and MCP batching by default in docker/profiles for all quickstart and debug deployments.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
