### PR TITLE
fix(ui): Show glossary term icon next to parent-less terms in glossary

### DIFF
--- a/datahub-web-react/src/app/glossaryV2/GlossaryBrowser/TermItem.tsx
+++ b/datahub-web-react/src/app/glossaryV2/GlossaryBrowser/TermItem.tsx
@@ -8,6 +8,7 @@ import { EDITING_DOCUMENTATION_URL_PARAM } from '@app/entityV2/shared/constants'
 import { useGlossaryActiveTabPath } from '@app/entityV2/shared/containers/profile/utils';
 import { SelectedMark } from '@app/glossaryV2/GlossaryBrowser/SelectedMark';
 import GlossaryColoredIcon from '@app/glossaryV2/GlossaryColoredIcon';
+import { useGenerateGlossaryColorFromPalette } from '@app/glossaryV2/colorUtils';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 
 import { ChildGlossaryTermFragment } from '@graphql/glossaryNode.generated';
@@ -94,6 +95,8 @@ function TermItem(props: Props) {
     const { entityData } = useGlossaryEntityData();
     const entityRegistry = useEntityRegistry();
     const activeTabPath = useGlossaryActiveTabPath();
+    const generateColor = useGenerateGlossaryColorFromPalette();
+    const resolvedIconColor = iconColor || generateColor(term.urn);
 
     function handleSelectTerm() {
         if (selectTerm) {
@@ -110,7 +113,7 @@ function TermItem(props: Props) {
 
     return (
         <TermWrapper $isSelected={entityData?.urn === term.urn} $depth={props.depth}>
-            {iconColor && <StyledTermIcon color={iconColor} icon={BookmarkSimple} size={24} iconSize={14} />}
+            <StyledTermIcon color={resolvedIconColor} icon={BookmarkSimple} size={24} iconSize={14} />
             {!isSelecting && (
                 <TermLink
                     to={`${entityRegistry.getEntityUrl(term.type, term.urn)}${


### PR DESCRIPTION
Previously terms that were parent-less would show up in the nav sidebar without an icon. Now they do:

<img width="1276" height="1650" alt="image" src="https://github.com/user-attachments/assets/c1c67d70-7952-47ac-81eb-614ce3468a78" />


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
