### PR TITLE
feat(search): add timeseries write throttle for Elasticsearch index u…

### DIFF
--- a/docs/deploy/environment-vars.md
+++ b/docs/deploy/environment-vars.md
@@ -1015,6 +1015,24 @@ The following environment variables are used in the codebase but may not be expl
 | `MCP_TIMESERIES_MULTIPLIER`                   | `10`       | Timeseries multiplier                          | GMS, MCE Consumer |
 | `MCP_TIMESERIES_MAX_INTERVAL_MS`              | `30000`    | Timeseries max interval                        | GMS, MCE Consumer |
 
+### MCL Timeseries Write Throttle
+
+Controls how frequently timeseries aspect MCL events update the entity search index and/or
+timeseries index in Elasticsearch. When enabled, repeated writes for the same (URN, aspect) pair
+are dropped if they arrive within the configured refresh period. This reduces ES write pressure
+for high-rate timeseries producers (e.g. usage statistics, dataset profiles) at the cost of
+slightly stale search-index values. The in-memory cache TTL is automatically aligned with the
+refresh period.
+
+| Environment Variable                               | Default | Description                                                                                                    | Components        |
+| -------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------- | ----------------- |
+| `MCL_TIMESERIES_THROTTLE_ENTITY_INDEX_ENABLED`     | `false` | Suppress entity search index updates from timeseries aspects                                                   | GMS, MAE Consumer |
+| `MCL_TIMESERIES_THROTTLE_TIMESERIES_INDEX_ENABLED` | `false` | Suppress timeseries index writes                                                                               | GMS, MAE Consumer |
+| `MCL_TIMESERIES_THROTTLE_OBSERVE_ENABLED`          | `false` | Log-only mode: logs what would be throttled without suppressing writes (shadow mode)                           | GMS, MAE Consumer |
+| `MCL_TIMESERIES_THROTTLE_REFRESH_SECONDS`          | `3600`  | Default minimum seconds between writes per (URN, aspect); also the cache TTL                                   | GMS, MAE Consumer |
+| `MCL_TIMESERIES_THROTTLE_REFRESH_OVERRIDES`        | `{}`    | JSON per-entity, per-aspect refresh overrides, e.g. `{"dataset": {"operation": 300, "datasetProfile": 86400}}` | GMS, MAE Consumer |
+| `MCL_TIMESERIES_THROTTLE_MAX_URNS`                 | `10000` | Maximum URNs tracked in the throttle cache before eviction                                                     | GMS, MAE Consumer |
+
 ### Events API Configuration
 
 | Environment Variable | Default | Description       | Components |

