### PR TITLE
fix(quickstart): move mysql defaults to 8.4

### DIFF
--- a/.github/workflows/security-scan-linear-sync.yml
+++ b/.github/workflows/security-scan-linear-sync.yml
@@ -78,13 +78,16 @@ env:
   RESOLVED_SCAN_WITH_TRIVY: ${{ github.event_name == 'workflow_run' && 'true' || (inputs.scan_with_trivy && 'true' || 'false') }}
   RESOLVED_SCAN_WITH_GRYPE: ${{ github.event_name == 'workflow_run' && 'true' || (inputs.scan_with_grype && 'true' || 'false') }}
   RESOLVED_SCAN_ARTIFACT_RETENTION_DAYS: ${{ github.event_name == 'workflow_run' && '5' || github.event.inputs.scan_artifact_retention_days }}
+  # This workflow resolves published image refs directly (for example `acryldata/datahub-gms:head`),
+  # so Docker Hub uses the namespace prefix rather than `docker.io/...`.
+  RESOLVED_DOCKER_REGISTRY: ${{ vars.DOCKER_REGISTRY || 'acryldata' }}
 
 jobs:
   select-runner:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     env:
-      DOCKER_REGISTRY: ${{ vars.DOCKER_REGISTRY }}
+      DOCKER_REGISTRY: ${{ env.RESOLVED_DOCKER_REGISTRY }}
       DEPOT_PROJECT_ID: ${{ vars.DEPOT_PROJECT_ID }}
     outputs:
       image_matrix_json: ${{ steps.build-image-matrix.outputs.matrix_json }}
@@ -101,6 +104,7 @@ jobs:
           EVENT_INPUTS_JSON: ${{ toJSON(github.event.inputs) }}
           EVENT_NAME: ${{ github.event_name }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
+          CONFIGURED_DOCKER_REGISTRY: ${{ vars.DOCKER_REGISTRY }}
           INPUT_DOCKER_TAG: ${{ env.RESOLVED_DOCKER_TAG }}
           INPUT_SCAN_WITH_TRIVY: ${{ env.RESOLVED_SCAN_WITH_TRIVY }}
           INPUT_SCAN_WITH_GRYPE: ${{ env.RESOLVED_SCAN_WITH_GRYPE }}
@@ -117,8 +121,11 @@ jobs:
               exit 1
             fi
           fi
+          if [[ -z "${CONFIGURED_DOCKER_REGISTRY:-}" ]]; then
+            echo "::notice::vars.DOCKER_REGISTRY is unset; defaulting to DockerHub namespace acryldata."
+          fi
           if [[ -z "${DOCKER_REGISTRY:-}" ]]; then
-            echo "::error::Organization / repository var DOCKER_REGISTRY is required; this workflow only pulls images from the registry (no local Gradle build path)."
+            echo "::error::DOCKER_REGISTRY resolved empty. Set vars.DOCKER_REGISTRY or use the default DockerHub namespace fallback."
             exit 1
           fi
           if [[ "${INPUT_SCAN_WITH_TRIVY}" != "true" && "${INPUT_SCAN_WITH_GRYPE}" != "true" ]]; then
@@ -286,7 +293,7 @@ jobs:
           }
 
           if [[ -z "${REGISTRY_PREFIX}" ]]; then
-            echo "::error::vars.DOCKER_REGISTRY is not set. This workflow only resolves images from the container registry (no local build path)."
+            echo "::error::DOCKER_REGISTRY resolved empty. Set vars.DOCKER_REGISTRY or use the default DockerHub namespace fallback."
             exit 1
           fi
 
@@ -430,7 +437,7 @@ jobs:
     runs-on: ${{ needs.select-runner.outputs.runner }}
     timeout-minutes: 300
     env:
-      DOCKER_REGISTRY: ${{ vars.DOCKER_REGISTRY }}
+      DOCKER_REGISTRY: ${{ env.RESOLVED_DOCKER_REGISTRY }}
     steps:
       - name: Checkout (Trivy config)
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -563,7 +570,7 @@ jobs:
     runs-on: ${{ needs.select-runner.outputs.grype_runner }}
     timeout-minutes: 300
     env:
-      DOCKER_REGISTRY: ${{ vars.DOCKER_REGISTRY }}
+      DOCKER_REGISTRY: ${{ env.RESOLVED_DOCKER_REGISTRY }}
     steps:
       - *ecr_login
 
