### PR TITLE
fix(ui/lineageV3): show column-level lineage on chart/dashboard endpoints

### DIFF
--- a/datahub-web-react/src/app/lineageV3/useComputeGraph/__tests__/getFineGrainedLineage.test.ts
+++ b/datahub-web-react/src/app/lineageV3/useComputeGraph/__tests__/getFineGrainedLineage.test.ts
@@ -159,4 +159,68 @@ describe('schemaFieldExists', () => {
         expect(schemaFieldExists('urn:li:dataset:1', 'userid', nodes)).toBe(false);
         expect(schemaFieldExists('urn:li:dataset:1', 'USERID', nodes)).toBe(false);
     });
+
+    // Entities that surface their columns via the `inputFields` aspect rather
+    // than `schemaMetadata` (Chart, Dashboard, DataJob) used to fail this
+    // existence check — which caused V3 to silently drop every column-level
+    // edge that touched a chart endpoint. These tests pin the fallback.
+    const createMockChartNode = (urn: string, inputFields?: { fieldPath: string }[]): LineageEntity => ({
+        id: urn,
+        urn,
+        type: EntityType.Chart,
+        entity: inputFields
+            ? ({
+                  urn,
+                  type: EntityType.Chart,
+                  name: 'chart',
+                  inputFields: {
+                      fields: inputFields.map((f) => ({ schemaField: f })),
+                  },
+              } as any)
+            : undefined,
+        isExpanded: {} as any,
+        fetchStatus: {} as any,
+        filters: {} as any,
+    });
+
+    it('returns true for a chart-side field surfaced via inputFields', () => {
+        const nodes = new Map([
+            [
+                'urn:li:chart:1',
+                createMockChartNode('urn:li:chart:1', [
+                    { fieldPath: 'orders_order_region' },
+                    { fieldPath: 'orders_order_count' },
+                ]),
+            ],
+        ]);
+
+        expect(schemaFieldExists('urn:li:chart:1', 'orders_order_region', nodes)).toBe(true);
+        expect(schemaFieldExists('urn:li:chart:1', 'orders_order_count', nodes)).toBe(true);
+    });
+
+    it('returns false for a chart-side field not present in inputFields', () => {
+        const nodes = new Map([
+            ['urn:li:chart:1', createMockChartNode('urn:li:chart:1', [{ fieldPath: 'orders_order_region' }])],
+        ]);
+
+        expect(schemaFieldExists('urn:li:chart:1', 'orders_order_count', nodes)).toBe(false);
+    });
+
+    it('returns false when chart has an inputFields aspect but no fields', () => {
+        const nodes = new Map([['urn:li:chart:1', createMockChartNode('urn:li:chart:1', [])]]);
+
+        expect(schemaFieldExists('urn:li:chart:1', 'whatever', nodes)).toBe(false);
+    });
+
+    it('normalizes V2 field paths for inputFields-based entities too', () => {
+        const nodes = new Map([
+            [
+                'urn:li:chart:1',
+                createMockChartNode('urn:li:chart:1', [{ fieldPath: '[version=2.0].[type=string].order_region' }]),
+            ],
+        ]);
+
+        // V1 query path should match the V2 inputFields path after normalisation
+        expect(schemaFieldExists('urn:li:chart:1', 'order_region', nodes)).toBe(true);
+    });
 });

