### PR TITLE
fix(security): Fix home page templates/module scope highjacking

### DIFF
--- a/metadata-service/services/src/main/java/com/linkedin/metadata/service/PageModuleService.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/service/PageModuleService.java
@@ -54,7 +54,8 @@ public class PageModuleService {
    * Upserts a DataHub page module. If the page module with the provided urn already exists, then it
    * will be overwritten.
    *
-   * <p>This method assumes that authorization has already been verified at the calling layer.
+   * <p>Callers must hold MANAGE_HOME_PAGE_TEMPLATES_PRIVILEGE to create or modify GLOBAL-scoped
+   * modules, or to modify any module whose existing scope is GLOBAL.
    *
    * @return the URN of the new page module.
    */
@@ -85,6 +86,27 @@ public class PageModuleService {
     // 2. Build Page Module Properties
     DataHubPageModuleProperties properties = new DataHubPageModuleProperties();
     DataHubPageModuleProperties existingProperties = getPageModuleProperties(opContext, moduleUrn);
+
+    // Prevent scope-hijacking: a low-privileged user must not be able to overwrite a GLOBAL module
+    // by supplying its URN with scope=PERSONAL in the request. Check the persisted scope, not the
+    // caller-supplied scope.
+    if (existingProperties != null
+        && existingProperties.getVisibility() != null
+        && PageModuleScope.GLOBAL.equals(existingProperties.getVisibility().getScope())
+        && !AuthUtil.isAuthorized(opContext, PoliciesConfig.MANAGE_HOME_PAGE_TEMPLATES_PRIVILEGE)) {
+      throw new UnauthorizedException(
+          String.format(
+              "User is unauthorized to modify global page module with urn %s", moduleUrn));
+    }
+
+    // Prevent privilege escalation: creating or re-scoping a module to GLOBAL also requires the
+    // manage privilege.
+    if (PageModuleScope.GLOBAL.equals(scope)
+        && !AuthUtil.isAuthorized(opContext, PoliciesConfig.MANAGE_HOME_PAGE_TEMPLATES_PRIVILEGE)) {
+      throw new UnauthorizedException(
+          "User is unauthorized to create or modify global page modules.");
+    }
+
     if (existingProperties != null) {
       properties = existingProperties;
     } else {

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/service/PageTemplateService.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/service/PageTemplateService.java
@@ -54,7 +54,8 @@ public class PageTemplateService {
    * Upserts a DataHub page template. If the page template with the provided urn already exists,
    * then it will be overwritten.
    *
-   * <p>This method assumes that authorization has already been verified at the calling layer.
+   * <p>Callers must hold MANAGE_HOME_PAGE_TEMPLATES_PRIVILEGE to create or modify GLOBAL-scoped
+   * templates, or to modify any template whose existing scope is GLOBAL.
    *
    * @return the URN of the new page template.
    */
@@ -85,6 +86,27 @@ public class PageTemplateService {
     DataHubPageTemplateProperties properties = new DataHubPageTemplateProperties();
     DataHubPageTemplateProperties existingProperties =
         getPageTemplateProperties(opContext, templateUrn);
+
+    // Prevent scope-hijacking: a low-privileged user must not be able to overwrite a GLOBAL
+    // template by supplying its URN with scope=PERSONAL in the request. Check the persisted scope,
+    // not the caller-supplied scope.
+    if (existingProperties != null
+        && existingProperties.getVisibility() != null
+        && PageTemplateScope.GLOBAL.equals(existingProperties.getVisibility().getScope())
+        && !AuthUtil.isAuthorized(opContext, PoliciesConfig.MANAGE_HOME_PAGE_TEMPLATES_PRIVILEGE)) {
+      throw new UnauthorizedException(
+          String.format(
+              "User is unauthorized to modify global page template with urn %s", templateUrn));
+    }
+
+    // Prevent privilege escalation: creating or re-scoping a template to GLOBAL also requires the
+    // manage privilege.
+    if (PageTemplateScope.GLOBAL.equals(scope)
+        && !AuthUtil.isAuthorized(opContext, PoliciesConfig.MANAGE_HOME_PAGE_TEMPLATES_PRIVILEGE)) {
+      throw new UnauthorizedException(
+          "User is unauthorized to create or modify global page templates.");
+    }
+
     if (existingProperties != null) {
       properties = existingProperties;
     } else {

--- a/metadata-service/services/src/test/java/com/linkedin/metadata/service/PageModuleServiceTest.java
+++ b/metadata-service/services/src/test/java/com/linkedin/metadata/service/PageModuleServiceTest.java
@@ -99,6 +99,93 @@ public class PageModuleServiceTest {
   }
 
   @Test
+  public void testUpsertGlobalPageModuleWithoutPrivilegeThrowsUnauthorized() throws Exception {
+    // A Reader-level user must not be able to create a GLOBAL-scoped module.
+    DataHubPageModuleType type = DataHubPageModuleType.RICH_TEXT;
+    PageModuleScope scope = PageModuleScope.GLOBAL;
+    DataHubPageModuleParams params = createTestParams();
+
+    when(mockOpContext.getAuditStamp()).thenReturn(createTestAuditStamp());
+
+    try (MockedStatic<AuthUtil> authUtilMock = mockStatic(AuthUtil.class)) {
+      authUtilMock
+          .when(
+              () ->
+                  AuthUtil.isAuthorized(
+                      mockOpContext, PoliciesConfig.MANAGE_HOME_PAGE_TEMPLATES_PRIVILEGE))
+          .thenReturn(false);
+
+      assertThrows(
+          UnauthorizedException.class,
+          () ->
+              service.upsertPageModule(mockOpContext, null, TEST_MODULE_NAME, type, scope, params));
+    }
+  }
+
+  @Test
+  public void testUpsertPersonalScopeOverGlobalModuleUrnThrowsUnauthorized() throws Exception {
+    // Core fix for GHSA-q33f-6fh7-4cgj: a user submits scope=PERSONAL with the URN of an existing
+    // GLOBAL module. The persisted scope must be checked, not the caller-supplied scope.
+    Urn moduleUrn = UrnUtils.getUrn(TEST_MODULE_URN);
+    DataHubPageModuleType type = DataHubPageModuleType.RICH_TEXT;
+    PageModuleScope scope = PageModuleScope.PERSONAL; // attacker supplies PERSONAL
+    DataHubPageModuleParams params = createTestParams();
+
+    // The module already exists in the store with GLOBAL scope.
+    DataHubPageModuleProperties globalProperties = createTestModuleProperties();
+    globalProperties.getVisibility().setScope(com.linkedin.module.PageModuleScope.GLOBAL);
+
+    when(mockOpContext.getAuditStamp()).thenReturn(createTestAuditStamp());
+    when(mockEntityClient.getV2(
+            any(),
+            eq(Constants.DATAHUB_PAGE_MODULE_ENTITY_NAME),
+            eq(moduleUrn),
+            eq(null),
+            eq(false)))
+        .thenReturn(createMockEntityResponse(moduleUrn, globalProperties));
+
+    try (MockedStatic<AuthUtil> authUtilMock = mockStatic(AuthUtil.class)) {
+      authUtilMock
+          .when(
+              () ->
+                  AuthUtil.isAuthorized(
+                      mockOpContext, PoliciesConfig.MANAGE_HOME_PAGE_TEMPLATES_PRIVILEGE))
+          .thenReturn(false);
+
+      assertThrows(
+          UnauthorizedException.class,
+          () ->
+              service.upsertPageModule(
+                  mockOpContext, TEST_MODULE_URN, TEST_MODULE_NAME, type, scope, params));
+    }
+  }
+
+  @Test
+  public void testUpsertGlobalPageModuleWithPrivilegeSucceeds() throws Exception {
+    DataHubPageModuleType type = DataHubPageModuleType.RICH_TEXT;
+    PageModuleScope scope = PageModuleScope.GLOBAL;
+    DataHubPageModuleParams params = createTestParams();
+
+    when(mockOpContext.getAuditStamp()).thenReturn(createTestAuditStamp());
+    when(mockEntityClient.batchIngestProposals(any(), any(), eq(false))).thenReturn(null);
+
+    try (MockedStatic<AuthUtil> authUtilMock = mockStatic(AuthUtil.class)) {
+      authUtilMock
+          .when(
+              () ->
+                  AuthUtil.isAuthorized(
+                      mockOpContext, PoliciesConfig.MANAGE_HOME_PAGE_TEMPLATES_PRIVILEGE))
+          .thenReturn(true);
+
+      Urn result =
+          service.upsertPageModule(mockOpContext, null, TEST_MODULE_NAME, type, scope, params);
+
+      assertNotNull(result);
+      verify(mockEntityClient, times(1)).batchIngestProposals(any(), any(), eq(false));
+    }
+  }
+
+  @Test
   public void testUpsertPageModuleFailure() throws Exception {
     // Arrange
     DataHubPageModuleType type = DataHubPageModuleType.RICH_TEXT;

--- a/metadata-service/services/src/test/java/com/linkedin/metadata/service/PageTemplateServiceTest.java
+++ b/metadata-service/services/src/test/java/com/linkedin/metadata/service/PageTemplateServiceTest.java
@@ -68,7 +68,7 @@ public class PageTemplateServiceTest {
             mockOpContext,
             templateUrn.toString(),
             rows,
-            PageTemplateScope.GLOBAL,
+            PageTemplateScope.PERSONAL,
             PageTemplateSurfaceType.HOME_PAGE);
     assertNotNull(urn);
     assertEquals(urn.toString(), templateUrn.toString());
@@ -87,7 +87,7 @@ public class PageTemplateServiceTest {
             mockOpContext,
             null, // null urn should generate a new one
             rows,
-            PageTemplateScope.GLOBAL,
+            PageTemplateScope.PERSONAL,
             PageTemplateSurfaceType.HOME_PAGE);
     assertNotNull(urn);
     assertTrue(urn.toString().startsWith("urn:li:dataHubPageTemplate:"));
@@ -106,7 +106,7 @@ public class PageTemplateServiceTest {
         mockOpContext,
         templateUrn.toString(),
         Collections.emptyList(),
-        PageTemplateScope.GLOBAL,
+        PageTemplateScope.PERSONAL,
         PageTemplateSurfaceType.HOME_PAGE);
   }
 
@@ -119,7 +119,7 @@ public class PageTemplateServiceTest {
         mockOpContext,
         templateUrn.toString(),
         rows,
-        PageTemplateScope.GLOBAL,
+        PageTemplateScope.PERSONAL,
         PageTemplateSurfaceType.HOME_PAGE);
   }
 
@@ -133,8 +133,95 @@ public class PageTemplateServiceTest {
         mockOpContext,
         templateUrn.toString(),
         rows,
-        PageTemplateScope.GLOBAL,
+        PageTemplateScope.PERSONAL,
         PageTemplateSurfaceType.HOME_PAGE);
+  }
+
+  @Test
+  public void testUpsertGlobalPageTemplateWithoutPrivilegeThrowsUnauthorized() throws Exception {
+    when(mockEntityClient.exists(any(), any())).thenReturn(true);
+
+    try (MockedStatic<AuthUtil> authUtilMock = mockStatic(AuthUtil.class)) {
+      authUtilMock
+          .when(
+              () ->
+                  AuthUtil.isAuthorized(
+                      mockOpContext, PoliciesConfig.MANAGE_HOME_PAGE_TEMPLATES_PRIVILEGE))
+          .thenReturn(false);
+
+      assertThrows(
+          UnauthorizedException.class,
+          () ->
+              service.upsertPageTemplate(
+                  mockOpContext,
+                  null,
+                  createTestRows(),
+                  PageTemplateScope.GLOBAL,
+                  PageTemplateSurfaceType.HOME_PAGE));
+    }
+  }
+
+  @Test
+  public void testUpsertPersonalScopeOverGlobalTemplateUrnThrowsUnauthorized() throws Exception {
+    // Mirrors GHSA-q33f-6fh7-4cgj for templates: attacker supplies scope=PERSONAL with the URN of
+    // an existing GLOBAL template. The persisted scope must be checked, not the input scope.
+    DataHubPageTemplateProperties globalProperties = createTestTemplateProperties();
+    globalProperties.getVisibility().setScope(PageTemplateScope.GLOBAL);
+
+    EntityResponse mockResponse = mock(EntityResponse.class);
+    EnvelopedAspectMap aspectMap = new EnvelopedAspectMap();
+    EnvelopedAspect aspect = new EnvelopedAspect();
+    aspect.setValue(new com.linkedin.entity.Aspect(globalProperties.data()));
+    aspectMap.put(Constants.DATAHUB_PAGE_TEMPLATE_PROPERTIES_ASPECT_NAME, aspect);
+    when(mockResponse.getAspects()).thenReturn(aspectMap);
+    when(mockEntityClient.getV2(any(), anyString(), eq(templateUrn), any(), eq(false)))
+        .thenReturn(mockResponse);
+    when(mockEntityClient.exists(any(), any())).thenReturn(true);
+
+    try (MockedStatic<AuthUtil> authUtilMock = mockStatic(AuthUtil.class)) {
+      authUtilMock
+          .when(
+              () ->
+                  AuthUtil.isAuthorized(
+                      mockOpContext, PoliciesConfig.MANAGE_HOME_PAGE_TEMPLATES_PRIVILEGE))
+          .thenReturn(false);
+
+      assertThrows(
+          UnauthorizedException.class,
+          () ->
+              service.upsertPageTemplate(
+                  mockOpContext,
+                  templateUrn.toString(),
+                  createTestRows(),
+                  PageTemplateScope.PERSONAL, // attacker supplies PERSONAL
+                  PageTemplateSurfaceType.HOME_PAGE));
+    }
+  }
+
+  @Test
+  public void testUpsertGlobalPageTemplateWithPrivilegeSucceeds() throws Exception {
+    when(mockEntityClient.batchIngestProposals(any(), anyList(), eq(false))).thenReturn(null);
+    when(mockEntityClient.exists(any(), any())).thenReturn(true);
+
+    try (MockedStatic<AuthUtil> authUtilMock = mockStatic(AuthUtil.class)) {
+      authUtilMock
+          .when(
+              () ->
+                  AuthUtil.isAuthorized(
+                      mockOpContext, PoliciesConfig.MANAGE_HOME_PAGE_TEMPLATES_PRIVILEGE))
+          .thenReturn(true);
+
+      Urn urn =
+          service.upsertPageTemplate(
+              mockOpContext,
+              null,
+              createTestRows(),
+              PageTemplateScope.GLOBAL,
+              PageTemplateSurfaceType.HOME_PAGE);
+
+      assertNotNull(urn);
+      verify(mockEntityClient, times(1)).batchIngestProposals(any(), anyList(), eq(false));
+    }
   }
 
   @Test
@@ -152,7 +239,7 @@ public class PageTemplateServiceTest {
             mockOpContext,
             templateUrn.toString(),
             rows,
-            PageTemplateScope.GLOBAL,
+            PageTemplateScope.PERSONAL,
             PageTemplateSurfaceType.HOME_PAGE,
             assetSummary);
 


### PR DESCRIPTION
Fixes an issue raised by customers where users could send in a `PERSONAL` value for `scope` in graphql and make changes to global home page modules and templates, changing the default global template for everyone.

Now we properly guard against that and check for the proper permissions for `GLOBAL` scope modules and templates.


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
