### PR TITLE
fix(admin): layout and onboarding badge CAT-2121 CAT-2120

### DIFF
--- a/datahub-web-react/src/app/entityV2/view/ManageViews.tsx
+++ b/datahub-web-react/src/app/entityV2/view/ManageViews.tsx
@@ -42,13 +42,32 @@ const HeaderActionsContainer = styled.div`
 
 const ListContainer = styled.div`
     flex: 1;
+    min-height: 0;
     display: flex;
     flex-direction: column;
+    overflow: hidden;
+    color: ${(props) => props.theme.colors.text};
+
     &&& .ant-tabs-nav {
         margin: 0;
     }
-    color: ${(props) => props.theme.colors.text};
-    overflow: auto;
+
+    .ant-tabs-content-holder {
+        flex: 1;
+        min-height: 0;
+        overflow: hidden;
+    }
+
+    .ant-tabs-content {
+        flex: 1;
+        min-height: 0;
+    }
+
+    .ant-tabs-tabpane-active {
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+    }
 `;
 
 enum TabType {

--- a/datahub-web-react/src/app/entityV2/view/ViewsList.tsx
+++ b/datahub-web-react/src/app/entityV2/view/ViewsList.tsx
@@ -54,7 +54,6 @@ const TableContainer = styled.div`
     display: flex;
     flex-direction: column;
     min-height: 0;
-    max-height: calc(100vh - 330px); /* Constrain to page height minus header/filters space */
     overflow: auto;
 
     /* Make table header sticky */
@@ -80,9 +79,11 @@ const SearchContainer = styled.div`
 `;
 
 const ViewsContainer = styled.div`
+    flex: 1;
+    min-height: 0;
     display: flex;
     flex-direction: column;
-    overflow: auto;
+    overflow: hidden;
     padding-top: 7px;
 `;
 

--- a/datahub-web-react/src/app/identity/user/UserListV2.components.tsx
+++ b/datahub-web-react/src/app/identity/user/UserListV2.components.tsx
@@ -48,6 +48,14 @@ const ActionsButtonStyle = {
     boxShadow: 'none',
 };
 
+export const PageContainer = styled.div`
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+`;
+
 export const UserContainer = styled.div`
     display: flex;
     flex-direction: column;
@@ -59,20 +67,10 @@ export const TableContainer = styled.div`
     display: flex;
     flex-direction: column;
     min-height: 0;
-    overflow: auto;
+    overflow: hidden;
 
