### PR TITLE
fix(security): Validate URLs before rendering links with them in the app

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/LinkUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/LinkUtils.java
@@ -19,7 +19,10 @@ import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.entity.EntityUtils;
 import io.datahubproject.metadata.context.OperationContext;
+import java.net.URI;
+import java.util.Locale;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -27,6 +30,10 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class LinkUtils {
+  // Only permit navigation schemes. Dangerous pseudo-schemes (javascript:, data:, vbscript:, etc.)
+  // are excluded to prevent stored-XSS when URLs are rendered as <a href> attributes.
+  private static final Set<String> ALLOWED_URL_SCHEMES = Set.of("http", "https", "ftp", "mailto");
+
   private static final ConjunctivePrivilegeGroup ALL_PRIVILEGES_GROUP =
       new ConjunctivePrivilegeGroup(
           ImmutableList.of(PoliciesConfig.EDIT_ENTITY_PRIVILEGE.getType()));
@@ -316,7 +323,27 @@ public class LinkUtils {
     } catch (Exception e) {
       throw new IllegalArgumentException(
           String.format(
-              "Failed to change institutional memory for resource %s. Expected an url.",
+              "Failed to change institutional memory for resource %s. Expected a url.",
+              resourceUrn));
+    }
+
+    // The Url constructor is a thin string wrapper with no scheme enforcement. Reject dangerous
+    // pseudo-schemes (javascript:, data:, vbscript:, etc.) that can execute code when a browser
+    // navigates to the stored URL.
+    try {
+      final String scheme = URI.create(url).getScheme();
+      if (scheme == null || !ALLOWED_URL_SCHEMES.contains(scheme.toLowerCase(Locale.ROOT))) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Failed to change institutional memory for resource %s. URL scheme '%s' is not allowed.",
+                resourceUrn, scheme));
+      }
+    } catch (IllegalArgumentException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Failed to change institutional memory for resource %s. Expected a valid URL.",
               resourceUrn));
     }
   }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/mutate/util/LinkUtilsTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/mutate/util/LinkUtilsTest.java
@@ -496,4 +496,40 @@ public class LinkUtilsTest {
     // Execute - should not throw exception
     LinkUtils.validateUpdateInput(mockOpContext, TEST_URL, NEW_URL, resourceUrn, mockEntityService);
   }
+
+  @Test
+  public void testValidateUrlRejectsDangerousSchemes() {
+    String[] dangerousUrls = {
+      "javascript:alert(1)",
+      "javascript:void(0)",
+      "JAVASCRIPT:alert(document.cookie)",
+      "data:text/html,<script>alert(1)</script>",
+      "data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==",
+      "vbscript:MsgBox(1)",
+    };
+
+    for (String url : dangerousUrls) {
+      final String finalUrl = url;
+      assertThrows(
+          IllegalArgumentException.class,
+          () ->
+              LinkUtils.validateAddRemoveInput(
+                  mockOpContext, finalUrl, resourceUrn, mockEntityService));
+    }
+  }
+
+  @Test
+  public void testValidateUrlAllowsSafeSchemes() throws Exception {
+    String[] safeUrls = {
+      "https://example.com/path?query=value",
+      "http://example.com",
+      "ftp://files.example.com/file.txt",
+      "mailto:user@example.com",
+    };
+
+    for (String url : safeUrls) {
+      // Should not throw
+      LinkUtils.validateAddRemoveInput(mockOpContext, url, resourceUrn, mockEntityService);
+    }
+  }
 }

--- a/datahub-web-react/src/app/entityV2/dataJob/tabs/RunsTab.tsx
+++ b/datahub-web-react/src/app/entityV2/dataJob/tabs/RunsTab.tsx
@@ -12,6 +12,7 @@ import {
 } from '@app/ingest/source/utils';
 import { CompactEntityNameList } from '@app/recommendations/renderer/component/CompactEntityNameList';
 import { scrollToTop } from '@app/shared/searchUtils';
+import { safeUrl } from '@app/shared/urlUtils';
 
 import { useGetExecutionRunsQuery } from '@graphql/runs.generated';
 import { DataProcessInstanceRunResultType, DataProcessRunStatus } from '@types';
