### PR TITLE
docs(observe): address PR #17491 review feedback

### DIFF
--- a/docs/features/feature-guides/observe.md
+++ b/docs/features/feature-guides/observe.md
@@ -1,5 +1,7 @@
 ---
 description: "Detect and resolve quality issues before they impact production. Automated anomaly detection and quality checks keep data reliable."
+sidebar_custom_props:
+  icon: "🔍"
 ---
 
 import FeatureAvailability from '@site/src/components/FeatureAvailability';
@@ -25,10 +27,10 @@ The capability area is organized around three jobs:
 Catch issues as close to the source as possible.
 
 - **[Data Observability Agent](/docs/managed-datahub/observe/data-health-dashboard.md#data-observability-agent-private-beta)** — an AI assistant that scans your data landscape and provisions the right assertions for the right tables in minutes, not weeks. Tell it which slice of your data matters most (or let it figure that out from usage and ownership signals), and it creates Freshness, Volume, Field, and other checks automatically — closing coverage gaps without manual setup per table. _DataHub Cloud only. Private Beta._
-- **[Assertions](/docs/managed-datahub/observe/assertions.md)** — the core data-quality test primitive in DataHub. Assertions can be **active** (DataHub Cloud issues SQL against your warehouse on a schedule) or **ingestion-driven** (DataHub Cloud evaluates the assertion against profiles and operations already reported during ingestion, on any platform). Active, ingestion-driven, and anomaly-detection assertions are all DataHub Cloud features. DataHub Core can ingest and display assertion results that you self-report — from dbt, Great Expectations, Snowflake DMFs, or any custom source pushed via the SDK.
+- **[Assertions](/docs/managed-datahub/observe/assertions.md)** — the core data-quality test primitive in DataHub. Assertions can be **active** (DataHub Cloud issues queries against your warehouse on a schedule) or **ingestion-driven** (DataHub Cloud evaluates the assertion against profiles and operations already reported during ingestion, on any platform). Active, ingestion-driven, and anomaly-detection assertions are all DataHub Cloud features. DataHub Core can ingest and display assertion results that you self-report — from dbt, Great Expectations, Snowflake DMFs, or any custom source pushed via the SDK.
   - [Freshness](/docs/managed-datahub/observe/freshness-assertions.md) — has the table updated recently?
   - [Volume](/docs/managed-datahub/observe/volume-assertions.md) — is row count in the expected range?
-  - [Column](/docs/managed-datahub/observe/column-assertions.md) — column-level metrics and value constraints.
+  - [Column](/docs/managed-datahub/observe/column-assertions.md) — column-level metrics and value constraints (e.g. `status` must be in `active`, `pending`, or `closed`; or null rate stays below 5%).
   - [Custom SQL](/docs/managed-datahub/observe/custom-sql-assertions.md) — arbitrary SQL returning a numeric value.
   - [Schema](/docs/managed-datahub/observe/schema-assertions.md) — expected columns and types are present.
   - [Anomaly Detection](/docs/managed-datahub/observe/anomaly-detection.md) — DataHub Cloud auto-learns normal behavior for freshness, volume, and column metrics. _DataHub Cloud only._


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses Adrian's post-merge review feedback on #17491 for the Data Quality & Observability hub page.

## Changes

- **Active assertions wording**: Replace "issues SQL against your warehouse" with "issues queries against your warehouse" (per inline review suggestion).
- **Column assertions example**: Add concrete examples for Column Value (`status` in allowed set) and Column Metric (null rate) checks.
- **Core Capabilities card icon**: Add `sidebar_custom_props.icon: "🔍"` in `observe.md` frontmatter so the generated-index DocCard shows a magnifying glass instead of the default page icon. The sidebar already had `customProps.icon`, but frontmatter is what `DocCard` reads via `useDocById` when sidebar props do not propagate.

## Test plan

- [x] `./gradlew :datahub-web-react:mdPrettierWrite` passes

Fixes follow-up to #17491.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-25c77cd0-63e2-4dc8-963c-c003d35ed675"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25c77cd0-63e2-4dc8-963c-c003d35ed675"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