@@ -660,7 +667,7 @@ jobs:
     runs-on: ${{ needs.select-runner.outputs.default_gh_runner }}
     timeout-minutes: 60
     env:
-      DOCKER_REGISTRY: ${{ vars.DOCKER_REGISTRY }}
+      DOCKER_REGISTRY: ${{ env.RESOLVED_DOCKER_REGISTRY }}
     steps:
       # Cone checkout of `.github/scripts` for the sync entrypoint and `utils/` imports.
       - name: Checkout (sync script)

--- a/docker/docker-compose-without-neo4j.override.yml
+++ b/docker/docker-compose-without-neo4j.override.yml
@@ -39,8 +39,8 @@ services:
       - DATAHUB_PRECREATE_TOPICS=${DATAHUB_PRECREATE_TOPICS:-false}
   mysql:
     hostname: mysql
-    image: mysql:${DATAHUB_MYSQL_VERSION:-8.2}
-    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_bin --default-authentication-plugin=mysql_native_password
+    image: mysql:${DATAHUB_MYSQL_VERSION:-8.4}
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_bin --default-authentication-plugin=caching_sha2_password
     ports:
       - ${DATAHUB_MAPPED_MYSQL_PORT:-3306}:3306
     env_file: mysql/env/docker.env

--- a/docker/docker-compose.override.yml
+++ b/docker/docker-compose.override.yml
@@ -31,8 +31,8 @@ services:
     - DATAHUB_PRECREATE_TOPICS=${DATAHUB_PRECREATE_TOPICS:-false}
   mysql:
     hostname: mysql
-    image: mysql:${DATAHUB_MYSQL_VERSION:-8.2}
-    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_bin --default-authentication-plugin=mysql_native_password
+    image: mysql:${DATAHUB_MYSQL_VERSION:-8.4}
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_bin --default-authentication-plugin=caching_sha2_password
     ports:
     - ${DATAHUB_MAPPED_MYSQL_PORT:-3306}:3306
     env_file: mysql/env/docker.env

--- a/docker/mysql/docker-compose.mysql.yml
+++ b/docker/mysql/docker-compose.mysql.yml
@@ -3,7 +3,7 @@
 services:
   mysql:
     hostname: mysql
-    image: mysql:${DATAHUB_MYSQL_VERSION:-8.2}
+    image: mysql:${DATAHUB_MYSQL_VERSION:-8.4}
     env_file: env/docker.env
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
     ports:

--- a/docker/profiles/docker-compose.prerequisites.yml
+++ b/docker/profiles/docker-compose.prerequisites.yml
@@ -129,7 +129,7 @@ services:
   mysql:
     profiles: *mysql-profiles
     hostname: mysql
-    image: mysql:${DATAHUB_MYSQL_VERSION:-8.2}
+    image: mysql:${DATAHUB_MYSQL_VERSION:-8.4}
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_bin --default-authentication-plugin=caching_sha2_password
     ports:
       - ${DATAHUB_MAPPED_MYSQL_PORT:-3306}:3306

--- a/docker/quickstart/docker-compose-without-neo4j.quickstart.yml
+++ b/docker/quickstart/docker-compose-without-neo4j.quickstart.yml
@@ -188,7 +188,7 @@ services:
     labels:
       datahub_setup_job: true
   mysql:
-    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_bin --default-authentication-plugin=mysql_native_password
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_bin --default-authentication-plugin=caching_sha2_password
     environment:
     - MYSQL_DATABASE=datahub
     - MYSQL_USER=datahub
@@ -202,7 +202,7 @@ services:
       test: mysqladmin ping -h mysql -u $$MYSQL_USER --password=$$MYSQL_PASSWORD
       timeout: 5s
     hostname: mysql
-    image: mysql:${DATAHUB_MYSQL_VERSION:-8.2}
+    image: mysql:${DATAHUB_MYSQL_VERSION:-8.4}
     ports:
     - ${DATAHUB_MAPPED_MYSQL_PORT:-3306}:3306
     restart: on-failure

--- a/docker/quickstart/docker-compose.quickstart-profile.yml
+++ b/docker/quickstart/docker-compose.quickstart-profile.yml
@@ -287,7 +287,7 @@ services:
       interval: 2s
       retries: 5
       start_period: 20s
-    image: mysql:8.2
+    image: mysql:8.4
     networks:
       default: null
     ports:

--- a/docker/quickstart/docker-compose.quickstart.yml
+++ b/docker/quickstart/docker-compose.quickstart.yml
@@ -195,7 +195,7 @@ services:
     labels:
       datahub_setup_job: true
   mysql:
