### PR TITLE
refactor(glossary): redesign cards and sidebar with semantic tokens

### DIFF
--- a/datahub-web-react/src/app/glossaryV2/GlossaryBrowser/NodeItem.tsx
+++ b/datahub-web-react/src/app/glossaryV2/GlossaryBrowser/NodeItem.tsx
@@ -1,5 +1,7 @@
-import { LoadingOutlined } from '@ant-design/icons';
-import { KeyboardArrowDownRounded, KeyboardArrowRightRounded } from '@mui/icons-material';
+import { BookmarkSimple } from '@phosphor-icons/react/dist/csr/BookmarkSimple';
+import { BookmarksSimple } from '@phosphor-icons/react/dist/csr/BookmarksSimple';
+import { CaretDown } from '@phosphor-icons/react/dist/csr/CaretDown';
+import { CaretRight } from '@phosphor-icons/react/dist/csr/CaretRight';
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components/macro';
 
@@ -8,8 +10,10 @@ import { sortGlossaryTerms } from '@app/entityV2/glossaryTerm/utils';
 import { useGlossaryEntityData } from '@app/entityV2/shared/GlossaryEntityContext';
 import { SelectedMark } from '@app/glossaryV2/GlossaryBrowser/SelectedMark';
 import TermItem, { NameWrapper, TermLink as NodeLink } from '@app/glossaryV2/GlossaryBrowser/TermItem';
+import GlossaryColoredIcon from '@app/glossaryV2/GlossaryColoredIcon';
 import { useGenerateGlossaryColorFromPalette } from '@app/glossaryV2/colorUtils';
 import { useEntityRegistry } from '@app/useEntityRegistry';
+import { Loader } from '@src/alchemy-components';
 import useGlossaryChildren from '@src/app/entityV2/glossaryNode/useGlossaryChildren';
 
 import { GlossaryNodeFragment } from '@graphql/fragments.generated';
@@ -25,18 +29,10 @@ const ItemWrapper = styled.div<ItemWrapperProps>`
     flex-direction: column;
     font-weight: 700;
     position: relative;
-    overflow: ${(props) => !props.$isChildNode && 'hidden'};
 `;
 
-const NodeBadge = styled.span<{ color: string }>`
-    position: absolute;
-    height: 9px;
-    width: 50px;
-    background-color: ${({ color }) => color};
-    top: 0;
-    left: -15px;
-    transform: rotate(-45deg);
-    opacity: 1;
+const StyledNodeIcon = styled(GlossaryColoredIcon)`
+    margin-right: 8px;
 `;
 
 const NodeWrapper = styled.div<{ $isSelected: boolean; $depth: number }>`
@@ -54,40 +50,38 @@ const NodeWrapper = styled.div<{ $isSelected: boolean; $depth: number }>`
     }
 `;
 
-const StyledRightOutlined = styled(KeyboardArrowRightRounded)<{ isSelected: boolean }>`
-    color: ${(props) => (props.isSelected ? `${props.theme.colors.textHover}` : `${props.theme.colors.borderFocused}`)};
-    cursor: pointer;
+const CaretSlot = styled.div`
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 14px;
     margin-right: 6px;
+`;
+
+const StyledCaretRight = styled(CaretRight)<{ $isSelected: boolean }>`
+    color: ${(props) => (props.$isSelected ? props.theme.colors.iconSelected : props.theme.colors.icon)};
+    cursor: pointer;
     line-height: 0;
+    flex-shrink: 0;
+
     :hover {
-        stroke: ${(props) =>
-            props.isSelected ? `${props.theme.colors.textHover}` : `${props.theme.colors.borderFocused}`};
+        color: ${(props) => props.theme.colors.iconHover};
     }
 `;
 
-const StyledDownOutlined = styled(KeyboardArrowDownRounded)<{ isSelected: boolean }>`
-    color: ${(props) => (props.isSelected ? `${props.theme.colors.textHover}` : `${props.theme.colors.textActive}`)};
+const StyledCaretDown = styled(CaretDown)<{ $isSelected: boolean }>`
+    color: ${(props) => (props.$isSelected ? props.theme.colors.iconSelected : props.theme.colors.icon)};
     cursor: pointer;
-    margin-right: 6px;
     line-height: 0;
+    flex-shrink: 0;
+
     :hover {
-        stroke: ${(props) =>
-            props.isSelected ? `${props.theme.colors.textHover}` : `${props.theme.colors.textActive}`};
+        color: ${(props) => props.theme.colors.iconHover};
     }
 `;
 
 const ChildrenWrapper = styled.div``;