-    /* Make table header sticky */
-    .ant-table-thead {
-        position: sticky;
-        top: 0;
-        z-index: 1;
-        background: ${(props) => props.theme.colors.bg};
-    }
-
-    /* Ensure header cells have proper background */
-    .ant-table-thead > tr > th {
-        background: ${(props) => props.theme.colors.bg} !important;
-        border-bottom: 1px solid ${(props) => props.theme.colors.border};
+    table {
+        table-layout: fixed;
     }
 `;
 
@@ -86,6 +84,13 @@ export const FiltersHeader = styled.div`
 export const SearchContainer = styled.div`
     display: flex;
     flex-direction: column;
+    flex: 1;
+`;
+
+export const PaginationContainer = styled.div`
+    padding-top: 8px;
+    display: flex;
+    justify-content: center;
 `;
 
 export const FilterContainer = styled.div`

--- a/datahub-web-react/src/app/identity/user/UserListV2.tsx
+++ b/datahub-web-react/src/app/identity/user/UserListV2.tsx
@@ -6,6 +6,8 @@ import {
     FilterContainer,
     FiltersHeader,
     ModalFooter,
+    PageContainer,
+    PaginationContainer,
     SearchContainer,
     TableContainer,
     UserActionsMenu,
@@ -157,7 +159,7 @@ export const UserList = () => {
     ];
 
     return (
-        <>
+        <PageContainer>
             {!data && loading && <Message type="loading" content="Loading users..." />}
             {error && <Message type="error" content="Failed to load users! An unexpected error occurred." />}
 
@@ -203,7 +205,7 @@ export const UserList = () => {
                 {usersList.length > 0 ? (
                     <>
                         <Table columns={columns} data={usersList} isLoading={loading} isScrollable />
-                        <div style={{ padding: '8px 20px 0 20px', display: 'flex', justifyContent: 'center' }}>
+                        <PaginationContainer>
                             <Pagination
                                 currentPage={page}
                                 itemsPerPage={pageSize}
@@ -217,7 +219,7 @@ export const UserList = () => {
                                 showSizeChanger
                                 pageSizeOptions={[10, 25, 50, 100]}
                             />
-                        </div>
+                        </PaginationContainer>
                     </>
                 ) : (
                     <div style={{ padding: '20px', textAlign: 'center' }}>
@@ -273,6 +275,6 @@ export const UserList = () => {
                     })()}
                 </Modal>
             )}
-        </>
+        </PageContainer>
     );
 };

--- a/datahub-web-react/src/app/onboarding/OnboardingTour.tsx
+++ b/datahub-web-react/src/app/onboarding/OnboardingTour.tsx
@@ -128,6 +128,7 @@ export const OnboardingTour = ({ stepIds }: Props) => {
             rounded={10}
             scrollDuration={500}
             accentColor={accentColor}
+            badgeContent={(current) => <span style={{ color: theme.colors.text }}>{current}</span>}
             lastStepNextButton={<Button>Let&apos;s go!</Button>}
             getCurrentStep={handleStepChange}
             update={updateKey}

--- a/datahub-web-react/src/app/settingsV2/posts/PostsList.tsx
+++ b/datahub-web-react/src/app/settingsV2/posts/PostsList.tsx
@@ -17,17 +17,35 @@ import { Column } from '@src/alchemy-components/components/Table/types';
 import { useListPostsQuery } from '@graphql/post.generated';
 import { PostContentType } from '@types';
 
-const PostsContainer = styled.div`
+const PageContainer = styled.div`
+    flex: 1;
+    min-height: 0;
     display: flex;
     flex-direction: column;
-    overflow: auto;
+    overflow: hidden;
+`;
+
+const PostsContainer = styled.div`
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
     gap: 16px;
+    overflow: hidden;
 `;
 
 const TableContainer = styled.div`
     flex: 1;
     min-height: 0;
-    overflow: auto;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+`;
+
+const PaginationContainer = styled.div`
+    padding-top: 8px;
+    display: flex;
+    justify-content: center;
 `;
 
 const DEFAULT_PAGE_SIZE = 10;
@@ -163,7 +181,7 @@ export const PostList = ({ isCreatingPost, setIsCreatingPost }: PostListProps) =
     };
 
     return (
-        <>
+        <PageContainer>
             {error && <Alert variant="error" title="Failed to load Posts! An unexpected error occurred." />}
             <PostsContainer>
                 <SearchBar
@@ -178,13 +196,15 @@ export const PostList = ({ isCreatingPost, setIsCreatingPost }: PostListProps) =
                 />
                 <TableContainer>{renderContent()}</TableContainer>
                 {totalPosts > pageSize && (
-                    <Pagination
-                        currentPage={page}
-                        itemsPerPage={pageSize}
-                        total={totalPosts}
-                        onPageChange={onChangePage}
-                        showSizeChanger={false}
-                    />
+                    <PaginationContainer>
+                        <Pagination
+                            currentPage={page}
+                            itemsPerPage={pageSize}
+                            total={totalPosts}
+                            onPageChange={onChangePage}
+                            showSizeChanger={false}
+                        />
+                    </PaginationContainer>
                 )}
                 {isCreatingPost && (
                     <CreatePostModal
@@ -208,6 +228,6 @@ export const PostList = ({ isCreatingPost, setIsCreatingPost }: PostListProps) =
                     />
                 )}
             </PostsContainer>
-        </>
+        </PageContainer>
     );
 };