-    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_bin --default-authentication-plugin=mysql_native_password
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_bin --default-authentication-plugin=caching_sha2_password
     environment:
     - MYSQL_DATABASE=datahub
     - MYSQL_USER=datahub
@@ -209,7 +209,7 @@ services:
       test: mysqladmin ping -h mysql -u $$MYSQL_USER --password=$$MYSQL_PASSWORD
       timeout: 5s
     hostname: mysql
-    image: mysql:${DATAHUB_MYSQL_VERSION:-8.2}
+    image: mysql:${DATAHUB_MYSQL_VERSION:-8.4}
     ports:
     - ${DATAHUB_MAPPED_MYSQL_PORT:-3306}:3306
     restart: on-failure

--- a/docker/quickstart/quickstart_version_mapping.yaml
+++ b/docker/quickstart/quickstart_version_mapping.yaml
@@ -29,7 +29,7 @@ quickstart_version_map:
   default:
     composefile_git_ref: v1.5.0.3
     docker_tag: v1.5.0.3
-    mysql_tag: "8.2"
+    mysql_tag: "8.4"
   # default:  # Use this to pin default to a specific version.
   #   composefile_git_ref: fd1bd51541a132017a648f4a2f037eec8f70ba26 # v0.10.0 + quickstart compose file fixes
   #   docker_tag: v0.10.0
@@ -37,25 +37,25 @@ quickstart_version_map:
   head:
     composefile_git_ref: master
     docker_tag: head
-    mysql_tag: "8.2"
+    mysql_tag: "8.4"
 
   # Must be v1.4.0.3+ so datahub-upgrade runs SqlSetup when DATAHUB_SQL_SETUP_ENABLED=true.
   v1.4.0:
     composefile_git_ref: v1.4.0.3
     docker_tag: v1.4.0.3
-    mysql_tag: "8.2"
+    mysql_tag: "8.4"
 
   # Locked for previous-release testing (compatibility/regression). Default is v1.4.0.3+.
   v1.3.0:
     composefile_git_ref: v1.3.0.1
     docker_tag: v1.3.0.1
-    mysql_tag: "8.2"
+    mysql_tag: "8.4"
 
   # v0.13.0 we upgraded MySQL image for EOL
   v0.13.0:
     composefile_git_ref: master
     docker_tag: v0.13.0
-    mysql_tag: "8.2"
+    mysql_tag: "8.4"
 
   # v0.9.6 images contain security vulnerabilities
   v0.9.6:

--- a/metadata-ingestion/src/datahub/cli/quickstart_versioning.py
+++ b/metadata-ingestion/src/datahub/cli/quickstart_versioning.py
@@ -105,7 +105,7 @@ class QuickstartVersionMappingConfig(BaseModel):
             return QuickstartVersionMappingConfig(
                 quickstart_version_map={
                     "default": QuickstartExecutionPlan(
-                        composefile_git_ref="master", docker_tag="head", mysql_tag="8.2"
+                        composefile_git_ref="master", docker_tag="head", mysql_tag="8.4"
                     ),
                 }
             )