--- a/datahub-web-react/src/app/lineageV3/useComputeGraph/getFineGrainedLineage.ts
+++ b/datahub-web-react/src/app/lineageV3/useComputeGraph/getFineGrainedLineage.ts
@@ -38,16 +38,25 @@ interface TentativeEdge {
  */
 export function schemaFieldExists(datasetUrn: string, fieldPath: string, nodes: NodeContext['nodes']): boolean {
     const node = nodes.get(datasetUrn);
-    if (!node?.entity?.schemaMetadata?.fields) {
+
+    // Field source priority: a dataset's schemaMetadata.fields, otherwise the
+    // entity's inputFields[].schemaField. Charts and dashboards don't have
+    // schemaMetadata in the GraphQL schema, but they DO have inputFields, so
+    // without this fallback their column-level lineage is silently dropped by
+    // the existence check below.
+    const schemaFields = node?.entity?.schemaMetadata?.fields;
+    const inputFields = node?.entity?.inputFields?.fields
+        ?.map((f) => f?.schemaField)
+        ?.filter((f): f is NonNullable<typeof f> => !!f);
+    const fields = schemaFields ?? inputFields;
+    if (!fields?.length) {
         return false;
     }
 
     // Normalize both paths to V1 format for comparison, since fineGrainedLineages paths
     // are downgraded to V1 in EntityRegistry but schema field paths may still be V2
     const normalizedFieldPath = downgradeV2FieldPath(fieldPath);
-    return node.entity.schemaMetadata.fields.some(
-        (field) => downgradeV2FieldPath(field.fieldPath) === normalizedFieldPath,
-    );
+    return fields.some((field) => downgradeV2FieldPath(field.fieldPath) === normalizedFieldPath);
 }
 
 /**


### PR DESCRIPTION
## Summary

Column-level lineage edges that terminate on a Chart or Dashboard are silently dropped by the V3 lineage UI, even when `inputFields` and `fineGrainedLineages` are present on the backend. The user-visible symptom is **"Column has no lineage"** on every chart column in `/lineage` (`is_lineage_mode=true`), regardless of the BI source (Lightdash, Looker, Tableau, …).

## Root cause

`schemaFieldExists` in `datahub-web-react/src/app/lineageV3/useComputeGraph/getFineGrainedLineage.ts` is called by `processEdge` to validate **both** endpoints of every `fineGrainedLineages` edge. It only consults `entity.schemaMetadata.fields`:

```ts
export function schemaFieldExists(datasetUrn, fieldPath, nodes) {
    const node = nodes.get(datasetUrn);
    if (!node?.entity?.schemaMetadata?.fields) {
        return false;
    }
    // …
}
```

The GraphQL `Chart` and `Dashboard` types **do not expose `schemaMetadata`** at all (see `datahub-graphql-core` / `entity.graphql`). Their columns are surfaced via the `inputFields` aspect (`InputFields { fields { schemaField { fieldPath, … } } }`). As a result `schemaFieldExists(chartUrn, fieldPath, …)` returns `false` for every chart column, `processEdge` discards the edge, and the column rail never lights up.

The bug is reproducible on `v1.5.0` through the latest `v1.5.0.6` and on `master`.

## Fix

Consult `entity.inputFields[].schemaField` as a fallback when `schemaMetadata` is unavailable. The existing V2 → V1 path normalisation is preserved.

```ts
const schemaFields = node?.entity?.schemaMetadata?.fields;
const inputFields = node?.entity?.inputFields?.fields
    ?.map((f) => f?.schemaField)
    ?.filter((f): f is NonNullable<typeof f> => !!f);
const fields = schemaFields ?? inputFields;
if (!fields?.length) {
    return false;
}
const normalizedFieldPath = downgradeV2FieldPath(fieldPath);
return fields.some((field) => downgradeV2FieldPath(field.fieldPath) === normalizedFieldPath);
```

The dataset code path is functionally unchanged (`schemaMetadata` still wins when present), so this is a strict additive fix.

## Reproduction (against a clean v1.5.0 quickstart)

```bash
datahub docker quickstart --version v1.5.0
```

Ingest one dataset with `schemaMetadata` and one chart whose `inputFields` point at the dataset's columns:

<details><summary>repro.py</summary>

```python
import json, os, urllib.request

GMS = os.environ.get("DH_GMS", "http://localhost:8080")
H = {"Content-Type": "application/json"}

DATASET = "urn:li:dataset:(urn:li:dataPlatform:clickhouse,test.orders,PROD)"
CHART = "urn:li:chart:(repro,region_summary)"


def ingest(mcp):
    req = urllib.request.Request(
        f"{GMS}/aspects?action=ingestProposal",
        data=json.dumps({"proposal": mcp}).encode(),
        headers=H,
    )
    return urllib.request.urlopen(req).read().decode()[:200]


ingest({
    "entityType": "dataset", "entityUrn": DATASET, "changeType": "UPSERT",
    "aspectName": "schemaMetadata",
    "aspect": {"contentType": "application/json", "value": json.dumps({
        "schemaName": "test.orders", "platform": "urn:li:dataPlatform:clickhouse",
        "version": 0,
        "created": {"time": 0, "actor": "urn:li:corpuser:repro"},
        "lastModified": {"time": 0, "actor": "urn:li:corpuser:repro"},
        "hash": "", "platformSchema": {"com.linkedin.schema.OtherSchema": {"rawSchema": ""}},
        "fields": [
            {"fieldPath": "order_id", "nullable": False,
             "type": {"type": {"com.linkedin.schema.NumberType": {}}},
             "nativeDataType": "UInt64", "recursive": False},
            {"fieldPath": "order_region", "nullable": True,
             "type": {"type": {"com.linkedin.schema.StringType": {}}},
             "nativeDataType": "LowCardinality(String)", "recursive": False},
        ],
    })},
})

ingest({
    "entityType": "chart", "entityUrn": CHART, "changeType": "UPSERT",
    "aspectName": "chartInfo",
    "aspect": {"contentType": "application/json", "value": json.dumps({
        "customProperties": {}, "title": "Region summary",
        "chartUrl": "http://localhost/chart/region_summary",
        "inputEdges": [{"destinationUrn": DATASET}], "type": "BAR",
        "lastModified": {
            "created": {"time": 0, "actor": "urn:li:corpuser:repro"},
            "lastModified": {"time": 0, "actor": "urn:li:corpuser:repro"},
        },
    })},
})

ingest({
    "entityType": "chart", "entityUrn": CHART, "changeType": "UPSERT",
    "aspectName": "inputFields",
    "aspect": {"contentType": "application/json", "value": json.dumps({
        "fields": [
            {"schemaFieldUrn": f"urn:li:schemaField:({DATASET},order_region)",
             "schemaField": {"fieldPath": "orders_order_region", "nullable": True,
                             "type": {"type": {"com.linkedin.schema.StringType": {}}},
                             "nativeDataType": "LowCardinality(String)", "recursive": False}},
            {"schemaFieldUrn": f"urn:li:schemaField:({DATASET},order_id)",
             "schemaField": {"fieldPath": "orders_order_count", "nullable": False,
                             "type": {"type": {"com.linkedin.schema.NumberType": {}}},
                             "nativeDataType": "UInt64", "recursive": False}},
        ],
    })},
})

# Force schemaField docs into the search index so the column rail can resolve.
for sf in [f"urn:li:schemaField:({DATASET},order_id)",
           f"urn:li:schemaField:({DATASET},order_region)",
           f"urn:li:schemaField:({CHART},orders_order_region)",
           f"urn:li:schemaField:({CHART},orders_order_count)"]:
    ingest({"entityType": "schemaField", "entityUrn": sf, "changeType": "UPSERT",
            "aspectName": "status",
            "aspect": {"contentType": "application/json",
                       "value": json.dumps({"removed": False})}})

print(f"http://localhost:9002/chart/{CHART}/Lineage?is_lineage_mode=true")
```

</details>

Then open the printed URL.

- **Before this PR:** clicking either chart column shows "Column has no lineage" on the right panel and no orange rail is drawn between chart and dataset columns.
- **After this PR:** the rail renders and the column highlights correctly trace `orders_order_region → order_region` and `orders_order_count → order_id`.

## Tests

`datahub-web-react/src/app/lineageV3/useComputeGraph/__tests__/getFineGrainedLineage.test.ts` is extended with the chart/`inputFields` fallback paths:

- chart-side field present in `inputFields` → `true`
- chart-side field missing from `inputFields` → `false`
- empty `inputFields.fields` → `false`
- V2 path in `inputFields` normalised against a V1 query path → `true`

All 15 tests in the suite pass:

```
$ yarn vitest run src/app/lineageV3/useComputeGraph/__tests__/getFineGrainedLineage.test.ts
 ✓ src/app/lineageV3/useComputeGraph/__tests__/getFineGrainedLineage.test.ts (15 tests)
   Tests  15 passed (15)
```

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (`fix(<scope>): <description>` format).
- [x] Tests for the changes have been added.
- [ ] No docs change required (this is a strict bug fix; no API or behaviour surface added).
- [ ] No breaking change / no entry needed in `docs/how/updating-datahub.md`.

Made with [Cursor](https://cursor.com)