### PR TITLE
ci(playwright): publish HTML reports to S3 with VPN-gated access

### DIFF
--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -242,7 +242,7 @@ jobs:
 
       - name: Build Playwright shard matrix
         id: set-playwright-matrix
-        if: ${{ steps.publish.outputs.publish == 'true' || steps.ci-optimize.outputs.backend-change == 'true' || steps.ci-optimize.outputs.frontend-change == 'true' || steps.ci-optimize.outputs.playwright-change == 'true' }}
+        if: ${{ steps.ci-optimize.outputs.backend-change == 'true' || steps.ci-optimize.outputs.frontend-change == 'true' || steps.ci-optimize.outputs.playwright-change == 'true' }}
         run: |
           shard_count=$(( ${{ github.event.inputs.playwright_shard_count || env.PLAYWRIGHT_SHARD_COUNT }} ))
           matrix=''
@@ -1368,7 +1368,7 @@ jobs:
         continue-on-error: true
         with:
           role-to-assume: ${{ github.repository == 'datahub-project/datahub' && 'arn:aws:iam::863541928889:role/github-actions-playwright-reports-oss' || 'arn:aws:iam::863541928889:role/github-actions-playwright-reports-fork' }}
-          aws-region: us-east-1
+          aws-region: us-west-2
 
       - name: Publish Playwright report to S3
         id: publish-s3-report
@@ -1381,9 +1381,9 @@ jobs:
           fi
 
           if [[ "${{ github.repository }}" == "datahub-project/datahub" ]]; then
-            BUCKET="datahub-oss-ci-build-artifacts-dev"
+            BUCKET="datahub-oss-ci-build-artifacts.dev.dh-int.zone"
           else