### PR DESCRIPTION
Fixed:
<img width="1031" height="894" alt="Screenshot 2026-05-20 at 4 55 25 PM" src="https://github.com/user-attachments/assets/a7fb3d7f-c198-4458-b83e-27f97272f3b0" />
<img width="1840" height="1188" alt="Screenshot 2026-05-20 at 4 55 43 PM" src="https://github.com/user-attachments/assets/e80e1c57-05cc-4906-967e-65de35738497" />


## Summary

Two small, related frontend polish fixes that came out of auditing admin pages for inconsistent height/scroll behavior and theme contrast.

### 1. Admin list-page layouts (`fix(ui)`)

The Users (`UserListV2`), Posts (`PostsList`), and Views (`ViewsList` / `ManageViews`) pages were each handling their own page height differently:

- `UserListV2` set `overflow: auto` on outer wrappers without a height-constrained parent, so the whole page grew with the list instead of the table scrolling internally.
- `PostsList` used a `<>` fragment as root and an ad-hoc pagination `div`, with no flex container, so it inherited the same stretching behavior.
- `ViewsList` hardcoded `max-height: calc(100vh - 330px)`, which is brittle — any change to surrounding chrome (banners, breadcrumbs, tab headers) silently breaks the calculation.
- `ManageViews` wrapped `ViewsList` in an Ant `Tabs` but didn't propagate height through the Ant Tabs internals, so even after `ViewsList` was fixed it still wouldn't get the height of its tab pane.

This PR aligns all four with the existing `GroupList` / `ManagePolicies` pattern:

- A `PageContainer` that is `flex: 1; min-height: 0; display: flex; flex-direction: column; overflow: hidden`.
- An inner `TableContainer` with `overflow: hidden` so the `Table` itself handles internal scrolling via `isScrollable`.
- A dedicated `PaginationContainer` styled component instead of inline pagination divs.
- For `ManageViews`, explicit overrides for `.ant-tabs-content-holder`, `.ant-tabs-content`, and `.ant-tabs-tabpane-active` so flex height actually propagates through to `ViewsList`.

Net effect: tables scroll internally, the page itself does not scroll, and no admin list page depends on `vh` math anymore.

### 2. Onboarding tour step badge contrast (`fix(onboarding)`)

`reactour` renders the step number with hardcoded `color: white` on top of `accentColor`. In our `OnboardingTour`, `accentColor` is bound to `theme.colors.bgSurfaceBrand`, which on the light theme is a pale violet (`violet0`). The result was a nearly invisible step number (white on near-white) — fine on dark theme, broken on light.

Using `reactour`'s `badgeContent` prop, the step number is now rendered inside a `<span>` with `color: theme.colors.text`, which is dark on light themes and light on dark themes, so the number stays legible on both.

## Test plan

- [ ] **Users tab** (`/settings/identities/users`): scroll a long user list — only the table scrolls, the page chrome stays fixed; pagination stays anchored at the bottom of the table container.
- [ ] **Groups tab**: confirm no visual regression (this was the reference pattern, not changed).
- [ ] **Posts page** (`/settings/posts`): same scroll behavior as Users.
- [ ] **Views page** (`/settings/views`): switch between the "My Views" and "All Views" tabs — both fill the tab pane, neither relies on `calc(100vh - …)`, table scrolls internally.
- [ ] **Onboarding tour**: navigate to `/settings/identities/groups`, press `⌘ + ⌃ + T` to force-reshow the tour, and confirm the numbered step badge is legible on both **light** and **dark** themes.

## Checklist

- [x] PR conforms to the [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (PR Title Format)
- [ ] Links to related issues (n/a)
- [ ] Tests added/updated (n/a — visual layout / styling only; no behavior change)
- [ ] Docs added/updated (n/a)
- [x] No breaking changes — `docs/how/updating-datahub.md` not touched


CAT-2121
CAT-2120
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
