### PR TITLE
fix(ingestion/redshift): fix late-binding view columns silently dropped due to wrong WHERE clause column name

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/query.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/query.py
@@ -291,7 +291,7 @@ class RedshiftCommonQuery:
               col_name name,
               col_type varchar,
               col_num int)
-            WHERE 1 and schema = '{schema_name}'
+            WHERE 1 and view_schema = '{schema_name}'
             UNION
             SELECT
               c.schemaname as "schema",

--- a/metadata-ingestion/tests/unit/redshift/test_redshift_queries.py
+++ b/metadata-ingestion/tests/unit/redshift/test_redshift_queries.py
@@ -70,6 +70,13 @@ class TestCommonQueries:
         assert 'table_owner AS "owner_name"' in sql
         assert "pg_user" not in sql
 
+    def test_list_columns_late_binding_view_filters_by_view_schema(self):
+        sql = RedshiftCommonQuery.list_columns("mydb", "common")
+        # pg_get_late_binding_view_cols() exposes "view_schema", not "schema" —
+        # the WHERE clause must use the correct column name or late-binding view
+        # columns are silently dropped.
+        assert "view_schema = 'common'" in sql
+
 
 class TestProvisionedQueries:
     def test_list_insert_create_queries_uses_boundary_aware_listagg(self):


### PR DESCRIPTION
## Summary

- `pg_get_late_binding_view_cols()` exposes a column named `view_schema`, but the `list_columns` query was filtering with `schema = '{schema_name}'` — a column that does not exist in that context
- In Redshift, referencing an undefined column evaluates to `NULL`, so `NULL = 'common'` is never true and all rows from the late-binding view branch are silently discarded
- This caused every column on every `WITH NO SCHEMA BINDING` view to be missing from DataHub after ingestion
- Fix: rename `schema` → `view_schema` in the `WHERE` clause of the `pg_get_late_binding_view_cols()` UNION branch

## Test plan

- [ ] Added a unit test to `test_redshift_queries.py` that asserts `view_schema = '<schema>'` appears in the generated SQL — this test fails on the old code and passes with the fix
- [ ] All 80 existing Redshift unit tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)