### PR TITLE
fix(ingestion): fall back to default CLI version when config version …

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/CreateIngestionExecutionRequestResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/CreateIngestionExecutionRequestResolver.java
@@ -122,12 +122,11 @@ public class CreateIngestionExecutionRequestResolver
               recipe = injectRunId(recipe, executionRequestUrn.toString());
               recipe = IngestionUtils.injectPipelineName(recipe, ingestionSourceUrn.toString());
               arguments.put(RECIPE_ARG_NAME, recipe);
-              String version = ingestionSourceInfo.getConfig().getVersion();
               arguments.put(
                   VERSION_ARG_NAME,
-                  version != null && !version.isEmpty()
-                      ? version
-                      : _ingestionConfiguration.getDefaultCliVersion());
+                  IngestionUtils.resolveIngestionCliVersion(
+                      ingestionSourceInfo.getConfig().getVersion(),
+                      _ingestionConfiguration.getDefaultCliVersion()));
               String debugMode = "false";
               if (ingestionSourceInfo.getConfig().hasDebugMode()) {
                 debugMode = ingestionSourceInfo.getConfig().isDebugMode() ? "true" : "false";

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/CreateTestConnectionRequestResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/CreateTestConnectionRequestResolver.java
@@ -80,8 +80,9 @@ public class CreateTestConnectionRequestResolver implements DataFetcher<Completa
                 RECIPE_ARG_NAME,
                 IngestionUtils.injectPipelineName(
                     input.getRecipe(), executionRequestUrn.toString()));