@@ -117,7 +117,7 @@ class QuickstartVersionMappingConfig(BaseModel):
             try:
                 release = cls._fetch_latest_version()
                 config.quickstart_version_map["stable"] = QuickstartExecutionPlan(
-                    composefile_git_ref=release, docker_tag=release, mysql_tag="8.2"
+                    composefile_git_ref=release, docker_tag=release, mysql_tag="8.4"
                 )
             except Exception:
                 click.echo(
@@ -139,8 +139,8 @@ class QuickstartVersionMappingConfig(BaseModel):
             requested_version = "default"
         composefile_git_ref = requested_version
         docker_tag = requested_version
-        # Default to 8.2 if not specified in version map
-        mysql_tag = "8.2"
+        # Default to 8.4 if not specified in version map
+        mysql_tag = "8.4"
         result = self.quickstart_version_map.get(
             requested_version,
             QuickstartExecutionPlan(

--- a/metadata-ingestion/tests/unit/cli/docker/test_quickstart_version_mapping.py
+++ b/metadata-ingestion/tests/unit/cli/docker/test_quickstart_version_mapping.py
@@ -12,7 +12,7 @@ example_version_mapper = QuickstartVersionMappingConfig.model_validate(
             "default": {
                 "composefile_git_ref": "master",
                 "docker_tag": "head",
-                "mysql_tag": "8.2",
+                "mysql_tag": "8.4",
             },
             "v0.9.6": {
                 "composefile_git_ref": "v0.9.6.1",
@@ -22,17 +22,17 @@ example_version_mapper = QuickstartVersionMappingConfig.model_validate(
             "v2.0.0": {
                 "composefile_git_ref": "v2.0.1",
                 "docker_tag": "v2.0.0",
-                "mysql_tag": "8.2",
+                "mysql_tag": "8.4",
             },
             "v1.2.0": {
                 "composefile_git_ref": "v1.2.0",
                 "docker_tag": "v1.2.0",
-                "mysql_tag": "8.2",
+                "mysql_tag": "8.4",
             },
             "stable": {
                 "composefile_git_ref": "v1.2.1",
                 "docker_tag": "v1.2.1",
-                "mysql_tag": "8.2",
+                "mysql_tag": "8.4",
             },
         },
     }
@@ -44,7 +44,7 @@ def test_quickstart_version_config():
     expected = QuickstartExecutionPlan(
         docker_tag="v1.2.0",
         composefile_git_ref="v1.2.0",
-        mysql_tag="8.2",
+        mysql_tag="8.4",
     )
     assert execution_plan == expected
 
@@ -54,7 +54,7 @@ def test_quickstart_version_config_default():
     expected = QuickstartExecutionPlan(
         docker_tag="v2.0.0",
         composefile_git_ref="v2.0.1",
-        mysql_tag="8.2",
+        mysql_tag="8.4",
     )
     assert execution_plan == expected
 
@@ -62,7 +62,7 @@ def test_quickstart_version_config_default():
 def test_quickstart_version_config_stable():
     execution_plan = example_version_mapper.get_quickstart_execution_plan("stable")
     expected = QuickstartExecutionPlan(
-        docker_tag="v1.2.1", composefile_git_ref="v1.2.1", mysql_tag="8.2"
+        docker_tag="v1.2.1", composefile_git_ref="v1.2.1", mysql_tag="8.4"
     )
     assert execution_plan == expected
 
@@ -71,13 +71,13 @@ def test_quickstart_forced_stable():
     example_version_mapper.quickstart_version_map["default"] = QuickstartExecutionPlan(
         composefile_git_ref="v1.2.0",
         docker_tag="head",
-        mysql_tag="8.2",
+        mysql_tag="8.4",
     )
     execution_plan = example_version_mapper.get_quickstart_execution_plan(None)
     expected = QuickstartExecutionPlan(
         docker_tag="head",
         composefile_git_ref="v1.2.0",
-        mysql_tag="8.2",
+        mysql_tag="8.4",
     )
     assert execution_plan == expected
 
@@ -95,7 +95,7 @@ def test_quickstart_forced_not_a_version_tag():
     expected = QuickstartExecutionPlan(
         docker_tag="NOT A VERSION",
         composefile_git_ref="NOT A VERSION",
-        mysql_tag="8.2",
+        mysql_tag="8.4",
     )
     assert execution_plan == expected
 
@@ -118,7 +118,7 @@ def test_quickstart_version_older_than_v1_2_0_uses_commit_hash():
                 "v1.1.0": {
                     "composefile_git_ref": "v1.1.0",
                     "docker_tag": "v1.1.0",
-                    "mysql_tag": "8.2",
+                    "mysql_tag": "8.4",
                 },
             },
         }
@@ -128,6 +128,6 @@ def test_quickstart_version_older_than_v1_2_0_uses_commit_hash():
     expected = QuickstartExecutionPlan(
         docker_tag="v1.1.0",
         composefile_git_ref="21726bc3341490f4182b904626c793091ac95edd",  # This should be the commit hash from line 168
-        mysql_tag="8.2",
+        mysql_tag="8.4",
     )
     assert execution_plan == expected


### PR DESCRIPTION
## Summary
- move DataHub quickstart MySQL defaults to 8.4 across compose files and version mapping
- update the quickstart version mapping test to match the new MySQL default
- restore a safe DockerHub namespace fallback in `security-scan-linear-sync` when `vars.DOCKER_REGISTRY` is unset

## Testing
- updated `metadata-ingestion/tests/unit/cli/docker/test_quickstart_version_mapping.py`
- validated `.github/workflows/security-scan-linear-sync.yml` with local YAML parsing and `git diff --check`

## Docs
- no docs changes

## Notes
- no breaking changes intended
