### PR TITLE
fix(build): copy buildArgs map to avoid UnsupportedOperationException…

### DIFF
--- a/gradle/docker/docker.gradle
+++ b/gradle/docker/docker.gradle
@@ -271,7 +271,7 @@ project.afterEvaluate {
           }).toList()
         }
         if (extension.buildArgs.get()) {
-          bake_spec_target.args = extension.buildArgs.get()
+          bake_spec_target.args = new HashMap(extension.buildArgs.get())
         } else {
           bake_spec_target.args = [:]
         }


### PR DESCRIPTION
… in bake snippet

Gradle's MapProperty.get() returns an immutable map. When debugBuildArgs are present, putAll() on that immutable reference throws UnsupportedOperationException. Wrapping in a new HashMap makes the map mutable before merging debug args.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