--- a/metadata-io/src/main/java/com/linkedin/metadata/service/TimeseriesWriteThrottleCache.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/service/TimeseriesWriteThrottleCache.java
@@ -1,0 +1,288 @@
+package com.linkedin.metadata.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.linkedin.metadata.config.search.TimeseriesWriteThrottleConfiguration;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Shared cache that throttles timeseries aspect writes to Elasticsearch. A single cache entry per
+ * URN holds last-write timestamps keyed by aspect name. A default refresh period applies to all
+ * (entity, aspect) pairs unless overridden via a JSON map of entity &rarr; aspect &rarr; seconds.
+ */
+@Slf4j
+public class TimeseriesWriteThrottleCache {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  public enum ThrottleTarget {
+    ENTITY_INDEX,
+    TIMESERIES_INDEX
+  }
+
+  private final Cache<String, ConcurrentHashMap<String, Long>> cache;
+  private final boolean entityIndexEnabled;
+  private final boolean timeseriesIndexEnabled;
+  private final boolean observeEnabled;
+  private final long defaultRefreshPeriodMs;
+  private final Map<String, Map<String, Long>> refreshOverridesMs;
+
+  public TimeseriesWriteThrottleCache(@Nonnull TimeseriesWriteThrottleConfiguration config) {
+    TimeseriesWriteThrottleConfiguration.IndexThrottleConfig entityCfg = config.getEntityIndex();
+    TimeseriesWriteThrottleConfiguration.IndexThrottleConfig tsCfg = config.getTimeseriesIndex();
+    TimeseriesWriteThrottleConfiguration.IndexThrottleConfig observeCfg = config.getObserve();
+
+    this.entityIndexEnabled = entityCfg != null && entityCfg.isEnabled();
+    this.timeseriesIndexEnabled = tsCfg != null && tsCfg.isEnabled();
+    this.observeEnabled = observeCfg != null && observeCfg.isEnabled();
+    this.defaultRefreshPeriodMs = config.getRefreshPeriodSeconds() * 1000L;
+    this.refreshOverridesMs = parseOverrides(config.getRefreshOverrides());
+
+    long maxRefreshSeconds = computeMaxRefreshSeconds(config);
+    this.cache =
+        CacheBuilder.newBuilder()
+            .expireAfterAccess(maxRefreshSeconds, TimeUnit.SECONDS)
+            .maximumSize(config.getMaxCacheUrns())
+            .build();
+
+    log.info(
+        "TimeseriesWriteThrottleCache initialized: entityIndex={}, timeseriesIndex={}, "
+            + "observe={}, defaultRefreshPeriod={}s, overrides={}, cacheTtl={}s, maxUrns={}",
+        entityIndexEnabled,
+        timeseriesIndexEnabled,
+        observeEnabled,
+        config.getRefreshPeriodSeconds(),
+        config.getRefreshOverrides(),
+        maxRefreshSeconds,
+        config.getMaxCacheUrns());
+  }
+
+  /** Whether any throttle target (including observe-only) is enabled. */
+  public boolean isEnabled() {
+    return entityIndexEnabled || timeseriesIndexEnabled || observeEnabled;
+  }
+
+  public boolean isEntityIndexEnabled() {
+    return entityIndexEnabled;
+  }
+
+  public boolean isTimeseriesIndexEnabled() {
+    return timeseriesIndexEnabled;
+  }
+
+  /**
+   * Whether log-only observe mode is enabled (tracks throttle-eligible writes without suppressing).
+   */
+  public boolean isObserveEnabled() {
+    return observeEnabled;
+  }
+
+  /**
+   * Returns {@code true} if the (URN, aspect) pair is within the refresh period and should be
+   * throttled. The refresh period is resolved per (entityName, aspectName) with a fallback to the
+   * default.
+   */
+  public boolean shouldThrottle(
+      @Nonnull String entityName,
+      @Nonnull String urnStr,
+      @Nonnull String aspectName,
+      long eventTimeMs) {
+
+    if (!isEnabled()) {
+      return false;
+    }
+
+    ConcurrentHashMap<String, Long> timestamps = cache.getIfPresent(urnStr);
+    if (timestamps == null) {
+      return false;
+    }
+
+    Long lastWriteMs = timestamps.get(aspectName);
+    if (lastWriteMs == null) {
+      return false;
+    }
+
+    long refreshMs = getRefreshPeriodMs(entityName, aspectName);
+    return eventTimeMs > lastWriteMs && (eventTimeMs - lastWriteMs) < refreshMs;
+  }
+
+  /**
+   * Records a successful write so subsequent events within the refresh period are throttled.
+   *
+   * @param urnStr the entity URN string
+   * @param aspectName the timeseries aspect name
+   * @param eventTimeMs the event timestamp (epoch ms) written
+   */
+  public void recordWrite(@Nonnull String urnStr, @Nonnull String aspectName, long eventTimeMs) {
+
+    if (!isEnabled()) {
+      return;
+    }
+
+    cache
+        .asMap()
+        .compute(
+            urnStr,
+            (urn, existing) -> {
+              ConcurrentHashMap<String, Long> map =
+                  existing != null ? existing : new ConcurrentHashMap<>();
+              map.merge(aspectName, eventTimeMs, Math::max);
+              return map;
+            });
+  }
+
+  @Nonnull
+  public ThrottleSummary newSummary() {
+    return new ThrottleSummary();
+  }
+
+  @VisibleForTesting
+  long getRefreshPeriodMs(@Nonnull String entityName, @Nonnull String aspectName) {
+    Map<String, Long> entityOverrides = refreshOverridesMs.get(entityName);
+    if (entityOverrides != null) {
+      Long overrideMs = entityOverrides.get(aspectName);
+      if (overrideMs != null) {
+        return overrideMs;
+      }
+    }
+    return defaultRefreshPeriodMs;
+  }
+
+  @VisibleForTesting
+  Cache<String, ConcurrentHashMap<String, Long>> getCache() {
+    return cache;
+  }
+
+  private static Map<String, Map<String, Long>> parseOverrides(String json) {
+    if (json == null || json.isBlank()) {
+      return Collections.emptyMap();
+    }
+    try {
+      Map<String, Map<String, Long>> parsed =
+          MAPPER.readValue(json, new TypeReference<Map<String, Map<String, Long>>>() {});
+      // Convert seconds to millis
+      ConcurrentHashMap<String, Map<String, Long>> result = new ConcurrentHashMap<>();
+      for (Map.Entry<String, Map<String, Long>> entityEntry : parsed.entrySet()) {
+        ConcurrentHashMap<String, Long> aspectMap = new ConcurrentHashMap<>();
+        for (Map.Entry<String, Long> aspectEntry : entityEntry.getValue().entrySet()) {
+          aspectMap.put(aspectEntry.getKey(), aspectEntry.getValue() * 1000L);
+        }
+        result.put(entityEntry.getKey(), aspectMap);
+      }
+      return result;
+    } catch (Exception e) {
+      log.warn("Failed to parse refreshOverrides JSON '{}', using defaults only", json, e);
+      return Collections.emptyMap();
+    }
+  }
+
+  private static long computeMaxRefreshSeconds(TimeseriesWriteThrottleConfiguration config) {
+    long max = config.getRefreshPeriodSeconds();
+    try {
+      if (config.getRefreshOverrides() != null && !config.getRefreshOverrides().isBlank()) {
+        Map<String, Map<String, Long>> parsed =
+            MAPPER.readValue(
+                config.getRefreshOverrides(),
+                new TypeReference<Map<String, Map<String, Long>>>() {});
+        for (Map<String, Long> aspects : parsed.values()) {
+          for (Long seconds : aspects.values()) {
+            max = Math.max(max, seconds);
+          }
+        }
+      }
+    } catch (Exception e) {
+      // already warned in parseOverrides
+    }
+    return max;
+  }
+
+  /** Accumulates throttle decisions within a single batch and logs a summary at the end. */
+  public static class ThrottleSummary {
+    private int entityIndexSuppressed;
+    private int timeseriesIndexSuppressed;
+    private int entityIndexWritten;
+    private int timeseriesIndexWritten;
+    private int observed;
+
+    public void recordSuppressed(@Nonnull ThrottleTarget target) {
+      switch (target) {
+        case ENTITY_INDEX:
+          entityIndexSuppressed++;
+          break;
+        case TIMESERIES_INDEX:
+          timeseriesIndexSuppressed++;
+          break;
+      }
+    }
+
+    public void recordWritten(@Nonnull ThrottleTarget target) {
+      switch (target) {
+        case ENTITY_INDEX:
+          entityIndexWritten++;
+          break;
+        case TIMESERIES_INDEX:
+          timeseriesIndexWritten++;
+          break;
+      }
+    }
+
+    /** Records an event that would have been throttled (observe/log-only mode). */
+    public void recordObserved() {
+      observed++;
+    }
+
+    public int getEntityIndexSuppressed() {
+      return entityIndexSuppressed;
+    }
+
+    public int getTimeseriesIndexSuppressed() {
+      return timeseriesIndexSuppressed;
+    }
+
+    public int getEntityIndexWritten() {
+      return entityIndexWritten;
+    }
+
+    public int getTimeseriesIndexWritten() {
+      return timeseriesIndexWritten;
+    }
+
+    public int getObserved() {
+      return observed;
+    }
+
+    /** Logs summary lines for suppressed writes and/or observed throttle-eligible events. */
+    public void logIfSuppressed() {
+      int totalSuppressed = entityIndexSuppressed + timeseriesIndexSuppressed;
+      if (totalSuppressed > 0) {
+        int totalEvents =
+            entityIndexSuppressed
+                + entityIndexWritten
+                + timeseriesIndexSuppressed
+                + timeseriesIndexWritten;
+        log.warn(
+            "Timeseries throttle: suppressed {} entity-index writes, {} timeseries-index writes "
+                + "(passed {} entity-index, {} timeseries-index) in batch of {} timeseries events",
+            entityIndexSuppressed,
+            timeseriesIndexSuppressed,
+            entityIndexWritten,
+            timeseriesIndexWritten,
+            totalEvents);
+      }
+      if (observed > 0) {
+        log.warn(
+            "Timeseries throttle [observe]: {} writes would have been throttled "
+                + "(no writes suppressed — observe mode only)",
+            observed);
+      }
+    }
+  }
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/service/UpdateIndicesService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/service/UpdateIndicesService.java
@@ -42,6 +42,7 @@ public class UpdateIndicesService implements SearchIndicesService {
   @VisibleForTesting @Getter private final UpdateGraphIndicesService updateGraphIndicesService;
   private final ElasticSearchService elasticSearchService;
   private final SystemMetadataService systemMetadataService;
+  @Nullable private final TimeseriesWriteThrottleCache timeseriesThrottleCache;
 
   @Getter private final boolean searchDiffMode;
 
@@ -68,6 +69,7 @@ public class UpdateIndicesService implements SearchIndicesService {
       ElasticSearchService elasticSearchService,
       SystemMetadataService systemMetadataService,
       @Nonnull Collection<UpdateIndicesStrategy> updateStrategies,
+      @Nullable TimeseriesWriteThrottleCache timeseriesThrottleCache,
       boolean searchDiffMode,
       boolean structuredPropertiesHookEnabled,
       boolean structuredPropertiesWriteEnabled) {
@@ -75,6 +77,7 @@ public class UpdateIndicesService implements SearchIndicesService {
     this.elasticSearchService = elasticSearchService;
     this.systemMetadataService = systemMetadataService;
     this.updateStrategies = updateStrategies;
+    this.timeseriesThrottleCache = timeseriesThrottleCache;
     this.searchDiffMode = searchDiffMode;
     this.structuredPropertiesHookEnabled = structuredPropertiesHookEnabled;
     this.structuredPropertiesWriteEnabled = structuredPropertiesWriteEnabled;
@@ -116,6 +119,10 @@ public class UpdateIndicesService implements SearchIndicesService {
         strategy.processBatch(opContext, groupedEvents, structuredPropertiesHookEnabled);
       }
     }
+
+    // Record throttle writes after all strategies have processed, so no strategy's
+    // recordWrite can race with another strategy's shouldThrottle on the same event.
+    recordThrottleWrites(groupedEvents);
 
     // Process each group of events for the same URN
     for (List<MCLItem> urnEvents : groupedEvents.values()) {
@@ -237,6 +244,40 @@ public class UpdateIndicesService implements SearchIndicesService {
     for (UpdateIndicesStrategy strategy : updateStrategies) {
       if (strategy.isEnabled()) {
         strategy.updateIndexMappings(opContext, urn, entitySpec, aspectSpec, newValue, oldValue);
+      }
+    }
+  }
+
+  /**
+   * After all strategies have processed, record throttle writes for timeseries events that were not
+   * throttled. This ensures no strategy's recordWrite races with another strategy's shouldThrottle
+   * on the same event within a batch.
+   */
+  private void recordThrottleWrites(LinkedHashMap<Urn, List<MCLItem>> groupedEvents) {
+    if (timeseriesThrottleCache == null || !timeseriesThrottleCache.isEnabled()) {
+      return;
+    }
+
+    for (List<MCLItem> urnEvents : groupedEvents.values()) {
+      for (MCLItem event : urnEvents) {
+        if (!UPDATE_CHANGE_TYPES.contains(event.getMetadataChangeLog().getChangeType())) {
+          continue;
+        }
+        if (!event.getAspectSpec().isTimeseries()) {
+          continue;
+        }
+
+        String entityName = event.getEntitySpec().getName();
+        String urnStr = event.getUrn().toString();
+        String aspectName = event.getAspectName();
+        long eventTimeMs =
+            event.getAuditStamp() != null
+                ? event.getAuditStamp().getTime()
+                : System.currentTimeMillis();
+
+        if (!timeseriesThrottleCache.shouldThrottle(entityName, urnStr, aspectName, eventTimeMs)) {
+          timeseriesThrottleCache.recordWrite(urnStr, aspectName, eventTimeMs);
+        }
       }
     }
   }

--- a/metadata-io/src/main/java/com/linkedin/metadata/service/UpdateIndicesV2Strategy.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/service/UpdateIndicesV2Strategy.java
@@ -83,6 +83,9 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
   // Cache for semantic index existence checks to avoid repeated HEAD requests
   private final Cache<String, Boolean> semanticIndexExistsCache;
 
+  // Throttle cache for timeseries aspect writes
+  @Nullable private final TimeseriesWriteThrottleCache timeseriesThrottleCache;
+
   /**
    * Creates an UpdateIndicesV2Strategy with optional semantic search support.
    *
@@ -112,7 +115,8 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
       @Nullable SemanticSearchConfiguration semanticSearchConfig,
       @Nonnull IndexConvention indexConvention,
       boolean coalesceBatchUpdates,
-      @Nonnull V2MappingsBuilder mappingsBuilder) {
+      @Nonnull V2MappingsBuilder mappingsBuilder,
+      @Nullable TimeseriesWriteThrottleCache timeseriesThrottleCache) {
     this.v2Config = v2Config;
     this.elasticSearchService = elasticSearchService;
     this.searchDocumentTransformer = searchDocumentTransformer;
@@ -122,6 +126,7 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
     this.indexConvention = indexConvention;
     this.coalesceBatchUpdates = coalesceBatchUpdates;
     this.mappingsBuilder = mappingsBuilder;
+    this.timeseriesThrottleCache = timeseriesThrottleCache;
     this.semanticIndexExistsCache =
         CacheBuilder.newBuilder()
             .expireAfterWrite(SEMANTIC_INDEX_CACHE_TTL_MINUTES, TimeUnit.MINUTES)
@@ -146,6 +151,9 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
       @Nonnull Map<Urn, List<MCLItem>> groupedEvents,
       boolean structuredPropertiesHookEnabled) {
 
+    TimeseriesWriteThrottleCache.ThrottleSummary throttleSummary =
+        timeseriesThrottleCache != null ? timeseriesThrottleCache.newSummary() : null;
+
     // Process each group of events for the same URN
     for (List<MCLItem> urnEvents : groupedEvents.values()) {
 
@@ -162,7 +170,8 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
           LinkedHashMap<String, List<MCLItem>> byAspect =
               UpdateIndicesUtil.groupUpdatesByAspect(updateEvents);
           for (List<MCLItem> aspectEvents : byAspect.values()) {
-            processAspectGroup(opContext, aspectEvents, structuredPropertiesHookEnabled);
+            processAspectGroup(
+                opContext, aspectEvents, structuredPropertiesHookEnabled, throttleSummary);
           }
         } else {
           // Legacy per-event behavior preserved for rollback via flag.
@@ -170,8 +179,12 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
             if (structuredPropertiesHookEnabled) {
               updateIndexMappings(opContext, event);
             }
-            updateSearchIndicesForEvent(opContext, event);
-            updateTimeseriesFieldsForEvent(opContext, event);
+            processTimeseriesThrottled(
+                opContext,
+                event,
+                throttleSummary,
+                () -> updateSearchIndicesForEvent(opContext, event),
+                () -> updateTimeseriesFieldsForEvent(opContext, event));
           }
         }
       }
@@ -198,6 +211,10 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
         }
       }
     }
+
+    if (throttleSummary != null) {
+      throttleSummary.logIfSuppressed();
+    }
   }
 
   /**
@@ -209,7 +226,8 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
   private void processAspectGroup(
       @Nonnull OperationContext opContext,
       @Nonnull List<MCLItem> aspectEvents,
-      boolean structuredPropertiesHookEnabled) {
+      boolean structuredPropertiesHookEnabled,
+      @Nullable TimeseriesWriteThrottleCache.ThrottleSummary throttleSummary) {
     if (aspectEvents.isEmpty()) {
       return;
     }
@@ -218,8 +236,12 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
         if (structuredPropertiesHookEnabled) {
           updateIndexMappings(opContext, event);
         }
-        updateSearchIndicesForEvent(opContext, event);
-        updateTimeseriesFieldsForEvent(opContext, event);
+        processTimeseriesThrottled(
+            opContext,
+            event,
+            throttleSummary,
+            () -> updateSearchIndicesForEvent(opContext, event),
+            () -> updateTimeseriesFieldsForEvent(opContext, event));
       }
       return;
     }
@@ -244,6 +266,77 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
     updateSearchIndicesForEvent(opContext, survivor, baseline);
     updateTimeseriesFieldsForEvent(opContext, survivor);
     appendCoalescedRunIds(opContext, survivor, aspectEvents);
+  }
+
+  /**
+   * Applies timeseries throttle checks around entity-index and timeseries-index writes. For
+   * non-timeseries aspects, both writes execute unconditionally.
+   */
+  private void processTimeseriesThrottled(
+      @Nonnull OperationContext opContext,
+      @Nonnull MCLItem event,
+      @Nullable TimeseriesWriteThrottleCache.ThrottleSummary throttleSummary,
+      @Nonnull Runnable entityIndexWrite,
+      @Nonnull Runnable timeseriesIndexWrite) {
+
+    if (!event.getAspectSpec().isTimeseries() || timeseriesThrottleCache == null) {
+      entityIndexWrite.run();
+      timeseriesIndexWrite.run();
+      return;
+    }
+
+    boolean entityEnabled = timeseriesThrottleCache.isEntityIndexEnabled();
+    boolean tsEnabled = timeseriesThrottleCache.isTimeseriesIndexEnabled();
+    boolean observeEnabled = timeseriesThrottleCache.isObserveEnabled();
+
+    // Short-circuit: if no throttle paths are active, skip the cache lookup entirely
+    if (!entityEnabled && !tsEnabled && !observeEnabled) {
+      entityIndexWrite.run();
+      timeseriesIndexWrite.run();
+      return;
+    }
+
+    String entityName = event.getEntitySpec().getName();
+    String urnStr = event.getUrn().toString();
+    String aspectName = event.getAspectName();
+    long eventTimeMs =
+        event.getAuditStamp() != null
+            ? event.getAuditStamp().getTime()
+            : System.currentTimeMillis();
+
+    boolean throttled =
+        timeseriesThrottleCache.shouldThrottle(entityName, urnStr, aspectName, eventTimeMs);
+
+    // Entity index path
+    if (throttled && entityEnabled) {
+      if (throttleSummary != null) {
+        throttleSummary.recordSuppressed(TimeseriesWriteThrottleCache.ThrottleTarget.ENTITY_INDEX);
+      }
+    } else {
+      entityIndexWrite.run();
+      if (throttleSummary != null) {
+        throttleSummary.recordWritten(TimeseriesWriteThrottleCache.ThrottleTarget.ENTITY_INDEX);
+      }
+    }
+
+    // Timeseries index path
+    if (throttled && tsEnabled) {
+      if (throttleSummary != null) {
+        throttleSummary.recordSuppressed(
+            TimeseriesWriteThrottleCache.ThrottleTarget.TIMESERIES_INDEX);
+      }
+    } else {
+      timeseriesIndexWrite.run();
+      if (throttleSummary != null) {
+        throttleSummary.recordWritten(TimeseriesWriteThrottleCache.ThrottleTarget.TIMESERIES_INDEX);
+      }
+    }
+
+    // Observe mode: log what would have been throttled without suppressing
+    if (throttled && observeEnabled && throttleSummary != null) {
+      throttleSummary.recordObserved();
+    }
+    // recordWrite is handled by UpdateIndicesService after all strategies have processed
   }
 
   /**

--- a/metadata-io/src/main/java/com/linkedin/metadata/service/UpdateIndicesV3Strategy.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/service/UpdateIndicesV3Strategy.java
@@ -50,6 +50,7 @@ public class UpdateIndicesV3Strategy implements UpdateIndicesStrategy {
   private final String idHashAlgo;
   private final MultiEntityMappingsBuilder mappingsBuilder;
   private final boolean v2Enabled;
+  @Nullable private final TimeseriesWriteThrottleCache timeseriesThrottleCache;
 
   public UpdateIndicesV3Strategy(
       @Nonnull EntityIndexVersionConfiguration v3Config,
@@ -57,13 +58,15 @@ public class UpdateIndicesV3Strategy implements UpdateIndicesStrategy {
       @Nonnull SearchDocumentTransformer searchDocumentTransformer,
       @Nonnull TimeseriesAspectService timeseriesAspectService,
       @Nonnull String idHashAlgo,
-      boolean v2Enabled) {
+      boolean v2Enabled,
+      @Nullable TimeseriesWriteThrottleCache timeseriesThrottleCache) {
     this.v3Config = v3Config;
     this.elasticSearchService = elasticSearchService;
     this.searchDocumentTransformer = searchDocumentTransformer;
     this.timeseriesAspectService = timeseriesAspectService;
     this.idHashAlgo = idHashAlgo;
     this.v2Enabled = v2Enabled;
+    this.timeseriesThrottleCache = timeseriesThrottleCache;
     try {
       this.mappingsBuilder =
           new MultiEntityMappingsBuilder(
@@ -85,6 +88,9 @@ public class UpdateIndicesV3Strategy implements UpdateIndicesStrategy {
       return;
     }
 
+    TimeseriesWriteThrottleCache.ThrottleSummary throttleSummary =
+        timeseriesThrottleCache != null ? timeseriesThrottleCache.newSummary() : null;
+
     log.debug("Processing {} URN groups with V3 unified batch optimization", groupedEvents.size());
 
     // Process each group of events for the same URN
@@ -97,7 +103,11 @@ public class UpdateIndicesV3Strategy implements UpdateIndicesStrategy {
       if (structuredPropertiesHookEnabled) {}
 
       // V3 optimization: single operation per URN
-      processUrnBatch(opContext, urn, urnEvents, structuredPropertiesHookEnabled);
+      processUrnBatch(opContext, urn, urnEvents, structuredPropertiesHookEnabled, throttleSummary);
+    }
+
+    if (throttleSummary != null) {
+      throttleSummary.logIfSuppressed();
     }
   }
 
@@ -186,7 +196,8 @@ public class UpdateIndicesV3Strategy implements UpdateIndicesStrategy {
       @Nonnull OperationContext opContext,
       @Nonnull Urn urn,
       @Nonnull List<MCLItem> events,
-      boolean structuredPropertiesHookEnabled) {
+      boolean structuredPropertiesHookEnabled,
+      @Nullable TimeseriesWriteThrottleCache.ThrottleSummary throttleSummary) {
 
     log.debug("V3 unified batch processing for URN: {} with {} events", urn, events.size());
 
@@ -232,7 +243,7 @@ public class UpdateIndicesV3Strategy implements UpdateIndicesStrategy {
     }
 
     // Build the combined V3 document with _aspect structure
-    ObjectNode combinedDocument = buildV3SearchDocument(opContext, urn, events);
+    ObjectNode combinedDocument = buildV3SearchDocument(opContext, urn, events, throttleSummary);
 
     if (combinedDocument == null) {
       log.debug("V3 combined document is empty for URN: {}, skipping update", urn);
@@ -296,7 +307,10 @@ public class UpdateIndicesV3Strategy implements UpdateIndicesStrategy {
    * @return the combined V3 document or null if no aspects to process
    */
   private ObjectNode buildV3SearchDocument(
-      @Nonnull OperationContext opContext, @Nonnull Urn urn, @Nonnull List<MCLItem> events) {
+      @Nonnull OperationContext opContext,
+      @Nonnull Urn urn,
+      @Nonnull List<MCLItem> events,
+      @Nullable TimeseriesWriteThrottleCache.ThrottleSummary throttleSummary) {
 
     ObjectNode combinedDocument = JsonNodeFactory.instance.objectNode();
     combinedDocument.put("urn", urn.toString());
@@ -322,12 +336,38 @@ public class UpdateIndicesV3Strategy implements UpdateIndicesStrategy {
           continue;
         }
 
+        // Throttle timeseries aspects for entity index writes
+        if (aspectSpec.isTimeseries() && timeseriesThrottleCache != null) {
+          long eventTimeMs =
+              event.getAuditStamp() != null
+                  ? event.getAuditStamp().getTime()
+                  : System.currentTimeMillis();
+          if (timeseriesThrottleCache.shouldThrottle(
+              event.getEntitySpec().getName(), urn.toString(), aspectName, eventTimeMs)) {
+            if (timeseriesThrottleCache.isEntityIndexEnabled()) {
+              if (throttleSummary != null) {
+                throttleSummary.recordSuppressed(
+                    TimeseriesWriteThrottleCache.ThrottleTarget.ENTITY_INDEX);
+              }
+              continue;
+            }
+            if (timeseriesThrottleCache.isObserveEnabled() && throttleSummary != null) {
+              throttleSummary.recordObserved();
+            }
+          }
+        }
+
         // Process ALL other aspects (including timeseries) under _aspects
         // In V3, timeseries aspects are treated the same as other versioned aspects
         ObjectNode aspectDocument = processAspectForV3(opContext, urn, event);
         if (aspectDocument != null) {
           aspectsNode.set(aspectName, aspectDocument);
           hasAnyAspects = true;
+
+          // recordWrite is handled by UpdateIndicesService after all strategies have processed
+          if (aspectSpec.isTimeseries() && throttleSummary != null) {
+            throttleSummary.recordWritten(TimeseriesWriteThrottleCache.ThrottleTarget.ENTITY_INDEX);
+          }
 
           if (aspectSpec.isTimeseries()) {
             log.debug(

--- a/metadata-io/src/test/java/com/linkedin/metadata/service/TimeseriesWriteThrottleCacheTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/service/TimeseriesWriteThrottleCacheTest.java
@@ -1,0 +1,308 @@
+package com.linkedin.metadata.service;
+
+import static org.testng.Assert.*;
+
+import com.linkedin.metadata.config.search.TimeseriesWriteThrottleConfiguration;
+import org.testng.annotations.Test;
+
+public class TimeseriesWriteThrottleCacheTest {
+
+  private static final String ENTITY_DATASET = "dataset";
+  private static final String URN_1 = "urn:li:dataset:(urn:li:dataPlatform:mysql,db.table1,PROD)";
+  private static final String URN_2 = "urn:li:dataset:(urn:li:dataPlatform:mysql,db.table2,PROD)";
+  private static final String ASPECT_PROFILE = "datasetProfile";
+  private static final String ASPECT_USAGE = "datasetUsageStatistics";
+  private static final String ASPECT_OPERATION = "operation";
+
+  private TimeseriesWriteThrottleCache buildCache(
+      boolean entityEnabled, boolean tsEnabled, long refreshSec, int maxUrns) {
+    return buildCache(entityEnabled, tsEnabled, refreshSec, "{}", maxUrns);
+  }
+
+  private TimeseriesWriteThrottleCache buildCache(
+      boolean entityEnabled,
+      boolean tsEnabled,
+      long refreshSec,
+      String overridesJson,
+      int maxUrns) {
+    return buildCache(entityEnabled, tsEnabled, false, refreshSec, overridesJson, maxUrns);
+  }
+
+  private TimeseriesWriteThrottleCache buildCache(
+      boolean entityEnabled,
+      boolean tsEnabled,
+      boolean observeEnabled,
+      long refreshSec,
+      String overridesJson,
+      int maxUrns) {
+    return new TimeseriesWriteThrottleCache(
+        TimeseriesWriteThrottleConfiguration.builder()
+            .entityIndex(
+                TimeseriesWriteThrottleConfiguration.IndexThrottleConfig.builder()
+                    .enabled(entityEnabled)
+                    .build())
+            .timeseriesIndex(
+                TimeseriesWriteThrottleConfiguration.IndexThrottleConfig.builder()
+                    .enabled(tsEnabled)
+                    .build())
+            .observe(
+                TimeseriesWriteThrottleConfiguration.IndexThrottleConfig.builder()
+                    .enabled(observeEnabled)
+                    .build())
+            .refreshPeriodSeconds(refreshSec)
+            .refreshOverrides(overridesJson)
+            .maxCacheUrns(maxUrns)
+            .build());
+  }
+
+  @Test
+  public void testFirstWriteIsNeverThrottled() {
+    TimeseriesWriteThrottleCache cache = buildCache(true, true, 3600, 10_000);
+    long now = System.currentTimeMillis();
+
+    assertFalse(cache.shouldThrottle(ENTITY_DATASET, URN_1, ASPECT_PROFILE, now));
+  }
+
+  @Test
+  public void testSecondWriteWithinRefreshPeriodIsThrottled() {
+    TimeseriesWriteThrottleCache cache = buildCache(true, true, 3600, 10_000);
+    long t0 = 1_000_000_000L;
+    long t1 = t0 + 1000;
+
+    cache.recordWrite(URN_1, ASPECT_PROFILE, t0);
+    assertTrue(cache.shouldThrottle(ENTITY_DATASET, URN_1, ASPECT_PROFILE, t1));
+  }
+
+  @Test
+  public void testWriteAfterRefreshPeriodPasses() {
+    TimeseriesWriteThrottleCache cache = buildCache(true, true, 60, 10_000);
+    long t0 = 1_000_000_000L;
+    long t1 = t0 + 61_000;
+
+    cache.recordWrite(URN_1, ASPECT_PROFILE, t0);
+    assertFalse(cache.shouldThrottle(ENTITY_DATASET, URN_1, ASPECT_PROFILE, t1));
+  }
+
+  @Test
+  public void testSameTimestampNotThrottled() {
+    TimeseriesWriteThrottleCache cache = buildCache(true, true, 3600, 10_000);
+    long t0 = 1_000_000_000L;
+
+    cache.recordWrite(URN_1, ASPECT_PROFILE, t0);
+    assertFalse(cache.shouldThrottle(ENTITY_DATASET, URN_1, ASPECT_PROFILE, t0));
+
+    assertTrue(cache.shouldThrottle(ENTITY_DATASET, URN_1, ASPECT_PROFILE, t0 + 1));
+  }
+
+  @Test
+  public void testDifferentAspectsOnSameUrnTrackedIndependently() {
+    TimeseriesWriteThrottleCache cache = buildCache(true, false, 3600, 10_000);
+    long t0 = 1_000_000_000L;
+    long t1 = t0 + 1000;
+
+    cache.recordWrite(URN_1, ASPECT_PROFILE, t0);
+
+    assertTrue(cache.shouldThrottle(ENTITY_DATASET, URN_1, ASPECT_PROFILE, t1));
+    assertFalse(cache.shouldThrottle(ENTITY_DATASET, URN_1, ASPECT_USAGE, t1));
+  }
+
+  @Test
+  public void testDifferentUrnsTrackedIndependently() {
+    TimeseriesWriteThrottleCache cache = buildCache(true, false, 3600, 10_000);
+    long t0 = 1_000_000_000L;
+    long t1 = t0 + 1000;
+
+    cache.recordWrite(URN_1, ASPECT_PROFILE, t0);
+
+    assertTrue(cache.shouldThrottle(ENTITY_DATASET, URN_1, ASPECT_PROFILE, t1));
+    assertFalse(cache.shouldThrottle(ENTITY_DATASET, URN_2, ASPECT_PROFILE, t1));
+  }
+
+  @Test
+  public void testDisabledCacheNeverThrottles() {
+    TimeseriesWriteThrottleCache cache = buildCache(false, false, 3600, 10_000);
+    long t0 = 1_000_000_000L;
+    long t1 = t0 + 1000;
+
+    cache.recordWrite(URN_1, ASPECT_PROFILE, t0);
+    assertFalse(cache.shouldThrottle(ENTITY_DATASET, URN_1, ASPECT_PROFILE, t1));
+  }
+
+  @Test
+  public void testEnabledFlags() {
+    TimeseriesWriteThrottleCache entityOnly = buildCache(true, false, 3600, 10_000);
+    assertTrue(entityOnly.isEntityIndexEnabled());
+    assertFalse(entityOnly.isTimeseriesIndexEnabled());
+    assertTrue(entityOnly.isEnabled());
+
+    TimeseriesWriteThrottleCache tsOnly = buildCache(false, true, 3600, 10_000);
+    assertFalse(tsOnly.isEntityIndexEnabled());
+    assertTrue(tsOnly.isTimeseriesIndexEnabled());
+    assertTrue(tsOnly.isEnabled());
+
+    TimeseriesWriteThrottleCache neither = buildCache(false, false, 3600, 10_000);
+    assertFalse(neither.isEnabled());
+  }
+
+  @Test
+  public void testCacheEvictionByMaxSize() {
+    TimeseriesWriteThrottleCache cache = buildCache(true, false, 3600, 2);
+    long t0 = 1_000_000_000L;
+    long t1 = t0 + 1000;
+
+    cache.recordWrite(URN_1, ASPECT_PROFILE, t0);
+    cache.recordWrite(URN_2, ASPECT_PROFILE, t0);
+
+    String urn3 = "urn:li:dataset:(urn:li:dataPlatform:mysql,db.table3,PROD)";
+    cache.recordWrite(urn3, ASPECT_PROFILE, t0);
+
+    cache.getCache().cleanUp();
+
+    assertFalse(cache.shouldThrottle(ENTITY_DATASET, URN_1, ASPECT_PROFILE, t1));
+  }
+
+  @Test
+  public void testMultipleAspectsShareSameUrnEntry() {
+    TimeseriesWriteThrottleCache cache = buildCache(true, true, 3600, 10_000);
+    long t0 = 1_000_000_000L;
+
+    cache.recordWrite(URN_1, ASPECT_PROFILE, t0);
+    cache.recordWrite(URN_1, ASPECT_USAGE, t0);
+
+    assertEquals(cache.getCache().size(), 1);
+  }
+
+  // --- Per-entity, per-aspect override tests ---
+
+  @Test
+  public void testOverrideRefreshPeriodForSpecificAspect() {
+    // Default 3600s, but operation aspect on dataset gets 60s
+    TimeseriesWriteThrottleCache cache =
+        buildCache(true, true, 3600, "{\"dataset\": {\"operation\": 60}}", 10_000);
+    long t0 = 1_000_000_000L;
+
+    cache.recordWrite(URN_1, ASPECT_OPERATION, t0);
+    cache.recordWrite(URN_1, ASPECT_PROFILE, t0);
+
+    long t1 = t0 + 61_000; // 61s later
+
+    // operation at 61s: past the 60s override → not throttled
+    assertFalse(cache.shouldThrottle(ENTITY_DATASET, URN_1, ASPECT_OPERATION, t1));
+    // datasetProfile at 61s: still within the 3600s default → throttled
+    assertTrue(cache.shouldThrottle(ENTITY_DATASET, URN_1, ASPECT_PROFILE, t1));
+  }
+
+  @Test
+  public void testOverrideDoesNotAffectOtherEntities() {
+    TimeseriesWriteThrottleCache cache =
+        buildCache(true, true, 3600, "{\"dataset\": {\"operation\": 60}}", 10_000);
+
+    // "chart" entity has no override → falls back to default 3600s
+    assertEquals(cache.getRefreshPeriodMs("chart", ASPECT_OPERATION), 3600_000L);
+    // "dataset" entity + "operation" aspect → 60s override
+    assertEquals(cache.getRefreshPeriodMs(ENTITY_DATASET, ASPECT_OPERATION), 60_000L);
+    // "dataset" entity + other aspect → default
+    assertEquals(cache.getRefreshPeriodMs(ENTITY_DATASET, ASPECT_PROFILE), 3600_000L);
+  }
+
+  @Test
+  public void testInvalidOverrideJsonFallsBackToDefault() {
+    TimeseriesWriteThrottleCache cache = buildCache(true, true, 3600, "not-valid-json", 10_000);
+
+    assertEquals(cache.getRefreshPeriodMs(ENTITY_DATASET, ASPECT_OPERATION), 3600_000L);
+  }
+
+  @Test
+  public void testRecordWriteUsesMaxTimestamp() {
+    TimeseriesWriteThrottleCache cache = buildCache(true, true, 3600, 10_000);
+    long t0 = 1_000_000_000L;
+    long t1 = t0 + 5000;
+
+    // Record newer first, then older (out-of-order) — max should win
+    cache.recordWrite(URN_1, ASPECT_PROFILE, t1);
+    cache.recordWrite(URN_1, ASPECT_PROFILE, t0);
+
+    // 2s after t1 → should still be throttled (max is t1)
+    assertTrue(cache.shouldThrottle(ENTITY_DATASET, URN_1, ASPECT_PROFILE, t1 + 2000));
+  }
+
+  // --- ThrottleSummary tests ---
+
+  @Test
+  public void testThrottleSummaryAccumulation() {
+    TimeseriesWriteThrottleCache cache = buildCache(true, true, 3600, 10_000);
+    TimeseriesWriteThrottleCache.ThrottleSummary summary = cache.newSummary();
+
+    summary.recordWritten(TimeseriesWriteThrottleCache.ThrottleTarget.ENTITY_INDEX);
+    summary.recordWritten(TimeseriesWriteThrottleCache.ThrottleTarget.ENTITY_INDEX);
+    summary.recordSuppressed(TimeseriesWriteThrottleCache.ThrottleTarget.ENTITY_INDEX);
+    summary.recordWritten(TimeseriesWriteThrottleCache.ThrottleTarget.TIMESERIES_INDEX);
+    summary.recordSuppressed(TimeseriesWriteThrottleCache.ThrottleTarget.TIMESERIES_INDEX);
+    summary.recordSuppressed(TimeseriesWriteThrottleCache.ThrottleTarget.TIMESERIES_INDEX);
+
+    assertEquals(summary.getEntityIndexWritten(), 2);
+    assertEquals(summary.getEntityIndexSuppressed(), 1);
+    assertEquals(summary.getTimeseriesIndexWritten(), 1);
+    assertEquals(summary.getTimeseriesIndexSuppressed(), 2);
+  }
+
+  @Test
+  public void testThrottleSummaryNoLogWhenNothingSuppressed() {
+    TimeseriesWriteThrottleCache cache = buildCache(true, true, 3600, 10_000);
+    TimeseriesWriteThrottleCache.ThrottleSummary summary = cache.newSummary();
+
+    summary.recordWritten(TimeseriesWriteThrottleCache.ThrottleTarget.ENTITY_INDEX);
+    summary.recordWritten(TimeseriesWriteThrottleCache.ThrottleTarget.TIMESERIES_INDEX);
+
+    assertEquals(summary.getEntityIndexSuppressed(), 0);
+    assertEquals(summary.getTimeseriesIndexSuppressed(), 0);
+    summary.logIfSuppressed();
+  }
+
+  // --- Observe (log-only) mode tests ---
+
+  @Test
+  public void testObserveOnlyEnabledMakesCacheActive() {
+    TimeseriesWriteThrottleCache cache = buildCache(false, false, true, 3600, "{}", 10_000);
+
+    assertTrue(cache.isEnabled());
+    assertFalse(cache.isEntityIndexEnabled());
+    assertFalse(cache.isTimeseriesIndexEnabled());
+    assertTrue(cache.isObserveEnabled());
+  }
+
+  @Test
+  public void testObserveModeShouldThrottleStillReturnsTrue() {
+    // Observe mode alone enables the cache so shouldThrottle works
+    TimeseriesWriteThrottleCache cache = buildCache(false, false, true, 3600, "{}", 10_000);
+    long t0 = 1_000_000_000L;
+    long t1 = t0 + 1000;
+
+    cache.recordWrite(URN_1, ASPECT_PROFILE, t0);
+    assertTrue(cache.shouldThrottle(ENTITY_DATASET, URN_1, ASPECT_PROFILE, t1));
+  }
+
+  @Test
+  public void testObserveSummaryTracksObservedEvents() {
+    TimeseriesWriteThrottleCache cache = buildCache(false, false, true, 3600, "{}", 10_000);
+    TimeseriesWriteThrottleCache.ThrottleSummary summary = cache.newSummary();
+
+    summary.recordObserved();
+    summary.recordObserved();
+    summary.recordObserved();
+
+    assertEquals(summary.getObserved(), 3);
+    assertEquals(summary.getEntityIndexSuppressed(), 0);
+    assertEquals(summary.getTimeseriesIndexSuppressed(), 0);
+    summary.logIfSuppressed();
+  }
+
+  @Test
+  public void testObserveAndEntityThrottleBothEnabled() {
+    TimeseriesWriteThrottleCache cache = buildCache(true, false, true, 3600, "{}", 10_000);
+
+    assertTrue(cache.isEnabled());
+    assertTrue(cache.isEntityIndexEnabled());
+    assertTrue(cache.isObserveEnabled());
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateIndicesServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateIndicesServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertTrue;
 
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
@@ -66,7 +67,8 @@ public class UpdateIndicesServiceTest {
             null, // No semantic search config for this test
             mock(IndexConvention.class),
             false,
-            mock(V2MappingsBuilder.class));
+            mock(V2MappingsBuilder.class),
+            null);
 
     UpdateIndicesV3Strategy v3Strategy =
         new UpdateIndicesV3Strategy(
@@ -75,7 +77,8 @@ public class UpdateIndicesServiceTest {
             searchDocumentTransformer,
             timeseriesAspectService,
             "MD5",
-            true); // v2Enabled = true (both strategies active)
+            true, // v2Enabled = true (both strategies active)
+            null);
 
     Collection<UpdateIndicesStrategy> strategies = Arrays.asList(v2Strategy, v3Strategy);
 
@@ -85,6 +88,7 @@ public class UpdateIndicesServiceTest {
             entitySearchService,
             systemMetadataService,
             strategies,
+            null,
             true, // searchDiffMode
             true, // structuredPropertiesHookEnabled
             true); // structuredPropertiesWriteEnabled
@@ -203,6 +207,48 @@ public class UpdateIndicesServiceTest {
             eq(aspectSpec),
             eq(false),
             eq(event.getCreated()));
+  }
+
+  @Test
+  public void testThrottle_ServiceAcceptsNonNullThrottleCache() {
+    TimeseriesWriteThrottleCache cache =
+        new TimeseriesWriteThrottleCache(
+            com.linkedin.metadata.config.search.TimeseriesWriteThrottleConfiguration.builder()
+                .entityIndex(
+                    com.linkedin.metadata.config.search.TimeseriesWriteThrottleConfiguration
+                        .IndexThrottleConfig.builder()
+                        .enabled(true)
+                        .build())
+                .refreshPeriodSeconds(3600)
+                .maxCacheUrns(10_000)
+                .build());
+
+    UpdateIndicesV2Strategy v2Strategy =
+        new UpdateIndicesV2Strategy(
+            EntityIndexVersionConfiguration.builder().enabled(true).cleanup(false).build(),
+            entitySearchService,
+            searchDocumentTransformer,
+            timeseriesAspectService,
+            "MD5",
+            null,
+            mock(IndexConvention.class),
+            false,
+            mock(V2MappingsBuilder.class),
+            cache);
+
+    UpdateIndicesService serviceWithThrottle =
+        new UpdateIndicesService(
+            updateGraphIndicesService,
+            entitySearchService,
+            systemMetadataService,
+            Collections.singletonList(v2Strategy),
+            cache,
+            true,
+            true,
+            true);
+
+    assertTrue(cache.isEnabled());
+    assertTrue(cache.isEntityIndexEnabled());
   }
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateIndicesV2StrategyTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateIndicesV2StrategyTest.java
@@ -90,6 +90,9 @@ public class UpdateIndicesV2StrategyTest {
     when(mockEvent.getSystemMetadata()).thenReturn(mockSystemMetadata);
     when(mockEvent.getAuditStamp()).thenReturn(mockAuditStamp);
     when(mockEvent.getChangeType()).thenReturn(ChangeType.UPSERT);
+    MetadataChangeLog mockMcl = mock(MetadataChangeLog.class);
+    when(mockMcl.getChangeType()).thenReturn(ChangeType.UPSERT);
+    when(mockEvent.getMetadataChangeLog()).thenReturn(mockMcl);
     when(mockEvent.getAspectName()).thenReturn("datasetProperties");
     when(mockEntitySpec.getName()).thenReturn("dataset");
     when(mockEntitySpec.getKeyAspectName()).thenReturn("datasetKey");
@@ -117,7 +120,8 @@ public class UpdateIndicesV2StrategyTest {
             null, // No semantic search config for basic tests
             mock(IndexConvention.class),
             true,
-            mockMappingsBuilder);
+            mockMappingsBuilder,
+            null);
   }
 
   @Test
@@ -425,7 +429,8 @@ public class UpdateIndicesV2StrategyTest {
             semanticConfig,
             indexConvention,
             false,
-            mockMappingsBuilder);
+            mockMappingsBuilder,
+            null);
 
     // Verify: Should not write to semantic index when not enabled
     assertFalse(
@@ -450,7 +455,8 @@ public class UpdateIndicesV2StrategyTest {
             semanticConfig,
             indexConvention,
             false,
-            mockMappingsBuilder);
+            mockMappingsBuilder,
+            null);
 
     // Verify: Should not write to semantic index for dataset (not in enabled list)
     assertFalse(
@@ -478,7 +484,8 @@ public class UpdateIndicesV2StrategyTest {
             semanticConfig,
             indexConvention,
             false,
-            mockMappingsBuilder);
+            mockMappingsBuilder,
+            null);
 
     // Verify: Should not write to semantic index when index doesn't exist
     assertFalse(strategyWithMissingIndex.shouldWriteToSemanticIndex(operationContext, "dataset"));
@@ -505,7 +512,8 @@ public class UpdateIndicesV2StrategyTest {
             semanticConfig,
             indexConvention,
             false,
-            mockMappingsBuilder);
+            mockMappingsBuilder,
+            null);
 
     // Verify: Should write to semantic index when all conditions are met
     assertTrue(strategyWithAllConditions.shouldWriteToSemanticIndex(operationContext, "dataset"));
@@ -532,7 +540,8 @@ public class UpdateIndicesV2StrategyTest {
             semanticConfig,
             indexConvention,
             false,
-            mockMappingsBuilder);
+            mockMappingsBuilder,
+            null);
 
     // Call shouldWriteToSemanticIndex multiple times
     assertTrue(strategyWithCaching.shouldWriteToSemanticIndex(operationContext, "dataset"));
@@ -564,7 +573,8 @@ public class UpdateIndicesV2StrategyTest {
             semanticConfig,
             indexConvention,
             false,
-            mockMappingsBuilder);
+            mockMappingsBuilder,
+            null);
 
     // Setup mocks for document transformation
     when(searchDocumentTransformer.transformAspect(
@@ -658,7 +668,8 @@ public class UpdateIndicesV2StrategyTest {
             semanticConfig,
             indexConvention,
             false,
-            mockMappingsBuilder);
+            mockMappingsBuilder,
+            null);
 
     // Execute with isKeyAspect = true (full delete)
     strategyWithSemantic.deleteSearchData(
@@ -889,7 +900,8 @@ public class UpdateIndicesV2StrategyTest {
             null,
             mock(IndexConvention.class),
             false,
-            mockMappingsBuilder);
+            mockMappingsBuilder,
+            null);
 
     AspectSpec ownershipSpec = mock(AspectSpec.class);
     when(ownershipSpec.getName()).thenReturn("ownership");
@@ -1071,6 +1083,308 @@ public class UpdateIndicesV2StrategyTest {
         applied.contains(typeX),
         "Coalesced mapping diff dropped entityType X added by an earlier MCL in the batch");
     assertTrue(applied.contains(typeY), "Coalesced mapping diff missing newly-added entityType Y");
+  }
+
+  // ==================== Timeseries throttle tests ====================
+
+  private TimeseriesWriteThrottleCache buildThrottleCache(
+      boolean entityEnabled, boolean tsEnabled, boolean observeEnabled) {
+    return new TimeseriesWriteThrottleCache(
+        com.linkedin.metadata.config.search.TimeseriesWriteThrottleConfiguration.builder()
+            .entityIndex(
+                com.linkedin.metadata.config.search.TimeseriesWriteThrottleConfiguration
+                    .IndexThrottleConfig.builder()
+                    .enabled(entityEnabled)
+                    .build())
+            .timeseriesIndex(
+                com.linkedin.metadata.config.search.TimeseriesWriteThrottleConfiguration
+                    .IndexThrottleConfig.builder()
+                    .enabled(tsEnabled)
+                    .build())
+            .observe(
+                com.linkedin.metadata.config.search.TimeseriesWriteThrottleConfiguration
+                    .IndexThrottleConfig.builder()
+                    .enabled(observeEnabled)
+                    .build())
+            .refreshPeriodSeconds(3600)
+            .maxCacheUrns(10_000)
+            .build());
+  }
+
+  private UpdateIndicesV2Strategy strategyWithThrottle(TimeseriesWriteThrottleCache cache) {
+    return new UpdateIndicesV2Strategy(
+        v2Config,
+        elasticSearchService,
+        searchDocumentTransformer,
+        timeseriesAspectService,
+        "MD5",
+        null,
+        mock(IndexConvention.class),
+        true,
+        mockMappingsBuilder,
+        cache);
+  }
+
+  @Test
+  public void testThrottle_EntityIndexSuppressesEntityWrite() throws Exception {
+    TimeseriesWriteThrottleCache cache = buildThrottleCache(true, false, false);
+    UpdateIndicesV2Strategy throttledStrategy = strategyWithThrottle(cache);
+
+    // Setup timeseries event with required timestampMillis field
+    when(mockAspectSpec.isTimeseries()).thenReturn(true);
+    when(mockAspectSpec.getName()).thenReturn("datasetProfile");
+    when(mockAspectSpec.getTimeseriesFieldSpecs()).thenReturn(Collections.emptyList());
+    when(mockAspectSpec.getTimeseriesFieldCollectionSpecs()).thenReturn(Collections.emptyList());
+    when(mockEvent.getAspectName()).thenReturn("datasetProfile");
+    DataMap tsData = new DataMap();
+    tsData.put("timestampMillis", 1_000_001_000L);
+    when(mockAspect.data()).thenReturn(tsData);
+
+    // Prime the cache with a recent write
+    cache.recordWrite(testUrn.toString(), "datasetProfile", 1_000_000_000L);
+
+    // Process at t+1s (within 3600s refresh period)
+    when(mockAuditStamp.getTime()).thenReturn(1_000_001_000L);
+    when(searchDocumentTransformer.transformAspect(
+            any(OperationContext.class),
+            any(Urn.class),
+            any(RecordTemplate.class),
+            any(AspectSpec.class),
+            eq(false),
+            any(AuditStamp.class)))
+        .thenReturn(Optional.empty());
+
+    throttledStrategy.processBatch(operationContext, groupedFor(List.of(mockEvent)), false);
+
+    // Entity index write should be suppressed
+    verify(elasticSearchService, never())
+        .upsertDocument(any(OperationContext.class), anyString(), anyString(), anyString());
+    // Timeseries index write still fires (only entity throttle enabled)
+    verify(timeseriesAspectService)
+        .upsertDocument(any(OperationContext.class), anyString(), anyString(), anyString(), any());
+  }
+
+  @Test
+  public void testThrottle_TimeseriesIndexSuppressesTimeseriesWrite() throws Exception {
+    TimeseriesWriteThrottleCache cache = buildThrottleCache(false, true, false);
+    UpdateIndicesV2Strategy throttledStrategy = strategyWithThrottle(cache);
+
+    when(mockAspectSpec.isTimeseries()).thenReturn(true);
+    when(mockAspectSpec.getTimeseriesFieldSpecs()).thenReturn(Collections.emptyList());
+    when(mockAspectSpec.getTimeseriesFieldCollectionSpecs()).thenReturn(Collections.emptyList());
+    when(mockEvent.getAspectName()).thenReturn("datasetProfile");
+
+    cache.recordWrite(testUrn.toString(), "datasetProfile", 1_000_000_000L);
+    when(mockAuditStamp.getTime()).thenReturn(1_000_001_000L);
+    when(searchDocumentTransformer.transformAspect(
+            any(OperationContext.class),
+            any(Urn.class),
+            any(RecordTemplate.class),
+            any(AspectSpec.class),
+            eq(false),
+            any(AuditStamp.class)))
+        .thenReturn(Optional.empty());
+
+    throttledStrategy.processBatch(operationContext, groupedFor(List.of(mockEvent)), false);
+
+    // Timeseries index write should be suppressed
+    verify(timeseriesAspectService, never())
+        .upsertDocument(any(OperationContext.class), anyString(), anyString(), anyString(), any());
+  }
+
+  @Test
+  public void testThrottle_ObserveModeDoesNotSuppressWrites() throws Exception {
+    TimeseriesWriteThrottleCache cache = buildThrottleCache(false, false, true);
+    UpdateIndicesV2Strategy throttledStrategy = strategyWithThrottle(cache);
+
+    when(mockAspectSpec.isTimeseries()).thenReturn(true);
+    when(mockAspectSpec.getName()).thenReturn("datasetProfile");
+    when(mockAspectSpec.getTimeseriesFieldSpecs()).thenReturn(Collections.emptyList());
+    when(mockAspectSpec.getTimeseriesFieldCollectionSpecs()).thenReturn(Collections.emptyList());
+    when(mockEvent.getAspectName()).thenReturn("datasetProfile");
+    DataMap tsData = new DataMap();
+    tsData.put("timestampMillis", 1_000_001_000L);
+    when(mockAspect.data()).thenReturn(tsData);
+
+    cache.recordWrite(testUrn.toString(), "datasetProfile", 1_000_000_000L);
+    when(mockAuditStamp.getTime()).thenReturn(1_000_001_000L);
+    when(searchDocumentTransformer.transformAspect(
+            any(OperationContext.class),
+            any(Urn.class),
+            any(RecordTemplate.class),
+            any(AspectSpec.class),
+            eq(false),
+            any(AuditStamp.class)))
+        .thenReturn(Optional.empty());
+
+    throttledStrategy.processBatch(operationContext, groupedFor(List.of(mockEvent)), false);
+
+    // Both writes should proceed (observe mode doesn't suppress)
+    verify(timeseriesAspectService)
+        .upsertDocument(any(OperationContext.class), anyString(), anyString(), anyString(), any());
+  }
+
+  @Test
+  public void testThrottle_NonTimeseriesAspectBypasses() throws Exception {
+    TimeseriesWriteThrottleCache cache = buildThrottleCache(true, true, false);
+    UpdateIndicesV2Strategy throttledStrategy = strategyWithThrottle(cache);
+
+    // Non-timeseries aspect should bypass throttle entirely
+    when(mockAspectSpec.isTimeseries()).thenReturn(false);
+    when(searchDocumentTransformer.transformAspect(
+            any(OperationContext.class),
+            any(Urn.class),
+            any(RecordTemplate.class),
+            any(AspectSpec.class),
+            eq(false),
+            any(AuditStamp.class)))
+        .thenReturn(Optional.of(mockSearchDocument));
+    when(mockSearchDocument.toString()).thenReturn("{\"test\": \"document\"}");
+    when(mockSearchDocument.isEmpty()).thenReturn(false);
+
+    ObjectNode mockPreviousDoc = mock(ObjectNode.class);
+    when(mockPreviousDoc.toString()).thenReturn("{\"previous\": \"document\"}");
+    when(searchDocumentTransformer.transformAspect(
+            eq(operationContext),
+            eq(testUrn),
+            eq(mockPreviousAspect),
+            eq(mockAspectSpec),
+            eq(false),
+            eq(mockAuditStamp)))
+        .thenReturn(Optional.of(mockPreviousDoc));
+
+    throttledStrategy.processBatch(operationContext, groupedFor(List.of(mockEvent)), false);
+
+    // Entity index write should proceed (not timeseries, so no throttle)
+    verify(elasticSearchService)
+        .upsertDocument(eq(operationContext), eq("dataset"), anyString(), anyString());
+  }
+
+  @Test
+  public void testThrottle_FirstWriteNotThrottled() throws Exception {
+    TimeseriesWriteThrottleCache cache = buildThrottleCache(true, true, false);
+    UpdateIndicesV2Strategy throttledStrategy = strategyWithThrottle(cache);
+
+    when(mockAspectSpec.isTimeseries()).thenReturn(true);
+    when(mockAspectSpec.getName()).thenReturn("datasetProfile");
+    when(mockAspectSpec.getTimeseriesFieldSpecs()).thenReturn(Collections.emptyList());
+    when(mockAspectSpec.getTimeseriesFieldCollectionSpecs()).thenReturn(Collections.emptyList());
+    when(mockEvent.getAspectName()).thenReturn("datasetProfile");
+    when(mockAuditStamp.getTime()).thenReturn(1_000_000_000L);
+    DataMap tsData = new DataMap();
+    tsData.put("timestampMillis", 1_000_000_000L);
+    when(mockAspect.data()).thenReturn(tsData);
+    when(searchDocumentTransformer.transformAspect(
+            any(OperationContext.class),
+            any(Urn.class),
+            any(RecordTemplate.class),
+            any(AspectSpec.class),
+            eq(false),
+            any(AuditStamp.class)))
+        .thenReturn(Optional.empty());
+
+    // No prior cache entry — first write should not be throttled
+    throttledStrategy.processBatch(operationContext, groupedFor(List.of(mockEvent)), false);
+
+    // Timeseries write should proceed
+    verify(timeseriesAspectService)
+        .upsertDocument(any(OperationContext.class), anyString(), anyString(), anyString(), any());
+  }
+
+  @Test
+  public void testThrottle_BothEntityAndTimeseriesSuppresses() throws Exception {
+    TimeseriesWriteThrottleCache cache = buildThrottleCache(true, true, false);
+    UpdateIndicesV2Strategy throttledStrategy = strategyWithThrottle(cache);
+
+    when(mockAspectSpec.isTimeseries()).thenReturn(true);
+    when(mockAspectSpec.getName()).thenReturn("datasetProfile");
+    when(mockAspectSpec.getTimeseriesFieldSpecs()).thenReturn(Collections.emptyList());
+    when(mockAspectSpec.getTimeseriesFieldCollectionSpecs()).thenReturn(Collections.emptyList());
+    when(mockEvent.getAspectName()).thenReturn("datasetProfile");
+
+    cache.recordWrite(testUrn.toString(), "datasetProfile", 1_000_000_000L);
+    when(mockAuditStamp.getTime()).thenReturn(1_000_001_000L);
+    when(searchDocumentTransformer.transformAspect(
+            any(OperationContext.class),
+            any(Urn.class),
+            any(RecordTemplate.class),
+            any(AspectSpec.class),
+            eq(false),
+            any(AuditStamp.class)))
+        .thenReturn(Optional.empty());
+
+    throttledStrategy.processBatch(operationContext, groupedFor(List.of(mockEvent)), false);
+
+    // Both entity index and timeseries index writes should be suppressed
+    verify(elasticSearchService, never())
+        .upsertDocument(any(OperationContext.class), anyString(), anyString(), anyString());
+    verify(timeseriesAspectService, never())
+        .upsertDocument(any(OperationContext.class), anyString(), anyString(), anyString(), any());
+  }
+
+  @Test
+  public void testThrottle_CacheDisabledShortCircuits() throws Exception {
+    // All throttle configs disabled — should short-circuit without calling shouldThrottle
+    TimeseriesWriteThrottleCache cache = buildThrottleCache(false, false, false);
+    UpdateIndicesV2Strategy throttledStrategy = strategyWithThrottle(cache);
+
+    when(mockAspectSpec.isTimeseries()).thenReturn(true);
+    when(mockAspectSpec.getName()).thenReturn("datasetProfile");
+    when(mockAspectSpec.getTimeseriesFieldSpecs()).thenReturn(Collections.emptyList());
+    when(mockAspectSpec.getTimeseriesFieldCollectionSpecs()).thenReturn(Collections.emptyList());
+    when(mockEvent.getAspectName()).thenReturn("datasetProfile");
+    when(mockAuditStamp.getTime()).thenReturn(1_000_000_000L);
+    DataMap tsData = new DataMap();
+    tsData.put("timestampMillis", 1_000_000_000L);
+    when(mockAspect.data()).thenReturn(tsData);
+    when(searchDocumentTransformer.transformAspect(
+            any(OperationContext.class),
+            any(Urn.class),
+            any(RecordTemplate.class),
+            any(AspectSpec.class),
+            eq(false),
+            any(AuditStamp.class)))
+        .thenReturn(Optional.empty());
+
+    throttledStrategy.processBatch(operationContext, groupedFor(List.of(mockEvent)), false);
+
+    // Both writes should proceed (throttle disabled → short-circuit)
+    verify(timeseriesAspectService)
+        .upsertDocument(any(OperationContext.class), anyString(), anyString(), anyString(), any());
+  }
+
+  @Test
+  public void testThrottle_EntityAndObserveBothEnabled() throws Exception {
+    TimeseriesWriteThrottleCache cache = buildThrottleCache(true, false, true);
+    UpdateIndicesV2Strategy throttledStrategy = strategyWithThrottle(cache);
+
+    when(mockAspectSpec.isTimeseries()).thenReturn(true);
+    when(mockAspectSpec.getName()).thenReturn("datasetProfile");
+    when(mockAspectSpec.getTimeseriesFieldSpecs()).thenReturn(Collections.emptyList());
+    when(mockAspectSpec.getTimeseriesFieldCollectionSpecs()).thenReturn(Collections.emptyList());
+    when(mockEvent.getAspectName()).thenReturn("datasetProfile");
+    DataMap tsData = new DataMap();
+    tsData.put("timestampMillis", 1_000_001_000L);
+    when(mockAspect.data()).thenReturn(tsData);
+
+    cache.recordWrite(testUrn.toString(), "datasetProfile", 1_000_000_000L);
+    when(mockAuditStamp.getTime()).thenReturn(1_000_001_000L);
+    when(searchDocumentTransformer.transformAspect(
+            any(OperationContext.class),
+            any(Urn.class),
+            any(RecordTemplate.class),
+            any(AspectSpec.class),
+            eq(false),
+            any(AuditStamp.class)))
+        .thenReturn(Optional.empty());
+
+    throttledStrategy.processBatch(operationContext, groupedFor(List.of(mockEvent)), false);
+
+    // Entity write suppressed, timeseries write proceeds, observe logged
+    verify(elasticSearchService, never())
+        .upsertDocument(any(OperationContext.class), anyString(), anyString(), anyString());
+    verify(timeseriesAspectService)
+        .upsertDocument(any(OperationContext.class), anyString(), anyString(), anyString(), any());
   }
 
   private MCLItem makeStructuredPropertyEvent(

--- a/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateIndicesV3StrategyTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateIndicesV3StrategyTest.java
@@ -111,7 +111,8 @@ public class UpdateIndicesV3StrategyTest {
             searchDocumentTransformer,
             timeseriesAspectService,
             "MD5",
-            false); // v2Enabled = false
+            false, // v2Enabled = false
+            null);
   }
 
   @Test
@@ -258,7 +259,8 @@ public class UpdateIndicesV3StrategyTest {
             searchDocumentTransformer,
             timeseriesAspectService,
             "MD5",
-            true); // v2Enabled = true
+            true, // v2Enabled = true
+            null);
 
     // Setup for structured property
     when(mockEntitySpec.getName()).thenReturn(STRUCTURED_PROPERTY_ENTITY_NAME);
@@ -354,7 +356,8 @@ public class UpdateIndicesV3StrategyTest {
                     searchDocumentTransformer,
                     timeseriesAspectService,
                     "MD5",
-                    false));
+                    false,
+                    null));
 
     // Verify the exception message and cause
     assertTrue(exception.getMessage().contains("Failed to initialize V3 mappings builder"));
