### PR TITLE
docs(cli): document brew install for the DataHub CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,11 +192,16 @@ Yes. DataHub was originally built at LinkedIn to manage metadata at scale across
 <summary><b>How do I install the DataHub metadata platform?</b></summary>
 
 ```bash
+# macOS / Linux (simplest)
+brew install datahub-project/tap/datahub
+
+# Or via pip (any platform)
 pip install acryl-datahub
+
 datahub docker quickstart
 ```
 
-See the [Quick Start](#-quick-start-60-seconds) section below for full instructions. The PyPI package is [`acryl-datahub`](https://pypi.org/project/acryl-datahub/).
+See the [Quick Start](#-quick-start-60-seconds) section below for full instructions. The PyPI package is [`acryl-datahub`](https://pypi.org/project/acryl-datahub/); the Homebrew tap is [`datahub-project/homebrew-tap`](https://github.com/datahub-project/homebrew-tap).
 
 </details>
 
@@ -242,25 +247,33 @@ No installation required. Explore a fully-loaded DataHub instance with sample da
 
 **🌐 [Launch Live Demo: demo.datahub.com](https://demo.datahub.com)**
 
-### Option 2: Run Locally with Python (Recommended)
+### Option 2: Run Locally (Recommended)
 
-Get DataHub running on your machine in under 2 minutes:
+Get DataHub running on your machine in under 2 minutes.
+
+**Prerequisites:** Docker Desktop with 8GB+ RAM allocated.
+
+Install the DataHub CLI using either Homebrew (macOS / Linux) or pip:
 
 ```bash
-# Prerequisites: Docker Desktop with 8GB+ RAM allocated
+# Homebrew (macOS / Linux)
+brew install datahub-project/tap/datahub
 
-# Upgrade pip and install DataHub CLI
+# Or pip (any platform)
 python3 -m pip install --upgrade pip wheel setuptools
 python3 -m pip install --upgrade acryl-datahub
+```
 
-# Launch DataHub locally via Docker
+Then launch DataHub locally via Docker:
+
+```bash
 datahub docker quickstart
 
 # Access DataHub at http://localhost:9002
 # Default credentials: datahub / datahub
 ```
 
-**Note:** You can also use `uv` or other Python package managers instead of pip.
+**Note:** For pip, you can also use `uv` or other Python package managers.
 
 **What's included:**
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -11,6 +11,27 @@ DataHub comes with a friendly cli called `datahub` that allows you to perform a 
 
 ## Installation
 
+### Using Homebrew (macOS / Linux)
+
+The simplest way to install the DataHub CLI on macOS or Linux:
+
+```shell
+brew install datahub-project/tap/datahub
+datahub version
+datahub init
+# authenticate your datahub CLI with your datahub instance
+```
+
+Homebrew manages an isolated Python environment for `datahub`, so there's no venv to activate and no PATH conflicts with system Python. To upgrade later, run `brew upgrade datahub`.
+
+**Note:** The Homebrew formula installs the **core CLI only**. To add ingestion connectors (Snowflake, BigQuery, Looker, etc.), install them into the brew-managed environment:
+
+```shell
+"$(brew --prefix datahub)/libexec/bin/pip" install 'acryl-datahub[snowflake,bigquery]'
+```
+
+The full list of available connector extras is shown in the [Installing Plugins](#installing-plugins) section below.
+
 ### Using pip
 
 We recommend Python virtual environments (venv-s) to namespace pip modules. Here's an example setup:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -32,6 +32,20 @@ Tested & confirmed config: 2 CPUs, 8GB RAM, 2GB Swap area, and 12GB disk space.
 ## Install the DataHub CLI
 
 <Tabs>
+<TabItem value="brew" label="Homebrew">
+
+```bash
+brew install datahub-project/tap/datahub
+datahub version
+```
+
+Homebrew manages an isolated Python environment for `datahub`, so there's no venv to activate. The formula installs the **core CLI only** — to add ingestion connectors, install them into the brew-managed environment:
+
+```bash
+"$(brew --prefix datahub)/libexec/bin/pip" install 'acryl-datahub[snowflake,bigquery]'
+```
+
+</TabItem>
 <TabItem value="pip" label="pip">
 
 ```bash

--- a/metadata-ingestion/cli-ingestion.md
+++ b/metadata-ingestion/cli-ingestion.md
@@ -9,13 +9,20 @@ The metadata that is extracted includes point-in-time instances of dataset, char
 
 ## Installing DataHub CLI
 
+On macOS or Linux, the simplest install is via Homebrew:
+
+```bash
+brew install datahub-project/tap/datahub
+datahub version
+```
+
+Or via pip on any platform:
+
 :::note Required Python Version
-Installing DataHub CLI requires Python 3.6+.
+Installing DataHub CLI via pip requires Python 3.10+.
 :::
 
-Run the following commands in your terminal:
-
-```
+```bash
 python3 -m pip install --upgrade pip wheel setuptools
 python3 -m pip install --upgrade acryl-datahub
 python3 -m datahub version


### PR DESCRIPTION
## Summary

The DataHub CLI is now available as a Homebrew tap at [datahub-project/homebrew-tap](https://github.com/datahub-project/homebrew-tap). This PR documents the new install path in every place that currently carries CLI install instructions:

- **`docs/cli.md`** — new `### Using Homebrew (macOS / Linux)` section ahead of `### Using pip`, including the one-line install command, the upgrade note, the **core-CLI-only** caveat, and the exact `pip install` pattern for adding connector extras into the brew-managed venv. Links to the existing _Installing Plugins_ section for the full extras list.
- **`docs/quickstart.md`** — adds a `Homebrew` tab as the first (default) option in the existing `<Tabs>` install block alongside `pip` and `poetry`.
- **`metadata-ingestion/cli-ingestion.md`** — adds brew alongside the pip snippet. Also corrects the stated minimum Python from `3.6+` to `3.10+` (the package already requires `>=3.10` per `pyproject.toml`).
- **`README.md`** — adds brew alongside pip in:
  - The _How do I install the DataHub metadata platform?_ FAQ snippet.
  - The _Quick Start → Option 2: Run Locally_ block (renamed from _Run Locally with Python_ since brew is no longer Python-centric for the install step).

End-to-end verified: `brew install datahub-project/tap/datahub && datahub --version` works on macOS 14 / arm64 (Python 3.13).

## Test plan

- [x] `./gradlew :datahub-web-react:mdPrettierWrite` — clean on all four files
- [x] Manually verified `brew install datahub-project/tap/datahub` succeeds and `datahub --version` returns `acryl-datahub, version 1.6.0`
- [ ] (Reviewer) Render the updated docs locally and confirm the new Homebrew tab appears first in `docs/quickstart.md` and the new section appears above pip in `docs/cli.md`