-            if (input.getVersion() != null) {
-              arguments.put(VERSION_ARG_NAME, input.getVersion());
+            String testVersion = input.getVersion();
+            if (testVersion != null && !testVersion.trim().isEmpty()) {
+              arguments.put(VERSION_ARG_NAME, testVersion.trim());
             }
             execInput.setArgs(new StringMap(arguments));
 

--- a/ingestion-scheduler/src/main/java/com/datahub/metadata/ingestion/IngestionScheduler.java
+++ b/ingestion-scheduler/src/main/java/com/datahub/metadata/ingestion/IngestionScheduler.java
@@ -411,9 +411,9 @@ public class IngestionScheduler {
         arguments.put(RECIPE_ARGUMENT_NAME, recipe);
         arguments.put(
             VERSION_ARGUMENT_NAME,
-            ingestionSourceInfo.getConfig().hasVersion()
-                ? ingestionSourceInfo.getConfig().getVersion()
-                : ingestionConfiguration.getDefaultCliVersion());
+            IngestionUtils.resolveIngestionCliVersion(
+                ingestionSourceInfo.getConfig().getVersion(),
+                ingestionConfiguration.getDefaultCliVersion()));
         String debugMode = "false";
         if (ingestionSourceInfo.getConfig().hasDebugMode()) {
           debugMode = ingestionSourceInfo.getConfig().isDebugMode() ? "true" : "false";

--- a/metadata-service/configuration/src/main/resources/bootstrap_mcps.yaml
+++ b/metadata-service/configuration/src/main/resources/bootstrap_mcps.yaml
@@ -56,14 +56,14 @@ bootstrap:
 
     # Ingestion Recipes
     - name: ingestion-datahub-gc
-      version: v5
+      version: v6
       optional: false
       mcps_location: "bootstrap_mcps/ingestion-datahub-gc.yaml"
       values_env: "DATAHUB_GC_BOOTSTRAP_VALUES"
       revision_env: "DATAHUB_GC_BOOTSTRAP_REVISION"
 
     - name: ingestion-datahub-documents
-      version: v1
+      version: v2
       optional: true
       mcps_location: "bootstrap_mcps/ingestion-datahub-documents.yaml"
       values_env: "DATAHUB_DOCUMENTS_BOOTSTRAP_VALUES"

--- a/metadata-service/configuration/src/main/resources/bootstrap_mcps/ingestion-datahub-documents.yaml
+++ b/metadata-service/configuration/src/main/resources/bootstrap_mcps/ingestion-datahub-documents.yaml
@@ -12,7 +12,9 @@
       timezone: '{{schedule.timezone}}{{^schedule.timezone}}UTC{{/schedule.timezone}}'
       interval: '{{schedule.interval}}{{^schedule.interval}}*/15 * * * *{{/schedule.interval}}'
     config:
-      version: '{{&ingestion.version}}{{^ingestion.version}}{{/ingestion.version}}'
+{{#ingestion.version}}
+      version: '{{{.}}}'
+{{/ingestion.version}}
       recipe:
         source:
           type: datahub-documents

--- a/metadata-service/configuration/src/main/resources/bootstrap_mcps/ingestion-datahub-gc.yaml
+++ b/metadata-service/configuration/src/main/resources/bootstrap_mcps/ingestion-datahub-gc.yaml
@@ -12,7 +12,9 @@
       timezone: '{{schedule.timezone}}{{^schedule.timezone}}UTC{{/schedule.timezone}}'
       interval: '{{schedule.interval}}{{^schedule.interval}}0 1 * * *{{/schedule.interval}}'
     config:
-      version: '{{&ingestion.version}}{{^ingestion.version}}{{/ingestion.version}}'
+{{#ingestion.version}}
+      version: '{{{.}}}'
+{{/ingestion.version}}
       recipe:
         source:
           type: 'datahub-gc'

--- a/metadata-utils/src/main/java/com/linkedin/metadata/utils/IngestionUtils.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/utils/IngestionUtils.java
@@ -1,6 +1,7 @@
 package com.linkedin.metadata.utils;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -9,6 +10,20 @@ public class IngestionUtils {
   private static final String PIPELINE_NAME = "pipeline_name";
 
   private IngestionUtils() {}
+
+  /**
+   * Returns the CLI version to pass into an ingestion execution when the ingestion source config
+   * may carry an optional version (including blank strings from templated bootstrap YAML). Blank or
+   * null configured values fall back to the server default.
+   */
+  @Nonnull
+  public static String resolveIngestionCliVersion(
+      @Nullable String configuredVersion, @Nonnull String defaultCliVersion) {
+    if (configuredVersion != null && !configuredVersion.trim().isEmpty()) {
+      return configuredVersion.trim();
+    }
+    return defaultCliVersion;
+  }
 
   /**
    * Injects a pipeline_name into a recipe if there isn't a pipeline_name already there. The

--- a/metadata-utils/src/test/java/com/linkedin/metadata/utils/IngestionUtilsTest.java
+++ b/metadata-utils/src/test/java/com/linkedin/metadata/utils/IngestionUtilsTest.java
@@ -17,6 +17,20 @@ public class IngestionUtilsTest {
   }
 
   @Test
+  public void resolveIngestionCliVersionUsesDefaultForNullBlankOrEmpty() {
+    String def = "0.12.3";
+    assertEquals(def, IngestionUtils.resolveIngestionCliVersion(null, def));
+    assertEquals(def, IngestionUtils.resolveIngestionCliVersion("", def));
+    assertEquals(def, IngestionUtils.resolveIngestionCliVersion("   ", def));
+  }
+
+  @Test
+  public void resolveIngestionCliVersionUsesConfiguredWhenPresent() {
+    assertEquals("1.2.3", IngestionUtils.resolveIngestionCliVersion("1.2.3", "0.12.3"));
+    assertEquals("1.2.3", IngestionUtils.resolveIngestionCliVersion("  1.2.3  ", "0.12.3"));
+  }
+
+  @Test
   public void injectPipelineNameWhenNotThere() {
     String recipe =
         "{\"source\":{\"type\":\"snowflake\",\"config\":{\"stateful_ingestion\":{\"enabled\":true}}}}";


### PR DESCRIPTION
…is blank

Scheduled runs used hasVersion() and forwarded empty strings from bootstrap templates, breaking pip installs. Centralize resolution in IngestionUtils, fix MCP Mustache so version is omitted unless set, and bump bootstrap step versions so upgrades reapply the templates.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
