### PR TITLE
fix(ingest/snowflake): allow overriding Snowsight base URL for private link

### DIFF
--- a/metadata-ingestion/docs/sources/snowflake/snowflake_post.md
+++ b/metadata-ingestion/docs/sources/snowflake/snowflake_post.md
@@ -230,3 +230,21 @@ Module behavior is constrained by source APIs, permissions, and metadata exposed
 ### Troubleshooting
 
 If ingestion fails, validate credentials, permissions, connectivity, and scope filters first. Then review ingestion logs for source-specific errors and adjust configuration accordingly.
+
+#### Snowsight Links Point to the Wrong URL (Private Link)
+
+By default, DataHub generates Snowsight links of the form `https://app.snowflake.com/<region>/<account>/...`. If Snowsight is only reachable through private link in your environment, these links will not work for your users.
+
+To fix this, set `snowsight_base_url` in the recipe to your private-link Snowsight URL. Retrieve the value from Snowflake as `ACCOUNTADMIN`:
+
+```sql
+SELECT SYSTEM$GET_PRIVATELINK_CONFIG();
+-- Use either snowsight-privatelink-url or regionless-snowsight-privatelink-url.
+```
+
+```yaml
+source:
+  type: snowflake
+  config:
+    snowsight_base_url: "https://app.us-east-1.privatelink.snowflakecomputing.com/"
+```

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_config.py
@@ -407,6 +407,20 @@ class SnowflakeV2Config(
         description="Whether to populate Snowsight url for Snowflake Objects",
     )
 
