### PR TITLE
feat(ui): fully collapse nav redesign and add home hero toggler

### DIFF
--- a/datahub-web-react/src/app/homeV2/HomePage.tsx
+++ b/datahub-web-react/src/app/homeV2/HomePage.tsx
@@ -6,7 +6,6 @@ import { useRedirectToIntroduceYourself } from '@app/homeV2/introduce/useRedirec
 import { CenterContent } from '@app/homeV2/layout/CenterContent';
 import { LeftSidebar } from '@app/homeV2/layout/LeftSidebar';
 import { RightSidebar } from '@app/homeV2/layout/RightSidebar';
-import { NavBarStateType, useNavBarContext } from '@app/homeV2/layout/navBarRedesign/NavBarContext';
 import PersonalizationLoadingModal from '@app/homeV2/persona/PersonalizationLoadingModal';
 import { OnboardingTour } from '@app/onboarding/OnboardingTour';
 import { WelcomeToDataHubModal } from '@app/onboarding/WelcomeToDataHubModal';
@@ -35,16 +34,10 @@ export const HomePage = () => {
     useRedirectToIntroduceYourself();
 
     const isShowNavBarRedesign = useShowNavBarRedesign();
-    const { setDefaultNavBarState } = useNavBarContext();
 
     useEffect(() => {
         analytics.event({ type: EventType.HomePageViewEvent });
     }, []);
-
-    useEffect(() => {
-        setDefaultNavBarState(NavBarStateType.Opened);
-        return () => setDefaultNavBarState(NavBarStateType.Collapsed);
-    });
 
     return (
         <>

--- a/datahub-web-react/src/app/homeV2/layout/navBarRedesign/NavBarContext.tsx
+++ b/datahub-web-react/src/app/homeV2/layout/navBarRedesign/NavBarContext.tsx
@@ -3,7 +3,6 @@ import React, { ReactNode, useCallback, useContext, useEffect, useMemo, useState
 export enum NavBarStateType {
     Collapsed = 'COLLAPSED',
     Opened = 'OPENED',
-    Floating = 'FLOATING',
 }
 
 /**
@@ -18,18 +17,16 @@ type LocalState = {
     state?: NavBarStateType | null;
 };
 
-/**
- * Loads a persisted object from the local browser storage.
- */
-const loadLocalState = () => {
-    return JSON.parse(localStorage.getItem(LOCAL_STATE_KEY) || '{}') as LocalState;
+const loadLocalState = (): LocalState => {
+    const raw = JSON.parse(localStorage.getItem(LOCAL_STATE_KEY) || '{}') as LocalState;
+    if (raw.state && raw.state !== NavBarStateType.Collapsed && raw.state !== NavBarStateType.Opened) {
+        return { ...raw, state: null };
+    }
+    return raw;
 };
 
-/**
- * Saves an object to local browser storage.
- */
-const saveLocalState = (newState: LocalState) => {
-    return localStorage.setItem(LOCAL_STATE_KEY, JSON.stringify(newState));
+const saveLocalState = (newState: LocalState): void => {
+    localStorage.setItem(LOCAL_STATE_KEY, JSON.stringify(newState));
 };
 
 interface NavBarContextType {
@@ -38,16 +35,19 @@ interface NavBarContextType {
     toggle: () => void;
     selectedKey: string;
     setSelectedKey: (key: string) => void;
-    setDefaultNavBarState: (state: NavBarStateType) => void;
 }
 
+// First-time users (no persisted preference) see the nav opened so it's
+// discoverable. Once a user toggles, their choice is persisted to
+// localStorage and always wins on subsequent visits.
+const DEFAULT_NAV_BAR_STATE = NavBarStateType.Opened;
+
 const NavBarContext = React.createContext<NavBarContextType>({
-    state: NavBarStateType.Collapsed,
-    isCollapsed: true,
+    state: DEFAULT_NAV_BAR_STATE,
+    isCollapsed: false,
     toggle: () => {},
     selectedKey: '',
     setSelectedKey: () => {},
-    setDefaultNavBarState: () => {},
 });
 
 export const useNavBarContext = () => useContext(NavBarContext);
@@ -57,8 +57,6 @@ interface Props {
 }
 
 export const NavBarProvider = ({ children }: Props) => {
-    // Default state of the nav bar (if there are no state in local storage)
-    const [defaultState, setDefaultState] = useState<NavBarStateType>(NavBarStateType.Collapsed);
     const [localState, setLocalState] = useState<LocalState>(loadLocalState());
     const [selectedKey, setSelectedKey] = useState<string>('');
 
@@ -66,33 +64,19 @@ export const NavBarProvider = ({ children }: Props) => {
         saveLocalState(localState);
     }, [localState]);
 
-    const state = useMemo(() => {
-        return localState.state || defaultState || NavBarStateType.Collapsed;
-    }, [defaultState, localState.state]);
-
-    const updateState = useCallback((newState: NavBarStateType) => {
-        setLocalState((currentState) => ({ ...currentState, state: newState }));
-    }, []);
-
-    const getNewState = useCallback((currentState: NavBarStateType): NavBarStateType => {
-        switch (currentState) {
-            case NavBarStateType.Collapsed:
-                return NavBarStateType.Opened;
-            case NavBarStateType.Opened:
-                return NavBarStateType.Collapsed;
-            case NavBarStateType.Floating:
-                return NavBarStateType.Collapsed;
-            default:
-                return NavBarStateType.Collapsed;
-        }
-    }, []);
+    const state = useMemo(() => localState.state || DEFAULT_NAV_BAR_STATE, [localState.state]);
 
     const isCollapsed = useMemo(() => state === NavBarStateType.Collapsed, [state]);
 
     const toggle = useCallback(() => {
-        const newState = getNewState(state);
-        updateState(newState);
-    }, [state, getNewState, updateState]);
+        setLocalState((currentState) => {
+            const effective = currentState.state ?? DEFAULT_NAV_BAR_STATE;
+            return {
+                ...currentState,
+                state: effective === NavBarStateType.Opened ? NavBarStateType.Collapsed : NavBarStateType.Opened,
+            };
+        });
+    }, []);
 
     return (
         <NavBarContext.Provider
@@ -102,7 +86,6 @@ export const NavBarProvider = ({ children }: Props) => {
                 toggle,
                 selectedKey,
                 setSelectedKey,
-                setDefaultNavBarState: setDefaultState,
             }}
         >
             {children}

--- a/datahub-web-react/src/app/homeV2/layout/navBarRedesign/NavBarHeader.tsx
+++ b/datahub-web-react/src/app/homeV2/layout/navBarRedesign/NavBarHeader.tsx
@@ -18,7 +18,6 @@ const Container = styled.div`
     align-items: center;
     gap: 8px;
     margin-left: -3px;
-    transition: padding 250ms ease-in-out;
 `;
 
 const Logotype = styled.div`

--- a/datahub-web-react/src/app/homeV2/layout/navBarRedesign/NavBarMenuItem.tsx
+++ b/datahub-web-react/src/app/homeV2/layout/navBarRedesign/NavBarMenuItem.tsx
@@ -11,7 +11,7 @@ const StyledMenuItem = styled(Menu.Item)<{ isCollapsed?: boolean }>`
     &&& {
         position: relative;
         padding: 4px 8px;
-        margin: 8px 0;
+        margin: 4px 0;
         margin-bottom: 0;
         height: 36px;
         min-height: 36px;

--- a/datahub-web-react/src/app/homeV2/layout/navBarRedesign/NavBarToggler.tsx
+++ b/datahub-web-react/src/app/homeV2/layout/navBarRedesign/NavBarToggler.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { useNavBarContext } from '@app/homeV2/layout/navBarRedesign/NavBarContext';
+import { NAV_SIDEBAR_COLLAPSE_TRANSITION_MS } from '@app/shared/constants';
 import analytics, { EventType } from '@src/app/analytics';
 
 const Toggler = styled.button<{ $isCollapsed?: boolean }>`
@@ -12,8 +13,9 @@ const Toggler = styled.button<{ $isCollapsed?: boolean }>`
     border-radius: 6px;
     border: none;
     display: flex;
-    transition: left 250ms ease-in-out;
-    transition: background 300ms ease-in;
+    transition:
+        left ${NAV_SIDEBAR_COLLAPSE_TRANSITION_MS}ms ease-out,
+        background 300ms ease-in;
     background: ${(props) => props.theme.colors.bgSurfaceNewNav};
 
     &: hover {

--- a/datahub-web-react/src/app/homeV2/layout/navBarRedesign/NavSidebar.tsx
+++ b/datahub-web-react/src/app/homeV2/layout/navBarRedesign/NavSidebar.tsx
@@ -35,6 +35,12 @@ import { useMFEConfigFromBackend } from '@app/mfeframework/mfeConfigLoader';
 import { getMfeMenuDropdownItems, getMfeMenuItems } from '@app/mfeframework/mfeNavBarMenuUtils';
 import OnboardingContext from '@app/onboarding/OnboardingContext';
 import { useOnboardingTour } from '@app/onboarding/OnboardingTourContext.hooks';
+import {
+    NAV_SIDEBAR_COLLAPSE_TRANSITION_MS,
+    NAV_SIDEBAR_ID,
+    NAV_SIDEBAR_WIDTH_COLLAPSED,
+    NAV_SIDEBAR_WIDTH_EXPANDED,
+} from '@app/shared/constants';
 import { useIsHomePage } from '@app/shared/useIsHomePage';
 import { useAppConfig, useBusinessAttributesFlag, useIsContextDocumentsEnabled } from '@app/useAppConfig';
 import useGetLogoutHandler from '@src/app/auth/useGetLogoutHandler';
@@ -56,24 +62,26 @@ const Container = styled.div`
     align-items: center;
 `;
 
-const Content = styled.div<{ isCollapsed: boolean }>`
+const Content = styled.div<{ $isCollapsed: boolean }>`
     display: flex;
     flex-direction: column;
     height: 100%;
-    width: ${(props) => (props.isCollapsed ? '60px' : '264px')};
-    transition: width 250ms ease-in-out;
+    width: ${(props) => (props.$isCollapsed ? `${NAV_SIDEBAR_WIDTH_COLLAPSED}px` : `${NAV_SIDEBAR_WIDTH_EXPANDED}px`)};
+    /* ease-out feels snappier than ease-in-out for toggle expand/collapse —
+       it starts fast and decelerates rather than easing in slowly. */
+    transition: width ${NAV_SIDEBAR_COLLAPSE_TRANSITION_MS}ms ease-out;
+    will-change: width;
     overflow-x: hidden;
 `;
 
 const Header = styled.div`
     padding: 17px 8px 8px 16px;
-    border-bottom: 1px solid ${(props) => props.theme.colors.border};
 `;
 
 const ScrollableContent = styled.div`
     display: flex;
     flex-direction: column;
-    padding: 0px 8px 0px 16px;
+    padding: 0px 8px 17px 16px;
     flex: 1;
     overflow-y: auto;
     overflow-x: hidden;
@@ -101,9 +109,9 @@ const ScrollableContent = styled.div`
     scrollbar-color: ${(props) => props.theme.colors.scrollbarThumbOnDarkBg} transparent;
 `;
 
-const Footer = styled.div`
-    padding: 8px 8px 17px 16px;
-    border-top: 1px solid ${(props) => props.theme.colors.border};
+const Spacer = styled.div`
+    flex: 1;
+    min-height: 8px;
 `;
 
 const CustomLogo = styled.img`
@@ -128,7 +136,6 @@ export const NavSidebar = () => {
 
     const { toggle, isCollapsed, selectedKey, setSelectedKey } = useNavBarContext();
     const appConfig = useAppConfig();
-    const userContext = useUserContext();
     const me = useUserContext();
     const isHomePage = useIsHomePage();
     const location = useLocation();
@@ -369,64 +376,71 @@ export const NavSidebar = () => {
     const footerMenu: NavBarMenuItems = {
         items: [
             {
-                type: NavBarMenuItemTypes.Item,
-                title: 'Profile',
-                icon: <UserCircle />,
-                selectedIcon: <UserCircle weight="fill" />,
-                key: 'profile',
-                link: `/${entityRegistry.getPathName(EntityType.CorpUser)}/${userContext.urn}`,
-            },
-            {
-                type: NavBarMenuItemTypes.Item,
-                title: 'Settings',
-                icon: <Gear />,
-                selectedIcon: <Gear weight="fill" />,
-                key: 'settings',
-                link: '/settings',
-            },
-            {
-                type: NavBarMenuItemTypes.Dropdown,
-                title: 'Resources',
-                icon: <Question />,
-                selectedIcon: <Question weight="fill" />,
-                key: 'help',
+                type: NavBarMenuItemTypes.Group,
+                key: 'account',
+                title: 'Account',
                 items: [
-                    ...productTourMenuItems,
                     {
-                        type: NavBarMenuItemTypes.DropdownElement,
-                        title: 'GraphQL',
-                        description: 'Explore the GraphQL API',
-                        link: resolveRuntimePath(HelpLinkRoutes.GRAPHIQL),
-                        isExternalLink: true,
-                        key: 'helpGraphQL',
+                        type: NavBarMenuItemTypes.Item,
+                        title: 'Profile',
+                        icon: <UserCircle />,
+                        selectedIcon: <UserCircle weight="fill" />,
+                        key: 'profile',
+                        link: `/${entityRegistry.getPathName(EntityType.CorpUser)}/${me.urn}`,
                     },
                     {
-                        type: NavBarMenuItemTypes.DropdownElement,
-                        title: 'OpenAPI',
-                        description: 'Explore the OpenAPI endpoints',
-                        link: resolveRuntimePath(HelpLinkRoutes.OPENAPI),
-                        isExternalLink: true,
-                        key: 'helpOpenAPI',
+                        type: NavBarMenuItemTypes.Item,
+                        title: 'Settings',
+                        icon: <Gear />,
+                        selectedIcon: <Gear weight="fill" />,
+                        key: 'settings',
+                        link: '/settings',
                     },
-                    ...HelpContentMenuItems,
                     {
-                        type: NavBarMenuItemTypes.DropdownElement,
-                        title: config?.appVersion || '',
-                        isHidden: !config?.appVersion,
-                        isExternalLink: true,
-                        key: 'helpAppVersion',
-                        disabled: true,
+                        type: NavBarMenuItemTypes.Dropdown,
+                        title: 'Resources',
+                        icon: <Question />,
+                        selectedIcon: <Question weight="fill" />,
+                        key: 'help',
+                        items: [
+                            ...productTourMenuItems,
+                            {
+                                type: NavBarMenuItemTypes.DropdownElement,
+                                title: 'GraphQL',
+                                description: 'Explore the GraphQL API',
+                                link: resolveRuntimePath(HelpLinkRoutes.GRAPHIQL),
+                                isExternalLink: true,
+                                key: 'helpGraphQL',
+                            },
+                            {
+                                type: NavBarMenuItemTypes.DropdownElement,
+                                title: 'OpenAPI',
+                                description: 'Explore the OpenAPI endpoints',
+                                link: resolveRuntimePath(HelpLinkRoutes.OPENAPI),
+                                isExternalLink: true,
+                                key: 'helpOpenAPI',
+                            },
+                            ...HelpContentMenuItems,
+                            {
+                                type: NavBarMenuItemTypes.DropdownElement,
+                                title: config?.appVersion || '',
+                                isHidden: !config?.appVersion,
+                                isExternalLink: true,
+                                key: 'helpAppVersion',
+                                disabled: true,
+                            },
+                        ],
+                    },
+                    {
+                        type: NavBarMenuItemTypes.Item,
+                        title: 'Sign out',
+                        icon: <SignOut data-testid="log-out-menu-item" />,
+                        key: 'signOut',
+                        onClick: logout,
+                        href: resolveRuntimePath('/logOut'),
+                        dataTestId: 'nav-sidebar-sign-out',
                     },
                 ],
-            },
-            {
-                type: NavBarMenuItemTypes.Item,
-                title: 'Sign out',
-                icon: <SignOut data-testid="log-out-menu-item" />,
-                key: 'signOut',
-                onClick: logout,
-                href: resolveRuntimePath('/logOut'),
-                dataTestId: 'nav-sidebar-sign-out',
             },
         ],
     };
@@ -439,7 +453,7 @@ export const NavSidebar = () => {
 
     useEffect(() => setSelectedKey(sk), [sk, setSelectedKey]);
 
-    const showSkeleton = isUserInitializing || !appConfig.loaded || !userContext.loaded;
+    const showSkeleton = isUserInitializing || !appConfig.loaded || !me.loaded;
 
     const renderSvgSelectedGradientForReusingInIcons = () => {
         return (
@@ -459,7 +473,7 @@ export const NavSidebar = () => {
     return (
         <Container>
             {renderSvgSelectedGradientForReusingInIcons()}
-            <Content id="nav-sidebar" data-collapsed={isCollapsed} isCollapsed={isCollapsed}>
+            <Content id={NAV_SIDEBAR_ID} data-collapsed={isCollapsed} $isCollapsed={isCollapsed}>
                 {showSkeleton ? (
                     <NavSkeleton isCollapsed={isCollapsed} />
                 ) : (
@@ -478,10 +492,11 @@ export const NavSidebar = () => {
                                     menu={mainContentMenu}
                                 />
                             </MenuWrapper>
+                            <Spacer />
+                            <MenuWrapper>
+                                <NavBarMenu selectedKey={selectedKey} isCollapsed={isCollapsed} menu={footerMenu} />
+                            </MenuWrapper>
                         </ScrollableContent>
-                        <Footer>
-                            <NavBarMenu selectedKey={selectedKey} isCollapsed={isCollapsed} menu={footerMenu} />
-                        </Footer>
                     </>
                 )}
             </Content>

--- a/datahub-web-react/src/app/homeV3/header/Header.tsx
+++ b/datahub-web-react/src/app/homeV3/header/Header.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import styled from 'styled-components';
 
+import { useNavBarContext } from '@app/homeV2/layout/navBarRedesign/NavBarContext';
+import NavBarToggler from '@app/homeV2/layout/navBarRedesign/NavBarToggler';
 import GreetingText from '@app/homeV3/header/components/GreetingText';
 import SearchBar from '@app/homeV3/header/components/SearchBar';
 import { CenteredContainer, contentWidth } from '@app/homeV3/styledComponents';
+import { useShowNavBarRedesign } from '@app/useShowNavBarRedesign';
 
 const HeaderWrapper = styled.div`
     display: flex;
@@ -21,9 +24,24 @@ const StyledCenteredContainer = styled(CenteredContainer)`
     ${contentWidth(0)}
 `;
 
+const NavTogglerSlot = styled.div`
+    position: absolute;
+    top: 16px;
+    left: 16px;
+`;
+
 const Header = () => {
+    const isShowNavBarRedesign = useShowNavBarRedesign();
+    const { isCollapsed } = useNavBarContext();
+    const showHomeNavToggler = isShowNavBarRedesign && isCollapsed;
+
     return (
         <HeaderWrapper>
+            {showHomeNavToggler && (
+                <NavTogglerSlot>
+                    <NavBarToggler />
+                </NavTogglerSlot>
+            )}
             <StyledCenteredContainer>
                 <GreetingText />
                 <SearchBar />

--- a/datahub-web-react/src/app/searchV2/SearchHeader.tsx
+++ b/datahub-web-react/src/app/searchV2/SearchHeader.tsx
@@ -11,6 +11,7 @@ import { V2_SEARCH_BAR_ID } from '@app/onboarding/configV2/HomePageOnboardingCon
 import { SearchBar } from '@app/searchV2/SearchBar';
 import { SearchBarV2 } from '@app/searchV2/searchBarV2/SearchBarV2';
 import useSearchViewAll from '@app/searchV2/useSearchViewAll';
+import { NAV_SIDEBAR_COLLAPSE_TRANSITION_MS } from '@app/shared/constants';
 import { useIsHomePage } from '@app/shared/useIsHomePage';
 import { useAppConfig } from '@app/useAppConfig';
 import { useShowNavBarRedesign } from '@app/useShowNavBarRedesign';
@@ -61,15 +62,15 @@ const Header = styled(Layout)<{ $isNavBarCollapsed?: boolean; $isShowNavBarRedes
 
         // preventing of NavBar's overlapping
         position: relative;
-        padding-left: ${props.$isNavBarCollapsed ? '224px' : '540px'};
-        left: ${props.$isNavBarCollapsed ? '-112px' : '-270px'};
+        padding-left: ${props.$isNavBarCollapsed ? '104px' : '540px'};
+        left: ${props.$isNavBarCollapsed ? '-52px' : '-270px'};
         transition: none;
         @media only screen and (min-width: 1280px) {
             padding-left: 540px;
             left: -270px;
         }
         @media only screen and (max-width: 1200px) {
-            transition: padding 250ms ease-in-out;
+            transition: padding ${NAV_SIDEBAR_COLLAPSE_TRANSITION_MS}ms ease-out;
         }
     `}
     ${(props) => props.$isShowNavBarRedesign && !props.$isNavBarCollapsed && 'justify-content: space-between;'}
@@ -120,7 +121,7 @@ const StyledButton = styled(Button)`
 
 const NavBarTogglerWrapper = styled.div`
     position: fixed;
-    left: 68px;
+    left: 20px;
 `;
 
 type Props = {
@@ -154,6 +155,8 @@ export const SearchHeader = ({
     const isShowNavBarRedesign = useShowNavBarRedesign();
     const showHomepageRedesign = useShowHomePageRedesign();
     const isHomePage = useIsHomePage();
+    // On the redesigned home page the toggler is rendered inside the home
+    // hero container (homeV3/header/Header.tsx), not in the global header.
     const hideNavToggler = showHomepageRedesign && isHomePage;
     const themeConfig = useTheme();
     const styles = getStyles(isShowNavBarRedesign, themeConfig.colors);

--- a/datahub-web-react/src/app/searchV2/SearchablePage.tsx
+++ b/datahub-web-react/src/app/searchV2/SearchablePage.tsx
@@ -4,6 +4,7 @@ import styled, { useTheme } from 'styled-components';
 
 import { useUserContext } from '@app/context/useUserContext';
 import { NavSidebar } from '@app/homeV2/layout/NavSidebar';
+import { useNavBarContext } from '@app/homeV2/layout/navBarRedesign/NavBarContext';
 import { NavSidebar as NavSidebarRedesign } from '@app/homeV2/layout/navBarRedesign/NavSidebar';
 import { SearchHeader } from '@app/searchV2/SearchHeader';
 import useGoToSearchPage from '@app/searchV2/useGoToSearchPage';
@@ -39,7 +40,11 @@ const Navigation = styled.div<{ $isShowNavBarRedesign?: boolean }>`
     z-index: ${(props) => (props.$isShowNavBarRedesign ? 0 : 200)};
 `;
 
-const Content = styled.div<{ $isShowNavBarRedesign?: boolean; $hideSearchBar?: boolean }>`
+const Content = styled.div<{
+    $isShowNavBarRedesign?: boolean;
+    $hideSearchBar?: boolean;
+    $isNavBarCollapsed?: boolean;
+}>`
     border-radius: ${(props) =>
         props.$isShowNavBarRedesign ? props.theme.styles['border-radius-navbar-redesign'] : '8px'};
     margin-top: ${(props) => (props.$isShowNavBarRedesign ? '56px' : '72px')};
@@ -47,7 +52,7 @@ const Content = styled.div<{ $isShowNavBarRedesign?: boolean; $hideSearchBar?: b
     ${(props) =>
         props.$isShowNavBarRedesign &&
         `
-        padding: 11px 15px 11px 3px;
+        padding: 11px 15px 11px ${props.$isNavBarCollapsed ? '15px' : '3px'};
     `}
     flex: 1;
     display: flex;
@@ -72,6 +77,7 @@ export const SearchablePage = ({ children, hideSearchBar }: Props) => {
     const showSearchBarAutocompleteRedesign = appConfig.config.featureFlags?.showSearchBarAutocompleteRedesign;
     const { query: currentQuery } = useQueryAndFiltersFromLocation();
     const isShowNavBarRedesign = useShowNavBarRedesign();
+    const { isCollapsed } = useNavBarContext();
 
     const entityRegistry = useEntityRegistry();
     const themeConfig = useTheme();
@@ -141,7 +147,11 @@ export const SearchablePage = ({ children, hideSearchBar }: Props) => {
                 <Navigation $isShowNavBarRedesign={isShowNavBarRedesign}>
                     <FinalNavBar />
                 </Navigation>
-                <Content $isShowNavBarRedesign={isShowNavBarRedesign} $hideSearchBar={hideSearchBar}>
+                <Content
+                    $isShowNavBarRedesign={isShowNavBarRedesign}
+                    $hideSearchBar={hideSearchBar}
+                    $isNavBarCollapsed={isCollapsed}
+                >
                     {children}
                 </Content>
             </Body>

--- a/datahub-web-react/src/app/shared/constants.ts
+++ b/datahub-web-react/src/app/shared/constants.ts
@@ -31,4 +31,6 @@ export const SKIP_WELCOME_MODAL_KEY = 'skipWelcomeModal';
 // Navigation sidebar
 export const NAV_SIDEBAR_ID = 'nav-sidebar';
 export const NAV_SIDEBAR_WIDTH_EXPANDED = 264;
-export const NAV_SIDEBAR_WIDTH_COLLAPSED = 60;
+/** Collapsed nav is fully hidden (0px); expand/collapse togglers sit in the page chrome. */
+export const NAV_SIDEBAR_WIDTH_COLLAPSED = 0;
+export const NAV_SIDEBAR_COLLAPSE_TRANSITION_MS = 180;

--- a/datahub-web-react/src/app/shared/product/update/ProductUpdates.components.tsx
+++ b/datahub-web-react/src/app/shared/product/update/ProductUpdates.components.tsx
@@ -3,6 +3,8 @@ import { colors } from '@components';
 import { X } from '@phosphor-icons/react/dist/csr/X';
 import styled from 'styled-components';
 
+import { NAV_SIDEBAR_COLLAPSE_TRANSITION_MS } from '@app/shared/constants';
+
 export const ToastContainer = styled.div<{ $sidebarWidth: number }>`
     display: inline-flex;
     flex-direction: column;
@@ -19,8 +21,8 @@ export const ToastContainer = styled.div<{ $sidebarWidth: number }>`
     box-shadow: 0 4px 28px 0 rgba(9, 1, 61, 0.14);
     z-index: 1000;
     transition:
-        left 250ms ease-in-out,
-        max-width 250ms ease-in-out;
+        left ${NAV_SIDEBAR_COLLAPSE_TRANSITION_MS}ms ease-out,
+        max-width ${NAV_SIDEBAR_COLLAPSE_TRANSITION_MS}ms ease-out;
     animation: slideUpScale 500ms cubic-bezier(0.34, 1.56, 0.64, 1);
 
     @keyframes slideUpScale {

--- a/datahub-web-react/src/app/shared/product/update/ProductUpdates.components.tsx
+++ b/datahub-web-react/src/app/shared/product/update/ProductUpdates.components.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable rulesdir/no-hardcoded-colors */
-import { colors } from '@components';
 import { X } from '@phosphor-icons/react/dist/csr/X';
 import styled from 'styled-components';
 
@@ -17,8 +15,12 @@ export const ToastContainer = styled.div<{ $sidebarWidth: number }>`
     max-height: calc(100vh - 48px);
     padding: 0;
     border-radius: 12px;
-    background: linear-gradient(180deg, #f9fafc 0%, #f1f3fd 100%);
-    box-shadow: 0 4px 28px 0 rgba(9, 1, 61, 0.14);
+    background: linear-gradient(
+        180deg,
+        ${(props) => props.theme.colors.bgSurface} 0%,
+        ${(props) => props.theme.colors.bg} 100%
+    );
+    box-shadow: ${(props) => props.theme.colors.shadowXl};
     z-index: 1000;
     transition:
         left ${NAV_SIDEBAR_COLLAPSE_TRANSITION_MS}ms ease-out,
@@ -43,15 +45,15 @@ export const Header = styled.div`
     align-items: center;
     width: 100%;
     padding: 16px 16px 12px 16px;
-    border-bottom: 1px solid ${colors.gray[200]};
-    background: white;
+    border-bottom: 1px solid ${(props) => props.theme.colors.border};
+    background: ${(props) => props.theme.colors.bg};
     border-radius: 12px 12px 0 0;
 `;
 
 export const CloseButton = styled.button`
     background: none;
     border: none;
-    color: ${colors.gray[400]};
+    color: ${(props) => props.theme.colors.textTertiary};
     cursor: pointer;
     padding: 4px;
     display: flex;
@@ -60,7 +62,7 @@ export const CloseButton = styled.button`
     transition: color 0.2s;
 
     &:hover {
-        color: ${colors.gray[600]};
+        color: ${(props) => props.theme.colors.textSecondary};
     }
 `;
 
@@ -102,7 +104,7 @@ export const SectionHeaderContainer = styled.div`
 export const SectionHeaderLine = styled.div`
     flex: 1;
     height: 1px;
-    background: ${colors.gray[200]};
+    background: ${(props) => props.theme.colors.border};
 `;
 
 export const FeaturesSection = styled.div`
@@ -137,9 +139,9 @@ export const CTAContainer = styled.div`
     align-items: center;
     gap: 8px;
     padding: 16px;
-    border-top: 1px solid ${colors.gray[200]};
+    border-top: 1px solid ${(props) => props.theme.colors.border};
     width: calc(100% + 32px);
-    background: white;
+    background: ${(props) => props.theme.colors.bg};
     border-radius: 0 0 12px 12px;
     margin: 0 -16px;
 `;

--- a/smoke-test/tests/cypress/cypress/support/e2e.js
+++ b/smoke-test/tests/cypress/cypress/support/e2e.js
@@ -48,7 +48,10 @@ beforeEach(function () {
 
   cy.on("window:before:load", (win) => {
     win.localStorage.setItem(HOME_PAGE_REDESIGN_KEY, "false");
-    win.localStorage.setItem(NAV_BAR_STATE_KEY, JSON.stringify({ state: "COLLAPSED" }));
+    win.localStorage.setItem(
+      NAV_BAR_STATE_KEY,
+      JSON.stringify({ state: "COLLAPSED" }),
+    );
   });
 
   // Skip the introduce page for all tests

--- a/smoke-test/tests/cypress/cypress/support/e2e.js
+++ b/smoke-test/tests/cypress/cypress/support/e2e.js
@@ -44,9 +44,11 @@ beforeEach(function () {
   }
 
   const HOME_PAGE_REDESIGN_KEY = "showHomePageRedesign";
+  const NAV_BAR_STATE_KEY = "navBarState";
 
   cy.on("window:before:load", (win) => {
     win.localStorage.setItem(HOME_PAGE_REDESIGN_KEY, "false");
+    win.localStorage.setItem(NAV_BAR_STATE_KEY, JSON.stringify({ state: "COLLAPSED" }));
   });
 
   // Skip the introduce page for all tests


### PR DESCRIPTION
## Summary

- Collapse the redesigned left nav to **0px** when collapsed (was 60px) and keep search header / main content offsets and padding aligned with that behavior.
- **Default the nav to opened** for first-time users (no `localStorage` entry); persisted preference still wins. Remove the V2 home `useEffect` that called `setDefaultNavBarState` (and drop `Floating` / `setDefaultNavBarState` from `NavBarContext`).
- **Home V3 hero**: show `NavBarToggler` in the hero when the nav is collapsed so users can expand without relying on the global header toggler (still hidden on home).
- Move footer items into a scrollable **Account** group; tighten menu item spacing and nav width transition (**180ms ease-out**).
- **Cypress**: set `navBarState` to collapsed in `e2e.js` so specs that use `cy.contains` do not match sidebar labels when the default is opened.

OSS backport aligned with **acryldata/datahub-fork#9556** (SaaS), with OSS-only file shapes where the fork has extra UI (e.g. no free-trial branch in `SearchHeader`).

## Test plan

- [ ] Manual: nav redesign on — collapse to 0 width; expand; home V3 shows toggler in hero when collapsed; non-home shows fixed toggler at left edge.
- [ ] `yarn type-check` in `datahub-web-react`
- [ ] `./gradlew -x yarnInstall -x yarnGenerate :datahub-web-react:yarnLint -Pfile=...` on touched TS/TSX if needed
- [ ] Smoke Cypress subset or full matrix as you normally run for nav/search changes


Made with [Cursor](https://cursor.com)