### PR TITLE
fix(ingest/dataplex): name the actual GCP permission in project-number resolution error

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex.py
@@ -292,7 +292,8 @@ class DataplexSource(StatefulIngestionSourceBase, TestableSource):
 
             if self.config.include_glossary_term_associations:
                 # Project numbers are required for the lookupEntryLinks term entry path.
-                # Requires roles/resourcemanager.projectViewer on all configured projects.
+                # Requires a role granting resourcemanager.projects.get (e.g. roles/browser)
+                # on all configured projects.
                 try:
                     self.ctx_data.project_numbers = _resolve_project_numbers(
                         self._project_ids, credentials
@@ -302,7 +303,8 @@ class DataplexSource(StatefulIngestionSourceBase, TestableSource):
                         title="Failed to resolve GCP project numbers",
                         message=(
                             "Could not resolve project numbers via the Resource Manager API. "
-                            "Ensure the service account has roles/resourcemanager.projectViewer "
+                            "Ensure the service account has a role granting "
+                            "resourcemanager.projects.get (e.g. roles/browser) "
                             "on all configured projects."
                         ),
                         context=str(self._project_ids),

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_config.py
@@ -228,8 +228,9 @@ class DataplexConfig(
         description=(
             "Whether to ingest term-to-asset associations via the Dataplex lookupEntryLinks API. "
             "For each ingested term, all entries_locations are queried per project to find linked "
-            "assets. Requires roles/resourcemanager.projectViewer on all configured projects to "
-            "resolve GCP project numbers needed by the lookupEntryLinks API."
+            "assets. Requires a role granting resourcemanager.projects.get (e.g. roles/browser) "
+            "on all configured projects to resolve GCP project numbers needed by the "
+            "lookupEntryLinks API."
         ),
     )
 


### PR DESCRIPTION
## Summary

The customer-facing failure message raised when the Resource Manager API cannot resolve project numbers (and the matching code comment plus the `include_glossary_term_associations` config field description) referenced `roles/resourcemanager.projectViewer`. That predefined role does not exist in GCP, so customers hitting this message could not find the role and filed support tickets asking what to grant.

Name the actual required permission (`resourcemanager.projects.get`) and point at `roles/browser` as the lightweight role that grants it. This matches the wording already used in `DataplexConfig`'s class docstring at the top of `dataplex_config.py`.

See the [GCP Resource Manager roles reference](https://cloud.google.com/iam/docs/understanding-roles#resource-manager-roles) for the full list of `roles/resourcemanager.*` predefined roles (no `projectViewer` is defined).

Companion docs PR: #17495