### PR TITLE
fix(ui): Fix directing users to SSO from signup link

### DIFF
--- a/datahub-web-react/src/app/auth/signupV2/SignUpModal.tsx
+++ b/datahub-web-react/src/app/auth/signupV2/SignUpModal.tsx
@@ -1,8 +1,10 @@
 import { useReactiveVar } from '@apollo/client';
 import { Modal } from '@components';
 import { Form, message } from 'antd';
+import * as QueryString from 'query-string';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useHistory } from 'react-router';
+import { useLocation } from 'react-router-dom';
 
 import analytics, { EventType } from '@app/analytics';
 import { isLoggedInVar } from '@app/auth/checkAuthStatus';
@@ -18,6 +20,7 @@ import { useAcceptRoleMutation } from '@graphql/mutations.generated';
 
 export default function SignUpModal() {
     const history = useHistory();
+    const location = useLocation();
 
     const [form] = Form.useForm();
 
@@ -26,6 +29,24 @@ export default function SignUpModal() {
 
     const isLoggedIn = useReactiveVar(isLoggedInVar);
     const inviteToken = useGetInviteTokenFromUrlParams();
+
+    useEffect(() => {
+        const params = QueryString.parse(location.search, { decode: true });
+        if (params.redirect_on_sso) {
+            fetch(resolveRuntimePath('/sso'), {
+                method: 'HEAD',
+                redirect: 'manual',
+            })
+                .then((response) => {
+                    if (response.type === 'opaqueredirect' || response.status === 302) {
+                        window.location.href = resolveRuntimePath('/sso');
+                    }
+                })
+                .catch(() => {
+                    // SSO not configured or error - stay on signup
+                });
+        }
+    }, [location.search]);
 
     const [acceptRoleMutation] = useAcceptRoleMutation();
 


### PR DESCRIPTION
Fixes a regression once we moved to a new login/signup page where we didn't bring the pre-existing logic to redirect to `/sso` if the `redirect_on_sso` query param is included on invite links. This PR brings back that old behavior.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