-
-const LoadingWrapper = styled.div`
-    padding: 8px;
-    display: flex;
-    justify-content: center;
-
-    svg {
-        height: 15px;
-        width: 15px;
-    }
-`;
 
 const ChildrenCount = styled.div`
     padding: 0 8px;
@@ -122,6 +116,7 @@ interface Props {
     isChildNode?: boolean;
     depth: number;
     selectedUrns?: string[];
+    iconColor?: string;
 }
 
 function NodeItem(props: Props) {
@@ -137,6 +132,7 @@ function NodeItem(props: Props) {
         isChildNode,
         depth,
         selectedUrns,
+        iconColor,
     } = props;
     const shouldHideNode = nodeUrnToHide === node.urn;
 
@@ -183,28 +179,31 @@ function NodeItem(props: Props) {
 
     if (shouldHideNode) return null;
 
-    const glossaryColor = node.displayProperties?.colorHex || generateColor(node.urn);
+    const glossaryColor = iconColor || node.displayProperties?.colorHex || generateColor(node.urn);
+    const NodeIcon = iconColor ? BookmarkSimple : BookmarksSimple;
 
     return (
         <ItemWrapper $isSelected={entityData?.urn === node.urn} $isChildNode={isChildNode}>
-            {!isChildNode && <NodeBadge color={glossaryColor} />}
             <NodeWrapper $isSelected={entityData?.urn === node.urn} $depth={depth}>
-                {areChildrenVisible && (
-                    <StyledDownOutlined
-                        fontSize="inherit"
-                        viewBox="2 2 18 18"
-                        onClick={() => setAreChildrenVisible(false)}
-                        isSelected={entityData?.urn === node.urn}
-                    />
-                )}
-                {!areChildrenVisible && (
-                    <StyledRightOutlined
-                        fontSize="inherit"
-                        viewBox="2 2 18 18"
-                        onClick={() => setAreChildrenVisible(true)}
-                        isSelected={entityData?.urn === node.urn}
-                    />
-                )}
+                <CaretSlot>
+                    {noOfChildren > 0 &&
+                        (areChildrenVisible ? (
+                            <StyledCaretDown
+                                size={14}
+                                weight="regular"
+                                onClick={() => setAreChildrenVisible(false)}
+                                $isSelected={entityData?.urn === node.urn}
+                            />
+                        ) : (
+                            <StyledCaretRight
+                                size={14}
+                                weight="regular"
+                                onClick={() => setAreChildrenVisible(true)}
+                                $isSelected={entityData?.urn === node.urn}
+                            />
+                        ))}
+                </CaretSlot>
+                <StyledNodeIcon color={glossaryColor} icon={NodeIcon} size={24} iconSize={14} />
                 {!isSelecting && (
                     <NodeLink
                         to={`${entityRegistry.getEntityUrl(node.type, node.urn)}`}
@@ -227,11 +226,7 @@ function NodeItem(props: Props) {
             <StyledDivider depth={depth} />
             {areChildrenVisible && (
                 <>
-                    {!children.length && loading && (
-                        <LoadingWrapper>
-                            <LoadingOutlined />
-                        </LoadingWrapper>
-                    )}
+                    {!children.length && loading && <Loader size="xs" padding={8} />}
                     {children.length > 0 && (
                         <ChildrenWrapper>
                             {(childNodes as GlossaryNode[]).map((child) => (
@@ -247,6 +242,7 @@ function NodeItem(props: Props) {
                                     key={child.urn}
                                     depth={depth + 1}
                                     selectedUrns={selectedUrns}
+                                    iconColor={glossaryColor}
                                 />
                             ))}
                             {!hideTerms &&
@@ -259,6 +255,7 @@ function NodeItem(props: Props) {
                                             includeActiveTabPath
                                             depth={depth + 1}
                                             selectedUrns={selectedUrns}
+                                            iconColor={glossaryColor}
                                         />
                                         <StyledDivider depth={depth + 1} />
                                     </span>

--- a/datahub-web-react/src/app/glossaryV2/GlossaryBrowser/TermItem.tsx
+++ b/datahub-web-react/src/app/glossaryV2/GlossaryBrowser/TermItem.tsx
@@ -1,18 +1,20 @@
+import { BookmarkSimple } from '@phosphor-icons/react/dist/csr/BookmarkSimple';
 import React from 'react';
 import { Link } from 'react-router-dom';
-import styled from 'styled-components/macro';
+import styled, { css } from 'styled-components/macro';
 
 import { useGlossaryEntityData } from '@app/entityV2/shared/GlossaryEntityContext';
 import { EDITING_DOCUMENTATION_URL_PARAM } from '@app/entityV2/shared/constants';
 import { useGlossaryActiveTabPath } from '@app/entityV2/shared/containers/profile/utils';
 import { SelectedMark } from '@app/glossaryV2/GlossaryBrowser/SelectedMark';
+import GlossaryColoredIcon from '@app/glossaryV2/GlossaryColoredIcon';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 
 import { ChildGlossaryTermFragment } from '@graphql/glossaryNode.generated';
 
 const TermWrapper = styled.div<{ $isSelected: boolean; $depth: number }>`
     padding-left: calc(${(props) => (props.$depth ? props.$depth * 24 + 12 : 18)}px);
-    background-color: ${(props) => props.$isSelected && props.theme.colors.bgActive}};
+    background-color: ${(props) => (props.$isSelected ? props.theme.colors.bgActive : 'transparent')};
     display: flex;
     align-items: center;
 
@@ -25,7 +27,11 @@ const TermWrapper = styled.div<{ $isSelected: boolean; $depth: number }>`
     }
 `;
 
-const nameStyles = `
+const StyledTermIcon = styled(GlossaryColoredIcon)`
+    margin-right: 8px;
+`;
+
+const nameStyles = css`
     padding: 16px 0;
     display: inline-block;
     height: 100%;