@@ -378,7 +381,8 @@ public class UpdateIndicesV3StrategyTest {
                     searchDocumentTransformer,
                     timeseriesAspectService,
                     "MD5",
-                    false));
+                    false,
+                    null));
 
     // Verify the exception message and cause
     assertTrue(exception.getMessage().contains("Failed to initialize V3 mappings builder"));
@@ -401,7 +405,8 @@ public class UpdateIndicesV3StrategyTest {
                     searchDocumentTransformer,
                     timeseriesAspectService,
                     "MD5",
-                    false));
+                    false,
+                    null));
 
     // Verify the exception message and cause
     assertTrue(exception.getMessage().contains("Failed to initialize V3 mappings builder"));
@@ -423,7 +428,8 @@ public class UpdateIndicesV3StrategyTest {
             searchDocumentTransformer,
             timeseriesAspectService,
             "MD5",
-            false);
+            false,
+            null);
 
     // Verify strategy was created successfully
     assertTrue(strategyWithNullConfig.isEnabled());
@@ -442,7 +448,8 @@ public class UpdateIndicesV3StrategyTest {
             searchDocumentTransformer,
             timeseriesAspectService,
             "MD5",
-            false);
+            false,
+            null);
 
     // Verify strategy was created successfully
     assertTrue(strategyWithEmptyConfig.isEnabled());
