### PR TITLE
fix(ui): align tour fonts to alchemy; welcome modal keyboard nav

### DIFF
--- a/datahub-web-react/src/app/onboarding/WelcomeToDataHubModal.components.tsx
+++ b/datahub-web-react/src/app/onboarding/WelcomeToDataHubModal.components.tsx
@@ -1,6 +1,9 @@
+import { Heading, Text } from '@components';
 import { Spin } from 'antd';
 import React from 'react';
 import styled from 'styled-components';
+
+import { typography } from '@components/theme';
 
 /**
  * Container for individual carousel slides with centered content
@@ -12,27 +15,23 @@ export const SlideContainer = styled.div`
     min-height: 470px;
 `;
 
-/**
- * Theme-aware slide title (replaces Heading with raw alchemy gray)
- */
-export const SlideTitle = styled.h2`
-    font-size: 20px;
-    font-weight: 700;
-    line-height: 1.3;
+const SlideTitleWrapper = styled.div`
     margin: 0 0 4px;
-    color: ${(props) => props.theme.colors.text};
 `;
 
-/**
- * Theme-aware slide description (replaces Heading with raw alchemy gray)
- */
-export const SlideDescription = styled.h3`
-    font-size: 16px;
-    font-weight: 400;
-    line-height: 1.4;
-    margin: 0;
-    color: ${(props) => props.theme.colors.textSecondary};
-`;
+export const SlideTitle: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+    <SlideTitleWrapper>
+        <Heading type="h2" size="2xl" weight="bold">
+            {children}
+        </Heading>
+    </SlideTitleWrapper>
+);
+
+export const SlideDescription: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+    <Text type="p" size="lg" color="textSecondary">
+        {children}
+    </Text>
+);
 
 /**
  * Container for video elements with centered alignment
@@ -44,9 +43,6 @@ export const VideoContainer = styled.div`
     padding-top: 16px;
 `;
 
-/**
- * Styled loading container base
- */
 const LoadingContainerBase = styled.div<{ width: string }>`
     width: ${(props) => props.width};
     height: 350px; /* Match video aspect ratio for 620px width */
@@ -57,37 +53,27 @@ const LoadingContainerBase = styled.div<{ width: string }>`
     background-color: ${(props) => props.theme.colors.bgSurface};
     border: 2px dashed ${(props) => props.theme.colors.border};
     border-radius: 8px;
-    font-size: 16px;
-    color: ${(props) => props.theme.colors.textSecondary};
-    font-weight: 500;
     margin: 0 auto;
     gap: 16px;
 `;
 
-/**
- * Loading state container with Spin component
- * @param width - CSS width value for the container
- * @param children - Optional loading text
- */
 export const LoadingContainer: React.FC<{ width: string; children?: React.ReactNode }> = ({
     width,
     children = 'Loading video...',
 }) => (
     <LoadingContainerBase width={width}>
         <Spin size="large" />
-        {children}
+        <Text size="lg" weight="medium" color="textSecondary">
+            {children}
+        </Text>
     </LoadingContainerBase>
 );
 