@@ -56,7 +62,7 @@ export const TermLink = styled(Link)<TermLinkProps>`
 
     ${(props) => props.$isChildNode && `opacity: 1;`}
     ${(props) => props.$areChildrenVisible && `color: ${props.theme.colors.textActive}; font-weight: 500; opacity: 1;`}
-    ${(props) => props.$isSelected && `color: ${props.theme.colors.textActive}}; font-weight: 700; opacity: 1;`}
+    ${(props) => props.$isSelected && `color: ${props.theme.colors.textActive}; font-weight: 700; opacity: 1;`}
 `;
 
 export const NameWrapper = styled.span<{ showSelectStyles?: boolean }>`
@@ -79,10 +85,11 @@ interface Props {
     areChildrenVisible?: boolean;
     depth: number;
     selectedUrns?: string[];
+    iconColor?: string;
 }
 
 function TermItem(props: Props) {
-    const { term, isSelecting, selectTerm, includeActiveTabPath, areChildrenVisible, selectedUrns } = props;
+    const { term, isSelecting, selectTerm, includeActiveTabPath, areChildrenVisible, selectedUrns, iconColor } = props;
 
     const { entityData } = useGlossaryEntityData();
     const entityRegistry = useEntityRegistry();
@@ -103,6 +110,7 @@ function TermItem(props: Props) {
 
     return (
         <TermWrapper $isSelected={entityData?.urn === term.urn} $depth={props.depth}>
+            {iconColor && <StyledTermIcon color={iconColor} icon={BookmarkSimple} size={24} iconSize={14} />}
             {!isSelecting && (
                 <TermLink
                     to={`${entityRegistry.getEntityUrl(term.type, term.urn)}${

--- a/datahub-web-react/src/app/glossaryV2/GlossaryColoredIcon.tsx
+++ b/datahub-web-react/src/app/glossaryV2/GlossaryColoredIcon.tsx
@@ -1,0 +1,38 @@
+import type { Icon } from '@phosphor-icons/react';
+import React from 'react';
+import styled from 'styled-components/macro';
+
+import { hexToRgb } from '@app/sharedV2/colors/colorUtils';
+import { getLighterRGBColor } from '@app/sharedV2/icons/colorUtils';
+
+const Container = styled.div<{ $bg: string; $size: number }>`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: ${(props) => props.$size / 4}px;
+    height: ${(props) => props.$size}px;
+    width: ${(props) => props.$size}px;
+    min-width: ${(props) => props.$size}px;
+    background-color: ${(props) => props.$bg};
+    flex-shrink: 0;
+`;
+
+interface Props {
+    color: string;
+    icon: Icon;
+    size?: number;
+    iconSize?: number;
+    className?: string;
+}
+
+export default function GlossaryColoredIcon({ color, icon: IconComponent, size = 24, iconSize, className }: Props) {
+    const [r, g, b] = hexToRgb(color);
+    const bg = `rgb(${getLighterRGBColor(r, g, b).join(', ')})`;
+    const resolvedIconSize = iconSize ?? Math.round(size * 0.6);
+
+    return (
+        <Container $bg={bg} $size={size} className={className}>
+            <IconComponent size={resolvedIconSize} color={color} weight="regular" />
+        </Container>
+    );
+}

--- a/datahub-web-react/src/app/glossaryV2/GlossaryContentProvider.tsx
+++ b/datahub-web-react/src/app/glossaryV2/GlossaryContentProvider.tsx
@@ -31,7 +31,7 @@ const ButtonContainer = styled.div`
 `;
 
 const ListWrapper = styled.div`
-    padding: 4px 12px 12px 12px;
+    padding: 4px 20px 12px 20px;
     overflow: auto;
 `;
 

--- a/datahub-web-react/src/app/glossaryV2/GlossaryEntitiesList.tsx
+++ b/datahub-web-react/src/app/glossaryV2/GlossaryEntitiesList.tsx
@@ -1,4 +1,3 @@
-import { Typography } from 'antd';
 import React from 'react';
 import styled from 'styled-components/macro';
 
@@ -10,7 +9,7 @@ import { GlossaryNodeFragment, RootGlossaryNodeWithFourLayersFragment } from '@g
 import { ChildGlossaryTermFragment } from '@graphql/glossaryNode.generated';
 import { GlossaryNode, GlossaryTerm } from '@types';
 
-const SectionTitle = styled(Typography)`
+const SectionTitle = styled.div`
     margin: 12px 0 12px 16px;
     font-size: 12px;
     font-weight: 400;
@@ -23,23 +22,23 @@ const GlossaryNodes = styled.div<{ isGrid?: boolean }>`
         props.isGrid
             ? `
         display: grid;
-        grid-template-columns: repeat(auto-fill, minmax(24%, 1fr));
-        gap: 8px; /* Adjust gap as needed */
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 8px;
         `
             : `
         display: flex;
         flex-direction: column;
-        gap: 12px; /* Adjust gap as needed */
+        gap: 8px;
         `}
     width: 100%;
-    margin-bottom: 20px;
+    margin-bottom: 8px;
 `;
 
 const GlossaryTerms = styled.div`
     display: flex;
     flex-direction: column;
-    gap: 12px;
-    margin-bottom: 20px;
+    gap: 8px;
+    margin-bottom: 8px;
 `;
 
 interface Props {
@@ -72,8 +71,8 @@ function GlossaryEntitiesList(props: Props) {
                     ))}
                 </GlossaryNodes>
             ) : null}