@@ -461,7 +468,8 @@ public class UpdateIndicesV3StrategyTest {
             searchDocumentTransformer,
             timeseriesAspectService,
             "MD5",
-            false);
+            false,
+            null);
 
     // Verify strategy was created successfully
     assertTrue(strategyWithWhitespaceConfig.isEnabled());
@@ -675,6 +683,216 @@ public class UpdateIndicesV3StrategyTest {
     // Verify that no upsert operation was performed due to the exception
     verify(elasticSearchService, never())
         .upsertDocumentBySearchGroup(any(), anyString(), anyString(), anyString());
+  }
+
+  // ==================== Timeseries throttle tests ====================
+
+  private TimeseriesWriteThrottleCache buildThrottleCache(
+      boolean entityEnabled, boolean tsEnabled, boolean observeEnabled) {
+    return new TimeseriesWriteThrottleCache(
+        com.linkedin.metadata.config.search.TimeseriesWriteThrottleConfiguration.builder()
+            .entityIndex(
+                com.linkedin.metadata.config.search.TimeseriesWriteThrottleConfiguration
+                    .IndexThrottleConfig.builder()
+                    .enabled(entityEnabled)
+                    .build())
+            .timeseriesIndex(
+                com.linkedin.metadata.config.search.TimeseriesWriteThrottleConfiguration
+                    .IndexThrottleConfig.builder()
+                    .enabled(tsEnabled)
+                    .build())
+            .observe(
+                com.linkedin.metadata.config.search.TimeseriesWriteThrottleConfiguration
+                    .IndexThrottleConfig.builder()
+                    .enabled(observeEnabled)
+                    .build())
+            .refreshPeriodSeconds(3600)
+            .maxCacheUrns(10_000)
+            .build());
+  }
+
+  @Test
+  public void testThrottle_EntityIndexSuppressesTimeseriesAspect() throws Exception {
+    TimeseriesWriteThrottleCache cache = buildThrottleCache(true, false, false);
+    UpdateIndicesV3Strategy throttledStrategy =
+        new UpdateIndicesV3Strategy(
+            v3Config,
+            elasticSearchService,
+            searchDocumentTransformer,
+            timeseriesAspectService,
+            "MD5",
+            false,
+            cache);
+
+    when(mockAspectSpec.getName()).thenReturn("datasetProfile");
+    when(mockAspectSpec.isTimeseries()).thenReturn(true);
+    when(mockEvent.getAspectName()).thenReturn("datasetProfile");
+    when(mockAuditStamp.getTime()).thenReturn(1_000_001_000L);
+
+    // Prime cache
+    cache.recordWrite(testUrn.toString(), "datasetProfile", 1_000_000_000L);
+
+    when(searchDocumentTransformer.transformAspect(
+            any(OperationContext.class),
+            any(Urn.class),
+            any(RecordTemplate.class),
+            any(AspectSpec.class),
+            anyBoolean(),
+            any(AuditStamp.class)))
+        .thenReturn(Optional.of(mockSearchDocument));
+
+    Map<Urn, List<MCLItem>> groupedEvents =
+        Collections.singletonMap(testUrn, Collections.singletonList(mockEvent));
+
+    throttledStrategy.processBatch(operationContext, groupedEvents, true);
+
+    // Timeseries aspect should be excluded from the document (throttled)
+    // Since it's the only aspect, no upsert should happen
+    verify(elasticSearchService, never())
+        .upsertDocumentBySearchGroup(any(), anyString(), anyString(), anyString());
+  }
+
+  @Test
+  public void testThrottle_ObserveModeDoesNotSuppressInV3() throws Exception {
+    TimeseriesWriteThrottleCache cache = buildThrottleCache(false, false, true);
+    UpdateIndicesV3Strategy throttledStrategy =
+        new UpdateIndicesV3Strategy(
+            v3Config,
+            elasticSearchService,
+            searchDocumentTransformer,
+            timeseriesAspectService,
+            "MD5",
+            false,
+            cache);
+
+    when(mockAspectSpec.getName()).thenReturn("datasetProfile");
+    when(mockAspectSpec.isTimeseries()).thenReturn(true);
+    when(mockEvent.getAspectName()).thenReturn("datasetProfile");
+    when(mockAuditStamp.getTime()).thenReturn(1_000_001_000L);
+
+    cache.recordWrite(testUrn.toString(), "datasetProfile", 1_000_000_000L);
+
+    when(searchDocumentTransformer.transformAspect(
+            any(OperationContext.class),
+            any(Urn.class),
+            any(RecordTemplate.class),
+            any(AspectSpec.class),
+            anyBoolean(),
+            any(AuditStamp.class)))
+        .thenReturn(Optional.of(mockSearchDocument));
+
+    Map<Urn, List<MCLItem>> groupedEvents =
+        Collections.singletonMap(testUrn, Collections.singletonList(mockEvent));
+
+    throttledStrategy.processBatch(operationContext, groupedEvents, true);
+
+    // Observe mode should NOT suppress — the write should proceed
+    verify(elasticSearchService)
+        .upsertDocumentBySearchGroup(eq(operationContext), anyString(), anyString(), anyString());
+  }
+
+  @Test
+  public void testThrottle_FirstWritePassesThroughInV3() throws Exception {
+    TimeseriesWriteThrottleCache cache = buildThrottleCache(true, false, false);
+    UpdateIndicesV3Strategy throttledStrategy =
+        new UpdateIndicesV3Strategy(
+            v3Config,
+            elasticSearchService,
+            searchDocumentTransformer,
+            timeseriesAspectService,
+            "MD5",
+            false,
+            cache);
+
+    when(mockAspectSpec.getName()).thenReturn("datasetProfile");
+    when(mockAspectSpec.isTimeseries()).thenReturn(true);
+    when(mockEvent.getAspectName()).thenReturn("datasetProfile");
+    when(mockAuditStamp.getTime()).thenReturn(1_000_000_000L);
+    // No prior cache entry → not throttled
+
+    when(searchDocumentTransformer.transformAspect(
+            any(OperationContext.class),
+            any(Urn.class),
+            any(RecordTemplate.class),
+            any(AspectSpec.class),
+            anyBoolean(),
+            any(AuditStamp.class)))
+        .thenReturn(Optional.of(mockSearchDocument));
+
+    Map<Urn, List<MCLItem>> groupedEvents =
+        Collections.singletonMap(testUrn, Collections.singletonList(mockEvent));
+
+    throttledStrategy.processBatch(operationContext, groupedEvents, true);
+
+    // First write should not be throttled
+    verify(elasticSearchService)
+        .upsertDocumentBySearchGroup(eq(operationContext), anyString(), anyString(), anyString());
+  }
+
+  @Test
+  public void testThrottle_EntityAndObserveBothEnabledInV3() throws Exception {
+    TimeseriesWriteThrottleCache cache = buildThrottleCache(true, false, true);
+    UpdateIndicesV3Strategy throttledStrategy =
+        new UpdateIndicesV3Strategy(
+            v3Config,
+            elasticSearchService,
+            searchDocumentTransformer,
+            timeseriesAspectService,
+            "MD5",
+            false,
+            cache);
+
+    when(mockAspectSpec.getName()).thenReturn("datasetProfile");
+    when(mockAspectSpec.isTimeseries()).thenReturn(true);
+    when(mockEvent.getAspectName()).thenReturn("datasetProfile");
+    when(mockAuditStamp.getTime()).thenReturn(1_000_001_000L);
+
+    cache.recordWrite(testUrn.toString(), "datasetProfile", 1_000_000_000L);
+
+    when(searchDocumentTransformer.transformAspect(
+            any(OperationContext.class),
+            any(Urn.class),
+            any(RecordTemplate.class),
+            any(AspectSpec.class),
+            anyBoolean(),
+            any(AuditStamp.class)))
+        .thenReturn(Optional.of(mockSearchDocument));
+
+    Map<Urn, List<MCLItem>> groupedEvents =
+        Collections.singletonMap(testUrn, Collections.singletonList(mockEvent));
+
+    throttledStrategy.processBatch(operationContext, groupedEvents, true);
+
+    // Entity index enabled suppresses the write, observe mode logs but doesn't write
+    verify(elasticSearchService, never())
+        .upsertDocumentBySearchGroup(any(), anyString(), anyString(), anyString());
+  }
+
+  @Test
+  public void testThrottle_NullCacheNoThrottling() throws Exception {
+    // Default strategy (null cache) should not throttle timeseries aspects
+    when(mockAspectSpec.getName()).thenReturn("datasetProfile");
+    when(mockAspectSpec.isTimeseries()).thenReturn(true);
+    when(mockEvent.getAspectName()).thenReturn("datasetProfile");
+    when(mockAuditStamp.getTime()).thenReturn(1_000_000_000L);
+
+    when(searchDocumentTransformer.transformAspect(
+            any(OperationContext.class),
+            any(Urn.class),
+            any(RecordTemplate.class),
+            any(AspectSpec.class),
+            anyBoolean(),
+            any(AuditStamp.class)))
+        .thenReturn(Optional.of(mockSearchDocument));
+
+    Map<Urn, List<MCLItem>> groupedEvents =
+        Collections.singletonMap(testUrn, Collections.singletonList(mockEvent));
+
+    strategy.processBatch(operationContext, groupedEvents, true);
+
+    // With null throttle cache, all writes proceed
+    verify(elasticSearchService)
+        .upsertDocumentBySearchGroup(eq(operationContext), anyString(), anyString(), anyString());
   }
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
@@ -1016,6 +1016,12 @@ public class PropertiesCollectorConfigurationTest extends AbstractTestNGSpringCo
           // Metadata Change Log configuration
           "metadataChangeLog.consumer.batch.enabled",
           "metadataChangeLog.consumer.batch.size",
