### PR TITLE
feat(datahub-documents): better default behavior — auto-embed all unembedded docs with adoption tracking

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_config.py
@@ -89,11 +89,11 @@ class DataHubDocumentsSourceConfig(
     # Platform filtering (multi-platform support)
     platform_filter: Optional[list[str]] = Field(
         default=None,
-        description="Filter documents by platforms. "
-        "Default (None): Process all NATIVE documents (sourceType=NATIVE) regardless of platform. "
-        "To include external documents from specific platforms, add them here (e.g., ['notion', 'confluence']). "
-        "This will process NATIVE documents + EXTERNAL documents from the specified platforms. "
-        "Use ['*'] or ['ALL'] to process all documents regardless of source type or platform.",
+        description="Restrict which platforms are considered when adopting new unembedded documents. "
+        "Default (None): adopt unembedded documents from all platforms. "
+        "Set to a list of platform names (e.g., ['notion', 'confluence']) to restrict new adoptions "
+        "to those platforms. Previously adopted documents are always maintained regardless of this filter. "
+        "Use ['*'] or ['ALL'] as an explicit alias for 'all platforms'.",
     )
 
     # Optional URN filtering
@@ -103,10 +103,12 @@ class DataHubDocumentsSourceConfig(
     )
 
     include_unembedded: bool = Field(
-        default=False,
-        description="When True, include any document that has no semanticContent aspect yet, "
-        "regardless of platform_filter. Useful for initial backfill runs to catch all "
-        "documents that have never been embedded.",
+        default=True,
+        description="Automatically adopt and embed any document that has no semanticContent aspect yet, "
+        "regardless of platform_filter. Once adopted, the document is maintained (re-embedded on content "
+        "changes) across future runs. Documents that already have semanticContent when first seen are "
+        "left to the ingestion source that produced them. Set to False to disable this behavior and only "
+        "process documents matching platform_filter explicitly.",
     )
 
     # Mode selection
@@ -169,14 +171,6 @@ class DataHubDocumentsSourceConfig(
     @field_validator("platform_filter")
     @classmethod
     def validate_platform_filter(cls, v: list[str]) -> list[str]:
-        """Validate platform_filter.
-
-        Empty list is allowed (default - processes all NATIVE documents).
-        Non-empty list must contain at least one platform or wildcard.
-        """
-        # Empty list is valid (default behavior)
         if not v:
             return v
-        # Non-empty list must have at least one element
-        # (This check is redundant but kept for clarity)
         return v

--- a/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_config.py
@@ -102,6 +102,13 @@ class DataHubDocumentsSourceConfig(
         description="Specific document URNs to process (if None, process all matching platforms)",
     )
 
+    include_unembedded: bool = Field(
+        default=False,
+        description="When True, include any document that has no semanticContent aspect yet, "
+        "regardless of platform_filter. Useful for initial backfill runs to catch all "
+        "documents that have never been embedded.",
+    )
+
     # Mode selection
     event_mode: EventModeConfig = Field(
         default_factory=EventModeConfig,

--- a/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
@@ -869,7 +869,21 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
                         # We've embedded this before — maintain ownership going forward.
                         logger.debug(f"Maintaining {urn} — previously adopted")
                     elif urn in unembedded_urns:
-                        # New adoption: no semanticContent yet, ingestion didn't embed it.
+                        # New adoption candidate: no semanticContent yet.
+                        # Apply platform_filter to restrict new adoptions if specified.
+                        if (
+                            self.config.platform_filter
+                            and "*" not in self.config.platform_filter
+                            and "ALL" not in self.config.platform_filter
+                        ):
+                            platform = self._extract_platform_from_entity(entity)
+                            if platform not in self.config.platform_filter:
+                                logger.debug(
+                                    f"Skipping {urn} — platform '{platform}' not in "
+                                    f"platform_filter {self.config.platform_filter} "
+                                    "(new adoptions restricted)"
+                                )
+                                continue
                         logger.debug(
                             f"Adopting {urn} — no semanticContent aspect found"
                         )

--- a/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
@@ -723,6 +723,39 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
                 return parts[-1]
         return None
 
+    def _get_unembedded_urns(self) -> set[str]:
+        """Return the set of document URNs that have NO semanticContent aspect.
+
+        Uses a single Elasticsearch query: EXISTS on the 'embeddings' field
+        (which is indexed from semanticContent) with negated=True.  One round-trip
+        regardless of how many documents exist.
+        """
+        from datahub.ingestion.graph.filters import RawSearchFilterRule
+
+        no_embeddings_filter: RawSearchFilterRule = {
+            "field": "embeddings",
+            "condition": "EXISTS",
+            "values": [],
+            "negated": True,
+        }
+        try:
+            urns = set(
+                self.graph.get_urns_by_filter(
+                    entity_types=["document"],
+                    extraFilters=[no_embeddings_filter],
+                )
+            )
+            logger.info(
+                f"Elasticsearch filter found {len(urns)} documents without semanticContent."
+            )
+            return urns
+        except Exception as e:
+            logger.warning(
+                f"Could not query unembedded documents via Elasticsearch, "
+                f"falling back to processing all documents: {e}"
+            )
+            return set()
+
     def _fetch_documents_graphql(self) -> list[dict[str, Any]]:
         """Fetch Document entities from DataHub using GraphQL."""
         query = """
@@ -760,18 +793,20 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
         }
         """
 
-        # Build search input with optional multi-platform filter
+        # Build search input — when include_unembedded is set, fetch all docs
+        # regardless of platform so we can catch every unembedded document.
         search_input: dict[str, Any] = {
             "type": "DOCUMENT",
             "query": "*",
             "start": 0,
-            "count": 1000,  # Fetch in batches
+            "count": 10000,
         }
 
-        # Only add platform filter if specific platforms are provided
-        # Empty list or wildcard ("*", "ALL") means no GraphQL filter (client-side filtering instead)
+        # Only add platform filter if specific platforms are provided and we're NOT
+        # doing an include_unembedded scan (which needs all platforms).
         if (
-            self.config.platform_filter
+            not self.config.include_unembedded
+            and self.config.platform_filter
             and "*" not in self.config.platform_filter
             and "ALL" not in self.config.platform_filter
         ):
@@ -792,6 +827,17 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
             search_data = response.get("search") or {}
             search_results = search_data.get("searchResults") or []
 
+            # When include_unembedded is set, fetch the set of URNs that have no
+            # semanticContent aspect yet via a single ES query, so we can include
+            # those regardless of platform_filter.
+            unembedded_urns: set[str] = set()
+            if self.config.include_unembedded:
+                logger.info(
+                    "include_unembedded=True: querying Elasticsearch for documents "
+                    "without semanticContent aspect."
+                )
+                unembedded_urns = self._get_unembedded_urns()
+
             documents = []
             for result in search_results:
                 entity = result.get("entity") or {}
@@ -809,10 +855,15 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
                 contents = info.get("contents") or {}
                 text = contents.get("text") or ""
 
-                # Filter by source type (NATIVE vs EXTERNAL) for batch mode
-                should_process = self._should_process_by_source_type(entity, info)
-                if not should_process:
-                    continue
+                # When include_unembedded is set: include if this URN has no
+                # semanticContent aspect yet, regardless of platform_filter.
+                # Otherwise apply the normal platform/source-type filter.
+                if self.config.include_unembedded and urn in unembedded_urns:
+                    logger.debug(f"Including {urn} — no semanticContent aspect found")
+                else:
+                    should_process = self._should_process_by_source_type(entity, info)
+                    if not should_process:
+                        continue
 
                 # Skip if no text or too short
                 if not text or (

--- a/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
@@ -51,6 +51,12 @@ from datahub.ingestion.source.unstructured.event_consumer import DocumentEventCo
 
 logger = logging.getLogger(__name__)
 
+# Bump this when the processing algorithm changes in a way that requires all previously
+# embedded documents to be re-processed (e.g., improved chunking logic, better text
+# normalization). A mismatch with the version stored in the last checkpoint triggers a
+# full re-process for the entire run, bypassing the per-document incremental check.
+PROCESSING_ALGO_VERSION = "1"
+
 
 class DataHubDocumentsReport(StatefulIngestionReport):
     """Report for DataHub documents source."""
@@ -235,20 +241,49 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
         if self.config.incremental.enabled:
             self._save_state()
 
+    def _is_bootstrap_run(self) -> bool:
+        """Return True if this run should bypass incremental and re-process everything.
+
+        True when:
+        - force_reprocess is set in config, OR
+        - the processing algorithm version in the last checkpoint differs from
+          PROCESSING_ALGO_VERSION (algorithm improved — old embeddings are stale)
+
+        False when:
+        - no previous state exists (first run — incremental handles it naturally), OR
+        - previous state exists and algo version matches (normal incremental run)
+        """
+        if self.config.incremental.force_reprocess:
+            return True
+        if self.state_handler and self.state_handler.is_checkpointing_enabled():
+            last_version = self.state_handler.get_last_processing_algo_version()
+            if last_version is not None and last_version != PROCESSING_ALGO_VERSION:
+                logger.info(
+                    f"Processing algorithm changed ({last_version!r} → {PROCESSING_ALGO_VERSION!r}). "
+                    "Switching to bootstrap mode — all documents will be re-processed."
+                )
+                return True
+        return False
+
     def _process_batch_mode(self) -> Iterable[MetadataWorkUnit]:
         """Process documents using GraphQL search (batch mode)."""
         logger.info("Running in batch mode")
+
+        bootstrap = self._is_bootstrap_run()
+        if bootstrap:
+            logger.info("Bootstrap mode: incremental check bypassed for this run.")
+
+        # Record current algo version in the checkpoint so future runs can detect changes.
+        if self.state_handler and self.state_handler.is_checkpointing_enabled():
+            self.state_handler.set_processing_algo_version(PROCESSING_ALGO_VERSION)
 
         # Fetch documents from DataHub
         documents = self._fetch_documents_graphql()
 
         # Process each document
         for doc in documents:
-            # Check if we should process this document (incremental mode)
-            if (
-                self.config.incremental.enabled
-                and not self.config.incremental.force_reprocess
-            ):
+            # Incremental check — skipped entirely in bootstrap mode
+            if self.config.incremental.enabled and not bootstrap:
                 if not self._should_process(doc["urn"], doc.get("text", "")):
                     logger.debug(
                         f"Skipping document {doc['urn']} (unchanged content hash)"

--- a/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
@@ -254,6 +254,9 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
                         f"Skipping document {doc['urn']} (unchanged content hash)"
                     )
                     self.report.report_document_skipped_unchanged()
+                    # Carry state forward so this doc stays in the adopted set
+                    # and is included in future runs even after it gains semanticContent.
+                    self._carry_forward_document_state(doc["urn"])
                     continue
 
             # Process document and yield workunits
@@ -827,14 +830,20 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
             search_data = response.get("search") or {}
             search_results = search_data.get("searchResults") or []
 
-            # When include_unembedded is set, fetch the set of URNs that have no
-            # semanticContent aspect yet via a single ES query, so we can include
-            # those regardless of platform_filter.
+            # When include_unembedded is set:
+            # - previously_adopted_urns: docs we've embedded before (own going forward)
+            # - unembedded_urns: docs with no semanticContent yet (new adoptions)
+            # A doc passes the filter if it's in either set.
+            previously_adopted_urns: set[str] = set()
             unembedded_urns: set[str] = set()
             if self.config.include_unembedded:
+                if self.state_handler and self.state_handler.is_checkpointing_enabled():
+                    previously_adopted_urns = self.state_handler.get_all_tracked_urns()
+                else:
+                    previously_adopted_urns = set(self.document_state.keys())
                 logger.info(
-                    "include_unembedded=True: querying Elasticsearch for documents "
-                    "without semanticContent aspect."
+                    f"include_unembedded=True: {len(previously_adopted_urns)} previously "
+                    "adopted docs; querying Elasticsearch for new unembedded docs."
                 )
                 unembedded_urns = self._get_unembedded_urns()
 
@@ -855,11 +864,18 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
                 contents = info.get("contents") or {}
                 text = contents.get("text") or ""
 
-                # When include_unembedded is set: include if this URN has no
-                # semanticContent aspect yet, regardless of platform_filter.
-                # Otherwise apply the normal platform/source-type filter.
-                if self.config.include_unembedded and urn in unembedded_urns:
-                    logger.debug(f"Including {urn} — no semanticContent aspect found")
+                if self.config.include_unembedded:
+                    if urn in previously_adopted_urns:
+                        # We've embedded this before — maintain ownership going forward.
+                        logger.debug(f"Maintaining {urn} — previously adopted")
+                    elif urn in unembedded_urns:
+                        # New adoption: no semanticContent yet, ingestion didn't embed it.
+                        logger.debug(
+                            f"Adopting {urn} — no semanticContent aspect found"
+                        )
+                    else:
+                        # Already has semanticContent from ingestion source — skip it.
+                        continue
                 else:
                     should_process = self._should_process_by_source_type(entity, info)
                     if not should_process:
@@ -968,6 +984,17 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
         # Deterministic JSON serialization
         hash_str = json.dumps(hash_input, sort_keys=True)
         return hashlib.sha256(hash_str.encode("utf-8")).hexdigest()
+
+    def _carry_forward_document_state(self, document_urn: str) -> None:
+        """Carry state forward for a skipped (unchanged) doc.
+
+        Keeps the URN in the adopted set so ownership persists across runs
+        even when the document content hasn't changed.
+        """
+        if self.state_handler and self.state_handler.is_checkpointing_enabled():
+            self.state_handler.carry_forward_document_state(document_urn)
+        # For file-based state (self.document_state dict), the full dict is
+        # loaded at startup and saved at close — unchanged entries persist automatically.
 
     def _update_document_state(self, document_urn: str, text: str) -> None:
         """Update state after processing document."""

--- a/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/document_chunking_state.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/document_chunking_state.py
@@ -24,3 +24,11 @@ class DocumentChunkingCheckpointState(CheckpointStateBase):
         default_factory=dict,
         description="Maps topic to offset_id for event-driven mode",
     )
+
+    # Processing algorithm version — bumping PROCESSING_ALGO_VERSION in the source
+    # causes a full re-process on the next run (old state is detected as stale).
+    processing_algo_version: str = pydantic.Field(
+        default="",
+        description="Version of the processing algorithm used to produce this state. "
+        "Mismatch with the current PROCESSING_ALGO_VERSION triggers a full re-process.",
+    )

--- a/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/document_chunking_state_handler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/document_chunking_state_handler.py
@@ -137,6 +137,19 @@ class DocumentChunkingStateHandler(
                 "last_processed": last_processed,
             }
 
+    def get_last_processing_algo_version(self) -> Optional[str]:
+        """Return the processing algo version stored in the previous run's checkpoint."""
+        state = self.get_last_state()
+        if state:
+            return state.processing_algo_version or None
+        return None
+
+    def set_processing_algo_version(self, version: str) -> None:
+        """Write the current processing algo version into the current checkpoint."""
+        current_state = self.get_current_state()
+        if current_state:
+            current_state.processing_algo_version = version
+
     def get_all_tracked_urns(self) -> set[str]:
         """Return URNs in the previous run's state — the set of docs datahub-documents owns."""
         state = self.get_last_state()

--- a/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/document_chunking_state_handler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/document_chunking_state_handler.py
@@ -137,6 +137,27 @@ class DocumentChunkingStateHandler(
                 "last_processed": last_processed,
             }
 
+    def get_all_tracked_urns(self) -> set[str]:
+        """Return URNs in the previous run's state — the set of docs datahub-documents owns."""
+        state = self.get_last_state()
+        if state:
+            return set(state.document_state.keys())
+        return set()
+
+    def carry_forward_document_state(self, document_urn: str) -> None:
+        """Copy a skipped doc's previous state entry into the current checkpoint.
+
+        Ensures the URN stays in the adopted set even when content is unchanged,
+        so ownership persists across multiple runs without re-processing.
+        """
+        last_state = self.get_last_state()
+        if last_state and document_urn in last_state.document_state:
+            current_state = self.get_current_state()
+            if current_state:
+                current_state.document_state[document_urn] = last_state.document_state[
+                    document_urn
+                ]
+
     def get_event_offset(self, topic: str) -> Optional[str]:
         """Get the stored offset for an event topic."""
         state = self.get_last_state()

--- a/metadata-ingestion/tests/unit/test_datahub_documents_source.py
+++ b/metadata-ingestion/tests/unit/test_datahub_documents_source.py
@@ -16,6 +16,7 @@ from datahub.ingestion.source.datahub_documents.datahub_documents_config import 
     DataHubDocumentsSourceConfig,
 )
 from datahub.ingestion.source.datahub_documents.datahub_documents_source import (
+    PROCESSING_ALGO_VERSION,
     DataHubDocumentsSource,
 )
 from datahub.ingestion.source.datahub_documents.text_partitioner import TextPartitioner
@@ -66,14 +67,14 @@ class TestDataHubDocumentsConfig:
         """Test default configuration values."""
         config = DataHubDocumentsSourceConfig()
 
-        assert config.platform_filter is None  # Default: None = all NATIVE documents
+        assert config.platform_filter is None
+        assert config.include_unembedded is True  # default: embed all unembedded docs
         assert config.incremental.enabled is True
         assert config.skip_empty_text is True
         assert config.min_text_length == 50
         assert config.event_mode.enabled is False
         assert config.chunking.strategy == "by_title"
         assert config.partition_strategy == "markdown"
-        # Embedding config defaults to None - loaded from server
         assert config.embedding.provider is None
         assert config.embedding.model is None
 
@@ -912,6 +913,9 @@ class TestStateStorage:
             # Mock state handler with existing document hash
             mock_state_handler = patch.object(source, "state_handler").start()
             mock_state_handler.is_checkpointing_enabled.return_value = True
+            mock_state_handler.get_last_processing_algo_version.return_value = (
+                PROCESSING_ALGO_VERSION
+            )
 
             # Document with same hash (unchanged)
             text = "Same content"
@@ -1540,7 +1544,8 @@ class TestConfigFingerprintInHash:
     def test_batch_mode_filters_by_source_type(self, ctx, mock_graph):
         """Test that batch mode filters documents by source type."""
         config = DataHubDocumentsSourceConfig(
-            platform_filter=None,  # Default: all NATIVE
+            platform_filter=None,
+            include_unembedded=False,  # test explicit source-type filtering
             datahub={"server": "http://test-server:8080"},
             embedding={
                 "provider": "bedrock",
@@ -1548,7 +1553,7 @@ class TestConfigFingerprintInHash:
                 "aws_region": "us-west-2",
                 "allow_local_embedding_config": True,
             },
-            min_text_length=10,  # Lower threshold for test,
+            min_text_length=10,
             stateful_ingestion={"enabled": False},
         )
 
@@ -1598,6 +1603,7 @@ class TestConfigFingerprintInHash:
         """Test batch mode with platform filter includes EXTERNAL from specified platforms."""
         config = DataHubDocumentsSourceConfig(
             platform_filter=["notion"],
+            include_unembedded=False,  # test explicit platform filtering
             datahub={"server": "http://test-server:8080"},
             embedding={
                 "provider": "bedrock",
@@ -1605,7 +1611,7 @@ class TestConfigFingerprintInHash:
                 "aws_region": "us-west-2",
                 "allow_local_embedding_config": True,
             },
-            min_text_length=10,  # Lower threshold for test,
+            min_text_length=10,
             stateful_ingestion={"enabled": False},
         )
 
@@ -1673,6 +1679,7 @@ class TestPartialEntityHandling:
         """Create test configuration."""
         return DataHubDocumentsSourceConfig(
             platform_filter=None,
+            include_unembedded=False,  # test source-type filtering, not adoption
             datahub={"server": "http://test-server:8080"},
             embedding={
                 "provider": "bedrock",
@@ -2314,3 +2321,334 @@ class TestDataHubGraphInitialization:
             # Verify source uses the context graph
             assert source.graph is mock_ctx_graph
             assert source.graph is not mock_graph_class.return_value
+
+
+GRAPH_PATCH = "datahub.ingestion.source.datahub_documents.datahub_documents_source.DataHubGraph"
+
+
+def _make_source(ctx, **config_kwargs):
+    """Helper: create a DataHubDocumentsSource with patched DataHubGraph."""
+    defaults = dict(
+        datahub={"server": "http://test-server:8080"},
+        embedding={
+            "provider": "bedrock",
+            "model": "cohere.embed-english-v3",
+            "aws_region": "us-west-2",
+            "allow_local_embedding_config": True,
+        },
+        stateful_ingestion={"enabled": False},
+    )
+    defaults.update(config_kwargs)
+    config = DataHubDocumentsSourceConfig(**defaults)
+    with patch(GRAPH_PATCH):
+        return DataHubDocumentsSource(ctx, config)
+
+
+@pytest.fixture
+def base_ctx():
+    return PipelineContext(run_id="test-run", pipeline_name="test-pipeline")
+
+
+class TestBootstrapMode:
+    """Tests for _is_bootstrap_run() and PROCESSING_ALGO_VERSION cache-busting."""
+
+    def test_first_run_no_previous_state(self, base_ctx):
+        """First run (no checkpoint) should NOT trigger bootstrap — incremental handles it."""
+        source = _make_source(base_ctx)
+        mock_sh = Mock()
+        mock_sh.is_checkpointing_enabled.return_value = True
+        mock_sh.get_last_processing_algo_version.return_value = None  # no prior state
+        source.state_handler = mock_sh
+
+        assert source._is_bootstrap_run() is False
+
+    def test_same_algo_version_is_normal_incremental(self, base_ctx):
+        """When stored version matches PROCESSING_ALGO_VERSION, run incrementally."""
+        from datahub.ingestion.source.datahub_documents.datahub_documents_source import (
+            PROCESSING_ALGO_VERSION,
+        )
+
+        source = _make_source(base_ctx)
+        mock_sh = Mock()
+        mock_sh.is_checkpointing_enabled.return_value = True
+        mock_sh.get_last_processing_algo_version.return_value = PROCESSING_ALGO_VERSION
+        source.state_handler = mock_sh
+
+        assert source._is_bootstrap_run() is False
+
+    def test_changed_algo_version_triggers_bootstrap(self, base_ctx):
+        """Stored version differs from PROCESSING_ALGO_VERSION → bootstrap this run."""
+        source = _make_source(base_ctx)
+        mock_sh = Mock()
+        mock_sh.is_checkpointing_enabled.return_value = True
+        mock_sh.get_last_processing_algo_version.return_value = "0"  # old version
+        source.state_handler = mock_sh
+
+        assert source._is_bootstrap_run() is True
+
+    def test_force_reprocess_config_triggers_bootstrap(self, base_ctx):
+        """force_reprocess=True always triggers bootstrap regardless of algo version."""
+        from datahub.ingestion.source.datahub_documents.datahub_documents_source import (
+            PROCESSING_ALGO_VERSION,
+        )
+
+        source = _make_source(base_ctx, incremental={"force_reprocess": True})
+        mock_sh = Mock()
+        mock_sh.is_checkpointing_enabled.return_value = True
+        mock_sh.get_last_processing_algo_version.return_value = PROCESSING_ALGO_VERSION
+        source.state_handler = mock_sh
+
+        assert source._is_bootstrap_run() is True
+
+    def test_no_state_handler_is_not_bootstrap(self, base_ctx):
+        """No state handler → can't detect algo change → not bootstrap."""
+        source = _make_source(base_ctx)
+        source.state_handler = None
+
+        assert source._is_bootstrap_run() is False
+
+    def test_algo_version_written_to_checkpoint(self, base_ctx):
+        """PROCESSING_ALGO_VERSION is recorded in the checkpoint at start of each run."""
+        from datahub.ingestion.source.datahub_documents.datahub_documents_source import (
+            PROCESSING_ALGO_VERSION,
+        )
+
+        source = _make_source(base_ctx)
+        mock_sh = Mock()
+        mock_sh.is_checkpointing_enabled.return_value = True
+        mock_sh.get_last_processing_algo_version.return_value = PROCESSING_ALGO_VERSION
+        source.state_handler = mock_sh
+
+        mock_docs = [{"urn": "urn:li:document:1", "text": "hello world content here"}]
+        with (
+            patch.object(source, "_fetch_documents_graphql", return_value=mock_docs),
+            patch.object(source, "_process_single_document", return_value=iter([])),
+        ):
+            list(source._process_batch_mode())
+
+        mock_sh.set_processing_algo_version.assert_called_once_with(PROCESSING_ALGO_VERSION)
+
+    def test_bootstrap_bypasses_incremental_check(self, base_ctx):
+        """In bootstrap mode every doc is processed even if hash is unchanged."""
+        source = _make_source(base_ctx)
+        mock_sh = Mock()
+        mock_sh.is_checkpointing_enabled.return_value = True
+        mock_sh.get_last_processing_algo_version.return_value = "0"  # triggers bootstrap
+        # Return the same hash the doc would compute → normally skipped
+        text = "unchanged content text here"
+        mock_sh.get_document_hash.return_value = source._calculate_text_hash(text)
+        source.state_handler = mock_sh
+
+        mock_docs = [{"urn": "urn:li:document:1", "text": text}]
+        with (
+            patch.object(source, "_fetch_documents_graphql", return_value=mock_docs),
+            patch.object(
+                source, "_process_single_document", return_value=iter([])
+            ) as mock_process,
+        ):
+            list(source._process_batch_mode())
+
+        # Bootstrap bypasses incremental — doc must be processed even though hash matches
+        mock_process.assert_called_once()
+
+    def test_normal_run_skips_unchanged_docs(self, base_ctx):
+        """In normal incremental mode, unchanged docs are still skipped."""
+        from datahub.ingestion.source.datahub_documents.datahub_documents_source import (
+            PROCESSING_ALGO_VERSION,
+        )
+
+        source = _make_source(base_ctx)
+        mock_sh = Mock()
+        mock_sh.is_checkpointing_enabled.return_value = True
+        mock_sh.get_last_processing_algo_version.return_value = PROCESSING_ALGO_VERSION
+        text = "unchanged content text here"
+        mock_sh.get_document_hash.return_value = source._calculate_text_hash(text)
+        source.state_handler = mock_sh
+
+        mock_docs = [{"urn": "urn:li:document:1", "text": text}]
+        with (
+            patch.object(source, "_fetch_documents_graphql", return_value=mock_docs),
+            patch.object(
+                source, "_process_single_document", return_value=iter([])
+            ) as mock_process,
+        ):
+            list(source._process_batch_mode())
+
+        mock_process.assert_not_called()
+
+
+class TestAdoptionTracking:
+    """Tests for include_unembedded adoption behavior and carry-forward state."""
+
+    @pytest.fixture
+    def ctx(self):
+        return PipelineContext(run_id="test-run", pipeline_name="test-pipeline")
+
+    def _make_graphql_result(self, urn, source_type="NATIVE", platform=None, text="enough content here"):
+        entity: dict[str, Any] = {
+            "urn": urn,
+            "info": {
+                "source": {"sourceType": source_type},
+                "contents": {"text": text},
+            },
+        }
+        if platform:
+            entity["dataPlatformInstance"] = {
+                "platform": {"urn": f"urn:li:dataPlatform:{platform}"}
+            }
+        return {"entity": entity}
+
+    def test_unembedded_doc_is_adopted(self, ctx):
+        """A doc with no semanticContent is adopted on first encounter."""
+        source = _make_source(ctx, include_unembedded=True, min_text_length=10)
+
+        urn = "urn:li:document:confluence1"
+        source.document_state = {}  # no previously adopted
+
+        mock_response = {"search": {"searchResults": [self._make_graphql_result(urn, "EXTERNAL", "confluence")]}}
+
+        with (
+            patch.object(source.graph, "execute_graphql", return_value=mock_response),
+            patch.object(source.graph, "get_urns_by_filter", return_value=iter([urn])),
+        ):
+            docs = source._fetch_documents_graphql()
+
+        assert len(docs) == 1
+        assert docs[0]["urn"] == urn
+
+    def test_previously_adopted_doc_is_maintained(self, ctx):
+        """A doc that was adopted before is included even after it gains semanticContent."""
+        source = _make_source(ctx, include_unembedded=True, min_text_length=10)
+
+        urn = "urn:li:document:confluence1"
+        # Simulate prior adoption: URN is in document_state
+        source.document_state = {urn: {"content_hash": "oldhash", "last_processed": "2026-01-01"}}
+
+        mock_response = {"search": {"searchResults": [self._make_graphql_result(urn, "EXTERNAL", "confluence")]}}
+
+        with (
+            patch.object(source.graph, "execute_graphql", return_value=mock_response),
+            # Doc now has semanticContent → NOT in unembedded_urns
+            patch.object(source.graph, "get_urns_by_filter", return_value=iter([])),
+        ):
+            docs = source._fetch_documents_graphql()
+
+        assert len(docs) == 1
+        assert docs[0]["urn"] == urn
+
+    def test_ingestion_embedded_doc_is_skipped(self, ctx):
+        """A doc with semanticContent that we've never processed is left to ingestion source."""
+        source = _make_source(ctx, include_unembedded=True, min_text_length=10)
+
+        urn = "urn:li:document:confluence1"
+        source.document_state = {}  # never adopted
+
+        mock_response = {"search": {"searchResults": [self._make_graphql_result(urn, "EXTERNAL", "confluence")]}}
+
+        with (
+            patch.object(source.graph, "execute_graphql", return_value=mock_response),
+            # Doc already has semanticContent → not in unembedded_urns
+            patch.object(source.graph, "get_urns_by_filter", return_value=iter([])),
+        ):
+            docs = source._fetch_documents_graphql()
+
+        assert len(docs) == 0
+
+    def test_platform_filter_restricts_new_adoptions(self, ctx):
+        """platform_filter limits which platforms can be newly adopted."""
+        source = _make_source(ctx, include_unembedded=True, platform_filter=["notion"], min_text_length=10)
+
+        notion_urn = "urn:li:document:notion1"
+        confluence_urn = "urn:li:document:confluence1"
+        source.document_state = {}
+
+        mock_response = {
+            "search": {
+                "searchResults": [
+                    self._make_graphql_result(notion_urn, "EXTERNAL", "notion"),
+                    self._make_graphql_result(confluence_urn, "EXTERNAL", "confluence"),
+                ]
+            }
+        }
+
+        with (
+            patch.object(source.graph, "execute_graphql", return_value=mock_response),
+            # Both are unembedded
+            patch.object(source.graph, "get_urns_by_filter", return_value=iter([notion_urn, confluence_urn])),
+        ):
+            docs = source._fetch_documents_graphql()
+
+        urns = [d["urn"] for d in docs]
+        assert notion_urn in urns
+        assert confluence_urn not in urns  # filtered by platform_filter
+
+    def test_platform_filter_does_not_restrict_previously_adopted(self, ctx):
+        """Previously adopted docs bypass platform_filter (ownership is maintained)."""
+        source = _make_source(ctx, include_unembedded=True, platform_filter=["notion"], min_text_length=10)
+
+        confluence_urn = "urn:li:document:confluence1"
+        # Previously adopted even though confluence is not in platform_filter
+        source.document_state = {confluence_urn: {"content_hash": "h", "last_processed": "2026-01-01"}}
+
+        mock_response = {
+            "search": {
+                "searchResults": [self._make_graphql_result(confluence_urn, "EXTERNAL", "confluence")]
+            }
+        }
+
+        with (
+            patch.object(source.graph, "execute_graphql", return_value=mock_response),
+            patch.object(source.graph, "get_urns_by_filter", return_value=iter([])),
+        ):
+            docs = source._fetch_documents_graphql()
+
+        assert len(docs) == 1
+        assert docs[0]["urn"] == confluence_urn
+
+    def test_carry_forward_state_for_skipped_doc(self, ctx):
+        """Skipped (unchanged) docs have their state carried forward into the new checkpoint."""
+        from datahub.ingestion.source.datahub_documents.datahub_documents_source import (
+            PROCESSING_ALGO_VERSION,
+        )
+
+        source = _make_source(ctx)
+        mock_sh = Mock()
+        mock_sh.is_checkpointing_enabled.return_value = True
+        mock_sh.get_last_processing_algo_version.return_value = PROCESSING_ALGO_VERSION
+
+        text = "unchanged content text here"
+        mock_sh.get_document_hash.return_value = source._calculate_text_hash(text)
+        source.state_handler = mock_sh
+
+        mock_docs = [{"urn": "urn:li:document:1", "text": text}]
+        with (
+            patch.object(source, "_fetch_documents_graphql", return_value=mock_docs),
+            patch.object(source, "_process_single_document", return_value=iter([])),
+        ):
+            list(source._process_batch_mode())
+
+        # Carry-forward must be called so the URN stays in the adopted set
+        mock_sh.carry_forward_document_state.assert_called_once_with("urn:li:document:1")
+
+
+class TestDocumentChunkingCheckpointState:
+    """Tests for DocumentChunkingCheckpointState schema."""
+
+    def test_has_processing_algo_version_field(self):
+        from datahub.ingestion.source.datahub_documents.document_chunking_state import (
+            DocumentChunkingCheckpointState,
+        )
+
+        state = DocumentChunkingCheckpointState()
+        assert hasattr(state, "processing_algo_version")
+        assert state.processing_algo_version == ""  # default empty = "unknown"
+
+    def test_processing_algo_version_round_trips(self):
+        from datahub.ingestion.source.datahub_documents.document_chunking_state import (
+            DocumentChunkingCheckpointState,
+        )
+
+        state = DocumentChunkingCheckpointState(processing_algo_version="2")
+        serialized = state.model_dump_json()
+        restored = DocumentChunkingCheckpointState.model_validate_json(serialized)
+        assert restored.processing_algo_version == "2"


### PR DESCRIPTION
## Summary

- **`include_unembedded=True` by default**: The `datahub-documents` source now automatically adopts and embeds any document that has no `semanticContent` aspect, across all platforms. This covers ingestion scenarios where the ingestion source cannot produce embeddings.
- **Persistent adoption tracking**: Once `datahub-documents` adopts a document (embeds it for the first time), it continues to maintain that document across future runs — re-embedding on content changes. Skipped (unchanged) documents have their state carried forward in the checkpoint so adoption persists without re-processing.
- **`PROCESSING_ALGO_VERSION` bootstrap mode**: A module-level constant in `datahub_documents_source.py`. When the processing algorithm improves, bumping this constant causes the source to run in "bootstrap mode" on the next run — bypassing the per-document incremental check and re-processing everything once. Subsequent runs return to normal incremental mode.
- **`platform_filter` scoping clarified**: The filter now applies only to *new* adoptions. Previously adopted documents are always maintained regardless of the filter value.

## Design notes

**Adoption semantics:** If an ingestion source later starts producing embeddings for a doc that `datahub-documents` already adopted, `datahub-documents` continues to maintain it (minor redundancy). This is intentional — deducing ownership from the ingestion source's current capability is fragile. The simpler rule: once adopted, always maintained.

**Bootstrap vs. per-doc invalidation:** `PROCESSING_ALGO_VERSION` is a run-level switch, not a per-doc hash component. When the version changes, the entire run operates in bootstrap mode; when it matches (normal case), incremental mode is used per-document. This avoids mixing a global algorithm decision into thousands of per-document hashes.

## Test plan

- [ ] `TestBootstrapMode` (8 tests): first-run, version-match, version-mismatch, force_reprocess, algo version written to checkpoint
- [ ] `TestAdoptionTracking` (6 tests): new doc is adopted, previously adopted doc maintained, ingestion-embedded doc skipped, platform filter restricts new adoptions, carry-forward state for skipped docs
- [ ] `TestDocumentChunkingCheckpointState` (2 tests): state serialization roundtrip, processing_algo_version field default
- [ ] `TestStateStorage::test_incremental_mode_skips_unchanged_documents`: verifies hash-unchanged docs are skipped when algo version matches

All 88 tests pass:
```
========================= 88 passed in 3.50s =========================
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)