-            BUCKET="datahub-fork-ci-build-artifacts-dev"
+            BUCKET="datahub-fork-ci-build-artifacts.dev.dh-int.zone"
           fi
 
           WORKFLOW_NAME=$(echo "${{ github.workflow }}" \
@@ -1397,7 +1397,7 @@ jobs:
             --cache-control "no-cache, no-store, must-revalidate" \
             --delete
 
-          REPORT_URL="http://${BUCKET}.s3-website-us-east-1.amazonaws.com/${S3_PATH}/index.html"
+          REPORT_URL="https://${BUCKET}/${S3_PATH}/index.html"
           echo "report_url=${REPORT_URL}" >> "$GITHUB_OUTPUT"
           echo "Published Playwright report to: ${REPORT_URL}"
 

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -1374,24 +1374,32 @@ jobs:
         id: publish-s3-report
         if: always()
         continue-on-error: true
+        env:
+          GH_REPOSITORY: ${{ github.repository }}
+          GH_WORKFLOW: ${{ github.workflow }}
+          GH_REPOSITORY_OWNER: ${{ github.repository_owner }}
+          GH_EVENT_REPOSITORY_NAME: ${{ github.event.repository.name }}
+          GH_EVENT_NAME: ${{ github.event_name }}
+          GH_RUN_ID: ${{ github.run_id }}
+          GH_RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           if [[ ! -d playwright-report ]] || [[ -z "$(ls -A playwright-report 2>/dev/null)" ]]; then
             echo "No playwright-report directory — skipping S3 upload"
             exit 0
           fi
 
-          if [[ "${{ github.repository }}" == "datahub-project/datahub" ]]; then
+          if [[ "$GH_REPOSITORY" == "datahub-project/datahub" ]]; then
             BUCKET="datahub-oss-ci-build-artifacts.dev.dh-int.zone"
           else
             BUCKET="datahub-fork-ci-build-artifacts.dev.dh-int.zone"
           fi
 
-          WORKFLOW_NAME=$(echo "${{ github.workflow }}" \
+          WORKFLOW_NAME=$(echo "$GH_WORKFLOW" \
             | tr '[:upper:]' '[:lower:]' \
             | sed 's/[^a-z0-9]/-/g' \
             | sed -E 's/-+/-/g' \
             | sed 's/^-//;s/-$//')
-          S3_PATH="${{ github.repository_owner }}/${{ github.event.repository.name }}/workflows/${{ github.event_name }}/${{ github.run_id }}_${{ github.run_attempt }}/${WORKFLOW_NAME}/playwright-report"
+          S3_PATH="${GH_REPOSITORY_OWNER}/${GH_EVENT_REPOSITORY_NAME}/workflows/${GH_EVENT_NAME}/${GH_RUN_ID}_${GH_RUN_ATTEMPT}/${WORKFLOW_NAME}/playwright-report"
 
           aws s3 sync playwright-report/ "s3://${BUCKET}/${S3_PATH}/" \
             --cache-control "no-cache, no-store, must-revalidate" \

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -1381,9 +1381,9 @@ jobs:
           fi
 
           if [[ "${{ github.repository }}" == "datahub-project/datahub" ]]; then
-            BUCKET="datahub-oss-ci-build-artifacts"
+            BUCKET="datahub-oss-ci-build-artifacts-dev"
           else
-            BUCKET="datahub-fork-ci-build-artifacts"
+            BUCKET="datahub-fork-ci-build-artifacts-dev"
           fi
 
           WORKFLOW_NAME=$(echo "${{ github.workflow }}" \

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -1367,7 +1367,7 @@ jobs:
         if: always()
         continue-on-error: true
         with:
-          role-to-assume: ${{ github.repository == 'datahub-project/datahub' && 'arn:aws:iam::863541928889:role/github-actions-playwright-reports-oss' || 'arn:aws:iam::863541928889:role/github-actions-playwright-reports-fork' }}
+          role-to-assume: ${{ github.repository == 'datahub-project/datahub' && secrets.PLAYWRIGHT_REPORTS_OSS_ROLE_ARN || secrets.PLAYWRIGHT_REPORTS_FORK_ROLE_ARN }}
           aws-region: us-west-2
 
       - name: Publish Playwright report to S3

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -1362,6 +1362,59 @@ jobs:
           path: playwright-report/
           retention-days: 5
 
+      - name: Configure AWS credentials for S3 report upload
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
+        if: always()
+        continue-on-error: true
+        with:
+          role-to-assume: ${{ github.repository == 'datahub-project/datahub' && 'arn:aws:iam::863541928889:role/github-actions-playwright-reports-oss' || 'arn:aws:iam::863541928889:role/github-actions-playwright-reports-fork' }}
+          aws-region: us-east-1
+
+      - name: Publish Playwright report to S3
+        id: publish-s3-report
+        if: always()
+        continue-on-error: true
+        run: |
+          if [[ ! -d playwright-report ]] || [[ -z "$(ls -A playwright-report 2>/dev/null)" ]]; then
+            echo "No playwright-report directory — skipping S3 upload"
+            exit 0
+          fi
+
+          if [[ "${{ github.repository }}" == "datahub-project/datahub" ]]; then
+            BUCKET="datahub-oss-ci-build-artifacts"
+          else
+            BUCKET="datahub-fork-ci-build-artifacts"
+          fi
+
+          WORKFLOW_NAME=$(echo "${{ github.workflow }}" \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed 's/[^a-z0-9]/-/g' \
+            | sed -E 's/-+/-/g' \
+            | sed 's/^-//;s/-$//')
+          S3_PATH="${{ github.repository_owner }}/${{ github.event.repository.name }}/workflows/${{ github.event_name }}/${{ github.run_id }}_${{ github.run_attempt }}/${WORKFLOW_NAME}/playwright-report"
+
+          aws s3 sync playwright-report/ "s3://${BUCKET}/${S3_PATH}/" \
+            --cache-control "no-cache, no-store, must-revalidate" \
+            --delete
+
+          REPORT_URL="http://${BUCKET}.s3-website-us-east-1.amazonaws.com/${S3_PATH}/index.html"
+          echo "report_url=${REPORT_URL}" >> "$GITHUB_OUTPUT"
+          echo "Published Playwright report to: ${REPORT_URL}"
+
+      - name: Add report link to GitHub Summary
+        if: ${{ always() && steps.publish-s3-report.outputs.report_url != '' }}
+        run: |
+          {
+            echo "## Playwright HTML Report"
+            echo ""
+            echo "| Resource | Link |"
+            echo "|----------|------|"
+            echo "| HTML Report (incl. Traces) | ${{ steps.publish-s3-report.outputs.report_url }} |"
+            echo ""
+            echo "> [!NOTE]"
+            echo "> Accessible from the DataHub VPN only."
+          } >> "$GITHUB_STEP_SUMMARY"
+
   publish_images:
     name: Update quickstart tag after tests pass on master
     runs-on: ${{ needs.setup.outputs.test_runner_type_small || 'ubuntu-latest' }}

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -242,7 +242,7 @@ jobs:
 
       - name: Build Playwright shard matrix
         id: set-playwright-matrix
-        if: ${{ steps.ci-optimize.outputs.backend-change == 'true' || steps.ci-optimize.outputs.frontend-change == 'true' || steps.ci-optimize.outputs.playwright-change == 'true' }}
+        if: ${{ steps.publish.outputs.publish == 'true' || steps.ci-optimize.outputs.backend-change == 'true' || steps.ci-optimize.outputs.frontend-change == 'true' || steps.ci-optimize.outputs.playwright-change == 'true' }}
         run: |
           shard_count=$(( ${{ github.event.inputs.playwright_shard_count || env.PLAYWRIGHT_SHARD_COUNT }} ))
           matrix=''

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -1403,6 +1403,7 @@ jobs:
 
           aws s3 sync playwright-report/ "s3://${BUCKET}/${S3_PATH}/" \
             --cache-control "no-cache, no-store, must-revalidate" \
+            --sse AES256 \
             --delete
 
           REPORT_URL="https://${BUCKET}/${S3_PATH}/index.html"

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -1367,7 +1367,7 @@ jobs:
         if: always()
         continue-on-error: true
         with:
-          role-to-assume: ${{ github.repository == 'datahub-project/datahub' && secrets.PLAYWRIGHT_REPORTS_OSS_ROLE_ARN || secrets.PLAYWRIGHT_REPORTS_FORK_ROLE_ARN }}
+          role-to-assume: ${{ secrets.PLAYWRIGHT_REPORTS_OSS_ROLE_ARN }}
           aws-region: us-west-2
 
       - name: Publish Playwright report to S3
@@ -1375,7 +1375,6 @@ jobs:
         if: always()
         continue-on-error: true
         env:
-          GH_REPOSITORY: ${{ github.repository }}
           GH_WORKFLOW: ${{ github.workflow }}
           GH_REPOSITORY_OWNER: ${{ github.repository_owner }}
           GH_EVENT_REPOSITORY_NAME: ${{ github.event.repository.name }}
@@ -1388,11 +1387,7 @@ jobs:
             exit 0
           fi
 
-          if [[ "$GH_REPOSITORY" == "datahub-project/datahub" ]]; then
-            BUCKET="datahub-oss-ci-build-artifacts.dev.dh-int.zone"
-          else
-            BUCKET="datahub-fork-ci-build-artifacts.dev.dh-int.zone"
-          fi
+          BUCKET="datahub-oss-ci-build-artifacts.dev.dh-int.zone"
 
           WORKFLOW_NAME=$(echo "$GH_WORKFLOW" \
             | tr '[:upper:]' '[:lower:]' \

--- a/.github/workflows/playwright-e2e-tests.yml
+++ b/.github/workflows/playwright-e2e-tests.yml
@@ -287,7 +287,7 @@ jobs:
         if: always()
         continue-on-error: true
         with:
-          role-to-assume: ${{ github.repository == 'datahub-project/datahub' && secrets.PLAYWRIGHT_REPORTS_OSS_ROLE_ARN || secrets.PLAYWRIGHT_REPORTS_FORK_ROLE_ARN }}
+          role-to-assume: ${{ secrets.PLAYWRIGHT_REPORTS_OSS_ROLE_ARN }}
           aws-region: us-west-2
 
       - name: Publish Playwright report to S3
@@ -295,7 +295,6 @@ jobs:
         if: always()
         continue-on-error: true
         env:
-          GH_REPOSITORY: ${{ github.repository }}
           GH_WORKFLOW: ${{ github.workflow }}
           GH_REPOSITORY_OWNER: ${{ github.repository_owner }}
           GH_EVENT_REPOSITORY_NAME: ${{ github.event.repository.name }}
@@ -308,11 +307,7 @@ jobs:
             exit 0
           fi
 
-          if [[ "$GH_REPOSITORY" == "datahub-project/datahub" ]]; then
-            BUCKET="datahub-oss-ci-build-artifacts.dev.dh-int.zone"
-          else
-            BUCKET="datahub-fork-ci-build-artifacts.dev.dh-int.zone"
-          fi
+          BUCKET="datahub-oss-ci-build-artifacts.dev.dh-int.zone"
 
           WORKFLOW_NAME=$(echo "$GH_WORKFLOW" \
             | tr '[:upper:]' '[:lower:]' \

--- a/.github/workflows/playwright-e2e-tests.yml
+++ b/.github/workflows/playwright-e2e-tests.yml
@@ -323,6 +323,7 @@ jobs:
 
           aws s3 sync playwright-report/ "s3://${BUCKET}/${S3_PATH}/" \
             --cache-control "no-cache, no-store, must-revalidate" \
+            --sse AES256 \
             --delete
 
           REPORT_URL="https://${BUCKET}/${S3_PATH}/index.html"

--- a/.github/workflows/playwright-e2e-tests.yml
+++ b/.github/workflows/playwright-e2e-tests.yml
@@ -288,7 +288,7 @@ jobs:
         continue-on-error: true
         with:
           role-to-assume: ${{ github.repository == 'datahub-project/datahub' && 'arn:aws:iam::863541928889:role/github-actions-playwright-reports-oss' || 'arn:aws:iam::863541928889:role/github-actions-playwright-reports-fork' }}
-          aws-region: us-east-1
+          aws-region: us-west-2
 
       - name: Publish Playwright report to S3
         id: publish-s3-report
@@ -301,9 +301,9 @@ jobs:
           fi
 
           if [[ "${{ github.repository }}" == "datahub-project/datahub" ]]; then
-            BUCKET="datahub-oss-ci-build-artifacts-dev"
+            BUCKET="datahub-oss-ci-build-artifacts.dev.dh-int.zone"
           else
-            BUCKET="datahub-fork-ci-build-artifacts-dev"
+            BUCKET="datahub-fork-ci-build-artifacts.dev.dh-int.zone"
           fi
 
           WORKFLOW_NAME=$(echo "${{ github.workflow }}" \
@@ -317,7 +317,7 @@ jobs:
             --cache-control "no-cache, no-store, must-revalidate" \
             --delete
 
-          REPORT_URL="http://${BUCKET}.s3-website-us-east-1.amazonaws.com/${S3_PATH}/index.html"
+          REPORT_URL="https://${BUCKET}/${S3_PATH}/index.html"
           echo "report_url=${REPORT_URL}" >> "$GITHUB_OUTPUT"
           echo "Published Playwright report to: ${REPORT_URL}"
 

--- a/.github/workflows/playwright-e2e-tests.yml
+++ b/.github/workflows/playwright-e2e-tests.yml
@@ -294,24 +294,32 @@ jobs:
         id: publish-s3-report
         if: always()
         continue-on-error: true
+        env:
+          GH_REPOSITORY: ${{ github.repository }}
+          GH_WORKFLOW: ${{ github.workflow }}
+          GH_REPOSITORY_OWNER: ${{ github.repository_owner }}
+          GH_EVENT_REPOSITORY_NAME: ${{ github.event.repository.name }}
+          GH_EVENT_NAME: ${{ github.event_name }}
+          GH_RUN_ID: ${{ github.run_id }}
+          GH_RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           if [[ ! -d playwright-report ]] || [[ -z "$(ls -A playwright-report 2>/dev/null)" ]]; then
             echo "No playwright-report directory — skipping S3 upload"
             exit 0
           fi
 
-          if [[ "${{ github.repository }}" == "datahub-project/datahub" ]]; then
+          if [[ "$GH_REPOSITORY" == "datahub-project/datahub" ]]; then
             BUCKET="datahub-oss-ci-build-artifacts.dev.dh-int.zone"
           else
             BUCKET="datahub-fork-ci-build-artifacts.dev.dh-int.zone"
           fi
 
-          WORKFLOW_NAME=$(echo "${{ github.workflow }}" \
+          WORKFLOW_NAME=$(echo "$GH_WORKFLOW" \
             | tr '[:upper:]' '[:lower:]' \
             | sed 's/[^a-z0-9]/-/g' \
             | sed -E 's/-+/-/g' \
             | sed 's/^-//;s/-$//')
-          S3_PATH="${{ github.repository_owner }}/${{ github.event.repository.name }}/workflows/${{ github.event_name }}/${{ github.run_id }}_${{ github.run_attempt }}/${WORKFLOW_NAME}/playwright-report"
+          S3_PATH="${GH_REPOSITORY_OWNER}/${GH_EVENT_REPOSITORY_NAME}/workflows/${GH_EVENT_NAME}/${GH_RUN_ID}_${GH_RUN_ATTEMPT}/${WORKFLOW_NAME}/playwright-report"
 
           aws s3 sync playwright-report/ "s3://${BUCKET}/${S3_PATH}/" \
             --cache-control "no-cache, no-store, must-revalidate" \

--- a/.github/workflows/playwright-e2e-tests.yml
+++ b/.github/workflows/playwright-e2e-tests.yml
@@ -301,9 +301,9 @@ jobs:
           fi
 
           if [[ "${{ github.repository }}" == "datahub-project/datahub" ]]; then
-            BUCKET="datahub-oss-ci-build-artifacts"
+            BUCKET="datahub-oss-ci-build-artifacts-dev"
           else
-            BUCKET="datahub-fork-ci-build-artifacts"
+            BUCKET="datahub-fork-ci-build-artifacts-dev"
           fi
 
           WORKFLOW_NAME=$(echo "${{ github.workflow }}" \

--- a/.github/workflows/playwright-e2e-tests.yml
+++ b/.github/workflows/playwright-e2e-tests.yml
@@ -287,7 +287,7 @@ jobs:
         if: always()
         continue-on-error: true
         with:
-          role-to-assume: ${{ github.repository == 'datahub-project/datahub' && 'arn:aws:iam::863541928889:role/github-actions-playwright-reports-oss' || 'arn:aws:iam::863541928889:role/github-actions-playwright-reports-fork' }}
+          role-to-assume: ${{ github.repository == 'datahub-project/datahub' && secrets.PLAYWRIGHT_REPORTS_OSS_ROLE_ARN || secrets.PLAYWRIGHT_REPORTS_FORK_ROLE_ARN }}
           aws-region: us-west-2
 
       - name: Publish Playwright report to S3

--- a/.github/workflows/playwright-e2e-tests.yml
+++ b/.github/workflows/playwright-e2e-tests.yml
@@ -233,6 +233,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [setup, playwright_test]
     if: ${{ !cancelled() && needs.playwright_test.result != 'skipped' }}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -278,3 +281,56 @@ jobs:
           name: playwright-html-report
           path: playwright-report/
           retention-days: 5
+
+      - name: Configure AWS credentials for S3 report upload
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
+        if: always()
+        continue-on-error: true
+        with:
+          role-to-assume: ${{ github.repository == 'datahub-project/datahub' && 'arn:aws:iam::863541928889:role/github-actions-playwright-reports-oss' || 'arn:aws:iam::863541928889:role/github-actions-playwright-reports-fork' }}
+          aws-region: us-east-1
+
+      - name: Publish Playwright report to S3
+        id: publish-s3-report
+        if: always()
+        continue-on-error: true
+        run: |
+          if [[ ! -d playwright-report ]] || [[ -z "$(ls -A playwright-report 2>/dev/null)" ]]; then
+            echo "No playwright-report directory — skipping S3 upload"
+            exit 0
+          fi
+
+          if [[ "${{ github.repository }}" == "datahub-project/datahub" ]]; then
+            BUCKET="datahub-oss-ci-build-artifacts"
+          else
+            BUCKET="datahub-fork-ci-build-artifacts"
+          fi
+
+          WORKFLOW_NAME=$(echo "${{ github.workflow }}" \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed 's/[^a-z0-9]/-/g' \
+            | sed -E 's/-+/-/g' \
+            | sed 's/^-//;s/-$//')
+          S3_PATH="${{ github.repository_owner }}/${{ github.event.repository.name }}/workflows/${{ github.event_name }}/${{ github.run_id }}_${{ github.run_attempt }}/${WORKFLOW_NAME}/playwright-report"
+
+          aws s3 sync playwright-report/ "s3://${BUCKET}/${S3_PATH}/" \
+            --cache-control "no-cache, no-store, must-revalidate" \
+            --delete
+
+          REPORT_URL="http://${BUCKET}.s3-website-us-east-1.amazonaws.com/${S3_PATH}/index.html"
+          echo "report_url=${REPORT_URL}" >> "$GITHUB_OUTPUT"
+          echo "Published Playwright report to: ${REPORT_URL}"
+
+      - name: Add report link to GitHub Summary
+        if: ${{ always() && steps.publish-s3-report.outputs.report_url != '' }}
+        run: |
+          {
+            echo "## Playwright HTML Report"
+            echo ""
+            echo "| Resource | Link |"
+            echo "|----------|------|"
+            echo "| HTML Report (incl. Traces) | ${{ steps.publish-s3-report.outputs.report_url }} |"
+            echo ""
+            echo "> [!NOTE]"
+            echo "> Accessible from the DataHub VPN only."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/e2e-test/ui/playwright/playwright.config.ts
+++ b/e2e-test/ui/playwright/playwright.config.ts
@@ -1,3 +1,4 @@
+// Playwright configuration for DataHub E2E tests
 import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({


### PR DESCRIPTION
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->

## Summary

Publishes Playwright HTML reports and traces to S3 after each CI run, with access gated to DataHub VPN only.

- Uploads reports to `datahub-oss-ci-build-artifacts.dev.dh-int.zone` (OSS) or `datahub-fork-ci-build-artifacts.dev.dh-int.zone` (fork) in `us-west-2`
- Report path: `<owner>/<repo>/workflows/<event>/<run_id>_<attempt>/<workflow>/<job>/playwright-report`
- Prints a direct HTTPS link in the GitHub Actions job summary after each run
- Access is restricted to DataHub VPN via S3 interface VPC endpoint + internal ALB (ALB + PrivateLink setup per [AWS reference architecture](https://aws.amazon.com/blogs/networking-and-content-delivery/hosting-internal-https-static-websites-with-alb-s3-and-privatelink/))
- Uses separate IAM OIDC roles for OSS (`datahub-project/datahub`) and fork (`acryldata/datahub-fork`) repos
- Playwright tests now also run on PRs when playwright/frontend/backend files change
- Fixes template injection (Aikido critical) by moving `github.*` context values into `env:` block

## Linear

https://linear.app/acryl-data/issue/PFP-4065/ci-changes-to-publish-playwright-reports-to-s3