@@ -116,7 +117,7 @@ export const RunsTab = () => {
             render: (externalUrl) =>
                 externalUrl && (
                     <Tooltip title="View task run details">
-                        <ExternalUrlLink href={externalUrl}>
+                        <ExternalUrlLink href={safeUrl(externalUrl)}>
                             <DeliveredProcedureOutlined />
                         </ExternalUrlLink>
                     </Tooltip>

--- a/datahub-web-react/src/app/entityV2/dataset/profile/OperationsTab.tsx
+++ b/datahub-web-react/src/app/entityV2/dataset/profile/OperationsTab.tsx
@@ -14,6 +14,7 @@ import {
 import { CompactEntityNameList } from '@app/recommendations/renderer/component/CompactEntityNameList';
 import { formatDuration } from '@app/shared/formatDuration';
 import { scrollToTop } from '@app/shared/searchUtils';
+import { safeUrl } from '@app/shared/urlUtils';
 
 import { GetDatasetRunsQuery, useGetDatasetRunsQuery } from '@graphql/dataset.generated';
 import { DataProcessInstanceRunResultType, DataProcessRunStatus, EntityType, RelationshipDirection } from '@types';
@@ -129,7 +130,7 @@ export const OperationsTab = () => {
             render: (externalUrl) =>
                 externalUrl && (
                     <Tooltip title="View task run details">
-                        <ExternalUrlLink href={externalUrl}>
+                        <ExternalUrlLink href={safeUrl(externalUrl)}>
                             <DeliveredProcedureOutlined />
                         </ExternalUrlLink>
                     </Tooltip>

--- a/datahub-web-react/src/app/entityV2/glossaryTerm/profile/GlossaryTermHeader.tsx
+++ b/datahub-web-react/src/app/entityV2/glossaryTerm/profile/GlossaryTermHeader.tsx
@@ -2,6 +2,7 @@ import { Divider, Space, Typography } from 'antd';
 import React from 'react';
 
 import { AvatarsGroup } from '@app/shared/avatar';
+import { safeUrl } from '@app/shared/urlUtils';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 
 type Props = {
@@ -20,7 +21,7 @@ export default function GlossaryTermHeader({ definition, sourceRef, sourceUrl, o
                     <Typography.Text>Source</Typography.Text>
                     <Typography.Text strong>{sourceRef}</Typography.Text>
                     {sourceUrl && (
-                        <a href={decodeURIComponent(sourceUrl)} target="_blank" rel="noreferrer">
+                        <a href={safeUrl(decodeURIComponent(sourceUrl))} target="_blank" rel="noreferrer">
                             view source
                         </a>
                     )}

--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/AboutSection/SourceRefSection.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/AboutSection/SourceRefSection.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 
 import { useEntityData } from '@app/entity/shared/EntityContext';
 import { SidebarSection } from '@app/entityV2/shared/containers/profile/sidebar/SidebarSection';
+import { safeUrl } from '@app/shared/urlUtils';
 
 const StyledAnchor = styled.a`
     text-decoration: none;
@@ -23,7 +24,7 @@ export default function SourceRefSection() {
             title="Source"
             content={
                 sourceUrl ? (
-                    <StyledAnchor href={sourceUrl} target="_blank" rel="noreferrer">
+                    <StyledAnchor href={safeUrl(sourceUrl)} target="_blank" rel="noreferrer">
                         <Button variant="text" color="violet">
                             <Icon icon={Link} size="md" color="inherit" />
                             {sourceRef}

--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/LinkButton.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/LinkButton.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { LinkIcon } from '@app/entityV2/shared/components/links/LinkIcon';
+import { safeUrl } from '@app/shared/urlUtils';
 
 import { InstitutionalMemoryMetadata } from '@types';
 
@@ -16,7 +17,7 @@ interface Props {
 
 export default function LinkButton({ link }: Props) {
     return (
-        <StyledAnchor href={link.url} target="_blank" rel="noreferrer">
+        <StyledAnchor href={safeUrl(link.url)} target="_blank" rel="noreferrer">
             <Button variant="text" color="violet">
                 <LinkIcon url={link.url} />
                 {link.description || link.label}

--- a/datahub-web-react/src/app/entityV2/shared/externalUrl/ExternalLink.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/externalUrl/ExternalLink.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { Popover } from '@src/alchemy-components';
+import { safeUrl } from '@src/app/shared/urlUtils';
 import useMeasureIfTrancated from '@src/app/shared/useMeasureIfTruncated';
 
 const Link = styled.a<{ $isEntityPageHeader?: boolean }>`
@@ -51,7 +52,7 @@ export default function ExternalLink({ href, label, onClick, className, isEntity
     return (
         <Popover content={isHorizontallyTruncated ? <PopoverWrapper>{label}</PopoverWrapper> : undefined}>
             <Link
-                href={href}
+                href={safeUrl(href)}
                 target="_blank"
                 onClick={onClick}
                 className={className}

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Validations/assertion/profile/shared/result/AssertionResultPopoverContent.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Validations/assertion/profile/shared/result/AssertionResultPopoverContent.tsx
@@ -15,6 +15,7 @@ import {
     getFormattedExpectedResultText,
     getFormattedReasonText,
 } from '@app/entityV2/shared/tabs/Dataset/Validations/assertion/profile/summary/shared/resultMessageUtils';
+import { safeUrl } from '@app/shared/urlUtils';
 
 import { Assertion, AssertionResult, AssertionResultType, AssertionRunEvent } from '@types';
 
@@ -227,7 +228,7 @@ const ExternalResultsSection = ({ assertion, result }: { assertion: Assertion; r
             externalResultsSections.push(
                 <ThinDivider key="external-results-link-divider" />,
                 <PlatformRow key="external-results-link">
-                    <a href={result.externalUrl} target="_blank" rel="noopener noreferrer">
+                    <a href={safeUrl(result.externalUrl)} target="_blank" rel="noopener noreferrer">
                         View results in{' '}
                         {assertion.platform?.name && assertion.platform?.name?.toLowerCase() !== 'unknown'
                             ? assertion.platform?.name

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Documentation/components/LinkList.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Documentation/components/LinkList.tsx
@@ -10,6 +10,7 @@ import { EditLinkModal } from '@app/entityV2/shared/components/links/EditLinkMod
 import { LinkIcon } from '@app/entityV2/shared/components/links/LinkIcon';
 import { useLinkUtils } from '@app/entityV2/shared/components/links/useLinkUtils';
 import { formatDateString } from '@app/entityV2/shared/containers/profile/utils';
+import { safeUrl } from '@app/shared/urlUtils';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 
 import { InstitutionalMemoryMetadata } from '@types';
@@ -97,7 +98,7 @@ export const LinkList = () => {
                             <List.Item.Meta
                                 title={
                                     <Typography.Title level={5}>
-                                        <a href={link.url} target="_blank" rel="noreferrer">
+                                        <a href={safeUrl(link.url)} target="_blank" rel="noreferrer">
                                             <ListOffsetIcon>
                                                 <LinkIcon url={link.url} />
                                             </ListOffsetIcon>

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Documentation/components/RelatedLinkItem.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Documentation/components/RelatedLinkItem.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 
 import { LinkIcon } from '@app/entityV2/shared/components/links/LinkIcon';
 import { formatDateString } from '@app/entityV2/shared/containers/profile/utils';
+import { safeUrl } from '@app/shared/urlUtils';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 import { Button } from '@src/alchemy-components';
 
@@ -112,7 +113,7 @@ export const RelatedLinkItem: React.FC<RelatedLinkItemProps> = ({ link, onEdit, 
                     <LinkIcon url={link.url} />
                 </IconContainer>
                 <ContentContainer>
-                    <TitleLink href={link.url} target="_blank" rel="noreferrer">
+                    <TitleLink href={safeUrl(link.url)} target="_blank" rel="noreferrer">
                         {link.description || link.label}
                     </TitleLink>
                     <Description>

--- a/datahub-web-react/src/app/entityV2/summary/links/LinkItem.tsx
+++ b/datahub-web-react/src/app/entityV2/summary/links/LinkItem.tsx
@@ -10,6 +10,7 @@ import { LinkIcon } from '@app/entityV2/shared/components/links/LinkIcon';
 import { formatDateString } from '@app/entityV2/shared/containers/profile/utils';
 import { useLinkPermission } from '@app/entityV2/summary/links/useLinkPermission';
 import { toRelativeTimeString } from '@app/shared/time/timeUtils';
+import { safeUrl } from '@app/shared/urlUtils';
 import { useEntityRegistryV2 } from '@app/useEntityRegistry';
 
 import { InstitutionalMemoryMetadata } from '@types';
@@ -60,7 +61,7 @@ export default function LinkItem({ link, setSelectedLink, setShowConfirmDelete, 
     const label = link.description || link.label;
 
     return (
-        <a href={link.url} target="_blank" rel="noreferrer" data-testid={`${link.url}-${label}`}>
+        <a href={safeUrl(link.url)} target="_blank" rel="noreferrer" data-testid={`${link.url}-${label}`}>
             <LinkContainer>
                 <LeftSection>
                     <LinkIcon url={link.url} />

--- a/datahub-web-react/src/app/homeV3/modules/link/LinkModule.tsx
+++ b/datahub-web-react/src/app/homeV3/modules/link/LinkModule.tsx
@@ -8,6 +8,7 @@ import SmallModule from '@app/homeV3/module/components/SmallModule';
 import { ModuleProps } from '@app/homeV3/module/types';
 import ImageOrIcon from '@app/homeV3/modules/link/ImageOrIcon';
 import { DescriptionContainer, NameContainer } from '@app/homeV3/styledComponents';
+import { safeUrl } from '@app/shared/urlUtils';
 
 const Container = styled.div`
     display: flex;
@@ -40,7 +41,7 @@ export default function LinkModule(props: ModuleProps) {
 
     function goToLink() {
         if (linkParams?.linkUrl) {
-            window.open(linkParams.linkUrl, '_blank');
+            window.open(safeUrl(linkParams.linkUrl), '_blank');
             analytics.event({
                 type: EventType.HomePageTemplateModuleLinkClick,
                 link: linkParams.linkUrl,
@@ -82,7 +83,7 @@ export default function LinkModule(props: ModuleProps) {
                     </TextSection>
                 </LeftSection>
                 <RightSection>
-                    <a href={linkParams?.linkUrl} target="_blank" rel="noopener noreferrer">
+                    <a href={safeUrl(linkParams?.linkUrl)} target="_blank" rel="noopener noreferrer">
                         <Icon icon={ArrowUpRight} size="lg" />
                     </a>
                 </RightSection>

--- a/datahub-web-react/src/app/shared/__tests__/urlUtils.test.ts
+++ b/datahub-web-react/src/app/shared/__tests__/urlUtils.test.ts
@@ -1,0 +1,53 @@
+import { safeUrl } from '@app/shared/urlUtils';
+
+describe('safeUrl', () => {
+    it('allows http URLs', () => {
+        expect(safeUrl('http://example.com')).toBe('http://example.com');
+    });
+
+    it('allows https URLs', () => {
+        expect(safeUrl('https://example.com/path?q=1')).toBe('https://example.com/path?q=1');
+    });
+
+    it('allows ftp URLs', () => {
+        expect(safeUrl('ftp://files.example.com/file.txt')).toBe('ftp://files.example.com/file.txt');
+    });
+
+    it('allows mailto URLs', () => {
+        expect(safeUrl('mailto:user@example.com')).toBe('mailto:user@example.com');
+    });
+
+    it('blocks javascript: scheme', () => {
+        // eslint-disable-next-line no-script-url
+        expect(safeUrl('javascript:alert(1)')).toBe('about:blank');
+    });
+
+    it('blocks javascript: scheme case-insensitively', () => {
+        // eslint-disable-next-line no-script-url
+        expect(safeUrl('JAVASCRIPT:alert(document.cookie)')).toBe('about:blank');
+    });
+
+    it('blocks data: scheme', () => {
+        expect(safeUrl('data:text/html,<script>alert(1)</script>')).toBe('about:blank');
+    });
+
+    it('blocks data: base64 scheme', () => {
+        expect(safeUrl('data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==')).toBe('about:blank');
+    });
+
+    it('blocks vbscript: scheme', () => {
+        expect(safeUrl('vbscript:MsgBox(1)')).toBe('about:blank');
+    });
+
+    it('returns empty string for null', () => {
+        expect(safeUrl(null)).toBe('');
+    });
+
+    it('returns empty string for undefined', () => {
+        expect(safeUrl(undefined)).toBe('');
+    });
+
+    it('returns relative paths unchanged', () => {
+        expect(safeUrl('/some/path')).toBe('/some/path');
+    });
+});

--- a/datahub-web-react/src/app/shared/urlUtils.ts
+++ b/datahub-web-react/src/app/shared/urlUtils.ts
@@ -1,0 +1,19 @@
+const SAFE_URL_SCHEMES = new Set(['http:', 'https:', 'ftp:', 'mailto:']);
+
+/**
+ * Returns the URL unchanged if its scheme is in the safe allowlist (http, https, ftp, mailto).
+ * Returns 'about:blank' for dangerous pseudo-schemes (javascript:, data:, vbscript:, etc.)
+ * to prevent stored XSS when persisted URLs are rendered as <a href> attributes.
+ *
+ * Relative URLs (no scheme) are returned unchanged — they inherit the page's scheme.
+ */
+export function safeUrl(url: string | null | undefined): string {
+    if (!url) return '';
+    try {
+        const { protocol } = new URL(url);
+        return SAFE_URL_SCHEMES.has(protocol) ? url : 'about:blank';
+    } catch {
+        // URL constructor throws for relative paths ("/some/path", "../foo") — those are safe.
+        return url;
+    }
+}


### PR DESCRIPTION
Fixes a security issue where we aren't properly validating our URLs against malicious actors. The main thing we need to check is the url scheme and make sure it's one of the allowed schemes so no one injects javascript or some other bad-actor script/link.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