+          "metadataChangeLog.throttle.timeseries.entityIndex.enabled",
+          "metadataChangeLog.throttle.timeseries.timeseriesIndex.enabled",
+          "metadataChangeLog.throttle.timeseries.observe.enabled",
+          "metadataChangeLog.throttle.timeseries.refreshPeriodSeconds",
+          "metadataChangeLog.throttle.timeseries.refreshOverrides",
+          "metadataChangeLog.throttle.timeseries.maxCacheUrns",
 
           // Elasticsearch Build Indices - Adaptive throttling configuration
           "elasticsearch.buildIndices.clusterHeapYellowThresholdPercent",

--- a/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHookTest.java
+++ b/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHookTest.java
@@ -146,7 +146,8 @@ public class UpdateIndicesHookTest {
             null,
             mock(IndexConvention.class),
             false,
-            mock(V2MappingsBuilder.class));
+            mock(V2MappingsBuilder.class),
+            null);
 
     updateIndicesService =
         new UpdateIndicesService(
@@ -154,6 +155,7 @@ public class UpdateIndicesHookTest {
             mockEntitySearchService,
             mockSystemMetadataService,
             java.util.Collections.singletonList(v2Strategy),
+            null,
             true, // searchDiffMode
             true, // structuredPropertiesHookEnabled
             true); // structuredPropertiesWriteEnabled
@@ -265,7 +267,8 @@ public class UpdateIndicesHookTest {
             null,
             mock(IndexConvention.class),
             false,
-            mock(V2MappingsBuilder.class));
+            mock(V2MappingsBuilder.class),
+            null);
 
     updateIndicesService =
         new UpdateIndicesService(
@@ -273,6 +276,7 @@ public class UpdateIndicesHookTest {
             mockEntitySearchService,
             mockSystemMetadataService,
             java.util.Collections.singletonList(testV2Strategy),
+            null,
             true,
             true,
             true);
@@ -899,7 +903,8 @@ public class UpdateIndicesHookTest {
               null, // No semantic search config for this test
               mock(IndexConvention.class),
               false,
-              mock(V2MappingsBuilder.class));
+              mock(V2MappingsBuilder.class),
+              null);
       strategies.add(v2Strategy);
     }
 