-            {terms.length > 0 && isGlossaryEntityPage ? <SectionTitle>Glossary Terms</SectionTitle> : null}
-            {terms.length ? (
+            {isGlossaryEntityPage && terms.length > 0 ? <SectionTitle>Glossary Terms</SectionTitle> : null}
+            {isGlossaryEntityPage && terms.length ? (
                 <GlossaryTerms>
                     {terms.map((term) => (
                         <GlossaryEntityItem

--- a/datahub-web-react/src/app/glossaryV2/GlossaryEntityItem.tsx
+++ b/datahub-web-react/src/app/glossaryV2/GlossaryEntityItem.tsx
@@ -1,4 +1,3 @@
-import { Tooltip } from 'antd';
 import { Maybe } from 'graphql/jsutils/Maybe';
 import React from 'react';
 import { Link } from 'react-router-dom';
@@ -7,6 +6,7 @@ import { useEntityData } from '@app/entity/shared/EntityContext';
 import GlossaryListCard from '@app/glossaryV2/GlossaryListCard';
 import GlossaryNodeCard from '@app/glossaryV2/GlossaryNodeCard';
 import { useEntityRegistry } from '@app/useEntityRegistry';
+import { Tooltip } from '@src/alchemy-components';
 
 import { GlossaryNodeFragment, RootGlossaryNodeWithFourLayersFragment } from '@graphql/fragments.generated';
 import { DisplayProperties, EntityType, GlossaryNode } from '@types';
@@ -69,31 +69,41 @@ function GlossaryEntityItem(props: Props) {
     const { termCount, nodeCount } = countTermsAndNodes(node as RootGlossaryNodeWithFourLayersFragment);
     const maxDepth = countMaxDepth(node as RootGlossaryNodeWithFourLayersFragment);
 
+    const showAsCard = type === EntityType.GlossaryNode && props.showAsCard;
+
+    const inner = (
+        <Link to={`${entityRegistry.getEntityUrl(type, urn)}`} data-testid={`glossary-entity-item-${urn}`}>
+            {showAsCard ? (
+                <GlossaryNodeCard
+                    name={name}
+                    description={description}
+                    displayProperties={displayProperties}
+                    urn={urn}
+                    termCount={termCount}
+                    nodeCount={nodeCount}
+                    maxDepth={maxDepth}
+                />
+            ) : (
+                <GlossaryListCard
+                    name={name}
+                    description={description}
+                    type={type}
+                    urn={urn}
+                    entityData={entityData}
+                    termCount={termCount}
+                    nodeCount={nodeCount}
+                />
+            )}
+        </Link>
+    );
+
+    if (showAsCard) {
+        return inner;
+    }
+
     return (
         <Tooltip title={name} showArrow={false} placement="top">
-            <Link to={`${entityRegistry.getEntityUrl(type, urn)}`} data-testid={`glossary-entity-item-${urn}`}>
-                {type === EntityType.GlossaryNode && props.showAsCard ? (
-                    <GlossaryNodeCard
-                        name={name}
-                        description={description}
-                        displayProperties={displayProperties}
-                        urn={urn}
-                        termCount={termCount}
-                        nodeCount={nodeCount}
-                        maxDepth={maxDepth}
-                    />
-                ) : (
-                    <GlossaryListCard
-                        name={name}
-                        description={description}
-                        type={type}
-                        urn={urn}
-                        entityData={entityData}
-                        termCount={termCount}
-                        nodeCount={nodeCount}
-                    />
-                )}
-            </Link>
+            {inner}
         </Tooltip>
     );
 }

--- a/datahub-web-react/src/app/glossaryV2/GlossaryListCard.tsx
+++ b/datahub-web-react/src/app/glossaryV2/GlossaryListCard.tsx
@@ -1,114 +1,55 @@
-/* eslint-disable rulesdir/no-hardcoded-colors */
 import { BookmarkSimple } from '@phosphor-icons/react/dist/csr/BookmarkSimple';
 import { BookmarksSimple } from '@phosphor-icons/react/dist/csr/BookmarksSimple';
-import { Tooltip } from 'antd';
 import React from 'react';
 import styled from 'styled-components/macro';
 
 import { GenericEntityProperties } from '@app/entity/shared/types';
-// eslint-disable-next-line no-restricted-imports -- TODO: migrate to semantic tokens
-import { ANTD_GRAY_V2, REDESIGN_COLORS } from '@app/entityV2/shared/constants';
+import GlossaryColoredIcon from '@app/glossaryV2/GlossaryColoredIcon';
 import { useGenerateGlossaryColorFromPalette } from '@app/glossaryV2/colorUtils';
-import { colors } from '@src/alchemy-components';
+import { Tooltip } from '@src/alchemy-components';
 
 import { EntityType, Maybe } from '@types';
 
 const SmallDescription = styled.div`
-    color: ${REDESIGN_COLORS.SUB_TEXT};
+    color: ${(props) => props.theme.colors.textSecondary};
     overflow: hidden;
 `;
 
-const EntityDetailsLeftColumn = styled.div`
-    display: flex;
-    gap: 15px;
-    align-items: center;
-`;
-
-const EntityDetailsRightColumn = styled.div`
-    margin-right: 5px;
-    svg {
-        display: none;
-    }
-`;
-
-const BookmarkIconWrapper = styled.div<{ $background: string }>`
-    width: 40px;
-    height: 40px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    background-color: ${(props) => props.$background};
-    border-radius: 11px;
+const StyledIcon = styled(GlossaryColoredIcon)`
     margin-right: 12px;
-    position: relative;
-    overflow: hidden;
-    flex-shrink: 0; /* Prevents the icon from being squashed */
 `;
 
-const EntityDetails = styled.div`
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    border-bottom: 1px solid ${REDESIGN_COLORS.LIGHT_GREY};
-    padding: 20px 0 20px 0;
-    margin: 0 23px 0 19px;
-`;
-
-const EntityDetailsWrapper = styled.div<{ type: EntityType }>`
+const EntityDetailsWrapper = styled.div`
     display: flex;
     align-items: center;
     justify-content: space-between;
     padding: 16px 16px;
-    border: 1px solid #ebecf0;
-    margin: 0px 12px;
+    border: 1px solid ${(props) => props.theme.colors.border};
     border-radius: 16px;
     position: relative;
     overflow: hidden;
 
-    &:hover > ${EntityDetails} > ${EntityDetailsLeftColumn} > ${BookmarkIconWrapper} > svg > g > path {
-        transition: 0.15s;
-        fill: rgba(216, 160, 75, 1);
-    }
-
-    &:hover > ${EntityDetails} > ${EntityDetailsRightColumn} > svg {
-        transition: 0.15s;
-        display: block;
-    }
-
     &:hover {
         transition: 0.15s;
-        background-color: ${colors.gray[100]};
+        background-color: ${(props) => props.theme.colors.bgHover};
     }
 `;
 
 const EntityName = styled.div`
-    color: ${REDESIGN_COLORS.SUBTITLE};
+    color: ${(props) => props.theme.colors.text};
     font-size: 14px;
-    font-weight: 400;
     font-weight: bold;
 `;
 
 const EntityTitleWrapper = styled.div`
     display: flex;
     align-items: center;
-    align-items: center;
 `;
 
 const NameAndDescription = styled.div`
     display: flex;
     flex-direction: column;
-    overflow hidden;
-`;
-
-const BookmarkRibbon = styled.span`
-    position: absolute;
-    left: -11px;
-    top: 7px;
-    width: 40px;
-    transform: rotate(-45deg);
-    padding: 4px;
-    opacity: 1;
-    background-color: rgba(0, 0, 0, 0.2);
+    overflow: hidden;
 `;
 
 const GlossaryItemCount = styled.span<{ count: number }>`
@@ -116,20 +57,20 @@ const GlossaryItemCount = styled.span<{ count: number }>`
     align-items: center;
     gap: 5px;
     border-radius: 20px;
-    background: ${ANTD_GRAY_V2[14]};
-    color: ${(props) => (props.count > 0 ? REDESIGN_COLORS.SUB_TEXT : colors.gray[400])};
+    background: ${(props) => props.theme.colors.bgSurface};
+    color: ${(props) => (props.count > 0 ? props.theme.colors.textSecondary : props.theme.colors.textDisabled)};
     padding: 5px 10px;
     width: max-content;
     svg {
         height: 14px;
         width: 14px;
         path {
-            fill: ${(props) => (props.count > 0 ? REDESIGN_COLORS.SUB_TEXT : colors.gray[400])};
+            fill: ${(props) => (props.count > 0 ? props.theme.colors.icon : props.theme.colors.iconDisabled)};
         }
     }
     border: 1px solid transparent;
     :hover {
-        border: 1px solid ${(props) => (props.count > 0 ? ANTD_GRAY_V2[13] : 'transparent')};
+        border: 1px solid ${(props) => (props.count > 0 ? props.theme.colors.borderHover : 'transparent')};
     }
 `;
 
@@ -160,77 +101,55 @@ interface Props {
 }
 
 const GlossaryListCard = (props: Props) => {
-    const { name, description, type, entityData } = props;
+    const { name, description, type, entityData, urn, nodeCount, termCount, maxDepth } = props;
     const isDescriptionTruncated = description && description.length > MAX_DESCRIPTION_LENGTH;
     const truncatedDescription = description?.slice(0, MAX_DESCRIPTION_LENGTH);
-    const isExceedingMaxDepth = (props.maxDepth || 0) > MAX_DEPTH_QUERIED;
+    const isExceedingMaxDepth = (maxDepth || 0) > MAX_DEPTH_QUERIED;
     const generateColor = useGenerateGlossaryColorFromPalette();
+    const isNode = type === EntityType.GlossaryNode;
+    const glossaryColor = generateColor(entityData?.urn || urn);
+    const Icon = isNode ? BookmarksSimple : BookmarkSimple;
 
     return (
-        <EntityDetailsWrapper type={props.type}>
-            {type === EntityType.GlossaryNode ? (
-                <EntityTitleWrapper>
-                    <BookmarkIconWrapper $background={generateColor(entityData?.urn || '')}>
-                        <BookmarkRibbon />
-                        <BookmarksSimple color="white" size="16px" weight="bold" />
-                    </BookmarkIconWrapper>
-                    <NameAndDescription>
-                        <EntityName>{name}</EntityName>
-                        {description && (
-                            <SmallDescription>
-                                <>
-                                    {truncatedDescription}
-                                    {isDescriptionTruncated ? '...' : null}
-                                </>
-                            </SmallDescription>
-                        )}
-                    </NameAndDescription>
-                </EntityTitleWrapper>
-            ) : (
-                <EntityTitleWrapper>
-                    <BookmarkIconWrapper $background={generateColor(entityData?.urn || '')}>
-                        <BookmarkRibbon />
-                        <BookmarkSimple color="white" size="16px" weight="bold" />
-                    </BookmarkIconWrapper>
-                    <NameAndDescription>
-                        <EntityName>{name}</EntityName>
-                        {description && (
-                            <SmallDescription>
-                                <>
-                                    {truncatedDescription}
-                                    {isDescriptionTruncated ? '...' : null}
-                                </>
-                            </SmallDescription>
-                        )}
-                    </NameAndDescription>
-                </EntityTitleWrapper>
-            )}
-            {type === EntityType.GlossaryNode ? (
+        <EntityDetailsWrapper>
+            <EntityTitleWrapper>
+                <StyledIcon color={glossaryColor} icon={Icon} size={40} iconSize={16} />
+                <NameAndDescription>
+                    <EntityName>{name}</EntityName>
+                    {description && (
+                        <SmallDescription>
+                            {truncatedDescription}
+                            {isDescriptionTruncated ? '...' : null}
+                        </SmallDescription>
+                    )}
+                </NameAndDescription>
+            </EntityTitleWrapper>
+            {isNode ? (
                 <Icons>
                     <Tooltip
-                        title={`Contains ${props.nodeCount} ${props.nodeCount === 1 ? 'term group' : 'term groups'}`}
+                        title={`Contains ${nodeCount} ${nodeCount === 1 ? 'term group' : 'term groups'}`}
                         placement="top"
                         showArrow={false}
                     >
-                        <GlossaryItemCount count={props.nodeCount || 0}>
+                        <GlossaryItemCount count={nodeCount || 0}>
                             <BookmarksSimple />
                             <CountText>
                                 {' '}
-                                {props.nodeCount}
+                                {nodeCount}
                                 {isExceedingMaxDepth && `+`}
                             </CountText>
                         </GlossaryItemCount>
                     </Tooltip>
                     <Tooltip
-                        title={`Contains ${props.termCount} ${props.termCount === 1 ? 'term' : 'terms'}`}
+                        title={`Contains ${termCount} ${termCount === 1 ? 'term' : 'terms'}`}
                         placement="top"
                         showArrow={false}
                     >
-                        <GlossaryItemCount count={props.termCount || 0}>
+                        <GlossaryItemCount count={termCount || 0}>
                             <BookmarkSimple />
                             <CountText>
                                 {' '}
-                                {props.termCount}
+                                {termCount}
                                 {isExceedingMaxDepth && `+`}
                             </CountText>
                         </GlossaryItemCount>

--- a/datahub-web-react/src/app/glossaryV2/GlossaryNodeCard.tsx
+++ b/datahub-web-react/src/app/glossaryV2/GlossaryNodeCard.tsx
@@ -1,142 +1,59 @@
-/* eslint-disable rulesdir/no-hardcoded-colors */
 import { BookmarkSimple } from '@phosphor-icons/react/dist/csr/BookmarkSimple';
 import { BookmarksSimple } from '@phosphor-icons/react/dist/csr/BookmarksSimple';
-import { Tooltip, Typography } from 'antd';
 import { Maybe } from 'graphql/jsutils/Maybe';
 import React from 'react';
-import styled from 'styled-components/macro';
+import styled, { useTheme } from 'styled-components/macro';
 
-// eslint-disable-next-line no-restricted-imports -- TODO: migrate to semantic tokens
-import { ANTD_GRAY, ANTD_GRAY_V2, REDESIGN_COLORS } from '@app/entityV2/shared/constants';
+import GlossaryColoredIcon from '@app/glossaryV2/GlossaryColoredIcon';
 import { useGenerateGlossaryColorFromPalette } from '@app/glossaryV2/colorUtils';
-import { colors } from '@src/alchemy-components';
+import { Card, Tooltip } from '@src/alchemy-components';
 
 import { DisplayProperties } from '@types';
-
-interface GlossaryItemCardHeaderProps {
-    color: string;
-}
-
-// there may be a good constant for this but I couldn't find one --Gabe
-// feel free to replace this color at a later date
-// eslint-disable-next-line rulesdir/no-hardcoded-colors -- TODO: replace with semantic token once disabled text color token is added
-const DISABLED_TEXT_COLOR = '#c5c6c9';
-
-const GlossaryItemCardHeader = styled.div<GlossaryItemCardHeaderProps>`
-    display: flex;
-    padding: 20px 20px 20px 30px;
-    justify-content: start;
-    border-radius: 12px 12px 0px 0px;
-    position: relative;
-    overflow: hidden;
-    gap: 5px;
-    background-color: ${(props) => props.color};
-
-    svg {
-        height: 22px;
-        width: 22px;
-        path {
-            fill: white;
-        }
-    }
-`;
-
-const GlossaryItemCardWrapper = styled.div`
-    padding: 12px;
-    border-radius: 13px;
-
-    &:hover {
-        transition: 0.15s;
-        background-color: ${colors.gray[100]};
-    }
-`;
-
-const GlossaryItemCard = styled.div`
-    display: flex;
-    flex-direction: column;
-    border-radius: 13px;
-    border: 1px solid ${REDESIGN_COLORS.LIGHT_GREY_BORDER};
-    background: ${ANTD_GRAY[1]};
-    transition: 0.15s;
-    height: 100%;
-    width: 100%;
-
-    &:hover {
-        transition: 0.15s;
-        border-color: ${(props) => props.theme.styles['primary-color']};
-    }
-
-    &:hover > ${GlossaryItemCardHeader} {
-        transition: 0.15s;
-        opacity: 0.9 !important;
-    }
-`;
 
 const GlossaryItemCount = styled.span<{ count: number }>`
     display: flex;
     align-items: center;
     gap: 5px;
     border-radius: 20px;
-    background: ${(props) => (props.count > 0 ? ANTD_GRAY_V2[14] : ANTD_GRAY_V2[14])};
-    color: ${(props) => (props.count > 0 ? REDESIGN_COLORS.SUB_TEXT : DISABLED_TEXT_COLOR)};
+    background: ${(props) => props.theme.colors.bgSurface};
+    color: ${(props) => (props.count > 0 ? props.theme.colors.textSecondary : props.theme.colors.textDisabled)};
     padding: 5px 10px;
     width: max-content;
     svg {
         height: 14px;
         width: 14px;
         path {
-            fill: ${(props) => (props.count > 0 ? REDESIGN_COLORS.SUB_TEXT : DISABLED_TEXT_COLOR)};
+            fill: ${(props) => (props.count > 0 ? props.theme.colors.icon : props.theme.colors.iconDisabled)};
         }
     }
     border: 1px solid transparent;
     :hover {
-        border: 1px solid ${(props) => (props.count > 0 ? ANTD_GRAY_V2[13] : 'transparent')};
+        border: 1px solid ${(props) => (props.count > 0 ? props.theme.colors.borderHover : 'transparent')};
     }
-`;
-
-const GlossaryItemBadge = styled.span`
-    position: absolute;
-    left: -35px;
-    top: 8px;
-    width: 100px;
-    transform: rotate(-45deg);
-    padding: 8px;
-    opacity: 1;
-    background-color: rgba(0, 0, 0, 0.17);
-`;
-
-const GlossaryItemCardDetails = styled.div`
-    display: flex;
-    flex-direction: column;
-    padding: 13px 16px;
-    gap: 10px;
-`;
-
-const GlossaryCardHeader = styled(Typography)`
-    color: #f9fafc;
-    font-size: 16px;
-    font-weight: 500;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-`;
-
-const GlossaryItemCardDescription = styled(Typography)`
-    color: ${REDESIGN_COLORS.SUB_TEXT};
-    font-size: 12px;
-    font-weight: 400;
-    margin-top: 1px;
-    width: 100%;
-    min-height: 30px;
-    overflow: hidden;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
 `;
 
 const CountText = styled.span`
     font-size: 10px;
     font-weight: 400;
+`;
+
+const Icons = styled.div`
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 5px;
+`;
+
+const CardDescription = styled.div`
+    color: ${(props) => props.theme.colors.textSecondary};
+    line-height: normal;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    word-break: break-word;
+    overflow-wrap: anywhere;
 `;
 
 interface Props {
@@ -149,65 +66,72 @@ interface Props {
     maxDepth?: number;
 }
 
-const Icons = styled.div`
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    gap: 5px;
-`;
-
 const MAX_DEPTH_QUERIED = 4;
 
 const GlossaryNodeCard = (props: Props) => {
     const { name, description, termCount, nodeCount, displayProperties, urn, maxDepth } = props;
     const generateColor = useGenerateGlossaryColorFromPalette();
     const glossaryColor = displayProperties?.colorHex || generateColor(urn);
+    const theme = useTheme();
 
     const isExceedingMaxDepth = (maxDepth || 0) > MAX_DEPTH_QUERIED;
 
     return (
-        <GlossaryItemCardWrapper>
-            <GlossaryItemCard>
-                <GlossaryItemCardHeader color={glossaryColor}>
-                    <BookmarksSimple style={{ flexShrink: 0 }} />
-                    <GlossaryCardHeader>{name}</GlossaryCardHeader>
-                    <GlossaryItemBadge />
-                </GlossaryItemCardHeader>
-                <GlossaryItemCardDetails>
-                    <GlossaryItemCardDescription>{description || '--'}</GlossaryItemCardDescription>
-                    <Icons>
-                        <Tooltip
-                            title={`Contains ${nodeCount} ${props.nodeCount === 1 ? 'term group' : 'term groups'}`}
-                            placement="top"
-                            showArrow={false}
-                        >
-                            <GlossaryItemCount count={nodeCount}>
-                                <BookmarksSimple />
-                                <CountText>
-                                    {' '}
-                                    {nodeCount}
-                                    {isExceedingMaxDepth && `+`}
-                                </CountText>
-                            </GlossaryItemCount>
-                        </Tooltip>
-                        <Tooltip
-                            title={`Contains ${termCount} ${props.termCount === 1 ? 'term' : 'terms'}`}
-                            placement="top"
-                            showArrow={false}
-                        >
-                            <GlossaryItemCount count={termCount}>
-                                <BookmarkSimple />
-                                <CountText>
-                                    {' '}
-                                    {termCount}
-                                    {isExceedingMaxDepth && `+`}
-                                </CountText>
-                            </GlossaryItemCount>
-                        </Tooltip>
-                    </Icons>
-                </GlossaryItemCardDetails>
-            </GlossaryItemCard>
-        </GlossaryItemCardWrapper>
+        <Card
+            title={name}
+            icon={<GlossaryColoredIcon color={glossaryColor} icon={BookmarksSimple} size={40} iconSize={22} />}
+            iconAlignment="horizontal"
+            onClick={() => {}}
+            style={{ overflow: 'hidden', width: '100%', height: '100%', minWidth: 0 }}
+        >
+            {description ? (
+                <Tooltip
+                    title={description}
+                    placement="top"
+                    showArrow={false}
+                    overlayStyle={{ maxWidth: 320, borderRadius: '12px' }}
+                    overlayInnerStyle={{
+                        color: theme.colors.textSecondary,
+                        wordBreak: 'break-word',
+                        overflowWrap: 'anywhere',
+                    }}
+                >
+                    <CardDescription>{description}</CardDescription>
+                </Tooltip>
+            ) : (
+                <CardDescription>--</CardDescription>
+            )}
+            <Icons>
+                <Tooltip
+                    title={`Contains ${nodeCount} ${props.nodeCount === 1 ? 'term group' : 'term groups'}`}
+                    placement="top"
+                    showArrow={false}
+                >
+                    <GlossaryItemCount count={nodeCount}>
+                        <BookmarksSimple />
+                        <CountText>
+                            {' '}
+                            {nodeCount}
+                            {isExceedingMaxDepth && `+`}
+                        </CountText>
+                    </GlossaryItemCount>
+                </Tooltip>
+                <Tooltip
+                    title={`Contains ${termCount} ${props.termCount === 1 ? 'term' : 'terms'}`}
+                    placement="top"
+                    showArrow={false}
+                >
+                    <GlossaryItemCount count={termCount}>
+                        <BookmarkSimple />
+                        <CountText>
+                            {' '}
+                            {termCount}
+                            {isExceedingMaxDepth && `+`}
+                        </CountText>
+                    </GlossaryItemCount>
+                </Tooltip>
+            </Icons>
+        </Card>
     );
 };
 


### PR DESCRIPTION
Before:
<img width="1840" height="1196" alt="Screenshot 2026-05-20 at 4 23 49 PM" src="https://github.com/user-attachments/assets/3edf37fb-dbdd-43c7-b66f-55f1c175b9e0" />
After: 
<img width="1840" height="1196" alt="Screenshot 2026-05-20 at 3 35 20 PM" src="https://github.com/user-attachments/assets/bfdeaa64-09a9-41a3-9f0f-84be20cf857a" />


Refresh the visual treatment of the glossary card grid and sidebar navigation, and bring the touched files in line with the project's design-system conventions (alchemy components + semantic theme tokens).

UI changes
- Glossary cards: drop the colored header and diagonal ribbon in favor of a 40x40 colored icon container (full-color Phosphor icon on a lighter tinted background), built on top of the shared alchemy Card. Lay out the grid as 3 equal columns with an 8px gap aligned to the PageTitle, and clamp/tooltip long descriptions so hover never causes a horizontal page shift from scrollbar reflow.
- Glossary sidebar: replace MUI carets with Phosphor CaretRight / CaretDown at 14px regular weight, preserve the caret slot when a node has no children so rows stay aligned, and swap the old ribbon badge for the same colored icon container pattern. Child nodes and terms inherit the parent node's color and render the singular BookmarkSimple icon.
- Root glossary page: hide the bottom term list; it now only renders inside a specific glossary node.

Cleanup
- New shared GlossaryColoredIcon component replaces three near-identical inline icon-container implementations (card, NodeItem, TermItem).
- Remove dead code from GlossaryListCard (EntityDetails, EntityDetailsLeftColumn, EntityDetailsRightColumn, BookmarkIconWrapper, BookmarkRibbon, leftover saffron hover fill, duplicate align-items, malformed 'overflow hidden' rule) and collapse the duplicated GlossaryNode / GlossaryTerm branches.
- Replace antd usage in all touched files: antd Tooltip ->
  alchemy Tooltip, antd Typography -> plain themed div.
- Migrate every color in the touched files to semantic theme tokens (text, textSecondary, textDisabled, icon, iconDisabled, b

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