+    snowsight_base_url: Optional[str] = Field(
+        default=None,
+        description=(
+            "Override for the Snowsight base URL used when generating external URLs "
+            "for Snowflake assets. Set this when Snowsight is only reachable via "
+            "private link (for example "
+            "`https://app.<region>.privatelink.snowflakecomputing.com/` or "
+            "`https://app-<org>-<account>.privatelink.snowflakecomputing.com/`). "
+            "If unset, defaults to the public `app.snowflake.com` URL. The value "
+            "can be obtained by running "
+            "`SELECT SYSTEM$GET_PRIVATELINK_CONFIG()` in Snowflake as ACCOUNTADMIN."
+        ),
+    )
+
     _use_legacy_lineage_method_removed = pydantic_removed_field(
         "use_legacy_lineage_method",
         month="August",
@@ -590,6 +604,15 @@ class SnowflakeV2Config(
             raise ValueError(
                 "include_assertion_results must be True for include_externally_managed_dmfs to be set."
             )
+        return v
+
+    @field_validator("snowsight_base_url", mode="after")
+    @classmethod
+    def validate_snowsight_base_url(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return v
+        if not v.startswith(("http://", "https://")):
+            raise ValueError("snowsight_base_url must start with http:// or https://")
         return v
 
     @model_validator(mode="after")

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_utils.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_utils.py
@@ -50,7 +50,21 @@ class SnowsightUrlBuilder:
         region: str,
         privatelink: bool = False,
         snowflake_domain: str = DEFAULT_SNOWFLAKE_DOMAIN,
+        base_url_override: Optional[str] = None,
     ):
+        if base_url_override:
+            # Whether Snowsight is reachable via the public internet
+            # (app.snowflake.com) or only via private link depends on the
+            # customer's Snowflake configuration. When private link is required
+            # for the UI, customers set `snowsight_base_url` in the ingestion
+            # config to the value returned by `SYSTEM$GET_PRIVATELINK_CONFIG()`,
+            # which lands here verbatim (with trailing slash normalisation).
+            self.snowsight_base_url = (
+                base_url_override
+                if base_url_override.endswith("/")
+                else f"{base_url_override}/"
+            )
+            return
         cloud, cloud_region_id = self.get_cloud_region_from_snowflake_region_id(region)
         self.snowsight_base_url = self.create_snowsight_base_url(
             account_locator, cloud_region_id, cloud, privatelink, snowflake_domain
@@ -77,12 +91,9 @@ class SnowsightUrlBuilder:
                 url_cloud_provider_suffix = ""
             else:
                 url_cloud_provider_suffix = f".{cloud}"
-        # Note: Snowsight is always accessed via the public internet (app.snowflake.com)
-        # even for accounts using privatelink. Privatelink only applies to database connections,
-        # not the Snowsight web UI.
-        # Standard Snowsight URL format - works for most regions
         # China region may use app.snowflake.cn instead of app.snowflake.com. This is not documented, just
-        # guessing Based on existence of snowflake.cn domain (https://domainindex.com/domains/snowflake.cn)
+        # guessing based on existence of snowflake.cn domain (https://domainindex.com/domains/snowflake.cn).
+        # For private-link-only Snowsight, callers should pass `base_url_override` to `__init__`.
         if snowflake_domain == "snowflakecomputing.cn":
             url = f"https://app.snowflake.cn/{cloud_region_id}{url_cloud_provider_suffix}/{account_locator}/"
         else:

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
@@ -881,6 +881,7 @@ class SnowflakeV2Source(
                 # See https://docs.snowflake.com/en/user-guide/organizations-connect.html#private-connectivity-urls
                 privatelink=self.config.account_id.endswith(".privatelink"),
                 snowflake_domain=self.config.snowflake_domain,
+                base_url_override=self.config.snowsight_base_url,
             )
 
         except Exception as e:

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_source.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_source.py
@@ -816,6 +816,83 @@ def test_snowsight_privatelink_external_urls():
     )
 
 
+def test_snowsight_base_url_override_normalises_trailing_slash():
+    builder = SnowsightUrlBuilder(
+        account_locator="ignored",
+        region="aws_us_east_1",
+        privatelink=True,
+        base_url_override="https://app.us-east-1.privatelink.snowflakecomputing.com",
+    )
+    assert (
+        builder.snowsight_base_url
+        == "https://app.us-east-1.privatelink.snowflakecomputing.com/"
+    )
+
+
+def test_snowsight_base_url_override_keeps_existing_trailing_slash():
+    builder = SnowsightUrlBuilder(
+        account_locator="ignored",
+        region="aws_us_east_1",
+        privatelink=True,
+        base_url_override="https://app.us-east-1.privatelink.snowflakecomputing.com/",
+    )
+    assert (
+        builder.snowsight_base_url
+        == "https://app.us-east-1.privatelink.snowflakecomputing.com/"
+    )
+
+
+def test_snowsight_base_url_override_used_for_all_entity_urls():
+    override = "https://app-myorg-myacct.privatelink.snowflakecomputing.com/"
+    builder = SnowsightUrlBuilder(
+        account_locator="ignored_locator",
+        region="aws_us_east_1",
+        privatelink=True,
+        base_url_override=override,
+    )
+
+    assert (
+        builder.get_external_url_for_database("DB") == f"{override}#/data/databases/DB/"
+    )
+    assert (
+        builder.get_external_url_for_schema("SCH", "DB")
+        == f"{override}#/data/databases/DB/schemas/SCH/"
+    )
+    assert (
+        builder.get_external_url_for_table(
+            "T", "SCH", "DB", domain=SnowflakeObjectDomain.TABLE
+        )
+        == f"{override}#/data/databases/DB/schemas/SCH/table/T/"
+    )
+    assert (
+        builder.get_external_url_for_streamlit("APP", "SCH", "DB")
+        == f"{override}#/streamlit-apps/DB.SCH.APP"
+    )
+
+
+def test_snowflake_config_rejects_non_http_snowsight_base_url():
+    with pytest.raises(ValueError, match="must start with http"):
+        SnowflakeV2Config(
+            account_id="ab12345",
+            username="u",
+            password="p",
+            snowsight_base_url="app.example.privatelink.snowflakecomputing.com",
+        )
+
+
+def test_snowflake_config_accepts_https_snowsight_base_url():
+    cfg = SnowflakeV2Config(
+        account_id="ab12345",
+        username="u",
+        password="p",
+        snowsight_base_url="https://app.us-east-1.privatelink.snowflakecomputing.com/",
+    )
+    assert (
+        cfg.snowsight_base_url
+        == "https://app.us-east-1.privatelink.snowflakecomputing.com/"
+    )
+
+
 def test_snowflake_utils() -> None:
     assert_doctest(datahub.ingestion.source.snowflake.snowflake_utils)
 


### PR DESCRIPTION
## Summary

- Adds `snowsight_base_url` config to `SnowflakeV2Config` so customers whose Snowsight is reachable only through private link can produce working asset external URLs in DataHub.
- The override is used verbatim (with trailing-slash normalisation) by all four Snowsight URL helpers — database, schema, table/view/dynamic-table/semantic-view, and Streamlit app. Default `https://app.snowflake.com/<region>/<account>/...` behaviour is unchanged when the field is unset.
- Adds a validator that rejects values not starting with `http://` / `https://`, and a troubleshooting subsection in the Snowflake docs explaining how to retrieve the value via `SYSTEM\$GET_PRIVATELINK_CONFIG()`.

## Why not auto-detect

There are several valid Snowsight private-link URL shapes (region-based `app.<region>.privatelink.snowflakecomputing.com`, regionless org-based `app-<org>-<account>.privatelink.snowflakecomputing.com`, and customer CNAMEs). Inferring from the `.privatelink` suffix on `account_id` would be wrong for many accounts — a prior auto-derivation in `5b4a082c032` was removed for exactly that reason. Explicit config keeps the customer in control with no ambiguity.

## Test plan

- [x] Unit tests pass: `./gradlew :metadata-ingestion:testSingle -PtestFile=tests/unit/snowflake/test_snowflake_source.py` (70 tests, +5 new)
- [x] `./gradlew :metadata-ingestion:lint` clean (ruff check + format, mypy)
- [ ] Manual recipe verification with a private-link Snowflake account (cannot reproduce locally — relies on customer-side network configuration)

New tests:

- `test_snowsight_base_url_override_normalises_trailing_slash`
- `test_snowsight_base_url_override_keeps_existing_trailing_slash`
- `test_snowsight_base_url_override_used_for_all_entity_urls`
- `test_snowflake_config_rejects_non_http_snowsight_base_url`
- `test_snowflake_config_accepts_https_snowsight_base_url`