-/**
- * Styled anchor for DataHub Docs link
- */
 export const StyledDocsLink = styled.a`
     color: ${(props) => props.theme.colors.textBrand};
     text-align: center;
-    font-size: 14px;
-    font-style: normal;
-    font-weight: 650;
+    font-size: ${typography.fontSizes.md};
+    font-weight: ${typography.fontWeights.semiBold};
     line-height: normal;
     letter-spacing: -0.07px;
     text-decoration: none;

--- a/datahub-web-react/src/app/onboarding/WelcomeToDataHubModal.tsx
+++ b/datahub-web-react/src/app/onboarding/WelcomeToDataHubModal.tsx
@@ -104,6 +104,32 @@ export const WelcomeToDataHubModal = () => {
         setVideosReady((prev) => ({ ...prev, [videoKey]: true }));
     };
 
+    // Keyboard navigation: Left/Right cycle slides, Escape closes the modal.
+    // Bound at document level because focus inside the modal sits on a non-carousel
+    // element (close button / body), so react-slick's built-in handler never fires.
+    useEffect(() => {
+        if (!shouldShow) return undefined;
+
+        function handleKeyDown(e: KeyboardEvent) {
+            if (e.key === 'ArrowLeft') {
+                e.preventDefault();
+                carouselRef.current?.prev();
+            } else if (e.key === 'ArrowRight') {
+                e.preventDefault();
+                carouselRef.current?.next();
+            } else if (e.key === 'Escape') {
+                e.preventDefault();
+                closeTour('escape_key');
+            }
+        }
+
+        document.addEventListener('keydown', handleKeyDown);
+        return () => document.removeEventListener('keydown', handleKeyDown);
+        // closeTour is stable for the lifetime of an open modal; depending on currentSlide
+        // would re-bind on every slide change without changing behavior.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [shouldShow]);
+
     // Track page view when modal opens
     useEffect(() => {
         if (shouldShow && !hasTrackedView.current) {
@@ -162,6 +188,7 @@ export const WelcomeToDataHubModal = () => {
                 title={WELCOME_TO_DATAHUB_MODAL_TITLE}
                 width={MODAL_WIDTH}
                 onCancel={() => closeTour('close_button')}
+                keyboard={false}
                 buttons={[
                     {
                         text: 'Get Started',
@@ -192,6 +219,7 @@ export const WelcomeToDataHubModal = () => {
             title={WELCOME_TO_DATAHUB_MODAL_TITLE}
             width={MODAL_WIDTH}
             onCancel={() => closeTour('close_button')}
+            keyboard={false}
             buttons={[]}
             zIndex={ANT_NOTIFICATION_Z_INDEX + 2} // 2 higher because home settings button is 1 higher
         >

--- a/datahub-web-react/src/app/onboarding/config/BusinessGlossaryOnboardingConfig.tsx
+++ b/datahub-web-react/src/app/onboarding/config/BusinessGlossaryOnboardingConfig.tsx
@@ -1,4 +1,4 @@
-import { Typography } from 'antd';
+import { Text } from '@components';
 import React from 'react';
 
 import { OnboardingStep } from '@app/onboarding/OnboardingStep';
@@ -12,7 +12,7 @@ export const BusinessGlossaryOnboardingConfig: OnboardingStep[] = [
         id: BUSINESS_GLOSSARY_INTRO_ID,
         title: 'Business Glossary 📖',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     Welcome to the <strong>Business Glossary</strong>!
                 </p>
@@ -20,7 +20,7 @@ export const BusinessGlossaryOnboardingConfig: OnboardingStep[] = [
                     The Glossary is a collection of structured, standarized labels you can use to categorize data
                     assets. You can view and create both <strong>Terms</strong> and <strong>Term Groups</strong> here.
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -28,14 +28,14 @@ export const BusinessGlossaryOnboardingConfig: OnboardingStep[] = [
         selector: `#${BUSINESS_GLOSSARY_CREATE_TERM_ID}`,
         title: 'Glossary Terms',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     Click here to create a new <strong>Term</strong> .
                 </p>
                 <p>
                     <strong>Terms</strong> are words or phrases with a specific business definition assigned to them.
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -43,7 +43,7 @@ export const BusinessGlossaryOnboardingConfig: OnboardingStep[] = [
         selector: `#${BUSINESS_GLOSSARY_CREATE_TERM_GROUP_ID}`,
         title: 'Glossary Term Groups',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     Click here to create a new <strong>Term Group</strong>.
                 </p>
@@ -65,7 +65,7 @@ export const BusinessGlossaryOnboardingConfig: OnboardingStep[] = [
                         here.
                     </a>
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
 ];

--- a/datahub-web-react/src/app/onboarding/config/DomainsOnboardingConfig.tsx
+++ b/datahub-web-react/src/app/onboarding/config/DomainsOnboardingConfig.tsx
@@ -1,4 +1,4 @@
-import { Typography } from 'antd';
+import { Text } from '@components';
 import React from 'react';
 
 import { OnboardingStep } from '@app/onboarding/OnboardingStep';
@@ -11,7 +11,7 @@ export const DomainsOnboardingConfig: OnboardingStep[] = [
         id: DOMAINS_INTRO_ID,
         title: 'Domains',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     Welcome to DataHub <strong>Domains</strong>!
                 </p>
@@ -26,7 +26,7 @@ export const DomainsOnboardingConfig: OnboardingStep[] = [
                         here.
                     </a>
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -34,11 +34,11 @@ export const DomainsOnboardingConfig: OnboardingStep[] = [
         selector: `#${DOMAINS_CREATE_DOMAIN_ID}`,
         title: 'Create a new Domain',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     Click here to create a new <strong>Domain</strong>.
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
 ];

--- a/datahub-web-react/src/app/onboarding/config/EntityProfileOnboardingConfig.tsx
+++ b/datahub-web-react/src/app/onboarding/config/EntityProfileOnboardingConfig.tsx
@@ -1,4 +1,4 @@
-import { Typography } from 'antd';
+import { Text } from '@components';
 import React from 'react';
 
 import { OnboardingStep } from '@app/onboarding/OnboardingStep';
@@ -23,11 +23,11 @@ export const EntityProfileOnboardingConfig: OnboardingStep[] = [
         selector: `[id^='rc-tabs'][id$='Entities']`,
         title: 'Entities Tab',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     You can view the <strong>Entities</strong> that belong to a <strong>Container</strong> on this tab.
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -35,7 +35,7 @@ export const EntityProfileOnboardingConfig: OnboardingStep[] = [
         selector: `[id^='rc-tabs'][id$='Properties']`,
         title: 'Properties Tab',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     You can view an entity&apos;s key-value <strong>Properties</strong> on this tab. These are sourced
                     from the original Data Platform.
@@ -43,7 +43,7 @@ export const EntityProfileOnboardingConfig: OnboardingStep[] = [
                 <p>
                     If this tab is disabled, <strong>Properties</strong> have not been ingested for this entity.
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -51,7 +51,7 @@ export const EntityProfileOnboardingConfig: OnboardingStep[] = [
         selector: `[id^='rc-tabs'][id$='Documentation']`,
         title: 'Documentation Tab',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     You can view and edit an entity&apos;s <strong>Documentation</strong> on this tab.
                 </p>
@@ -59,7 +59,7 @@ export const EntityProfileOnboardingConfig: OnboardingStep[] = [
                     <strong>Documentation</strong> should provide descriptive information about this data asset. It can
                     also contain links to external resources.
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -67,7 +67,7 @@ export const EntityProfileOnboardingConfig: OnboardingStep[] = [
         selector: `[id^='rc-tabs'][id$='Lineage']`,
         title: 'Lineage Tab',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     You can view an entity&apos;s <strong>Lineage</strong> on this tab.
                 </p>
@@ -78,7 +78,7 @@ export const EntityProfileOnboardingConfig: OnboardingStep[] = [
                 <p>
                     If this tab is disabled, <strong>Lineage</strong> have not been ingested for this entity.
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -86,7 +86,7 @@ export const EntityProfileOnboardingConfig: OnboardingStep[] = [
         selector: `[id^='rc-tabs'][id$='Schema']`,
         title: 'Schema Tab',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     You can view a Dataset&apos;s <strong>Schema</strong> on this tab.
                 </p>
@@ -94,7 +94,7 @@ export const EntityProfileOnboardingConfig: OnboardingStep[] = [
                     You can also view or add <strong>Documentation</strong>, <strong>Tags</strong>, and{' '}
                     <strong>Glossary Terms</strong> for specific columns.
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -102,7 +102,7 @@ export const EntityProfileOnboardingConfig: OnboardingStep[] = [
         selector: `#${ENTITY_PROFILE_OWNERS_ID}`,
         title: 'Owners',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     You can view and add <strong>Owners</strong> to this asset here.
                 </p>
@@ -110,7 +110,7 @@ export const EntityProfileOnboardingConfig: OnboardingStep[] = [
                     <strong>Owners</strong> are <strong>Users</strong> or <strong>Groups</strong> who are responsible
                     for managing this asset.
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -118,7 +118,7 @@ export const EntityProfileOnboardingConfig: OnboardingStep[] = [
         selector: `#${ENTITY_PROFILE_TAGS_ID}`,
         title: 'Tags',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     You can view and add <strong>Tags</strong> to this asset here.
                 </p>
@@ -133,7 +133,7 @@ export const EntityProfileOnboardingConfig: OnboardingStep[] = [
                         here.{' '}
                     </a>
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -141,7 +141,7 @@ export const EntityProfileOnboardingConfig: OnboardingStep[] = [
         selector: `#${ENTITY_PROFILE_GLOSSARY_TERMS_ID}`,
         title: 'Glossary Terms',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     You can view and add <strong>Glossary Terms</strong> to this asset here.
                 </p>
@@ -161,7 +161,7 @@ export const EntityProfileOnboardingConfig: OnboardingStep[] = [
                         here.
                     </a>
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -169,7 +169,7 @@ export const EntityProfileOnboardingConfig: OnboardingStep[] = [
         selector: `#${ENTITY_PROFILE_DOMAINS_ID}`,
         title: 'Domain',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     You can view and set this asset&apos;s <strong>Domain</strong> here.
                 </p>
@@ -184,7 +184,7 @@ export const EntityProfileOnboardingConfig: OnboardingStep[] = [
                         here.
                     </a>
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -192,13 +192,13 @@ export const EntityProfileOnboardingConfig: OnboardingStep[] = [
         selector: `#${ENTITY_PROFILE_V2_SIDEBAR_ID}`,
         title: 'Introducing the Asset Sidebar',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     The asset sidebar is a vertically organized set of important information about an asset. It shows up
                     on the right side of the screen when you view an asset, a search result, a lineage entry and a host
                     of other places.
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
 ];

--- a/datahub-web-react/src/app/onboarding/config/GroupsOnboardingConfig.tsx
+++ b/datahub-web-react/src/app/onboarding/config/GroupsOnboardingConfig.tsx
@@ -1,4 +1,4 @@
-import { Typography } from 'antd';
+import { Text } from '@components';
 import React from 'react';
 
 import { OnboardingStep } from '@app/onboarding/OnboardingStep';
@@ -11,7 +11,7 @@ export const GroupsOnboardingConfig: OnboardingStep[] = [
         id: GROUPS_INTRO_ID,
         title: 'Groups',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     Welcome to Datahub <strong>Groups</strong>!
                 </p>
@@ -34,7 +34,7 @@ export const GroupsOnboardingConfig: OnboardingStep[] = [
                         here.
                     </a>
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -42,11 +42,11 @@ export const GroupsOnboardingConfig: OnboardingStep[] = [
         selector: `#${GROUPS_CREATE_GROUP_ID}`,
         title: 'Create a new Group',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     Click here to create a new <strong>Group</strong>.
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
 ];

--- a/datahub-web-react/src/app/onboarding/config/HomePageOnboardingConfig.tsx
+++ b/datahub-web-react/src/app/onboarding/config/HomePageOnboardingConfig.tsx
@@ -1,4 +1,5 @@
-import { Image, Typography } from 'antd';
+import { Heading, Text } from '@components';
+import { Image } from 'antd';
 import React from 'react';
 import styled from 'styled-components';
 
@@ -37,12 +38,14 @@ export const HomePageOnboardingConfig: OnboardingStep[] = [
                     style={{ marginLeft: '50px' }}
                     src={dataHubFlowDiagram}
                 />
-                <Typography.Title level={3}>Welcome to DataHub Core! 👋</Typography.Title>
-                <Typography.Paragraph style={{ lineHeight: '22px' }}>
+                <Heading type="h3" size="2xl" weight="bold">
+                    Welcome to DataHub Core! 👋
+                </Heading>
+                <Text type="div" size="md">
                     <strong>DataHub</strong> helps you discover and organize the important data within your
                     organization. You can:
-                </Typography.Paragraph>
-                <Typography.Paragraph style={{ lineHeight: '24px' }}>
+                </Text>
+                <Text type="div" size="md">
                     <ul>
                         <li>
                             Quickly <strong>search</strong> for Datasets, Dashboards, Data Pipelines, and more
@@ -65,7 +68,7 @@ export const HomePageOnboardingConfig: OnboardingStep[] = [
                             Press <strong> Cmd + Ctrl + T</strong> to open up this tutorial at any time.
                         </span>
                     </InfoBox>
-                </Typography.Paragraph>
+                </Text>
             </div>
         ),
         style: { minWidth: '650px' },
@@ -75,9 +78,9 @@ export const HomePageOnboardingConfig: OnboardingStep[] = [
         selector: `#${HOME_PAGE_INGESTION_ID}`,
         title: 'Ingest Data',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 Start integrating your data sources immediately by navigating to the <strong>Ingestion</strong> page.
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -85,11 +88,11 @@ export const HomePageOnboardingConfig: OnboardingStep[] = [
         selector: `#${HOME_PAGE_DOMAINS_ID}`,
         title: 'Explore by Domain',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 Here are your organization&apos;s <strong>Domains</strong>. Domains are collections of data assets -
                 such as Tables, Dashboards, and ML Models - that make it easy to discover information relevant to a
                 particular part of your organization.
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -97,11 +100,11 @@ export const HomePageOnboardingConfig: OnboardingStep[] = [
         selector: `#${HOME_PAGE_PLATFORMS_ID}`,
         title: 'Explore by Platform',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 Here are your organization&apos;s <strong>Data Platforms</strong>. Data Platforms represent specific
                 third-party Data Systems or Tools. Examples include Data Warehouses like <strong>Snowflake</strong>,
                 Orchestrators like <strong>Airflow</strong>, and Dashboarding tools like <strong>Looker</strong>.
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -115,7 +118,7 @@ export const HomePageOnboardingConfig: OnboardingStep[] = [
         selector: `#${HOME_PAGE_SEARCH_BAR_ID}`,
         title: 'Find your Data 🔍',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     This is the <strong>Search Bar</strong>. It will serve as your launch point for discovering and
                     collaborating around the data most important to you.
@@ -123,7 +126,7 @@ export const HomePageOnboardingConfig: OnboardingStep[] = [
                 <p>
                     Not sure where to start? Click on <strong>Explore All</strong>!
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
 ];

--- a/datahub-web-react/src/app/onboarding/config/IngestionOnboardingConfig.tsx
+++ b/datahub-web-react/src/app/onboarding/config/IngestionOnboardingConfig.tsx
@@ -1,4 +1,4 @@
-import { Typography } from 'antd';
+import { Text } from '@components';
 import React from 'react';
 
 import { OnboardingStep } from '@app/onboarding/OnboardingStep';
@@ -13,7 +13,7 @@ export const IngestionOnboardingConfig: OnboardingStep[] = [
         selector: `#${INGESTION_CREATE_SOURCE_ID}`,
         title: 'Create a new Ingestion Source',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     Configure new Integrations from DataHub to your <strong>Data Platforms</strong>, including
                     Transactional Databases like <strong>MySQL</strong>, Data Warehouses such as{' '}
@@ -30,7 +30,7 @@ export const IngestionOnboardingConfig: OnboardingStep[] = [
                         here.
                     </a>
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -38,9 +38,9 @@ export const IngestionOnboardingConfig: OnboardingStep[] = [
         selector: `#${INGESTION_REFRESH_SOURCES_ID}`,
         title: 'Refresh Ingestion Sources',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>Click to force a refresh of running ingestion sources.</p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {

--- a/datahub-web-react/src/app/onboarding/config/LineageGraphOnboardingConfig.tsx
+++ b/datahub-web-react/src/app/onboarding/config/LineageGraphOnboardingConfig.tsx
@@ -1,4 +1,4 @@
-import { Typography } from 'antd';
+import { Text } from '@components';
 import React from 'react';
 
 import { OnboardingStep } from '@app/onboarding/OnboardingStep';
@@ -11,7 +11,7 @@ export const LineageGraphOnboardingConfig: OnboardingStep[] = [
         id: LINEAGE_GRAPH_INTRO_ID,
         title: 'Lineage Graph',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     You can view the <strong>Lineage Graph</strong> for an entity on this page.
                 </p>
@@ -29,7 +29,7 @@ export const LineageGraphOnboardingConfig: OnboardingStep[] = [
                         here.
                     </a>
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -37,13 +37,13 @@ export const LineageGraphOnboardingConfig: OnboardingStep[] = [
         selector: `#${LINEAGE_GRAPH_TIME_FILTER_ID}`,
         title: 'Filter Lineage Edges by Date',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     You can click which dates you would like to see lineage edges for on this graph. By default, the
                     graph will show edges observed in the last 14 days. Note that manual lineage edges and edges without
                     time information will always be shown.
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
 ];

--- a/datahub-web-react/src/app/onboarding/config/PoliciesOnboardingConfig.tsx
+++ b/datahub-web-react/src/app/onboarding/config/PoliciesOnboardingConfig.tsx
@@ -1,4 +1,4 @@
-import { Typography } from 'antd';
+import { Text } from '@components';
 import React from 'react';
 
 import { OnboardingStep } from '@app/onboarding/OnboardingStep';
@@ -11,7 +11,7 @@ export const PoliciesOnboardingConfig: OnboardingStep[] = [
         id: POLICIES_INTRO_ID,
         title: 'Policies',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     Welcome to DataHub <strong>Policies</strong>!
                 </p>
@@ -33,7 +33,7 @@ export const PoliciesOnboardingConfig: OnboardingStep[] = [
                         here.
                     </a>
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -41,11 +41,11 @@ export const PoliciesOnboardingConfig: OnboardingStep[] = [
         selector: `#${POLICIES_CREATE_POLICY_ID}`,
         title: 'Create a new Policy',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     Click here to create a new <strong>Policy</strong>.
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
 ];

--- a/datahub-web-react/src/app/onboarding/config/SearchOnboardingConfig.tsx
+++ b/datahub-web-react/src/app/onboarding/config/SearchOnboardingConfig.tsx
@@ -1,4 +1,4 @@
-import { Typography } from 'antd';
+import { Text } from '@components';
 import React from 'react';
 
 import { OnboardingStep } from '@app/onboarding/OnboardingStep';
@@ -14,10 +14,10 @@ export const SearchOnboardingConfig: OnboardingStep[] = [
         selector: `#${SEARCH_RESULTS_FILTERS_ID}`,
         title: '🕵️ Narrow your search',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 Quickly find relevant assets by applying one or more filters. Try filtering by <strong>Type</strong>,{' '}
                 <strong>Owner</strong>, and more!
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -25,9 +25,9 @@ export const SearchOnboardingConfig: OnboardingStep[] = [
         selector: `#${SEARCH_RESULTS_ADVANCED_SEARCH_ID}`,
         title: '💪 Dive deeper with advanced filters',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <strong>Advanced Filters</strong> offer additional capabilities to create more specific search queries.
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -36,11 +36,11 @@ export const SearchOnboardingConfig: OnboardingStep[] = [
         title: '🧭 Explore and refine your search by platform',
         style: { minWidth: '425px' },
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 Have a clear idea of the schema or folder you&apos;re searching for? Easily navigate your
                 organization&apos;s platforms inline. Then select a specific container you want to filter your results
                 by.
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -49,10 +49,10 @@ export const SearchOnboardingConfig: OnboardingStep[] = [
         selector: `#${SEARCH_RESULTS_FILTERS_V2_INTRO}`,
         title: 'Filters Have Moved',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 Quickly find relevant assets with our new and improved filter interface! Our latest update has relocated
                 filters to the top of the screen for ease of access.
-            </Typography.Paragraph>
+            </Text>
         ),
     },
 ];

--- a/datahub-web-react/src/app/onboarding/config/UsersOnboardingConfig.tsx
+++ b/datahub-web-react/src/app/onboarding/config/UsersOnboardingConfig.tsx
@@ -1,4 +1,4 @@
-import { Typography } from 'antd';
+import { Text } from '@components';
 import React from 'react';
 
 import { OnboardingStep } from '@app/onboarding/OnboardingStep';
@@ -13,21 +13,21 @@ export const UsersOnboardingConfig: OnboardingStep[] = [
         id: USERS_INTRO_ID,
         title: 'Users',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     Welcome to DataHub <strong>Users</strong>!
                 </p>
                 <p>
                     There are a few different ways to onboard new <strong>Users</strong> onto DataHub.
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
         id: USERS_SSO_ID,
         title: 'Configuring Single Sign-On (SSO)',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     The preferred way to onboard new <strong>Users</strong> is to use <strong>Single Sign-On</strong>.
                     Currently, DataHub supports OIDC SSO.
@@ -43,7 +43,7 @@ export const UsersOnboardingConfig: OnboardingStep[] = [
                         here.
                     </a>
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -51,7 +51,7 @@ export const UsersOnboardingConfig: OnboardingStep[] = [
         selector: `#${USERS_INVITE_LINK_ID}`,
         title: 'Invite New Users',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     Easily share an invite link with your colleagues to onboard them onto DataHub. Optionally assign a{' '}
                     <strong>Role</strong> to anyone who joins using the link.
@@ -67,7 +67,7 @@ export const UsersOnboardingConfig: OnboardingStep[] = [
                         here.
                     </a>
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -75,7 +75,7 @@ export const UsersOnboardingConfig: OnboardingStep[] = [
         selector: `#${USERS_ASSIGN_ROLE_ID}`,
         title: 'Assigning Roles',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     You can assign <strong>Roles</strong> to existing <strong>Users</strong> here.
                 </p>
@@ -90,7 +90,7 @@ export const UsersOnboardingConfig: OnboardingStep[] = [
                         here.
                     </a>
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
 ];

--- a/datahub-web-react/src/app/onboarding/configV2/EntityProfileOnboardingConfig.tsx
+++ b/datahub-web-react/src/app/onboarding/configV2/EntityProfileOnboardingConfig.tsx
@@ -1,4 +1,4 @@
-import { Typography } from 'antd';
+import { Text } from '@components';
 import React from 'react';
 
 import { OnboardingStep } from '@app/onboarding/OnboardingStep';
@@ -28,7 +28,7 @@ const EntityProfileOnboardingConfig: OnboardingStep[] = [
             }
         },
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     You can view an asset&apos;s <strong>Fields</strong> on this tab.
                 </p>
@@ -37,7 +37,7 @@ const EntityProfileOnboardingConfig: OnboardingStep[] = [
                     <strong>Glossary Terms</strong> for specific fields.
                 </p>
                 <p>Click on individual fields to view more details such as statistics and properties.</p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -51,12 +51,12 @@ const EntityProfileOnboardingConfig: OnboardingStep[] = [
             }
         },
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     You can view the child <strong>Assets</strong> that belong to this <strong>Asset</strong> on this
                     tab.
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -70,7 +70,7 @@ const EntityProfileOnboardingConfig: OnboardingStep[] = [
             }
         },
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     You can view and edit rich <strong>Documentation</strong> on this tab.
                 </p>
@@ -78,7 +78,7 @@ const EntityProfileOnboardingConfig: OnboardingStep[] = [
                     <strong>Documentation</strong> should provide descriptive information about this data asset to help
                     your data explorers understand it better. It can also contain links to external resources.
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -86,13 +86,13 @@ const EntityProfileOnboardingConfig: OnboardingStep[] = [
         selector: `#${ENTITY_PROFILE_V2_SIDEBAR_ID}`,
         title: 'Introducing the Asset Sidebar',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     The asset sidebar is a vertically organized set of important information about an asset. It appears
                     on the right side of the screen when viewing an asset, a search result, a lineage entry, and many
                     other places.
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -100,9 +100,9 @@ const EntityProfileOnboardingConfig: OnboardingStep[] = [
         selector: `[id^='entity-sidebar-tabs'][id$='About']`,
         title: 'Summary',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>Quick access to at-a-glance information about the asset.</p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -110,11 +110,11 @@ const EntityProfileOnboardingConfig: OnboardingStep[] = [
         selector: `[id^='entity-sidebar-tabs'][id$='Columns']`,
         title: 'Columns',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     Quick access to an asset&apos;s <strong>Fields</strong> on this tab.
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -122,9 +122,9 @@ const EntityProfileOnboardingConfig: OnboardingStep[] = [
         selector: `[id^='entity-sidebar-tabs'][id$='Lineage']`,
         title: 'Lineage 🕸️',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>Quick access to upstream and downstream lineage, both direct and indirect.</p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -132,7 +132,7 @@ const EntityProfileOnboardingConfig: OnboardingStep[] = [
         selector: `[id^='entity-sidebar-tabs'][id$='Properties']`,
         title: 'Properties 📑',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     Properties have moved to the asset sidebar! You can view and (soon) edit <strong>Properties</strong>{' '}
                     on this tab.
@@ -141,7 +141,7 @@ const EntityProfileOnboardingConfig: OnboardingStep[] = [
                     Properties are key value pairs that provide additional information about an asset. Some properties
                     are ingested from the source data platform, while others are added by users.
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -155,13 +155,13 @@ const EntityProfileOnboardingConfig: OnboardingStep[] = [
             }
         },
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     View highlighted and relevant <strong>Queries</strong> on this tab.
                 </p>
                 <p>Highlighted queries are handpicked by your data experts to help you get started with this asset.</p>
                 <p>Relevant queries are computed based on recency, popularity, and other factors.</p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -175,14 +175,14 @@ const EntityProfileOnboardingConfig: OnboardingStep[] = [
             }
         },
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     View <strong>Quality</strong> information on this tab.
                 </p>
                 <p>
                     Quality information includes <strong>data contracts</strong> and data quality test results.
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -196,7 +196,7 @@ const EntityProfileOnboardingConfig: OnboardingStep[] = [
             }
         },
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     View and manage <strong>Incidents</strong> on this tab.
                 </p>
@@ -204,7 +204,7 @@ const EntityProfileOnboardingConfig: OnboardingStep[] = [
                     Incidents are issues or events that require attention. They can be related to data quality,
                     governance, schema changes, and more.
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
 ];

--- a/datahub-web-react/src/app/onboarding/configV2/HomePageOnboardingConfig.tsx
+++ b/datahub-web-react/src/app/onboarding/configV2/HomePageOnboardingConfig.tsx
@@ -1,4 +1,5 @@
-import { Image, Typography } from 'antd';
+import { Heading, Text } from '@components';
+import { Image } from 'antd';
 import React from 'react';
 import styled from 'styled-components';
 
@@ -41,12 +42,14 @@ const HomePageOnboardingConfig: OnboardingStep[] = [
                 >
                     <Image preview={false} height={184} width={500} src={dataHubFlowDiagram} />
                 </div>
-                <Typography.Title level={3}>Welcome to DataHub Core! </Typography.Title>
-                <Typography.Paragraph style={{ lineHeight: '22px' }}>
+                <Heading type="h3" size="2xl" weight="bold">
+                    Welcome to DataHub Core!{' '}
+                </Heading>
+                <Text type="div" size="md">
                     <strong>DataHub</strong> helps you discover, govern and ensure high quality for the important data
                     within your organization. You can:
-                </Typography.Paragraph>
-                <Typography.Paragraph style={{ lineHeight: '24px' }}>
+                </Text>
+                <Text type="div" size="md">
                     <ul>
                         <li>
                             Quickly <strong>search</strong> for Tables, Dashboards, Data Pipelines, and more
@@ -77,7 +80,7 @@ const HomePageOnboardingConfig: OnboardingStep[] = [
                             Press <strong>Cmd + Ctrl + T</strong> to open up this tutorial at any time.
                         </span>
                     </InfoBox>
-                </Typography.Paragraph>
+                </Text>
             </div>
         ),
         style: { minWidth: '650px' },
@@ -87,12 +90,12 @@ const HomePageOnboardingConfig: OnboardingStep[] = [
         selector: `#${V2_SEARCH_BAR_ID}`,
         title: 'Find your Data 🔍',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     This is the <strong>Search Bar</strong>. It will serve as your launch point for discovering and
                     collaborating around the data most important to you.
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -100,13 +103,13 @@ const HomePageOnboardingConfig: OnboardingStep[] = [
         selector: `#${V2_SEARCH_BAR_VIEWS}`,
         title: 'Only the stuff you need 📷',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     Views help you focus on the assets that you care about. You can switch between views using the
                     dropdown. Your admin will configure the views that make sense for your organization. You can
                     customize and create your own views as well.
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -120,12 +123,12 @@ const HomePageOnboardingConfig: OnboardingStep[] = [
         selector: `#${V2_HOME_PAGE_DISCOVER_ID}`,
         title: 'Discover 🔍',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     The <strong> Discover</strong> section serves as your exploration center for discovering new areas
                     of your data estate. You can explore Domains, Platforms, and more.
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -133,12 +136,12 @@ const HomePageOnboardingConfig: OnboardingStep[] = [
         selector: `#${V2_HOME_PAGE_ANNOUNCEMENTS_ID}`,
         title: 'Announcements 📣',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     The <strong> Announcements</strong> tab contains important updates and information from your
                     organization. Be sure to check it out frequently!
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
     {
@@ -146,12 +149,12 @@ const HomePageOnboardingConfig: OnboardingStep[] = [
         selector: `#${V2_HOME_PAGE_PERSONAL_SIDEBAR_ID}`,
         title: 'Your Personal Sidebar 📌',
         content: (
-            <Typography.Paragraph>
+            <Text type="div" size="md">
                 <p>
                     This is your <strong> Personal Sidebar</strong>. It contains links to assets you own, groups you are
                     in, your subscriptions and more.
                 </p>
-            </Typography.Paragraph>
+            </Text>
         ),
     },
 ];

--- a/datahub-web-react/src/app/onboarding/utils.tsx
+++ b/datahub-web-react/src/app/onboarding/utils.tsx
@@ -1,4 +1,4 @@
-import { Typography } from 'antd';
+import { Heading } from '@components';
 import React from 'react';
 import styled from 'styled-components';
 
@@ -53,8 +53,8 @@ function hasSeenPrerequisiteStepIfExists(step: OnboardingStep, userUrn: string, 
     return true;
 }
 
-const StepTitle = styled(Typography.Title)`
-    margin-botton: 5px;
+const StepTitle = styled.div`
+    margin-bottom: 5px;
 `;
 
 export function getStepsToRender(
@@ -78,7 +78,11 @@ export function getStepsToRender(
             ...step,
             content: (
                 <div>
-                    <StepTitle level={5}>{step?.title}</StepTitle>
+                    <StepTitle>
+                        <Heading type="h5" size="lg" weight="bold">
+                            {step?.title}
+                        </Heading>
+                    </StepTitle>
                     <div>{step?.content}</div>
                 </div>
             ),

--- a/e2e-test/ui/playwright/pages/welcome-modal.page.ts
+++ b/e2e-test/ui/playwright/pages/welcome-modal.page.ts
@@ -102,10 +102,24 @@ export class WelcomeModalPage extends BasePage {
   }
 
   async closeViaEscape(): Promise<void> {
-    // Ensure the modal has focus so the Escape key event is captured by Ant Design.
+    // The modal's keydown listener is bound to document, so focus inside the modal
+    // is not required — but a defensive click is kept for older code paths that
+    // expected antd's built-in Esc handler (which needs focus inside the modal).
     await this.modal.click({ position: { x: 5, y: 5 }, force: true }).catch(() => {});
     await this.page.keyboard.press('Escape');
     await this.modal.waitFor({ state: 'hidden' });
+  }
+
+  async pressArrowRight(): Promise<void> {
+    await this.page.keyboard.press('ArrowRight');
+    // react-slick afterChange fires via setTimeout(speed=500ms). Match the
+    // wait used by clickCarouselDot for consistency.
+    await this.page.waitForTimeout(500);
+  }
+
+  async pressArrowLeft(): Promise<void> {
+    await this.page.keyboard.press('ArrowLeft');
+    await this.page.waitForTimeout(500);
   }
 
   async closeViaOutsideClick(): Promise<void> {

--- a/e2e-test/ui/playwright/tests/onboarding/welcome-modal.spec.ts
+++ b/e2e-test/ui/playwright/tests/onboarding/welcome-modal.spec.ts
@@ -72,6 +72,23 @@ test.describe('Welcome to DataHub Modal', () => {
       await expect(welcomeModalPage.docsLink).toBeVisible();
     });
 
+    test('should advance to next slide via ArrowRight key', async () => {
+      await welcomeModalPage.navigateToHome();
+      await welcomeModalPage.expectModalVisible();
+      await welcomeModalPage.expectSlide1Visible();
+      await welcomeModalPage.pressArrowRight();
+      await welcomeModalPage.expectSlide2Visible();
+    });
+
+    test('should go back to previous slide via ArrowLeft key', async () => {
+      await welcomeModalPage.navigateToHome();
+      await welcomeModalPage.expectModalVisible();
+      await welcomeModalPage.clickCarouselDot(1);
+      await welcomeModalPage.expectSlide2Visible();
+      await welcomeModalPage.pressArrowLeft();
+      await welcomeModalPage.expectSlide1Visible();
+    });
+
     test.skip('should auto-advance slides after 10 seconds', async () => {
       // Skipped in CI: react-slick autoplay is paused in headless Chromium
       // (window focus / visibilityState is not reliable), causing the 10-second
@@ -210,6 +227,22 @@ test.describe('Welcome to DataHub Modal', () => {
       const exitEvent = trackRequests.find((r) => r['type'] === 'WelcomeToDataHubModalExitEvent');
       expect(exitEvent).toBeDefined();
       expect(exitEvent?.['exitMethod']).toBe('close_button');
+    });
+
+    test('should track exit event with escape_key method when Esc is pressed', async ({ page }) => {
+      const trackRequests: Record<string, unknown>[] = [];
+      await page.route('**/track', (route) => {
+        const postData = route.request().postData();
+        if (postData) trackRequests.push(JSON.parse(postData) as Record<string, unknown>);
+        void route.continue();
+      });
+      await welcomeModalPage.navigateToHome();
+      await welcomeModalPage.expectModalVisible();
+      await welcomeModalPage.closeViaEscape();
+      await page.waitForTimeout(1000);
+      const exitEvent = trackRequests.find((r) => r['type'] === 'WelcomeToDataHubModalExitEvent');
+      expect(exitEvent).toBeDefined();
+      expect(exitEvent?.['exitMethod']).toBe('escape_key');
     });
 
     test('should track documentation link click event', async ({ page }) => {


### PR DESCRIPTION
## Summary

- Migrate the reactour onboarding bubbles (10 config files + `utils.tsx`) from antd `Typography.Title` / `Typography.Paragraph` to alchemy `Heading` / `Text`. The step title now uses `<Heading type="h5" size="lg" weight="bold">` and step body uses `<Text type="div" size="md">`, matching the established `RolesOnboardingConfig.tsx` pattern.
- Migrate `WelcomeToDataHubModal.components.tsx` to alchemy primitives:
  - `SlideTitle` → `<Heading type="h2" size="2xl" weight="bold">`
  - `SlideDescription` → `<Text type="p" size="lg" color="textSecondary">` (was semantically `<h3>` but visually body copy)
  - `LoadingContainer` text → `<Text size="lg" weight="medium" color="textSecondary">`
  - `StyledDocsLink` → uses `typography.fontSizes.md` and `typography.fontWeights.semiBold`. **Fixes a non-standard `font-weight: 650`** that was rounding to 700 in browsers without variable-font Mulish.
- Fix `margin-botton` typo (originally never applied a margin) in `utils.tsx`.
- Add document-level keyboard handler to the welcome modal:
  - `ArrowLeft` / `ArrowRight` cycle slides
  - `Escape` closes the modal (analytics `exitMethod: 'escape_key'`)
  - antd's built-in Esc handling disabled (`keyboard={false}`) to avoid double-firing `onCancel`.

## Why

- antd Typography and hand-rolled CSS were not on the alchemy scale, so titles/body across the tour drifted from the rest of the redesigned UI.
- The welcome modal had no global keyboard navigation. Esc only worked when focus happened to be inside the modal — react-slick's accessibility hook requires the `.slick-list` to be focused, which the modal never does. The existing Playwright `closeViaEscape` helper had to click inside the modal first to work around this; that workaround is no longer needed (and is documented as such).

## Test plan

- [x] `yarn lint-fix` + `yarn type-check` clean on `datahub-web-react`
- [x] `yarn lint` (tsc + eslint) clean on `e2e-test/ui/playwright`
- [x] Full Playwright `welcome-modal.spec.ts` suite against the dev server: **25 passed, 1 skipped** (existing autoplay skip)
  - 3 new tests added:
    - `should advance to next slide via ArrowRight key`
    - `should go back to previous slide via ArrowLeft key`
    - `should track exit event with escape_key method when Esc is pressed`
- [x] Manual visual check on the local frontend dev server for both surfaces (welcome modal carousel + reactour bubbles via ⌘+Ctrl+T)