### PR TITLE
fix(ingestion): bump idna >=3.15,<4.0.0 for CVE-2026-45409

### DIFF
--- a/docker/snippets/ingestion/constraints.txt
+++ b/docker/snippets/ingestion/constraints.txt
@@ -5,6 +5,9 @@ cmdstanpy>=1.3.0,<2.0.0
 # override in CI to work around this. This constraint is safe for Docker images
 # which don't coexist with Airflow's pinned dependencies.
 jaraco.context>=6.1.0,<7
+# CVE-2026-45409: DoS via idna.encode() on crafted inputs (bypass of CVE-2024-3651 fix).
+# Not in setup.py: Airflow constraints pin idna to older versions (e.g. 3.4, 3.10).
+idna>=3.15,<4.0.0
 # urllib3: CVE-2025-66418, CVE-2025-66471, CVE-2026-21441 fixed in >=2.6.3.
 # Not pinned here: acryl-great-expectations (via acryl-datahub[snowflake]) requires urllib3<1.27.
 # PyJWT: CVE-2026-32597

--- a/metadata-ingestion/constraints.txt
+++ b/metadata-ingestion/constraints.txt
@@ -628,7 +628,7 @@ ibm-db-sa==0.4.3 ; platform_machine == 'x86_64' or sys_platform == 'darwin'
     # via acryl-datahub
 id==1.5.0
     # via twine
-idna==3.11
+idna==3.15
     # via
     #   anyio
     #   httpx

--- a/metadata-ingestion/pyproject.toml
+++ b/metadata-ingestion/pyproject.toml
@@ -2125,6 +2125,10 @@ constraint-dependencies = [
     "jaraco-context>=6.1.0,<7",  # GHSA-58pv-8j8x-9vj2 (path traversal)
     "pypdf>=6.10.2",  # GHSA-4pxv-j86v-mhcw (incremental trailer /Size DoS)
     "authlib>=1.6.11,<2.0.0",  # GHSA-jj8c-mmj3-mmgv (OAuth cache CSRF)
+    # CVE-2026-45409: DoS via idna.encode() on crafted inputs (bypass of CVE-2024-3651 fix).
+    # Not in setup.py: Airflow constraints pin idna to older versions (e.g. 3.4, 3.10).
+    # Enforced for Docker via docker/snippets/ingestion/constraints.txt.
+    "idna>=3.15,<4.0.0",
 ]
 
 [tool.ruff]

--- a/metadata-ingestion/uv.lock
+++ b/metadata-ingestion/uv.lock
@@ -19,6 +19,7 @@ resolution-markers = [
 [manifest]
 constraints = [
     { name = "authlib", specifier = ">=1.6.11,<2.0.0" },
+    { name = "idna", specifier = ">=3.15,<4.0.0" },
     { name = "jaraco-context", specifier = ">=6.1.0,<7" },
     { name = "pypdf", specifier = ">=6.10.2" },
 ]
@@ -6831,11 +6832,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Specially crafted inputs to idna.encode() can bypass the CVE-2024-3651 mitigation and cause denial-of-service via excessive CPU use. Pin idna to the patched 3.15 release with an upper bound on the 3.x line.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
