### PR TITLE
fix(playwright): fix glossary and lineage tests after navbar updates

### DIFF
--- a/e2e-test/ui/playwright/tests/glossary/v2-glossary-term.spec.ts
+++ b/e2e-test/ui/playwright/tests/glossary/v2-glossary-term.spec.ts
@@ -37,6 +37,9 @@ test.describe('glossary term entity operations', () => {
 
   test.beforeEach(async ({ page, logger, logDir }) => {
     glossaryPage = new GlossaryPage(page, logger, logDir);
+    await page.addInitScript(() => {
+      localStorage.setItem('navBarState', '{"state":"COLLAPSED"}');
+    });
   });
 
   test('can search related entities by query', async () => {

--- a/e2e-test/ui/playwright/tests/lineage-v2/v2-lineage-column-path.spec.ts
+++ b/e2e-test/ui/playwright/tests/lineage-v2/v2-lineage-column-path.spec.ts
@@ -18,7 +18,10 @@ const DATASET_URN = 'urn:li:dataset:(urn:li:dataPlatform:hdfs,SamplePlaywrightHd
 const UPSTREAM_URN = 'urn:li:dataset:(urn:li:dataPlatform:kafka,SamplePlaywrightKafkaDataset,PROD)';
 
 test.describe('column-Level lineage and impact analysis path test', () => {
-  test.beforeEach(async ({ apiMock }) => {
+  test.beforeEach(async ({ page, apiMock }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('navBarState', '{"state":"COLLAPSED"}');
+    });
     await apiMock.setFeatureFlags({ lineageGraphV3: false });
   });
 


### PR DESCRIPTION
This PR fixes broken playwright tests after NavSidebar updates

Added collapsing of NavSidebar by default via localstorage

Examples: https://github.com/datahub-project/datahub/actions/runs/26077211766

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