@@ -911,7 +916,8 @@ public class UpdateIndicesHookTest {
               searchDocumentTransformer,
               mockTimeseriesAspectService,
               "MD5",
-              v2Enabled); // v2Enabled parameter
+              v2Enabled, // v2Enabled parameter
+              null);
       strategies.add(v3Strategy);
     }
 
@@ -922,6 +928,7 @@ public class UpdateIndicesHookTest {
             mockEntitySearchService,
             mockSystemMetadataService,
             strategies,
+            null,
             true, // searchDiffMode
             true, // structuredPropertiesHookEnabled
             true); // structuredPropertiesWriteEnabled

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/MetadataChangeLogConfig.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/MetadataChangeLogConfig.java
@@ -1,5 +1,6 @@
 package com.linkedin.metadata.config;
 
+import com.linkedin.metadata.config.search.TimeseriesWriteThrottleConfiguration;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -17,8 +18,17 @@ import lombok.experimental.Accessors;
 @Accessors(chain = true)
 public class MetadataChangeLogConfig {
 
-  /** Consumer configuration for MCL processing */
   private ConsumerBatchConfig consumer;
+  private ThrottleConfig throttle;
+
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder(toBuilder = true)
+  @Accessors(chain = true)
+  public static class ThrottleConfig {
+    private TimeseriesWriteThrottleConfiguration timeseries;
+  }
 
   @Data
   @NoArgsConstructor
@@ -26,7 +36,6 @@ public class MetadataChangeLogConfig {
   @Builder(toBuilder = true)
   @Accessors(chain = true)
   public static class ConsumerBatchConfig {
-    /** Batch processing configuration */
     private BatchConfig batch;
   }
 
@@ -36,10 +45,7 @@ public class MetadataChangeLogConfig {
   @Builder(toBuilder = true)
   @Accessors(chain = true)
   public static class BatchConfig {
-    /** Whether batch processing is enabled */
     private boolean enabled;
-
-    /** Maximum batch size in bytes */
     private Integer size;
   }
 }

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/search/TimeseriesWriteThrottleConfiguration.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/search/TimeseriesWriteThrottleConfiguration.java
@@ -1,0 +1,43 @@
+package com.linkedin.metadata.config.search;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Configuration for throttling timeseries aspect writes to Elasticsearch indices. A single refresh
+ * period controls the rate limit; independent enable flags gate which write paths (entity search
+ * index and/or timeseries index) are suppressed when throttled. The cache TTL is aligned with the
+ * refresh period automatically.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+public class TimeseriesWriteThrottleConfiguration {
+
+  @Builder.Default private IndexThrottleConfig entityIndex = new IndexThrottleConfig();
+  @Builder.Default private IndexThrottleConfig timeseriesIndex = new IndexThrottleConfig();
+
+  /** Log-only mode: tracks what would be throttled without suppressing writes. */
+  @Builder.Default private IndexThrottleConfig observe = new IndexThrottleConfig();
+
+  @Builder.Default private long refreshPeriodSeconds = 3600;
+
+  /**
+   * JSON override for per-entity, per-aspect refresh periods. Format: {@code {"entityType":
+   * {"aspectName": seconds}}}. Aspects not listed fall back to {@link #refreshPeriodSeconds}.
+   */
+  @Builder.Default private String refreshOverrides = "{}";
+
+  @Builder.Default private int maxCacheUrns = 10_000;
+
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder(toBuilder = true)
+  public static class IndexThrottleConfig {
+    @Builder.Default private boolean enabled = false;
+  }
+}

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -1434,6 +1434,17 @@ metadataChangeLog:
     batch:
       enabled: ${MCL_CONSUMER_BATCH_ENABLED:false}
       size: ${MCL_CONSUMER_BATCH_SIZE:1048576}
+  throttle:
+    timeseries:
+      entityIndex:
+        enabled: ${MCL_TIMESERIES_THROTTLE_ENTITY_INDEX_ENABLED:false}
+      timeseriesIndex:
+        enabled: ${MCL_TIMESERIES_THROTTLE_TIMESERIES_INDEX_ENABLED:false}
+      observe:
+        enabled: ${MCL_TIMESERIES_THROTTLE_OBSERVE_ENABLED:false}
+      refreshPeriodSeconds: ${MCL_TIMESERIES_THROTTLE_REFRESH_SECONDS:3600}
+      refreshOverrides: ${MCL_TIMESERIES_THROTTLE_REFRESH_OVERRIDES:{}}
+      maxCacheUrns: ${MCL_TIMESERIES_THROTTLE_MAX_URNS:10000}
 
 eventsApi:
   enabled: ${EVENTS_API_ENABLED:true}

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entity/update/indices/UpdateIndicesServiceFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entity/update/indices/UpdateIndicesServiceFactory.java
@@ -5,6 +5,7 @@ import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.graph.GraphService;
 import com.linkedin.metadata.search.elasticsearch.ElasticSearchService;
 import com.linkedin.metadata.search.transformer.SearchDocumentTransformer;
+import com.linkedin.metadata.service.TimeseriesWriteThrottleCache;
 import com.linkedin.metadata.service.UpdateGraphIndicesService;
 import com.linkedin.metadata.service.UpdateIndicesService;
 import com.linkedin.metadata.service.UpdateIndicesStrategy;
@@ -84,6 +85,7 @@ public class UpdateIndicesServiceFactory {
       TimeseriesAspectService timeseriesAspectService,
       SystemMetadataService systemMetadataService,
       SearchDocumentTransformer searchDocumentTransformer,
+      TimeseriesWriteThrottleCache timeseriesWriteThrottleCache,
       @Value("${elasticsearch.idHashAlgo}") final String idHashAlgo,
       @Value("#{'${featureFlags.fineGrainedLineageNotAllowedForPlatforms}'.split(',')}")
           final List<String> fineGrainedLineageNotAllowedForPlatforms,
@@ -103,6 +105,7 @@ public class UpdateIndicesServiceFactory {
         entitySearchService,
         systemMetadataService,
         strategies,
+        timeseriesWriteThrottleCache,
         searchDiffMode,
         structuredPropertiesHookEnabled,
         structuredPropertiesWriteEnabled);
@@ -117,6 +120,7 @@ public class UpdateIndicesServiceFactory {
       final SystemMetadataService systemMetadataService,
       final SearchDocumentTransformer searchDocumentTransformer,
       final EntityService<?> entityService,
+      final TimeseriesWriteThrottleCache timeseriesWriteThrottleCache,
       @Value("${elasticsearch.idHashAlgo}") final String idHashAlgo,
       @Value("#{'${featureFlags.fineGrainedLineageNotAllowedForPlatforms}'.split(',')}")
           final List<String> fineGrainedLineageNotAllowedForPlatforms,
@@ -137,6 +141,7 @@ public class UpdateIndicesServiceFactory {
             entitySearchService,
             systemMetadataService,
             strategies,
+            timeseriesWriteThrottleCache,
             searchDiffMode,
             structuredPropertiesHookEnabled,
             structuredPropertiesWriteEnabled);

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entity/update/indices/UpdateIndicesStrategyFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entity/update/indices/UpdateIndicesStrategyFactory.java
@@ -5,9 +5,11 @@ import com.linkedin.gms.factory.config.ConfigurationProvider;
 import com.linkedin.gms.factory.search.ElasticSearchServiceFactory;
 import com.linkedin.metadata.config.search.EntityIndexVersionConfiguration;
 import com.linkedin.metadata.config.search.SemanticSearchConfiguration;
+import com.linkedin.metadata.config.search.TimeseriesWriteThrottleConfiguration;
 import com.linkedin.metadata.search.elasticsearch.ElasticSearchService;
 import com.linkedin.metadata.search.elasticsearch.index.entity.v2.V2MappingsBuilder;
 import com.linkedin.metadata.search.transformer.SearchDocumentTransformer;
+import com.linkedin.metadata.service.TimeseriesWriteThrottleCache;
 import com.linkedin.metadata.service.UpdateIndicesStrategy;
 import com.linkedin.metadata.service.UpdateIndicesV2Strategy;
 import com.linkedin.metadata.service.UpdateIndicesV3Strategy;
@@ -27,6 +29,21 @@ import org.springframework.context.annotation.Import;
 @Slf4j
 public class UpdateIndicesStrategyFactory {
 
+  @Bean
+  @Nonnull
+  protected TimeseriesWriteThrottleCache timeseriesWriteThrottleCache(
+      ConfigurationProvider configProvider) {
+    TimeseriesWriteThrottleConfiguration throttleConfig =
+        configProvider.getMetadataChangeLog() != null
+                && configProvider.getMetadataChangeLog().getThrottle() != null
+            ? configProvider.getMetadataChangeLog().getThrottle().getTimeseries()
+            : null;
+    if (throttleConfig == null) {
+      throttleConfig = TimeseriesWriteThrottleConfiguration.builder().build();
+    }
+    return new TimeseriesWriteThrottleCache(throttleConfig);
+  }
+
   @Bean("updateIndicesV2Strategy")
   @ConditionalOnProperty(name = "elasticsearch.entityIndex.v2.enabled", havingValue = "true")
   @Nonnull
@@ -37,6 +54,7 @@ public class UpdateIndicesStrategyFactory {
       ConfigurationProvider configProvider,
       @Qualifier(IndexConventionFactory.INDEX_CONVENTION_BEAN) IndexConvention indexConvention,
       @Qualifier("legacyMappingsBuilder") V2MappingsBuilder mappingsBuilder,
+      TimeseriesWriteThrottleCache timeseriesWriteThrottleCache,
       @Value("${elasticsearch.idHashAlgo}") String idHashAlgo,
       @Value("${elasticsearch.entityIndex.v2.cleanup:false}") boolean v2Cleanup,
       @Value("${elasticsearch.entityIndex.v2.coalesceBatchUpdates:false}")
@@ -76,7 +94,8 @@ public class UpdateIndicesStrategyFactory {
         semanticSearchConfig,
         indexConvention,
         coalesceBatchUpdates,
-        mappingsBuilder);
+        mappingsBuilder,
+        timeseriesWriteThrottleCache);
   }
 
   @Bean("updateIndicesV3Strategy")
@@ -86,6 +105,7 @@ public class UpdateIndicesStrategyFactory {
       ElasticSearchService elasticSearchService,
       SearchDocumentTransformer searchDocumentTransformer,
       TimeseriesAspectService timeseriesAspectService,
+      TimeseriesWriteThrottleCache timeseriesWriteThrottleCache,
       @Value("${elasticsearch.idHashAlgo}") String idHashAlgo,
       @Value("${elasticsearch.entityIndex.v3.cleanup:false}") boolean v3Cleanup,
       @Value("${elasticsearch.entityIndex.v2.enabled:true}") boolean v2Enabled) {
@@ -100,6 +120,7 @@ public class UpdateIndicesStrategyFactory {
         searchDocumentTransformer,
         timeseriesAspectService,
         idHashAlgo,
-        v2Enabled);
+        v2Enabled,
+        timeseriesWriteThrottleCache);
   }
 }


### PR DESCRIPTION
…pdates

Introduces an in-memory Guava cache that rate-limits timeseries aspect writes to both entity search and timeseries Elasticsearch indices. This prevents high-frequency timeseries aspects (e.g. datasetProfile, operation) from overwhelming Elasticsearch with redundant index updates.

Key design decisions:
- Single shared cache keyed by (URN, aspect) across V2, V3, and semantic search strategies with centralized recordWrite to avoid race conditions
- Default refresh period with per-entity, per-aspect JSON overrides via MCL_TIMESERIES_THROTTLE_REFRESH_OVERRIDES
- Independent enable flags for entity index and timeseries index paths
- Disabled by default; cache TTL auto-derived from max configured period
- Batch-level ThrottleSummary logging to avoid per-event log spam

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
